### PR TITLE
feat: Real Lorentz vectors

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -195,6 +195,7 @@ import PhysLean.Relativity.Lorentz.RealTensor.Matrix.Pre
 import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Basic
 import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Pre
 import PhysLean.Relativity.Lorentz.RealTensor.Units.Pre
+import PhysLean.Relativity.Lorentz.RealTensor.Vector.Basic
 import PhysLean.Relativity.Lorentz.RealTensor.Vector.Pre.Basic
 import PhysLean.Relativity.Lorentz.RealTensor.Vector.Pre.Contraction
 import PhysLean.Relativity.Lorentz.RealTensor.Vector.Pre.Modules

--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -192,6 +192,7 @@ import PhysLean.Relativity.Lorentz.PauliMatrices.SelfAdjoint
 import PhysLean.Relativity.Lorentz.RealTensor.Basic
 import PhysLean.Relativity.Lorentz.RealTensor.Derivative
 import PhysLean.Relativity.Lorentz.RealTensor.Matrix.Pre
+import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Basic
 import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Pre
 import PhysLean.Relativity.Lorentz.RealTensor.Units.Pre
 import PhysLean.Relativity.Lorentz.RealTensor.Vector.Pre.Basic

--- a/PhysLean/Relativity/Lorentz/RealTensor/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Basic.lean
@@ -194,19 +194,23 @@ lemma contr_basis {d : ℕ} {c : (realLorentzTensor d).C}
     change Lorentz.coContrContract.hom
       (Lorentz.coBasisFin d i ⊗ₜ Lorentz.contrBasisFin d j) = _
     rw [Lorentz.coContrContract_hom_tmul]
-    simp
+    simp only [Action.instMonoidalCategory_tensorUnit_V, Lorentz.coBasisFin_toFin1dℝ,
+      Lorentz.contrBasisFin_toFin1dℝ, dotProduct_single, mul_one]
     rw [Pi.single_apply]
     refine ite_congr ?_ (congrFun rfl) (congrFun rfl)
     simp only [eq_comm, EmbeddingLike.apply_eq_iff_eq, Fin.ext_iff, repDim_up]
 
-lemma contr_tensorBasis_repr_apply_eq_contrSection {n d: ℕ} {c : Fin (n + 1 + 1) → (realLorentzTensor d).C}
+lemma contr_tensorBasis_repr_apply_eq_contrSection {n d: ℕ}
+    {c : Fin (n + 1 + 1) → (realLorentzTensor d).C}
     {i : Fin (n + 1 + 1)}
-    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)} (t : TensorTree (realLorentzTensor d) c)
+    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)}
+    (t : TensorTree (realLorentzTensor d) c)
     (b : Π k, Fin ((realLorentzTensor d).repDim (c (i.succAbove (j.succAbove k))))) :
