### PR TITLE
docs: reference index notation paper in OverColor.Basic

### DIFF
--- a/PhysLean/Relativity/Tensors/OverColor/Basic.lean
+++ b/PhysLean/Relativity/Tensors/OverColor/Basic.lean
@@ -20,6 +20,10 @@ In the case of complex Lorentz tensors, indices can take one of six different co
 corresponding to up and down, dotted and undotted weyl fermion indices and up and down
 Lorentz indices.
 
+## References
+- *Formalization of physics index notation in Lean 4*, Tooby-Smith.
+<https://doi.org/10.48550/arXiv.2411.07667>.
+
 -/
 
 namespace IndexNotation


### PR DESCRIPTION
It would be convenient to have a reference to https://doi.org/10.48550/arXiv.2411.07667 in the OverColor.Basic documentation.

The "References" header in this PR is inspired by Mathlib: https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Monoidal/Category.html#References