### PR TITLE
doc: Add note to informal graph maker

### DIFF
--- a/scripts/MetaPrograms/informal.lean
+++ b/scripts/MetaPrograms/informal.lean
@@ -16,6 +16,7 @@ import ImportGraph.RequiredModules
 To make the dot file for the dependency graph run:
 - lake exe informal mkDot
 - dot -Tsvg -o ./Docs/graph.svg ./Docs/InformalDot.dot
+- or dot -Tpng  -Gdpi=300 -o ./Docs/graph.png ./Docs/InformalDot.dot
 -/
 
 open Lean System Meta


### PR DESCRIPTION
This pull request includes a small change to the `scripts/MetaPrograms/informal.lean` file. The change adds an alternative command to generate a PNG image of the dependency graph.

* [`scripts/MetaPrograms/informal.lean`](diffhunk://#diff-387efe9390db501605b4b6620ad0b1b6c682a5870cbdf99d34c6c128dd574dd7R19): Added a command to generate a PNG image of the dependency graph with a specified DPI.