-    ((realLorentzTensor d).tensorBasis (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
+    ((realLorentzTensor d).tensorBasis
+    (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
     ∑ (x : TensorBasis.ContrSection b),
     (((realLorentzTensor d).tensorBasis c).repr t.tensor x.1) *
-     if (x.1 i).1 = (x.1 (i.succAbove j)).1 then 1 else 0 := by
+    if (x.1 i).1 = (x.1 (i.succAbove j)).1 then 1 else 0 := by
   rw [contr_tensorBasis_repr_apply]
   congr
   funext x
@@ -216,9 +220,11 @@ lemma contr_tensorBasis_repr_apply_eq_contrSection {n d: ℕ} {c : Fin (n + 1 + 
 open TensorSpecies.TensorBasis in
 lemma contr_tensorBasis_repr_apply_eq_fin {n d: ℕ} {c : Fin (n + 1 + 1) → (realLorentzTensor d).C}
     {i : Fin (n + 1 + 1)}
-    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)} (t : TensorTree (realLorentzTensor d) c)
+    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)}
+    (t : TensorTree (realLorentzTensor d) c)
     (b : Π k, Fin ((realLorentzTensor d).repDim (c (i.succAbove (j.succAbove k))))) :
-    ((realLorentzTensor d).tensorBasis (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
+    ((realLorentzTensor d).tensorBasis
+    (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
     ∑ (x : Fin (1 + d)),
     (((realLorentzTensor d).tensorBasis c).repr t.tensor
     (liftToContrSection b ⟨Fin.cast (by simp) x, Fin.cast (by simp) x⟩)) := by
@@ -230,7 +236,7 @@ lemma contr_tensorBasis_repr_apply_eq_fin {n d: ℕ} {c : Fin (n + 1 + 1) → (r
   rw [← e.symm.sum_comp]
   congr
   funext x
-  simp
+  simp only [C_eq_color, Nat.succ_eq_add_one, mul_ite, mul_one, mul_zero]
   rw [Finset.sum_eq_single (Fin.cast (by simp) x)]
   · simp [contrSectionEquiv, e]
   · intro y _ hy

--- a/PhysLean/Relativity/Lorentz/RealTensor/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Basic.lean
@@ -8,6 +8,7 @@ import PhysLean.Relativity.Lorentz.Weyl.Metric
 import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Pre
 import PhysLean.Relativity.Lorentz.RealTensor.Vector.Pre.Basic
 import PhysLean.Relativity.Lorentz.PauliMatrices.AsTensor
+import PhysLean.Relativity.Lorentz.ComplexTensor.Basic
 /-!
 
 ## Real Lorentz tensors
@@ -152,11 +153,93 @@ instance (d : ℕ) : DecidableEq (realLorentzTensor d).C := realLorentzTensor.in
 @[simp]
 lemma C_eq_color {d : ℕ} : (realLorentzTensor d).C = Color := rfl
 
-@[simp]
 lemma repDim_up {d : ℕ} : (realLorentzTensor d).repDim Color.up = 1 + d := rfl
 
-@[simp]
 lemma repDim_down {d : ℕ} : (realLorentzTensor d).repDim Color.down = 1 + d := rfl
+
+@[simp]
+lemma repDim_eq_one_plus_dim {d : ℕ} {c : (realLorentzTensor d).C} :
+    (realLorentzTensor d).repDim c = 1 + d := by
+  cases c
+  · rfl
+  · rfl
+
+/-!
+
+## Simplification of contractions with respect to basis
+
+-/
+
+open TensorTree
+open TensorSpecies
+
+lemma contr_basis {d : ℕ} {c : (realLorentzTensor d).C}
+    (i : Fin ((realLorentzTensor d).repDim c))
+    (j : Fin ((realLorentzTensor d).repDim ((realLorentzTensor d).τ c))) :
+    (realLorentzTensor d).castToField
+      (((realLorentzTensor d).contr.app (Discrete.mk c)).hom
+      ((realLorentzTensor d).basis c i ⊗ₜ
+      (realLorentzTensor d).basis ((realLorentzTensor d).τ c) j))
+      = (if i.val = j.val then 1 else 0) := by
+  match c with
+  | .up =>
+    change Lorentz.contrCoContract.hom
+      (Lorentz.contrBasisFin d i ⊗ₜ Lorentz.coBasisFin d j) = _
+    rw [Lorentz.contrCoContract_hom_tmul]
+    simp [Lorentz.contrBasisFin]
+    rw [Pi.single_apply]
+    refine ite_congr ?h₁ (congrFun rfl) (congrFun rfl)
+    simp only [eq_comm, EmbeddingLike.apply_eq_iff_eq, Fin.ext_iff, repDim_up]
+  | .down =>
+    change Lorentz.coContrContract.hom
+      (Lorentz.coBasisFin d i ⊗ₜ Lorentz.contrBasisFin d j) = _
+    rw [Lorentz.coContrContract_hom_tmul]
+    simp
+    rw [Pi.single_apply]
+    refine ite_congr ?_ (congrFun rfl) (congrFun rfl)
+    simp only [eq_comm, EmbeddingLike.apply_eq_iff_eq, Fin.ext_iff, repDim_up]
+
+lemma contr_tensorBasis_repr_apply_eq_contrSection {n d: ℕ} {c : Fin (n + 1 + 1) → (realLorentzTensor d).C}
+    {i : Fin (n + 1 + 1)}
+    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)} (t : TensorTree (realLorentzTensor d) c)
+    (b : Π k, Fin ((realLorentzTensor d).repDim (c (i.succAbove (j.succAbove k))))) :
+    ((realLorentzTensor d).tensorBasis (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
+    ∑ (x : TensorBasis.ContrSection b),
+    (((realLorentzTensor d).tensorBasis c).repr t.tensor x.1) *
+     if (x.1 i).1 = (x.1 (i.succAbove j)).1 then 1 else 0 := by
+  rw [contr_tensorBasis_repr_apply]
+  congr
+  funext x
+  congr 1
+  exact contr_basis _ _
+
+open TensorSpecies.TensorBasis in
+lemma contr_tensorBasis_repr_apply_eq_fin {n d: ℕ} {c : Fin (n + 1 + 1) → (realLorentzTensor d).C}
+    {i : Fin (n + 1 + 1)}
+    {j : Fin (n + 1)} {h : c (i.succAbove j) = (realLorentzTensor d).τ (c i)} (t : TensorTree (realLorentzTensor d) c)
+    (b : Π k, Fin ((realLorentzTensor d).repDim (c (i.succAbove (j.succAbove k))))) :
+    ((realLorentzTensor d).tensorBasis (c ∘ i.succAbove ∘ j.succAbove)).repr (contr i j h t).tensor b =
+    ∑ (x : Fin (1 + d)),
+    (((realLorentzTensor d).tensorBasis c).repr t.tensor
+    (liftToContrSection b ⟨Fin.cast (by simp) x, Fin.cast (by simp) x⟩)) := by
+  rw [contr_tensorBasis_repr_apply_eq_contrSection]
+  rw [← (contrSectionEquiv b).symm.sum_comp]
+  erw [Finset.sum_product]
+  let e : Fin ((realLorentzTensor d).repDim (c i)) ≃ Fin (1 + d) :=
+    (Fin.castOrderIso (by simp)).toEquiv
+  rw [← e.symm.sum_comp]
+  congr
+  funext x
+  simp
+  rw [Finset.sum_eq_single (Fin.cast (by simp) x)]
+  · simp [contrSectionEquiv, e]
+  · intro y _ hy
+    rw [if_neg]
+    · simp [contrSectionEquiv, e]
+      rw [Fin.ne_iff_vne] at hy
+      simp at hy
+      exact fun a => hy (id (Eq.symm a))
+  · simp
 
 end realLorentzTensor
 end

--- a/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2024 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdAssoc
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdComm
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdContr
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ContrContr
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ContrSwap
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.PermContr
+import PhysLean.Relativity.Lorentz.RealTensor.Basic
+
+/-!
+
+## Metrics as real Lorentz tensors
+
+-/
+open IndexNotation
+open CategoryTheory
+open MonoidalCategory
+open Matrix
+open MatrixGroups
+open Complex
+open TensorProduct
+open IndexNotation
+open CategoryTheory
+open TensorTree
+open OverColor.Discrete
+noncomputable section
+
+namespace realLorentzTensor
+open Fermion
+
+/-!
+
+## Definitions.
+
+-/
+
+/-- The metric `ηᵢᵢ` as a complex Lorentz tensor. -/
+def coMetric (d : ℕ := 3) := (TensorTree.constTwoNodeE (realLorentzTensor d)
+  .down .down (Lorentz.preCoMetric d)).tensor
+
+/-- The metric `ηⁱⁱ` as a complex Lorentz tensor. -/
+def contrMetric (d : ℕ := 3) := (TensorTree.constTwoNodeE (realLorentzTensor d)
+  .up .up (Lorentz.preContrMetric d)).tensor
+
+/-!
+
+## Notation
+
+-/
+
+/-- The metric `ηᵢᵢ` as a complex Lorentz tensors. -/
+scoped[realLorentzTensor] notation "η'" => @coMetric
+
+/-- The metric `ηⁱⁱ` as a complex Lorentz tensors. -/
+scoped[realLorentzTensor] notation "η" => @contrMetric
+
+/-!
+
+## Tensor nodes.
+
+-/
+
+/-- The definitional tensor node relation for `coMetric`. -/
+lemma tensorNode_coMetric {d : ℕ} : {η' d | μ ν}ᵀ.tensor =
+  (TensorTree.constTwoNodeE (realLorentzTensor d)
+    .down .down (Lorentz.preCoMetric d)).tensor := by
+  rfl
+
+/-- The definitional tensor node relation for `contrMetric`. -/
+lemma tensorNode_contrMetric : {η d | μ ν}ᵀ.tensor =
+    (TensorTree.constTwoNodeE (realLorentzTensor d)
+    .up .up (Lorentz.preContrMetric d)).tensor := by
+  rfl
+
+/-
+
+## Group actions
+
+-/
+
+/-- The tensor `coMetric` is invariant under the action of `LorentzGroup d`. -/
+lemma action_coMetric {d : ℕ} (g : LorentzGroup d) : {g •ₐ η' d | μ ν}ᵀ.tensor =
+    {η' d | μ ν}ᵀ.tensor := by
+  rw [tensorNode_coMetric, constTwoNodeE]
+  rw [← action_constTwoNode _ g]
+  rfl
+
+/-- The tensor `contrMetric` is invariant under the action of `LorentzGroup d`. -/
+lemma action_contrMetric (g : LorentzGroup d) : {g •ₐ η d | μ ν}ᵀ.tensor =
+    {η d | μ ν}ᵀ.tensor := by
+  rw [tensorNode_contrMetric, constTwoNodeE]
+  rw [← action_constTwoNode _ g]
+  rfl
+
+end realLorentzTensor

--- a/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
@@ -3,14 +3,9 @@ Copyright (c) 2024 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdAssoc
-import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdComm
-import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ProdContr
-import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ContrContr
-import PhysLean.Relativity.Tensors.Tree.NodeIdentities.ContrSwap
 import PhysLean.Relativity.Tensors.Tree.NodeIdentities.PermContr
 import PhysLean.Relativity.Lorentz.RealTensor.Basic
-
+import PhysLean.Relativity.Tensors.Tree.NodeIdentities.Basic
 /-!
 
 ## Metrics as real Lorentz tensors
@@ -95,5 +90,78 @@ lemma action_contrMetric (g : LorentzGroup d) : {g •ₐ η d | μ ν}ᵀ.tenso
   rw [tensorNode_contrMetric, constTwoNodeE]
   rw [← action_constTwoNode _ g]
   rfl
+
+/-
+
+## There value with respect to a basis
+
+-/
+
+lemma coMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
+    (b : (j : Fin (Nat.succ 0).succ) → Fin ((realLorentzTensor d).repDim (![Color.down, Color.down] j))) :
+    ((realLorentzTensor d).tensorBasis _).repr (coMetric d) b =
+    minkowskiMatrix (finSumFinEquiv.symm (b 0)) (finSumFinEquiv.symm (b 1)) := by
+  simp [coMetric]
+  erw [Lorentz.preCoMetric_apply_one]
+  simp [Lorentz.preCoMetricVal]
+  erw [Lorentz.coCoToMatrixRe_symm_expand_tmul]
+  simp only [map_sum, _root_.map_smul, Finsupp.coe_finset_sum, Finsupp.coe_smul, Finset.sum_apply,
+    Pi.smul_apply, smul_eq_mul, Fin.isValue]
+  conv_lhs =>
+    enter [2, x, 2, y, 2]
+    erw [TensorSpecies.pairIsoSep_tensorBasis_repr]
+    change (((Lorentz.coBasisFin d).tensorProduct (Lorentz.coBasisFin d)).repr
+        ((Lorentz.coBasis d) x ⊗ₜ[ℝ] (Lorentz.coBasis d) y)) (b 0, b 1)
+    simp  [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.coBasisFin]
+    rw [Finsupp.single_apply, Finsupp.single_apply]
+  rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 0))]
+  · rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 1))]
+    · simp
+    · intro y _ hy
+      simp
+      intro hy2
+      rw [← hy2] at hy
+      simp at hy
+    · simp
+  · intro y _ hy
+    simp
+    intro hy2
+    rw [← hy2] at hy
+    simp at hy
+  · simp
+
+
+lemma contrMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
+    (b : (j : Fin (Nat.succ 0).succ) → Fin ((realLorentzTensor d).repDim (![.up, .up] j))) :
+    ((realLorentzTensor d).tensorBasis _).repr (contrMetric d) b =
+    minkowskiMatrix (finSumFinEquiv.symm (b 0)) (finSumFinEquiv.symm (b 1)) := by
+  simp [contrMetric]
+  erw [Lorentz.preContrMetric_apply_one]
+  simp [Lorentz.preContrMetricVal]
+  erw [Lorentz.contrContrToMatrixRe_symm_expand_tmul]
+  simp only [map_sum, _root_.map_smul, Finsupp.coe_finset_sum, Finsupp.coe_smul, Finset.sum_apply,
+  Pi.smul_apply, smul_eq_mul, Fin.isValue]
+  conv_lhs =>
+    enter [2, x, 2, y, 2]
+    erw [TensorSpecies.pairIsoSep_tensorBasis_repr]
+    change (((Lorentz.contrBasisFin d).tensorProduct (Lorentz.contrBasisFin d)).repr
+      ((Lorentz.contrBasis d) x ⊗ₜ[ℝ] (Lorentz.contrBasis d) y)) (b 0, b 1)
+    simp  [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.contrBasisFin]
+    rw [Finsupp.single_apply, Finsupp.single_apply]
+  rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 0))]
+  · rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 1))]
+    · simp
+    · intro y _ hy
+      simp
+      intro hy2
+      rw [← hy2] at hy
+      simp at hy
+    · simp
+  · intro y _ hy
+    simp
+    intro hy2
+    rw [← hy2] at hy
+    simp at hy
+  · simp
 
 end realLorentzTensor

