### PR TITLE
Implement toLorentzGroup_det_one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 name: continuous integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
 
 name: continuous integration
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 
 on:
   push:
-    branches:
-      - master
-  pull_request_target:
+  pull_request:
 
 name: continuous integration
 

--- a/HepLean.lean
+++ b/HepLean.lean
@@ -105,8 +105,8 @@ import HepLean.Mathematics.Fin.Involutions
 import HepLean.Mathematics.LinearMaps
 import HepLean.Mathematics.List
 import HepLean.Mathematics.PiTensorProduct
-import HepLean.Mathematics.SchurTriangulation
 import HepLean.Mathematics.SO3.Basic
+import HepLean.Mathematics.SchurTriangulation
 import HepLean.Meta.AllFilePaths
 import HepLean.Meta.Basic
 import HepLean.Meta.Informal.Basic

--- a/HepLean.lean
+++ b/HepLean.lean
@@ -93,6 +93,7 @@ import HepLean.Lorentz.RealVector.Contraction
 import HepLean.Lorentz.RealVector.Modules
 import HepLean.Lorentz.RealVector.NormOne
 import HepLean.Lorentz.SL2C.Basic
+import HepLean.Lorentz.SL2C.SelfAdjoint
 import HepLean.Lorentz.Weyl.Basic
 import HepLean.Lorentz.Weyl.Contraction
 import HepLean.Lorentz.Weyl.Metric
@@ -104,6 +105,7 @@ import HepLean.Mathematics.Fin.Involutions
 import HepLean.Mathematics.LinearMaps
 import HepLean.Mathematics.List
 import HepLean.Mathematics.PiTensorProduct
+import HepLean.Mathematics.SchurTriangulation
 import HepLean.Mathematics.SO3.Basic
 import HepLean.Meta.AllFilePaths
 import HepLean.Meta.Basic

--- a/HepLean/Lorentz/SL2C/Basic.lean
+++ b/HepLean/Lorentz/SL2C/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import HepLean.Lorentz.Group.Restricted
+import HepLean.Lorentz.SL2C.SelfAdjoint
+import Mathlib.Analysis.Complex.Polynomial.Basic -- Complex.isAlgClosed
 /-!
 # The group SL(2, ℂ) and it's relation to the Lorentz group
 
@@ -282,9 +284,28 @@ In this section we will define this homomorphism.
 
 -/
 
