### PR TITLE
Update README links to new documentation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ into Lean 4.
 ## Some parts of PhysLean
 PhysLean _currently_ includes, but is not limited to, the following parts:
 
-__Lorentz [🗂️](https://heplean.github.io/HepLean/docs/HepLean/Lorentz/Group/Basic.html):__  The Lorentz group, Lorentz algebra, Weyl fermions, Real Lorentz vectors, complex Lorentz vectors, complex Lorentz tensors, bispinors, Pauli matrices, etc.
+__Lorentz [🗂️](https://physlean.com/docs/PhysLean/Relativity/Lorentz/Group/Basic.html):__  The Lorentz group, Lorentz algebra, Weyl fermions, Real Lorentz vectors, complex Lorentz vectors, complex Lorentz tensors, bispinors, Pauli matrices, etc.
 
-__Index notation [🗂️](https://heplean.github.io/HepLean/docs/HepLean/Tensors/OverColor/Basic.html) [📄](https://arxiv.org/abs/2411.07667):__  Formalization of index notation using category theory allowing commands like
+__Index notation [🗂️](https://physlean.com/docs/PhysLean/Relativity/Tensors/OverColor/Basic.html) [📄](https://arxiv.org/abs/2411.07667):__  Formalization of index notation using category theory allowing commands like
 
 ```Lean
 {A | μ ν ⊗ S | μ ν = - A | μ ν ⊗ S | μ ν}ᵀ
 ```
 
-__Anomaly cancellation [🗂️](https://heplean.github.io/HepLean/docs/HepLean/AnomalyCancellation/Basic.html):__  Results related to solutions to the anomaly cancellation conditions of several theories.
+__Anomaly cancellation [🗂️](https://physlean.com/docs/PhysLean/QFT/AnomalyCancellation/Basic.html):__  Results related to solutions to the anomaly cancellation conditions of several theories.
 
-__Standard Model physics [🗂️](https://heplean.github.io/HepLean/docs/HepLean/StandardModel/Basic.html):__ Properties of the Higgs potential.
+__Standard Model physics [🗂️](https://physlean.com/docs/PhysLean/Particles/StandardModel/Basic.html):__ Properties of the Higgs potential.
 
-__BSM physics [🗂️](https://heplean.github.io/HepLean/docs/HepLean/BeyondTheStandardModel/TwoHDM/Basic.html):__ Starts to: Georgi Glashow model, Pati-Salam, Spin(10), Two Higgs doublet model.
+__BSM physics [🗂️](https://physlean.com/docs/PhysLean/Particles/BeyondTheStandardModel/TwoHDM/Basic.html):__ Starts to: Georgi Glashow model, Pati-Salam, Spin(10), Two Higgs doublet model.
 
-__Flavor physics [🗂️](https://heplean.github.io/HepLean/docs/HepLean/FlavorPhysics/CKMMatrix/Basic.html):__ Properties of the CKM matrix.
+__Flavor physics [🗂️](https://physlean.com/docs/PhysLean/Particles/FlavorPhysics/CKMMatrix/Basic.html):__ Properties of the CKM matrix.
 
-__Perturbation Theory [🗂️](https://heplean.github.io/HepLean/docs/HepLean/PerturbationTheory/FieldOpAlgebra/WicksTheorem.html):__ Time-dependent version of Wick's theorem for both fermions and bosons.
+__Perturbation Theory [🗂️](https://physlean.com/docs/PhysLean/QFT/PerturbationTheory/WickContraction/Basic.html):__ Time-dependent version of Wick's theorem for both fermions and bosons.
 
 ## Associated media and publications
 - [📄](https://arxiv.org/abs/2405.08863) Joseph Tooby-Smith,


### PR DESCRIPTION
This PR updates the https://heplean.github.io/HepLean/docs/HepLean/... links to https://physlean.com/docs/PhysLean/... where some of the files were moved around.

To prevent this in the future (I mean the things moving around) one might consider using [this feature of doc-gen4](https://github.com/leanprover/doc-gen4?tab=readme-ov-file#how-does-docsnatadd-from-the-lean-zulip-work) if we know that definition or theorem names are more stable.

I also spotted some links to https://heplean.github.io/HepLean/ in [`/scripts/stats.lean`](https://github.com/HEPLean/PhysLean/blob/16554ebe68c9d58a963fcbf80c7bc5a05cad7268/scripts/stats.lean#L81-L99) and [`/scripts/MetaPrograms/informal.lean`](https://github.com/HEPLean/PhysLean/blob/08e9226e22155d89e6a7c503ab02994d4ef51f23/scripts/MetaPrograms/informal.lean#L115), but did not update them now.