--- a/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Metrics/Basic.lean
@@ -61,7 +61,7 @@ scoped[realLorentzTensor] notation "η" => @contrMetric
 
 /-- The definitional tensor node relation for `coMetric`. -/
 lemma tensorNode_coMetric {d : ℕ} : {η' d | μ ν}ᵀ.tensor =
-  (TensorTree.constTwoNodeE (realLorentzTensor d)
+    (TensorTree.constTwoNodeE (realLorentzTensor d)
     .down .down (Lorentz.preCoMetric d)).tensor := by
   rfl
 
@@ -98,7 +98,8 @@ lemma action_contrMetric (g : LorentzGroup d) : {g •ₐ η d | μ ν}ᵀ.tenso
 -/
 
 lemma coMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
-    (b : (j : Fin (Nat.succ 0).succ) → Fin ((realLorentzTensor d).repDim (![Color.down, Color.down] j))) :
+    (b : (j : Fin (Nat.succ 0).succ) →
+      Fin ((realLorentzTensor d).repDim (![Color.down, Color.down] j))) :
     ((realLorentzTensor d).tensorBasis _).repr (coMetric d) b =
     minkowskiMatrix (finSumFinEquiv.symm (b 0)) (finSumFinEquiv.symm (b 1)) := by
   simp [coMetric]
@@ -112,24 +113,26 @@ lemma coMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
     erw [TensorSpecies.pairIsoSep_tensorBasis_repr]
     change (((Lorentz.coBasisFin d).tensorProduct (Lorentz.coBasisFin d)).repr
         ((Lorentz.coBasis d) x ⊗ₜ[ℝ] (Lorentz.coBasis d) y)) (b 0, b 1)
-    simp  [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.coBasisFin]
+    simp [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.coBasisFin]
     rw [Finsupp.single_apply, Finsupp.single_apply]
   rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 0))]
   · rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 1))]
     · simp
     · intro y _ hy