-informal_lemma toLorentzGroup_det_one where
-  math :≈ "The determinant of the image of `SL(2, ℂ)` in the Lorentz group is one."
-  deps :≈ [``toLorentzGroup]
+/-- The determinant of the image of `SL(2, ℂ)` in the Lorentz group is one. -/
+lemma toLorentzGroup_det_one (M : SL(2, ℂ)) : det (toLorentzGroup M).val = 1 :=
+  let U := M.val.schurTriangulationUnitary
+  let N := M.val.schurTriangulation.val
+  have h : M.val = U * N * star U := M.val.schur_triangulation
+  haveI : Invertible U.val := ⟨star U.val, U.property.left, U.property.right⟩
+  calc  det (toLorentzGroup M).val
+    _ = LinearMap.det (toSelfAdjointMap' M) := LinearMap.det_toMatrix ..
+    _ = LinearMap.det (toSelfAdjointMap' (U * N * U.val⁻¹)) :=
+      suffices star U = U.val⁻¹ by rw [h, this]
+      calc  star U.val
+        _ = star U.val * (U.val * U.val⁻¹) := by simp
+        _ = star U.val * U.val * U.val⁻¹ := by noncomm_ring
+        _ = U.val⁻¹ := by simp
+    _ = LinearMap.det (toSelfAdjointMap' N) := toSelfAdjointMap_similar_det U N
+    _ = 1 :=
+      suffices N.det = 1 from toSelfAdjointMap_det_one' M.val.schurTriangulation.property this
+      calc  N.det
+        _ = det ((U * star U).val * N) := by simp
+        _ = det (U.val * N * star U.val) := det_mul_right_comm ..
+        _ = M.val.det := congrArg det h.symm
+        _ = 1 := M.property
 
 informal_lemma toRestrictedLorentzGroup where
   math :≈ "The homomorphism from `SL(2, ℂ)` to the restricted Lorentz group."

--- a/HepLean/Lorentz/SL2C/Basic.lean
+++ b/HepLean/Lorentz/SL2C/Basic.lean
@@ -290,18 +290,18 @@ lemma toLorentzGroup_det_one (M : SL(2, ℂ)) : det (toLorentzGroup M).val = 1 :
   let N := M.val.schurTriangulation.val
   have h : M.val = U * N * star U := M.val.schur_triangulation
   haveI : Invertible U.val := ⟨star U.val, U.property.left, U.property.right⟩
-  calc  det (toLorentzGroup M).val
+  calc det (toLorentzGroup M).val
     _ = LinearMap.det (toSelfAdjointMap' M) := LinearMap.det_toMatrix ..
     _ = LinearMap.det (toSelfAdjointMap' (U * N * U.val⁻¹)) :=
       suffices star U = U.val⁻¹ by rw [h, this]
-      calc  star U.val
+      calc star U.val
         _ = star U.val * (U.val * U.val⁻¹) := by simp
         _ = star U.val * U.val * U.val⁻¹ := by noncomm_ring
         _ = U.val⁻¹ := by simp
     _ = LinearMap.det (toSelfAdjointMap' N) := toSelfAdjointMap_similar_det U N
     _ = 1 :=
       suffices N.det = 1 from toSelfAdjointMap_det_one' M.val.schurTriangulation.property this
-      calc  N.det
+      calc N.det
         _ = det ((U * star U).val * N) := by simp
         _ = det (U.val * N * star U.val) := det_mul_right_comm ..
         _ = M.val.det := congrArg det h.symm

--- a/HepLean/Lorentz/SL2C/SelfAdjoint.lean
+++ b/HepLean/Lorentz/SL2C/SelfAdjoint.lean
@@ -1,0 +1,131 @@
+import Mathlib.LinearAlgebra.Matrix.SchurComplement
+import HepLean.Mathematics.SchurTriangulation
+
+namespace Lorentz
+
+open scoped Matrix
+open scoped ComplexConjugate
+
+notation "ℂ²ˣ²" => Matrix (Fin 2) (Fin 2) ℂ
+noncomputable abbrev ℍ₂ := selfAdjoint ℂ²ˣ²
+
+namespace SL2C
+
+noncomputable def toSelfAdjointMap' (M : ℂ²ˣ²) : ℍ₂ →ₗ[ℝ] ℍ₂ where
+  toFun | ⟨A, hA⟩ => ⟨M * A * Mᴴ, hA.conjugate M⟩
+  map_add' | ⟨A, _⟩, ⟨B, _⟩ => Subtype.ext <|
+    show M * (A + B) * Mᴴ = M * A * Mᴴ + M * B * Mᴴ by noncomm_ring
+  map_smul' | r, ⟨A, _⟩ => Subtype.ext <| by simp
+
+open Complex (I normSq) in
+theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (detM : M.det = 1)
+    : LinearMap.det (toSelfAdjointMap' M) = 1 :=
+  let b : Basis (Fin 2 ⊕ Fin 2) ℝ ℍ₂ := Basis.ofEquivFun {
+    toFun := fun ⟨A, _⟩ => ![(A 0 0).re, (A 1 1).re] ⊕ᵥ ![(A 0 1).re, (A 0 1).im]
+    map_add' := fun _ _ => funext fun | .inl 0 | .inl 1 | .inr 0 | .inr 1 => rfl
+    map_smul' := fun _ _ => funext fun | .inl 0 | .inl 1 | .inr 0 | .inr 1 => by simp
+    invFun := fun p => {
+      val := let z : ℂ := ⟨p (.inr 0), p (.inr 1)⟩ ; !![p (.inl 0), z; conj z, p (.inl 1)]
+      property := Matrix.ext fun | 0, 0 | 0, 1 | 1, 0 | 1, 1 => by simp
+    }
+    left_inv := fun ⟨A, hA⟩ => Subtype.ext <| Matrix.ext fun
+      | 0, 1 => rfl
+      | 1, 0 => show conj (A 0 1) = A 1 0 from congrFun₂ hA 1 0
+      | 0, 0 => show (A 0 0).re = A 0 0 from Complex.conj_eq_iff_re.mp (congrFun₂ hA 0 0)
+      | 1, 1 => show (A 1 1).re = A 1 1 from Complex.conj_eq_iff_re.mp (congrFun₂ hA 1 1)
+    right_inv := fun _ => funext fun | .inl 0 | .inl 1 | .inr 0 | .inr 1 => rfl
+  }
+  let E₀ : ℂ²ˣ² := !![1, 0; conj 0, 0] -- b (.inl 0)
+  let E₁ : ℂ²ˣ² := !![0, 0; conj 0, 1] -- b (.inl 1)
+  let E₂ : ℂ²ˣ² := !![0, 1; conj 1, 0] -- b (.inr 0)
+  let E₃ : ℂ²ˣ² := !![0, I; conj I, 0] -- b (.inr 1)
+  let F : Matrix (Fin 2 ⊕ Fin 2) (Fin 2 ⊕ Fin 2) ℝ := LinearMap.toMatrix b b (toSelfAdjointMap' M)
+  let A := F.toBlocks₁₁ ; let B := F.toBlocks₁₂ ; let C := F.toBlocks₂₁ ; let D := F.toBlocks₂₂
+  let x := M 0 0 ; let y := M 1 1 ; have hM10 : M 1 0 = 0 := hM <| show 0 < 1 by decide
+  have he : M = !![x, _; 0, y] := Matrix.ext fun | 0, 0 | 0, 1 | 1, 1 => rfl | 1, 0 => hM10
+  have he' : Mᴴ = !![conj x, 0; _, conj y] :=
+    Matrix.ext fun | 0, 0 | 1, 0 | 1, 1 => rfl | 0, 1 => by simp [hM10]
+
+  have detA_one : normSq x * normSq y = 1 := congrArg Complex.re <|
+    calc  ↑(normSq x * normSq y)
+      _ = x * conj x * (y * conj y) := by simp [Complex.mul_conj]
+      _ = x * y * (conj y * conj x) := by ring
+      _ = x * y * conj (x * y) := congrArg _ (star_mul ..).symm
+      _ = 1 := suffices x * y = 1 by simp [this]
+        calc  x * y
+          _ = !![x, _; 0, y].det := by simp
+          _ = M.det := congrArg _ he.symm
+          _ = 1 := detM
+  have detD_one : D.det = 1 :=
+    let z := x * conj y
+    have k₀ : (M * E₂ * Mᴴ) 0 1 = z := by rw [he', he] ; simp [E₂]
+    have k₁ : (M * E₃ * Mᴴ) 0 1 = ⟨-z.im, z.re⟩ :=
+      calc
+        _ = x * I * conj y := by rw [he', he] ; simp [E₃]
+        _ = Complex.I * z := by ring
+        _ = ⟨-z.im, z.re⟩ := z.I_mul
+    have hD : D = !![z.re, -z.im; z.im, z.re] := Matrix.ext fun
+      | 0, 0 => congrArg Complex.re k₀ | 1, 0 => congrArg Complex.im k₀
+      | 0, 1 => congrArg Complex.re k₁ | 1, 1 => congrArg Complex.im k₁
+    calc  D.det
+      _ = normSq z := by simp [hD, z.normSq_apply]
+      _ = normSq x * normSq y := by simp [x.normSq_mul]
+      _ = 1 := detA_one
+
+  letI : Invertible D.det := detD_one ▸ invertibleOne
+  letI : Invertible D := D.invertibleOfDetInvertible
+  have hE : A - B * ⅟D * C = !![normSq x, _; 0, normSq y] :=
+    have k : (M * E₀ * Mᴴ) 0 1 = 0 := by rw [he', he] ; simp [E₀]
+    have hC00 : C 0 0 = 0 := congrArg Complex.re k
+    have hC10 : C 1 0 = 0 := congrArg Complex.im k
+    Matrix.ext fun
+      | 0, 1 => rfl
+      | 1, 0 =>
+        have hA10 : A 1 0 = 0 := congrArg Complex.re <|
+          show (M * E₀ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₀]
+        show A 1 0 - (B * ⅟D) 1 ⬝ᵥ (C · 0) = 0 by simp [hC00, hC10, hA10]
+      | 0, 0 =>
+        have hA00 : A 0 0 = normSq x := congrArg Complex.re <|
+          show (M * E₀ * Mᴴ) 0 0 = normSq x by rw [he', he] ; simp [E₀, x.mul_conj]
+        show A 0 0 - (B * ⅟D) 0 ⬝ᵥ (C · 0) = normSq x by simp [hC00, hC10, hA00]
+      | 1, 1 =>
+        have hA11 : A 1 1 = normSq y := congrArg Complex.re <|
+          show (M * E₁ * Mᴴ) 1 1 = normSq y by rw [he', he] ; simp [E₁, y.mul_conj]
+        have hB10 : B 1 0 = 0 := congrArg Complex.re <|
+          show (M * E₂ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₂]
+        have hB11 : B 1 1 = 0 := congrArg Complex.re <|
+          show (M * E₃ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₃]
+        calc  A 1 1 - (B * ⅟D * C) 1 1
+          _ = A 1 1 - B 1 ⬝ᵥ ((⅟D * C) · 1) := by noncomm_ring
+          _ = normSq y := by simp [hB10, hB11, hA11]
+  calc  LinearMap.det (toSelfAdjointMap' M)
+    _ = F.det := (LinearMap.det_toMatrix ..).symm
+    _ = D.det * (A - B * ⅟D * C).det := F.fromBlocks_toBlocks ▸ Matrix.det_fromBlocks₂₂ ..
+    _ = 1 := by rw [hE] ; simp [detD_one, detA_one]
+
+noncomputable def toSelfAdjointEquiv (M : ℂ²ˣ²) [Invertible M] : ℍ₂ ≃ₗ[ℝ] ℍ₂ where
+  toLinearMap := toSelfAdjointMap' M
+  invFun := toSelfAdjointMap' M⁻¹
+  left_inv | ⟨A, _⟩ => Subtype.ext <|
+    calc  M⁻¹ * (M * A * Mᴴ) * M⁻¹ᴴ
+      _ = M⁻¹ * ↑M * A * (M⁻¹ * M)ᴴ := by noncomm_ring [Matrix.conjTranspose_mul]
+      _ = A := by simp
+  right_inv | ⟨A, _⟩ => Subtype.ext <|
+    calc  M * (M⁻¹ * A * M⁻¹ᴴ) * Mᴴ
+      _ = M * M⁻¹ * A * (M * M⁻¹)ᴴ := by noncomm_ring [Matrix.conjTranspose_mul]
+      _ = A := by simp
+
+theorem toSelfAdjointMap_mul (M N : ℂ²ˣ²)
+    : toSelfAdjointMap' (M * N) = toSelfAdjointMap' M ∘ₗ toSelfAdjointMap' N :=
+  LinearMap.ext fun A => Subtype.ext <|
+    show M * N * A * (M * N)ᴴ = M * (N * A * Nᴴ) * Mᴴ by noncomm_ring [Matrix.conjTranspose_mul]
+
+theorem toSelfAdjointMap_similar_det  (M N : ℂ²ˣ²) [Invertible M]
+    : LinearMap.det (toSelfAdjointMap' (M * N * M⁻¹)) = LinearMap.det (toSelfAdjointMap' N) :=
+  let e := toSelfAdjointEquiv M
+  let f := toSelfAdjointMap' N
+  suffices toSelfAdjointMap' (M * N * M⁻¹) = e ∘ₗ f ∘ₗ e.symm from this ▸ f.det_conj e
+  by rw [toSelfAdjointMap_mul, toSelfAdjointMap_mul] ; rfl
+
+end SL2C
+end Lorentz

--- a/HepLean/Lorentz/SL2C/SelfAdjoint.lean
+++ b/HepLean/Lorentz/SL2C/SelfAdjoint.lean
@@ -24,14 +24,16 @@ noncomputable def toSelfAdjointMap' (M : ℂ²ˣ²) : ℍ₂ →ₗ[ℝ] ℍ₂ 
   map_smul' | r, ⟨A, _⟩ => Subtype.ext <| by simp
 
 open Complex (I normSq) in
-theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (detM : M.det = 1)
-    : LinearMap.det (toSelfAdjointMap' M) = 1 :=
+lemma toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (detM : M.det = 1) :
+    LinearMap.det (toSelfAdjointMap' M) = 1 :=
   let b : Basis (Fin 2 ⊕ Fin 2) ℝ ℍ₂ := Basis.ofEquivFun {
     toFun := fun ⟨A, _⟩ => ![(A 0 0).re, (A 1 1).re] ⊕ᵥ ![(A 0 1).re, (A 0 1).im]
     map_add' := fun _ _ => funext fun | .inl 0 | .inl 1 | .inr 0 | .inr 1 => rfl
     map_smul' := fun _ _ => funext fun | .inl 0 | .inl 1 | .inr 0 | .inr 1 => by simp
     invFun := fun p => {
-      val := let z : ℂ := ⟨p (.inr 0), p (.inr 1)⟩ ; !![p (.inl 0), z; conj z, p (.inl 1)]
+      val :=
+        let z : ℂ := ⟨p (.inr 0), p (.inr 1)⟩
+        !![p (.inl 0), z; conj z, p (.inl 1)]
       property := Matrix.ext fun | 0, 0 | 0, 1 | 1, 0 | 1, 1 => by simp
     }
     left_inv := fun ⟨A, hA⟩ => Subtype.ext <| Matrix.ext fun
@@ -46,12 +48,11 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
   let E₂ : ℂ²ˣ² := !![0, 1; conj 1, 0] -- b (.inr 0)
   let E₃ : ℂ²ˣ² := !![0, I; conj I, 0] -- b (.inr 1)
   let F : Matrix (Fin 2 ⊕ Fin 2) (Fin 2 ⊕ Fin 2) ℝ := LinearMap.toMatrix b b (toSelfAdjointMap' M)
-  let A := F.toBlocks₁₁ ; let B := F.toBlocks₁₂ ; let C := F.toBlocks₂₁ ; let D := F.toBlocks₂₂
-  let x := M 0 0 ; let y := M 1 1 ; have hM10 : M 1 0 = 0 := hM <| show 0 < 1 by decide
+  let A := F.toBlocks₁₁; let B := F.toBlocks₁₂; let C := F.toBlocks₂₁; let D := F.toBlocks₂₂
+  let x := M 0 0; let y := M 1 1; have hM10 : M 1 0 = 0 := hM <| show 0 < 1 by decide
   have he : M = !![x, _; 0, y] := Matrix.ext fun | 0, 0 | 0, 1 | 1, 1 => rfl | 1, 0 => hM10
   have he' : Mᴴ = !![conj x, 0; _, conj y] :=
     Matrix.ext fun | 0, 0 | 1, 0 | 1, 1 => rfl | 0, 1 => by simp [hM10]
-
   have detA_one : normSq x * normSq y = 1 := congrArg Complex.re <|
     calc ↑(normSq x * normSq y)
       _ = x * conj x * (y * conj y) := by simp [Complex.mul_conj]
@@ -64,10 +65,10 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
           _ = 1 := detM
   have detD_one : D.det = 1 :=
     let z := x * conj y
-    have k₀ : (M * E₂ * Mᴴ) 0 1 = z := by rw [he', he] ; simp [E₂]
+    have k₀ : (M * E₂ * Mᴴ) 0 1 = z := by rw [he', he]; simp [E₂]
     have k₁ : (M * E₃ * Mᴴ) 0 1 = ⟨-z.im, z.re⟩ :=
       calc
-        _ = x * I * conj y := by rw [he', he] ; simp [E₃]
+        _ = x * I * conj y := by rw [he', he]; simp [E₃]
         _ = Complex.I * z := by ring
         _ = ⟨-z.im, z.re⟩ := z.I_mul
     have hD : D = !![z.re, -z.im; z.im, z.re] := Matrix.ext fun
@@ -81,33 +82,33 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
   letI : Invertible D.det := detD_one ▸ invertibleOne
   letI : Invertible D := D.invertibleOfDetInvertible
   have hE : A - B * ⅟D * C = !![normSq x, _; 0, normSq y] :=
-    have k : (M * E₀ * Mᴴ) 0 1 = 0 := by rw [he', he] ; simp [E₀]
+    have k : (M * E₀ * Mᴴ) 0 1 = 0 := by rw [he', he]; simp [E₀]
     have hC00 : C 0 0 = 0 := congrArg Complex.re k
     have hC10 : C 1 0 = 0 := congrArg Complex.im k
     Matrix.ext fun
       | 0, 1 => rfl
       | 1, 0 =>
         have hA10 : A 1 0 = 0 := congrArg Complex.re <|
-          show (M * E₀ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₀]
+          show (M * E₀ * Mᴴ) 1 1 = 0 by rw [he', he]; simp [E₀]
         show A 1 0 - (B * ⅟D) 1 ⬝ᵥ (C · 0) = 0 by simp [hC00, hC10, hA10]
       | 0, 0 =>
         have hA00 : A 0 0 = normSq x := congrArg Complex.re <|
-          show (M * E₀ * Mᴴ) 0 0 = normSq x by rw [he', he] ; simp [E₀, x.mul_conj]
+          show (M * E₀ * Mᴴ) 0 0 = normSq x by rw [he', he]; simp [E₀, x.mul_conj]
         show A 0 0 - (B * ⅟D) 0 ⬝ᵥ (C · 0) = normSq x by simp [hC00, hC10, hA00]
       | 1, 1 =>
         have hA11 : A 1 1 = normSq y := congrArg Complex.re <|
-          show (M * E₁ * Mᴴ) 1 1 = normSq y by rw [he', he] ; simp [E₁, y.mul_conj]
+          show (M * E₁ * Mᴴ) 1 1 = normSq y by rw [he', he]; simp [E₁, y.mul_conj]
         have hB10 : B 1 0 = 0 := congrArg Complex.re <|
-          show (M * E₂ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₂]
+          show (M * E₂ * Mᴴ) 1 1 = 0 by rw [he', he]; simp [E₂]
         have hB11 : B 1 1 = 0 := congrArg Complex.re <|
-          show (M * E₃ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₃]
+          show (M * E₃ * Mᴴ) 1 1 = 0 by rw [he', he]; simp [E₃]
         calc A 1 1 - (B * ⅟D * C) 1 1
           _ = A 1 1 - B 1 ⬝ᵥ ((⅟D * C) · 1) := by noncomm_ring
           _ = normSq y := by simp [hB10, hB11, hA11]
   calc LinearMap.det (toSelfAdjointMap' M)
     _ = F.det := (LinearMap.det_toMatrix ..).symm
     _ = D.det * (A - B * ⅟D * C).det := F.fromBlocks_toBlocks ▸ Matrix.det_fromBlocks₂₂ ..
-    _ = 1 := by rw [hE] ; simp [detD_one, detA_one]
+    _ = 1 := by rw [hE]; simp [detD_one, detA_one]
 
 /-- This promotes `Lorentz.SL2C.toSelfAdjointMap M` and its definitional equivalence,
 `Lorentz.SL2C.toSelfAdjointMap' M`, to a linear equivalence by recognising the linear inverse to be
@@ -124,17 +125,17 @@ noncomputable def toSelfAdjointEquiv (M : ℂ²ˣ²) [Invertible M] : ℍ₂ ≃
       _ = M * M⁻¹ * A * (M * M⁻¹)ᴴ := by noncomm_ring [Matrix.conjTranspose_mul]
       _ = A := by simp
 
-theorem toSelfAdjointMap_mul (M N : ℂ²ˣ²)
-    : toSelfAdjointMap' (M * N) = toSelfAdjointMap' M ∘ₗ toSelfAdjointMap' N :=
+lemma toSelfAdjointMap_mul (M N : ℂ²ˣ²) :
+    toSelfAdjointMap' (M * N) = toSelfAdjointMap' M ∘ₗ toSelfAdjointMap' N :=
   LinearMap.ext fun A => Subtype.ext <|
     show M * N * A * (M * N)ᴴ = M * (N * A * Nᴴ) * Mᴴ by noncomm_ring [Matrix.conjTranspose_mul]
 
-theorem toSelfAdjointMap_similar_det (M N : ℂ²ˣ²) [Invertible M]
-    : LinearMap.det (toSelfAdjointMap' (M * N * M⁻¹)) = LinearMap.det (toSelfAdjointMap' N) :=
+lemma toSelfAdjointMap_similar_det (M N : ℂ²ˣ²) [Invertible M] :
+    LinearMap.det (toSelfAdjointMap' (M * N * M⁻¹)) = LinearMap.det (toSelfAdjointMap' N) :=
   let e := toSelfAdjointEquiv M
   let f := toSelfAdjointMap' N
   suffices toSelfAdjointMap' (M * N * M⁻¹) = e ∘ₗ f ∘ₗ e.symm from this ▸ f.det_conj e
-  by rw [toSelfAdjointMap_mul, toSelfAdjointMap_mul] ; rfl
+  by rw [toSelfAdjointMap_mul, toSelfAdjointMap_mul]; rfl
 
 end SL2C
 end Lorentz

--- a/HepLean/Lorentz/SL2C/SelfAdjoint.lean
+++ b/HepLean/Lorentz/SL2C/SelfAdjoint.lean
@@ -6,11 +6,17 @@ namespace Lorentz
 open scoped Matrix
 open scoped ComplexConjugate
 
-notation "ℂ²ˣ²" => Matrix (Fin 2) (Fin 2) ℂ
+/-- A notation for the type of complex 2-by-2 matrices. It would have been better to make it an
+abbreviation if it wasn't for Lean's inability to recognize `ℂ²ˣ²` as an identifier. -/
+scoped notation "ℂ²ˣ²" => Matrix (Fin 2) (Fin 2) ℂ
+
+/-- A convenient abbreviation for the type of self-adjoint complex 2-by-2 matrices. -/
 noncomputable abbrev ℍ₂ := selfAdjoint ℂ²ˣ²
 
 namespace SL2C
 
+/-- Definitially equal to `Lorentz.SL2C.toSelfAdjointMap` but dropping the requirement that `M` be
+special linear. -/
 noncomputable def toSelfAdjointMap' (M : ℂ²ˣ²) : ℍ₂ →ₗ[ℝ] ℍ₂ where
   toFun | ⟨A, hA⟩ => ⟨M * A * Mᴴ, hA.conjugate M⟩
   map_add' | ⟨A, _⟩, ⟨B, _⟩ => Subtype.ext <|
@@ -47,12 +53,12 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
     Matrix.ext fun | 0, 0 | 1, 0 | 1, 1 => rfl | 0, 1 => by simp [hM10]
 
   have detA_one : normSq x * normSq y = 1 := congrArg Complex.re <|
-    calc  ↑(normSq x * normSq y)
+    calc ↑(normSq x * normSq y)
       _ = x * conj x * (y * conj y) := by simp [Complex.mul_conj]
       _ = x * y * (conj y * conj x) := by ring
       _ = x * y * conj (x * y) := congrArg _ (star_mul ..).symm
       _ = 1 := suffices x * y = 1 by simp [this]
-        calc  x * y
+        calc x * y
           _ = !![x, _; 0, y].det := by simp
           _ = M.det := congrArg _ he.symm
           _ = 1 := detM
@@ -67,7 +73,7 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
     have hD : D = !![z.re, -z.im; z.im, z.re] := Matrix.ext fun
       | 0, 0 => congrArg Complex.re k₀ | 1, 0 => congrArg Complex.im k₀
       | 0, 1 => congrArg Complex.re k₁ | 1, 1 => congrArg Complex.im k₁
-    calc  D.det
+    calc D.det
       _ = normSq z := by simp [hD, z.normSq_apply]
       _ = normSq x * normSq y := by simp [x.normSq_mul]
       _ = 1 := detA_one
@@ -95,23 +101,26 @@ theorem toSelfAdjointMap_det_one' {M : ℂ²ˣ²} (hM : M.IsUpperTriangular) (de
           show (M * E₂ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₂]
         have hB11 : B 1 1 = 0 := congrArg Complex.re <|
           show (M * E₃ * Mᴴ) 1 1 = 0 by rw [he', he] ; simp [E₃]
-        calc  A 1 1 - (B * ⅟D * C) 1 1
+        calc A 1 1 - (B * ⅟D * C) 1 1
           _ = A 1 1 - B 1 ⬝ᵥ ((⅟D * C) · 1) := by noncomm_ring
           _ = normSq y := by simp [hB10, hB11, hA11]
-  calc  LinearMap.det (toSelfAdjointMap' M)
+  calc LinearMap.det (toSelfAdjointMap' M)
     _ = F.det := (LinearMap.det_toMatrix ..).symm
     _ = D.det * (A - B * ⅟D * C).det := F.fromBlocks_toBlocks ▸ Matrix.det_fromBlocks₂₂ ..
     _ = 1 := by rw [hE] ; simp [detD_one, detA_one]
 
+/-- This promotes `Lorentz.SL2C.toSelfAdjointMap M` and its definitional equivalence,
+`Lorentz.SL2C.toSelfAdjointMap' M`, to a linear equivalence by recognising the linear inverse to be
+`Lorentz.SL2C.toSelfAdjointMap M⁻¹`, i.e., `Lorentz.SL2C.toSelfAdjointMap' M⁻¹`. -/
 noncomputable def toSelfAdjointEquiv (M : ℂ²ˣ²) [Invertible M] : ℍ₂ ≃ₗ[ℝ] ℍ₂ where
   toLinearMap := toSelfAdjointMap' M
   invFun := toSelfAdjointMap' M⁻¹
   left_inv | ⟨A, _⟩ => Subtype.ext <|
-    calc  M⁻¹ * (M * A * Mᴴ) * M⁻¹ᴴ
+    calc M⁻¹ * (M * A * Mᴴ) * M⁻¹ᴴ
       _ = M⁻¹ * ↑M * A * (M⁻¹ * M)ᴴ := by noncomm_ring [Matrix.conjTranspose_mul]
       _ = A := by simp
   right_inv | ⟨A, _⟩ => Subtype.ext <|
-    calc  M * (M⁻¹ * A * M⁻¹ᴴ) * Mᴴ
+    calc M * (M⁻¹ * A * M⁻¹ᴴ) * Mᴴ
       _ = M * M⁻¹ * A * (M * M⁻¹)ᴴ := by noncomm_ring [Matrix.conjTranspose_mul]
       _ = A := by simp
 
@@ -120,7 +129,7 @@ theorem toSelfAdjointMap_mul (M N : ℂ²ˣ²)
   LinearMap.ext fun A => Subtype.ext <|
     show M * N * A * (M * N)ᴴ = M * (N * A * Nᴴ) * Mᴴ by noncomm_ring [Matrix.conjTranspose_mul]
 
-theorem toSelfAdjointMap_similar_det  (M N : ℂ²ˣ²) [Invertible M]
+theorem toSelfAdjointMap_similar_det (M N : ℂ²ˣ²) [Invertible M]
     : LinearMap.det (toSelfAdjointMap' (M * N * M⁻¹)) = LinearMap.det (toSelfAdjointMap' N) :=
   let e := toSelfAdjointEquiv M
   let f := toSelfAdjointMap' N

--- a/HepLean/Mathematics/SchurTriangulation.lean
+++ b/HepLean/Mathematics/SchurTriangulation.lean
@@ -22,10 +22,10 @@ def finAddEquivSigmaCond : Fin (m + n) ≃ Σ b, cond b (Fin m) (Fin n) :=
 
 variable {i : Fin (m + n)}
 
-theorem finAddEquivSigmaCond_true (h : i < m) : finAddEquivSigmaCond i = ⟨true, i, h⟩ :=
+lemma finAddEquivSigmaCond_true (h : i < m) : finAddEquivSigmaCond i = ⟨true, i, h⟩ :=
   congrArg sumEquivSigmalCond <| finSumFinEquiv_symm_apply_castAdd ⟨i, h⟩
 
-theorem finAddEquivSigmaCond_false (h : ¬ i < m) : finAddEquivSigmaCond i = ⟨false, i.subNat' h⟩ :=
+lemma finAddEquivSigmaCond_false (h : ¬ i < m) : finAddEquivSigmaCond i = ⟨false, i.subNat' h⟩ :=
   let j : Fin n := i.subNat' h
   calc finAddEquivSigmaCond i
     _ = finAddEquivSigmaCond (Fin.natAdd m j) :=
@@ -66,15 +66,16 @@ variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 section
 variable [FiniteDimensional 𝕜 E] [Fintype n] [DecidableEq n]
 
-theorem toMatrixOrthonormal_apply_apply (b : OrthonormalBasis n 𝕜 E) (f : Module.End 𝕜 E) (i j : n)
-    : toMatrixOrthonormal b f i j = ⟪b i, f (b j)⟫_𝕜 :=
+lemma toMatrixOrthonormal_apply_apply (b : OrthonormalBasis n 𝕜 E) (f : Module.End 𝕜 E)
+    (i j : n) :
+    toMatrixOrthonormal b f i j = ⟪b i, f (b j)⟫_𝕜 :=
   calc
     _ = b.repr (f (b j)) i := f.toMatrix_apply ..
     _ = ⟪b i, f (b j)⟫_𝕜 := b.repr_apply_apply ..
 
-theorem toMatrixOrthonormal_reindex [Fintype m] [DecidableEq m]
-    (b : OrthonormalBasis m 𝕜 E) (e : m ≃ n) (f : Module.End 𝕜 E)
-    : toMatrixOrthonormal (b.reindex e) f = Matrix.reindex e e (toMatrixOrthonormal b f) :=
+lemma toMatrixOrthonormal_reindex [Fintype m] [DecidableEq m]
+    (b : OrthonormalBasis m 𝕜 E) (e : m ≃ n) (f : Module.End 𝕜 E) :
+    toMatrixOrthonormal (b.reindex e) f = Matrix.reindex e e (toMatrixOrthonormal b f) :=
   Matrix.ext fun i j =>
     calc toMatrixOrthonormal (b.reindex e) f i j
       _ = (b.reindex e).repr (f (b.reindex e j)) i := f.toMatrix_apply ..
@@ -101,8 +102,8 @@ variable [IsAlgClosed 𝕜]
 /-- **Don't use this definition directly.** This is the key algorithm behind
 `Matrix.schur_triangulation`. -/
 protected noncomputable def SchurTriangulationAux.of
-    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] (f : Module.End 𝕜 E)
-    : SchurTriangulationAux f :=
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] (f : Module.End 𝕜 E) :
+    SchurTriangulationAux f :=
   haveI : Decidable (Nontrivial E) := Classical.propDecidable _
   if hE : Nontrivial E then
     let μ : f.Eigenvalues := default
@@ -137,7 +138,9 @@ protected noncomputable def SchurTriangulationAux.of
             by simp
         have hf {bi i' bj j'} (hi : e i = ⟨bi, i'⟩) (hj : e j = ⟨bj, j'⟩) :=
           calc toMatrixOrthonormal basis f i j
-            _ = toMatrixOrthonormal bE f (e i) (e j) := by rw [f.toMatrixOrthonormal_reindex] ; rfl
+            _ = toMatrixOrthonormal bE f (e i) (e j) := by
+              rw [f.toMatrixOrthonormal_reindex]
+              rfl
             _ = ⟪bE (e i), f (bE (e j))⟫_𝕜 := f.toMatrixOrthonormal_apply_apply ..
             _ = ⟪(B bi i' : E), f (B bj j')⟫_𝕜 := by rw [hB, hB, hi, hj]
 
@@ -198,8 +201,8 @@ variable [RCLike 𝕜] [IsAlgClosed 𝕜] [Fintype n] [DecidableEq n] [LinearOrd
 `Matrix.schurTriangulationUnitary`, and `Matrix.schurTriangulation` for which this is their
 simultaneous definition. This is `LinearMap.SchurTriangulationAux` adapted for matrices in the
 Euclidean space. -/
-noncomputable def schurTriangulationAux
-    : OrthonormalBasis n 𝕜 (EuclideanSpace 𝕜 n) × UpperTriangular n 𝕜 :=
+noncomputable def schurTriangulationAux :
+    OrthonormalBasis n 𝕜 (EuclideanSpace 𝕜 n) × UpperTriangular n 𝕜 :=
   let f := toEuclideanLin A
   let ⟨d, hd, b, hut⟩ := LinearMap.SchurTriangulationAux.of f
   let e : Fin d ≃o n := Fintype.orderIsoFinOfCardEq n (finrank_euclideanSpace.symm.trans hd)
@@ -208,8 +211,9 @@ noncomputable def schurTriangulationAux
   suffices B.IsUpperTriangular from ⟨b', B, this⟩
   fun i j (hji : j < i) =>
     calc LinearMap.toMatrixOrthonormal b' f i j
-      _ = LinearMap.toMatrixOrthonormal b f (e.symm i) (e.symm j) :=
-        by rw [f.toMatrixOrthonormal_reindex] ; rfl
+      _ = LinearMap.toMatrixOrthonormal b f (e.symm i) (e.symm j) := by
+        rw [f.toMatrixOrthonormal_reindex]
+        rfl
       _ = 0 := hut (e.symm.lt_iff_lt.mpr hji)
 
 /-- The change of basis that induces the upper triangular form `A.schurTriangulation` of a matrix
@@ -231,8 +235,8 @@ noncomputable def schurTriangulation : UpperTriangular n 𝕜 :=
 /-- **Schur triangulation**, **Schur decomposition** for matrices over an algebraically closed
 field. In particular, a complex matrix can be converted to upper-triangular form by a change of
 basis. In other words, any complex matrix is unitarily similar to an upper triangular matrix. -/
-theorem schur_triangulation
-    : A = A.schurTriangulationUnitary * A.schurTriangulation * star A.schurTriangulationUnitary :=
+lemma schur_triangulation :
+    A = A.schurTriangulationUnitary * A.schurTriangulation * star A.schurTriangulationUnitary :=
   let U := A.schurTriangulationUnitary
   have h : U * A.schurTriangulation.val = A * U :=
     let b := A.schurTriangulationBasis.toBasis
@@ -243,6 +247,6 @@ theorem schur_triangulation
       _ = A * U := by simp
   calc A
     _ = A * U * star U := by simp [mul_assoc]
-    _ = U * A.schurTriangulation * star U := by rw [←h]
+    _ = U * A.schurTriangulation * star U := by rw [← h]
 
 end Matrix

--- a/HepLean/Mathematics/SchurTriangulation.lean
+++ b/HepLean/Mathematics/SchurTriangulation.lean
@@ -5,8 +5,6 @@ Authors: Gordon Hsu
 -/
 import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 import Mathlib.LinearAlgebra.Matrix.Spectrum
-open scoped InnerProductSpace
-
 /-! # Schur triangulation
 
 Schur triangulation is more commonly known as Schur decomposition or Schur triangularization, but
@@ -23,6 +21,8 @@ be decomposed as `A = U * T * star U` where `U` is unitary and `T` is upper tria
 `LinearMap.SchurTriangulationAux.of` contains the main algorithm for the triangulation procedure.
 
 -/
+
+open scoped InnerProductSpace
 
 /-- `subNat' i h` subtracts `m` from `i`. This is an alternative form of `Fin.subNat`. -/
 @[inline] def Fin.subNat' (i : Fin (m + n)) (h : ¬ i < m) : Fin n :=

--- a/HepLean/Mathematics/SchurTriangulation.lean
+++ b/HepLean/Mathematics/SchurTriangulation.lean
@@ -1,0 +1,213 @@
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.LinearAlgebra.Matrix.Spectrum
+open scoped InnerProductSpace
+
+namespace Fin
+variable {i : Fin (m + n)}
+
+def toSigmaBool_neg (h : ¬ i < m) : Fin n := ⟨i - m, Nat.sub_lt_left_of_lt_add (Nat.ge_of_not_lt h) i.isLt⟩
+def toSigmaBool (i : Fin (m + n)) : Σ b, cond b (Fin m) (Fin n) :=
+  if h : i < m then ⟨true, i, h⟩ else ⟨false, toSigmaBool_neg h⟩
+theorem toSigmaBool_fst (h : i < m) : i.toSigmaBool = ⟨true, i, h⟩ := dif_pos h
+theorem toSigmaBool_snd (h : ¬ i < m) : i.toSigmaBool = ⟨false, toSigmaBool_neg h⟩ := dif_neg h
+
+def ofSigmaBool : (Σ b, cond b (Fin m) (Fin n)) → Fin (m + n)
+  | ⟨true, i⟩ => Fin.castAdd n i
+  | ⟨false, i⟩ => Fin.natAdd m i
+
+end Fin
+
+def Equiv.finAddEquivSigmaBool : Fin (m + n) ≃ Σ b, cond b (Fin m) (Fin n) where
+  toFun := Fin.toSigmaBool
+  invFun := Fin.ofSigmaBool
+  left_inv i :=
+    if h : i < m
+    then congrArg Fin.ofSigmaBool (dif_pos h)
+    else
+      calc  Fin.ofSigmaBool i.toSigmaBool
+        _ = ⟨m + (i - m), _⟩ := congrArg Fin.ofSigmaBool (dif_neg h)
+        _ = i := Fin.ext <| Nat.add_sub_of_le (Nat.le_of_not_gt h)
+  right_inv
+    | ⟨true, i⟩ => dif_pos i.isLt
+    | ⟨false, (i : Fin n)⟩ =>
+      calc  (Fin.natAdd m i).toSigmaBool
+        _ = ⟨false, m + i - m, _⟩ := dif_neg <| Nat.not_lt_of_le (Nat.le_add_right ..)
+        _ = ⟨false, i⟩ := Sigma.eq rfl <| Fin.ext (Nat.add_sub_cancel_left ..)
+
+instance [M : Fintype m] [N : Fintype n] (b : Bool) : Fintype (cond b m n) := b.rec N M
+
+instance [DecidableEq m] [DecidableEq n] : DecidableEq (Σ b, cond b m n)
+  | ⟨true, _⟩, ⟨false, _⟩
+  | ⟨false, _⟩, ⟨true, _⟩ => isFalse nofun
+  | ⟨false, i⟩, ⟨false, j⟩
+  | ⟨true, i⟩, ⟨true, j⟩ => if h : i = j then isTrue (Sigma.eq rfl h) else isFalse fun | rfl => h rfl
+
+namespace Matrix
+
+abbrev IsUpperTriangular [LT n] [CommRing R] (A : Matrix n n R) := A.BlockTriangular id
+abbrev UpperTriangular (n R) [LT n] [CommRing R] := { A : Matrix n n R // A.IsUpperTriangular }
+
+end Matrix
+
+namespace LinearMap
+variable [RCLike 𝕜]
+
+section
+variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+section
+variable [FiniteDimensional 𝕜 E] [Fintype n] [DecidableEq n]
+
+theorem toMatrixOrthonormal_apply_apply (b : OrthonormalBasis n 𝕜 E) (f : Module.End 𝕜 E) (i j : n)
+    : toMatrixOrthonormal b f i j = ⟪b i, f (b j)⟫_𝕜 :=
+  calc
+    _ = b.repr (f (b j)) i := f.toMatrix_apply ..
+    _ = ⟪b i, f (b j)⟫_𝕜 := b.repr_apply_apply ..
+
+theorem toMatrixOrthonormal_reindex [Fintype m] [DecidableEq m]
+    (b : OrthonormalBasis m 𝕜 E) (e : m ≃ n) (f : Module.End 𝕜 E)
+    : toMatrixOrthonormal (b.reindex e) f = Matrix.reindex e e (toMatrixOrthonormal b f) :=
+  Matrix.ext fun i j => let c := b.toBasis
+    show toMatrix (b.reindex e).toBasis (b.reindex e).toBasis f i j = toMatrix c c f (e.symm i) (e.symm j) by
+    rw [b.reindex_toBasis, f.toMatrix_apply, c.repr_reindex_apply, c.reindex_apply, f.toMatrix_apply]
+
+end
+
+structure SchurTriangulationAux (f : Module.End 𝕜 E) where
+  dim : ℕ
+  hdim : Module.finrank 𝕜 E = dim
+  basis : OrthonormalBasis (Fin dim) 𝕜 E
+  upperTriangular : (toMatrix basis.toBasis basis.toBasis f).IsUpperTriangular
+
+end
+
+variable [IsAlgClosed 𝕜]
+
+protected noncomputable def SchurTriangulationAux.of
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] (f : Module.End 𝕜 E)
+    : SchurTriangulationAux f :=
+  haveI : Decidable (Nontrivial E) := Classical.propDecidable _
+  if hE : Nontrivial E then
+    let μ : f.Eigenvalues := default
+    let V : Submodule 𝕜 E := f.eigenspace μ
+    let W : Submodule 𝕜 E := Vᗮ
+    let m := Module.finrank 𝕜 V
+    have hdim : m + Module.finrank 𝕜 W = Module.finrank 𝕜 E := V.finrank_add_finrank_orthogonal
+    let g : Module.End 𝕜 W := orthogonalProjection W ∘ₗ f.domRestrict W
+    let ⟨n, hn, bW, hg⟩ := SchurTriangulationAux.of g
+
+    have bV : OrthonormalBasis (Fin m) 𝕜 V := stdOrthonormalBasis 𝕜 V
+    have hV := V.orthogonalFamily_self
+    have int : DirectSum.IsInternal (cond · V W) :=
+      suffices ⨆ b, cond b V W = ⊤ from (hV.decomposition this).isInternal _
+      (sup_eq_iSup V W).symm.trans Submodule.sup_orthogonal_of_completeSpace
+    let B (b : Bool) : OrthonormalBasis (cond b (Fin m) (Fin n)) 𝕜 ↥(cond b V W) := b.rec bW bV
+    let bE : OrthonormalBasis (Σ b, cond b (Fin m) (Fin n)) 𝕜 E := int.collectedOrthonormalBasis hV B
+    let e := Equiv.finAddEquivSigmaBool.symm
+    let basis := bE.reindex e
+    {
+      basis
+      dim := m + n
+      hdim := hn ▸ hdim.symm
+      upperTriangular := fun i j (hji : j < i) => show toMatrixOrthonormal basis f i j = 0 from
+        have hB : ∀ s, bE s = B s.1 s.2
+          | ⟨true, i⟩ => show bE ⟨true, i⟩ = bV i from
+            show (int.collectedBasis fun b => (B b).toBasis).toOrthonormalBasis _ ⟨true, i⟩ = bV i by simp
+          | ⟨false, j⟩ => show bE ⟨false, j⟩ = bW j from
+            show (int.collectedBasis fun b => (B b).toBasis).toOrthonormalBasis _ ⟨false, j⟩ = bW j by simp
+        have hf {bi i' bj j'} (hi : i.toSigmaBool = ⟨bi, i'⟩) (hj : j.toSigmaBool = ⟨bj, j'⟩) :=
+          calc  toMatrixOrthonormal basis f i j
+            _ = toMatrixOrthonormal bE f i.toSigmaBool j.toSigmaBool := by rw [f.toMatrixOrthonormal_reindex] ; rfl
+            _ = ⟪bE i.toSigmaBool, f (bE j.toSigmaBool)⟫_𝕜 := f.toMatrixOrthonormal_apply_apply ..
+            _ = ⟪(B bi i' : E), f (B bj j')⟫_𝕜 := by rw [hB, hB, hi, hj]
+
+        if hj : j < m then
+          let j' : Fin m := ⟨j, hj⟩
+          have hf' {bi i'} (hi : i.toSigmaBool = ⟨bi, i'⟩) (h0 : ⟪(B bi i' : E), bV j'⟫_𝕜 = 0) :=
+            calc  toMatrixOrthonormal basis f i j
+              _ = ⟪(B bi i' : E), f _⟫_𝕜 := hf hi (Fin.toSigmaBool_fst hj)
+              _ = ⟪_, f (bV j')⟫_𝕜 := rfl
+              _ = 0 :=
+                suffices f (bV j') = μ.val • bV j' by rw [this, inner_smul_right, h0, mul_zero]
+                suffices f.HasEigenvector μ (bV j') from this.apply_eq_smul
+                ⟨(bV j').property, fun h => bV.toBasis.ne_zero j' (Subtype.ext h)⟩
+
+          if hi : i < m then
+            let i' : Fin m := ⟨i, hi⟩
+            suffices ⟪(bV i' : E), bV j'⟫_𝕜 = 0 from hf' (Fin.toSigmaBool_fst hi) this
+            bV.orthonormal.right (Fin.ne_of_gt hji)
+          else
+            let i' : Fin n := Fin.toSigmaBool_neg hi
+            suffices ⟪(bW i' : E), bV j'⟫_𝕜 = 0 from hf' (Fin.toSigmaBool_snd hi) this
+            V.inner_left_of_mem_orthogonal (bV j').property (bW i').property
+        else
+          have hi (h : i < m) : False := hj (Nat.lt_trans hji h)
+          let i' : Fin n := Fin.toSigmaBool_neg hi
+          let j' : Fin n := Fin.toSigmaBool_neg hj
+          calc  toMatrixOrthonormal basis f i j
+            _ = ⟪(bW i' : E), f (bW j')⟫_𝕜 := hf (Fin.toSigmaBool_snd hi) (Fin.toSigmaBool_snd hj)
+            _ = ⟪bW i', g (bW j')⟫_𝕜 := by simp [g]
+            _ = toMatrixOrthonormal bW g i' j' := (g.toMatrixOrthonormal_apply_apply ..).symm
+            _ = 0 := hg (Nat.sub_lt_sub_right (Nat.le_of_not_lt hj) hji)
+    }
+  else
+    haveI : Subsingleton E := not_nontrivial_iff_subsingleton.mp hE
+    {
+      dim := 0
+      hdim := Module.finrank_zero_of_subsingleton
+      basis := (Basis.empty E).toOrthonormalBasis ⟨nofun, nofun⟩
+      upperTriangular := nofun
+    }
+termination_by Module.finrank 𝕜 E
+decreasing_by exact
+  calc  Module.finrank 𝕜 W
+    _ < m + Module.finrank 𝕜 W := Nat.lt_add_of_pos_left (Submodule.one_le_finrank_iff.mpr μ.property)
+    _ = Module.finrank 𝕜 E := hdim
+
+end LinearMap
+
+namespace Matrix
+/- IMPORTANT: existing `DecidableEq n` should take precedence over `LinearOrder.decidableEq`,
+a.k.a., `instDecidableEq_mathlib`. -/
+variable [RCLike 𝕜] [IsAlgClosed 𝕜] [Fintype n] [DecidableEq n] [LinearOrder n] (A : Matrix n n 𝕜)
+
+noncomputable def schurTriangulationAux : OrthonormalBasis n 𝕜 (EuclideanSpace 𝕜 n) × UpperTriangular n 𝕜 :=
+  let f := toEuclideanLin A
+  let ⟨d, hd, b, hut⟩ := LinearMap.SchurTriangulationAux.of f
+  let e : Fin d ≃o n := Fintype.orderIsoFinOfCardEq n (finrank_euclideanSpace.symm.trans hd)
+  let b' := b.reindex e
+  let B := LinearMap.toMatrixOrthonormal b' f
+  suffices B.IsUpperTriangular from ⟨b', B, this⟩
+  fun i j (hji : j < i) =>
+    calc  LinearMap.toMatrixOrthonormal b' f i j
+      _ = LinearMap.toMatrixOrthonormal b f (e.symm i) (e.symm j) := by rw [f.toMatrixOrthonormal_reindex] ; rfl
+      _ = 0 := hut (e.symm.lt_iff_lt.mpr hji)
+
+noncomputable def schurTriangulationBasis : OrthonormalBasis n 𝕜 (EuclideanSpace 𝕜 n) :=
+  A.schurTriangulationAux.1
+
+noncomputable def schurTriangulationUnitary : unitaryGroup n 𝕜 where
+  val := (EuclideanSpace.basisFun n 𝕜).toBasis.toMatrix A.schurTriangulationBasis
+  property := OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary ..
+
+noncomputable def schurTriangulation : UpperTriangular n 𝕜 :=
+  A.schurTriangulationAux.2
+
+/-- **Schur triangulation**, **Schur decomposition** for matrices over an algebraically closed
+field. In particular, a complex matrix can be converted to upper-triangular form by a change of
+basis. In other words, any complex matrix is unitarily similar to an upper triangular matrix. -/
+theorem schur_triangulation
+    : A = A.schurTriangulationUnitary * A.schurTriangulation * star A.schurTriangulationUnitary :=
+  let U := A.schurTriangulationUnitary
+  have h : U * A.schurTriangulation.val = A * U :=
+    let b := A.schurTriangulationBasis.toBasis
+    let c := (EuclideanSpace.basisFun n 𝕜).toBasis
+    calc  c.toMatrix b * LinearMap.toMatrix b b (toEuclideanLin A)
+      _ = LinearMap.toMatrix c c (toEuclideanLin A) * c.toMatrix b := by simp
+      _ = LinearMap.toMatrix c c (toLin c c A) * U := rfl
+      _ = A * U := by simp
+  calc  A
+    _ = A * U * star U := by simp [mul_assoc]
+    _ = U * A.schurTriangulation * star U := by rw [←h]
+
+end Matrix

--- a/HepLean/Mathematics/SchurTriangulation.lean
+++ b/HepLean/Mathematics/SchurTriangulation.lean
@@ -1,6 +1,28 @@
+/-
+Copyright (c) 2025 Gordon Hsu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gordon Hsu
+-/
 import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 import Mathlib.LinearAlgebra.Matrix.Spectrum
 open scoped InnerProductSpace
+
+/-! # Schur triangulation
+
+Schur triangulation is more commonly known as Schur decomposition or Schur triangularization, but
+"triangulation" makes the API more readable. It states that a square matrix over an algebraically
+closed field, e.g., `ℂ`, is unitarily similar to an upper triangular matrix.
+
+## Main definitions
+
+- `Matrix.schur_triangulation` : a matrix `A : Matrix n n 𝕜` with `𝕜` being algebraically closed can
+be decomposed as `A = U * T * star U` where `U` is unitary and `T` is upper triangular.
+- `Matrix.schurTriangulationUnitary` : the unitary matrix `U` as previously stated.
+- `Matrix.schurTriangulation` : the upper triangular matrix `T` as previously stated.
+- Some auxilary definitions are not meant to be used directly, but
+`LinearMap.SchurTriangulationAux.of` contains the main algorithm for the triangulation procedure.
+
+-/
 
 /-- `subNat' i h` subtracts `m` from `i`. This is an alternative form of `Fin.subNat`. -/
 @[inline] def Fin.subNat' (i : Fin (m + n)) (h : ¬ i < m) : Fin n :=
@@ -96,6 +118,35 @@ structure SchurTriangulationAux (f : Module.End 𝕜 E) where
   upperTriangular : (toMatrix basis.toBasis basis.toBasis f).IsUpperTriangular
 
 end
+
+/-! ## Schur's recursive triangulation procedure
+
+Given a linear endomorphism `f` on a non-trivial finite-dimensional vector space `E` over an
+algebraically closed field `𝕜`, one can always pick an eigenvalue `μ` of `f` whose corresponding
+eigenspace `V` is non-trivial. Given that `E` is also an inner product space, let `bV` and `bW` be
+othonormal bases for `V` and `Vᗮ` respectively. Then, the collection of vectors in `bV` and `bW`
+forms an othornomal basis `bE` for `E`, as the direct sum of `V` and `Vᗮ` is an internal
+decomposition of `E`. The matrix representation of `f` with respect to `bE` satisfies
+$$
+\sideset{_\mathrm{bE}}{_\mathrm{bE}}{[f]} =
+\begin{bmatrix}
+  \sideset{_\mathrm{bV}}{_\mathrm{bV}}{[f]} &
+  \sideset{_\mathrm{bW}}{_\mathrm{bV}}{[f]} \\
+  \sideset{_\mathrm{bV}}{_\mathrm{bW}}{[f]} &
+  \sideset{_\mathrm{bW}}{_\mathrm{bW}}{[f]}
+\end{bmatrix} =
+\begin{bmatrix} \mu I & □ \\ 0 & \sideset{_\mathrm{bW}}{_\mathrm{bW}}{[f]} \end{bmatrix},
+$$
+which is upper triangular as long as $\sideset{_\mathrm{bW}}{_\mathrm{bW}}{[f]}$ is. Finally, one
+observes that the recursion from $\sideset{_\mathrm{bE}}{_\mathrm{bE}}{[f]}$ to
+$\sideset{_\mathrm{bW}}{_\mathrm{bW}}{[f]}$ is well-founded, as the dimension of `bW` is smaller
+than that of `bE` because `bV` is non-trivial.
+
+However, in order to leverage `DirectSum.IsInternal.collectedOrthonormalBasis`, the type
+`Σ b, cond b (Fin m) (Fin n)` has to be used instead of the more natural `Fin m ⊕ Fin n` while their
+equivalence is propositionally established by `Equiv.sumEquivSigmalCond`.
+
+-/
 
 variable [IsAlgClosed 𝕜]
 


### PR DESCRIPTION
I implemented `HepLean.Lorentz.SL2C.toLorentzGroup_det_one` by way of `Matrix.schur_triangulation`. If my solution checks out. I would also like to upstream Schur triangulation to Mathlib.