-      simp
+      simp only [Fin.isValue, Equiv.apply_symm_apply, ↓reduceIte, mul_one, mul_ite, mul_zero,
+        ite_eq_right_iff]
       intro hy2
       rw [← hy2] at hy
       simp at hy
     · simp
   · intro y _ hy
-    simp
+    simp only [Fin.isValue, mul_ite, mul_one, mul_zero, Finset.sum_ite_irrel, Fintype.sum_sum_type,
+      Finset.univ_unique, Fin.default_eq_zero, finSumFinEquiv_apply_left, Finset.sum_singleton,
+      finSumFinEquiv_apply_right, Finset.sum_const_zero, ite_eq_right_iff]
     intro hy2
     rw [← hy2] at hy
     simp at hy
   · simp
-
 
 lemma contrMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
     (b : (j : Fin (Nat.succ 0).succ) → Fin ((realLorentzTensor d).repDim (![.up, .up] j))) :
@@ -146,19 +149,22 @@ lemma contrMetric_repr_apply_eq_minkowskiMatrix {d : ℕ}
     erw [TensorSpecies.pairIsoSep_tensorBasis_repr]
     change (((Lorentz.contrBasisFin d).tensorProduct (Lorentz.contrBasisFin d)).repr
       ((Lorentz.contrBasis d) x ⊗ₜ[ℝ] (Lorentz.contrBasis d) y)) (b 0, b 1)
-    simp  [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.contrBasisFin]
+    simp [Fin.isValue, Basis.tensorProduct_repr_tmul_apply, smul_eq_mul, Lorentz.contrBasisFin]
     rw [Finsupp.single_apply, Finsupp.single_apply]
   rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 0))]
   · rw [Finset.sum_eq_single (finSumFinEquiv.symm (b 1))]
     · simp
     · intro y _ hy
-      simp
+      simp only [Fin.isValue, Equiv.apply_symm_apply, ↓reduceIte, mul_one, mul_ite, mul_zero,
+        ite_eq_right_iff]
       intro hy2
       rw [← hy2] at hy
       simp at hy
     · simp
   · intro y _ hy
-    simp
+    simp only [Fin.isValue, mul_ite, mul_one, mul_zero, Finset.sum_ite_irrel, Fintype.sum_sum_type,
+      Finset.univ_unique, Fin.default_eq_zero, finSumFinEquiv_apply_left, Finset.sum_singleton,
+      finSumFinEquiv_apply_right, Finset.sum_const_zero, ite_eq_right_iff]
     intro hy2
     rw [← hy2] at hy
     simp at hy

--- a/PhysLean/Relativity/Lorentz/RealTensor/Vector/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Vector/Basic.lean
@@ -30,7 +30,8 @@ abbrev Vector (d : ℕ := 3) := ℝT[d, .up]
 
 namespace Vector
 
-
+/-- The equivalence between the type of indices of a Lorentz vector and
+  `Fin 1 ⊕ Fin d`. -/
 def indexEquiv {d : ℕ} :
     ((j : Fin (Nat.succ 0)) → Fin ((realLorentzTensor d).repDim (![Color.up] j)))
     ≃ Fin 1 ⊕ Fin d :=
@@ -63,10 +64,11 @@ lemma tensorNode_repr_apply {d : ℕ} (p : Vector d)
   fin_cases j
   simp
 
-/-- The Minkowski product of Lorentz vectors  in the +--- convention.. -/
+/-- The Minkowski product of Lorentz vectors in the +--- convention.. -/
 def innerProduct {d : ℕ} (p q : Vector d) : ℝ :=
   {η' d | μ ν ⊗ p | μ ⊗ q | ν}ᵀ.field
 
+@[inherit_doc innerProduct]
 notation "⟪" p ", " q "⟫ₘ" => innerProduct p q
 
 open TensorTree
@@ -85,26 +87,31 @@ lemma innerProduct_toCoord {d : ℕ} (p q : Vector d) :
     rw [tensorNode_repr_apply]
     enter [1]
     erw [coMetric_repr_apply_eq_minkowskiMatrix]
-  simp
+  simp only [Nat.succ_eq_add_one, Nat.reduceAdd, C_eq_color, Fin.isValue, Fin.succAbove_zero,
+    Function.comp_apply, Fin.zero_succAbove, Fin.succ_zero_eq_one, Fin.cast_eq_self,
+    Fin.succ_one_eq_two, tensorNode_tensor]
   conv_lhs =>
     enter [2, x, 2, 2]
-    simp
+    simp only [Fin.isValue]
     change finSumFinEquiv.symm x
   conv_lhs =>
     enter [2, x, 1, 2, y, 2, 2]
     change finSumFinEquiv.symm y
   conv_lhs =>
     enter [2, x, 1, 2, y, 1]
-    simp
+    simp only [Fin.isValue]
     change minkowskiMatrix (finSumFinEquiv.symm y) (finSumFinEquiv.symm x)
   conv_lhs =>
     enter [2, x, 1]
     rw [← finSumFinEquiv.sum_comp]
   rw [← finSumFinEquiv.sum_comp]
-  simp
+  simp only [Equiv.symm_apply_apply, Fintype.sum_sum_type, Finset.univ_unique, Fin.default_eq_zero,
+    Fin.isValue, Finset.sum_singleton, ne_eq, reduceCtorEq, not_false_eq_true,
+    minkowskiMatrix.off_diag_zero, zero_mul, Finset.sum_const_zero, _root_.add_zero,
+    _root_.zero_add]
   congr 1
   rw [minkowskiMatrix.inl_0_inl_0]
-  simp
+  simp only [Fin.isValue, one_mul]
   rw [← Finset.sum_neg_distrib]
   congr
   funext x

--- a/PhysLean/Relativity/Lorentz/RealTensor/Vector/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Vector/Basic.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matteo Cipollina, Joseph Tooby-Smith
+-/
+import PhysLean.Relativity.Lorentz.RealTensor.Metrics.Basic
+/-!
+
+## Metrics as real Lorentz tensors
+
+-/
+open IndexNotation
+open CategoryTheory
+open MonoidalCategory
+open Matrix
+open MatrixGroups
+open Complex
+open TensorProduct
+open IndexNotation
+open CategoryTheory
+open TensorTree
+open OverColor.Discrete
+noncomputable section
+
+namespace Lorentz
+open realLorentzTensor
+
+/-- Real contravariant Lorentz vector. -/
+abbrev Vector (d : ℕ := 3) := ℝT[d, .up]
+
+namespace Vector
+
+
+def indexEquiv {d : ℕ} :
+    ((j : Fin (Nat.succ 0)) → Fin ((realLorentzTensor d).repDim (![Color.up] j)))
+    ≃ Fin 1 ⊕ Fin d :=
+  let e :((j : Fin (Nat.succ 0)) → Fin ((realLorentzTensor d).repDim (![Color.up] j)))
+    ≃ Fin (1 + d) := {
+    toFun := fun f => Fin.cast (by rfl) (f 0)
+    invFun := fun x => (fun j => Fin.cast (by simp) x)
+    left_inv := fun f => by
+      ext j
+      fin_cases j
+      simp
+    right_inv := fun x => by rfl}
+  e.trans finSumFinEquiv.symm
+
+/-- The coordinates of a Lorentz vector -/
+def toCoord {d : ℕ} (p : Vector d) : Fin 1 ⊕ Fin d → ℝ :=
+  Equiv.piCongrLeft' _ indexEquiv
+  (Finsupp.equivFunOnFinite
+  (((realLorentzTensor d).tensorBasis _).repr p))
+
+instance : CoeFun (Vector d) (fun _ => Fin 1 ⊕ Fin d → ℝ) := ⟨toCoord⟩
+
+lemma tensorNode_repr_apply {d : ℕ} (p : Vector d)
+    (b : (j : Fin (Nat.succ 0)) → Fin ((realLorentzTensor d).repDim (![Color.up] j))) :
+    ((realLorentzTensor d).tensorBasis _).repr p b =
+    p (finSumFinEquiv.symm (b 0)) := by
+  simp [toCoord, indexEquiv]
+  congr
+  ext j
+  fin_cases j
+  simp
+
+/-- The Minkowski product of Lorentz vectors  in the +--- convention.. -/
+def innerProduct {d : ℕ} (p q : Vector d) : ℝ :=
+  {η' d | μ ν ⊗ p | μ ⊗ q | ν}ᵀ.field
+
+notation "⟪" p ", " q "⟫ₘ" => innerProduct p q
+
+open TensorTree
+lemma innerProduct_toCoord {d : ℕ} (p q : Vector d) :
+    ⟪p, q⟫ₘ = p (Sum.inl 0) * q (Sum.inl 0) - ∑ i, p (Sum.inr i) * q (Sum.inr i) := by
+  dsimp only [innerProduct, Nat.succ_eq_add_one, Nat.reduceAdd, C_eq_color, Fin.isValue]
+  rw [TensorTree.field_eq_repr]
+  rw [contr_tensorBasis_repr_apply_eq_fin]
+  conv_lhs =>
+    enter [2, x]
+    rw [prod_tensorBasis_repr_apply]
+    rw [contr_tensorBasis_repr_apply_eq_fin]
+    rw [tensorNode_repr_apply]
+    enter [1, 2, y]
+    rw [prod_tensorBasis_repr_apply]
+    rw [tensorNode_repr_apply]
+    enter [1]
+    erw [coMetric_repr_apply_eq_minkowskiMatrix]
+  simp
+  conv_lhs =>
+    enter [2, x, 2, 2]
+    simp
+    change finSumFinEquiv.symm x
+  conv_lhs =>
+    enter [2, x, 1, 2, y, 2, 2]
+    change finSumFinEquiv.symm y
+  conv_lhs =>
+    enter [2, x, 1, 2, y, 1]
+    simp
+    change minkowskiMatrix (finSumFinEquiv.symm y) (finSumFinEquiv.symm x)
+  conv_lhs =>
+    enter [2, x, 1]
+    rw [← finSumFinEquiv.sum_comp]
+  rw [← finSumFinEquiv.sum_comp]
+  simp
+  congr 1
+  rw [minkowskiMatrix.inl_0_inl_0]
+  simp
+  rw [← Finset.sum_neg_distrib]
+  congr
+  funext x
+  rw [Finset.sum_eq_single x]
+  · rw [minkowskiMatrix.inr_i_inr_i]
+    simp
+  · intro y _ hy
+    rw [minkowskiMatrix.off_diag_zero (by simp [hy])]
+    simp
+  · simp
+
+end Vector
+
+end Lorentz

--- a/PhysLean/Relativity/Lorentz/RealTensor/Vector/Pre/Basic.lean
+++ b/PhysLean/Relativity/Lorentz/RealTensor/Vector/Pre/Basic.lean
@@ -48,6 +48,11 @@ lemma contrBasis_toFin1dℝ {d : ℕ} (i : Fin (1) ⊕ Fin d) :
 def contrBasisFin (d : ℕ := 3) : Basis (Fin (1 + d)) ℝ (Contr d) :=
   Basis.reindex (contrBasis d) finSumFinEquiv
 
+@[simp]
+lemma contrBasisFin_toFin1dℝ {d : ℕ} (i : Fin (1 + d)) :
+    (contrBasisFin d i).toFin1dℝ = Pi.single (finSumFinEquiv.symm i) 1 := by
+  simp only [contrBasisFin, Basis.reindex_apply, contrBasis_toFin1dℝ, Basis.coe_ofEquivFun]
+
 /-- The representation of contravariant Lorentz vectors forms a topological space, induced
   by its equivalence to `Fin 1 ⊕ Fin d → ℝ`. -/
 instance : TopologicalSpace (Contr d) := TopologicalSpace.induced
@@ -90,6 +95,11 @@ lemma coBasis_toFin1dℝ {d : ℕ} (i : Fin (1) ⊕ Fin d) :
 /-- The standard basis of covaraitn Lorentz vectors indexed by `Fin (1 + d)`. -/
 def coBasisFin (d : ℕ := 3) : Basis (Fin (1 + d)) ℝ (Co d) :=
   Basis.reindex (coBasis d) finSumFinEquiv
+
+@[simp]
+lemma coBasisFin_toFin1dℝ {d : ℕ} (i : Fin (1 + d)) :
+    (coBasisFin d i).toFin1dℝ = Pi.single (finSumFinEquiv.symm i) 1 := by
+  simp only [coBasisFin, Basis.reindex_apply, coBasis_toFin1dℝ, Basis.coe_ofEquivFun]
 
 open CategoryTheory.MonoidalCategory
 

--- a/PhysLean/Relativity/Tensors/Tree/Basic.lean
+++ b/PhysLean/Relativity/Tensors/Tree/Basic.lean
@@ -519,6 +519,37 @@ lemma neg_tensorBasis_repr (t : TensorTree S c) :
   rw [neg_tensor]
   simp
 
+lemma field_eq_repr {c : Fin 0 → S.C} (t : TensorTree S c) :
+    t.field = (S.tensorBasis c).repr t.tensor (fun j => Fin.elim0 j) := by
+  simp [field]
+  have h0 : S.castFin0ToField ((S.tensorBasis c) default) = 1 := by
+    simp [castFin0ToField, tensorBasis]
+    trans (PiTensorProduct.isEmptyEquiv (Fin 0)) (S.fromCoordinates c
+      (Pi.single (fun a => 0) 1))
+    · rfl
+    simp [fromCoordinates, basisVector]
+    rw [Subsingleton.pi_single_eq]
+  have h1 (t : (S.F.obj (OverColor.mk c)).V) :
+      S.castFin0ToField t = ((S.tensorBasis c).repr t) fun j => j.elim0 := by
+    obtain ⟨t, rfl⟩ := (S.tensorBasis c).repr.symm.surjective t
+    simp only [Basis.repr_symm_apply, Basis.repr_linearCombination]
+    rw [@Finsupp.linearCombination_unique]
+    simp
+    trans t default * 1
+    · congr 1
+      · congr 1
+        exact Unique.default_eq default
+      · simp [castFin0ToField, tensorBasis]
+        change (PiTensorProduct.isEmptyEquiv (Fin 0)) (S.fromCoordinates c
+          (Pi.single _ 1)) = _
+        simp [fromCoordinates, basisVector]
+    · simp only [ Fin.default_eq_zero, mul_one]
+      congr
+      funext j
+      exact Fin.elim0 j
+  exact h1 t.tensor
+
+
 /-!
 
 ## The zero tensor tree

--- a/PhysLean/Relativity/Tensors/Tree/Basic.lean
+++ b/PhysLean/Relativity/Tensors/Tree/Basic.lean
@@ -522,19 +522,12 @@ lemma neg_tensorBasis_repr (t : TensorTree S c) :
 lemma field_eq_repr {c : Fin 0 → S.C} (t : TensorTree S c) :
     t.field = (S.tensorBasis c).repr t.tensor (fun j => Fin.elim0 j) := by
   simp [field]
-  have h0 : S.castFin0ToField ((S.tensorBasis c) default) = 1 := by
-    simp [castFin0ToField, tensorBasis]
-    trans (PiTensorProduct.isEmptyEquiv (Fin 0)) (S.fromCoordinates c
-      (Pi.single (fun a => 0) 1))
-    · rfl
-    simp [fromCoordinates, basisVector]
-    rw [Subsingleton.pi_single_eq]
   have h1 (t : (S.F.obj (OverColor.mk c)).V) :
       S.castFin0ToField t = ((S.tensorBasis c).repr t) fun j => j.elim0 := by
     obtain ⟨t, rfl⟩ := (S.tensorBasis c).repr.symm.surjective t
     simp only [Basis.repr_symm_apply, Basis.repr_linearCombination]
     rw [@Finsupp.linearCombination_unique]
-    simp
+    simp only [map_smul, smul_eq_mul]
     trans t default * 1
     · congr 1
       · congr 1
@@ -543,12 +536,11 @@ lemma field_eq_repr {c : Fin 0 → S.C} (t : TensorTree S c) :
         change (PiTensorProduct.isEmptyEquiv (Fin 0)) (S.fromCoordinates c
           (Pi.single _ 1)) = _
         simp [fromCoordinates, basisVector]
-    · simp only [ Fin.default_eq_zero, mul_one]
+    · simp only [Fin.default_eq_zero, mul_one]
       congr
       funext j
       exact Fin.elim0 j
   exact h1 t.tensor
-
 
 /-!
 


### PR DESCRIPTION
The main file added in this PR is RealTensor.Vector.Basic.
This includes the definition of real 4-vectors and their Minkowski product, and write their Minkowski product in terms of coordinates. 

This forms part of #399 
