### PR TITLE
refactor: remove `erw`s from LinearMaps.lean

### DIFF
--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -85,7 +85,7 @@ def mk₂ (f : V × V → ℚ) (map_smul : ∀ a S T, f (a • S, T) = a * f (S,
 
 lemma map_smul₁ (f : BiLinearSymm V) (a : ℚ) (S T : V) : f (a • S) T = a * f S T := by
   have h : f (a • S) = a • (f S) := by
-    exact f.toLinearMap.map_smul a S
+    exact f.map_smul a S
   simp [h]
 
 lemma swap (f : BiLinearSymm V) (S T : V) : f S T = f T S := f.swap' S T

--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -208,8 +208,9 @@ lemma swap₃ (f : TriLinearSymm V) (S T L : V) : f S T L = f L T S := by
 
 lemma map_smul₁ (f : TriLinearSymm V) (a : ℚ) (S T L : V) :
     f (a • S) T L = a * f S T L := by
-  erw [f.map_smul a S]
-  rfl
+  have h : f (a • S) = a • (f S) := by
+    exact f.map_smul a S
+  simp [h]
 
 lemma map_smul₂ (f : TriLinearSymm V) (S : V) (a : ℚ) (T L : V) :
     f S (a • T) L = a * f S T L := by

--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -94,8 +94,9 @@ lemma map_smul₂ (f : BiLinearSymm V) (a : ℚ) (S : V) (T : V) : f S (a • T)
   rw [f.swap, f.map_smul₁, f.swap]
 
 lemma map_add₁ (f : BiLinearSymm V) (S1 S2 T : V) : f (S1 + S2) T = f S1 T + f S2 T := by
-  erw [f.map_add]
-  rfl
+  have h : f (S1 + S2) = f S1 + f S2 := by
+    exact f.map_add S1 S2
+  simp [h]
 
 lemma map_add₂ (f : BiLinearSymm V) (S : V) (T1 T2 : V) :
     f S (T1 + T2) = f S T1 + f S T2 := by

--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -222,8 +222,9 @@ lemma map_smul₃ (f : TriLinearSymm V) (S T : V) (a : ℚ) (L : V) :
 
 lemma map_add₁ (f : TriLinearSymm V) (S1 S2 T L : V) :
     f (S1 + S2) T L = f S1 T L + f S2 T L := by
-  erw [f.map_add]
-  rfl
+  have h : f (S1 + S2) = f S1 + f S2 := by
+    exact f.map_add S1 S2
+  simp [h]
 
 lemma map_add₂ (f : TriLinearSymm V) (S T1 T2 L : V) :
     f S (T1 + T2) L = f S T1 L + f S T2 L := by

--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -83,18 +83,7 @@ def mk₂ (f : V × V → ℚ) (map_smul : ∀ a S T, f (a • S, T) = a * f (S,
   map_add' := fun S1 S2 => LinearMap.ext fun T => map_add S1 S2 T
   swap' := swap
 
--- variable (V : Type) [AddCommGroup V] [Module ℚ V]
--- variable (f : BiLinearSymm V) (a : ℚ) (S T : V)
-
--- #check f
--- #check f S
--- #check f S T
--- #check a * f S T
--- #check a * (f S) T
--- #check a • (f S)
--- #check (a • f.toLinearMap S)
-
-lemma map_smul₁ (f : BiLinearSymm V) (a : ℚ) (S T : V) : f (a • S) T = a * (f S) T := by
+lemma map_smul₁ (f : BiLinearSymm V) (a : ℚ) (S T : V) : f (a • S) T = a * f S T := by
   have h : f (a • S) = a • (f S) := by
     exact f.toLinearMap.map_smul a S
   simp [h]

--- a/PhysLean/Mathematics/LinearMaps.lean
+++ b/PhysLean/Mathematics/LinearMaps.lean
@@ -83,9 +83,21 @@ def mk₂ (f : V × V → ℚ) (map_smul : ∀ a S T, f (a • S, T) = a * f (S,
   map_add' := fun S1 S2 => LinearMap.ext fun T => map_add S1 S2 T
   swap' := swap
 
-lemma map_smul₁ (f : BiLinearSymm V) (a : ℚ) (S T : V) : f (a • S) T = a * f S T := by
-  erw [f.map_smul a S]
-  rfl
+-- variable (V : Type) [AddCommGroup V] [Module ℚ V]
+-- variable (f : BiLinearSymm V) (a : ℚ) (S T : V)
+
+-- #check f
+-- #check f S
+-- #check f S T
+-- #check a * f S T
+-- #check a * (f S) T
+-- #check a • (f S)
+-- #check (a • f.toLinearMap S)
+
+lemma map_smul₁ (f : BiLinearSymm V) (a : ℚ) (S T : V) : f (a • S) T = a * (f S) T := by
+  have h : f (a • S) = a • (f S) := by
+    exact f.toLinearMap.map_smul a S
+  simp [h]
 
 lemma swap (f : BiLinearSymm V) (S T : V) : f S T = f T S := f.swap' S T
 


### PR DESCRIPTION
This PR is my first attempt to make progress on https://github.com/HEPLean/PhysLean/issues/385. A few questions / comments:

1. Surely, the performance hit by `erw` varies depending on context, and we'd like to focus on where it's particularly bad. @jstoobysmith, do you have a preference of which `erw`s we should focus on? Nevertheless, being new to Lean, LinearMaps.lean seemed like a nice way for me to cut my teeth. 
1. My proofs for `BiLinearSymm` and `TriLinearSymm` are identical. Do we need more abstraction?
1. There's a note `TODO "6VZLZ" "Replace the definitions in this file with Mathlib definitions."` at the top of the file. Haven't looked into this yet.
1. It's possible I've completely missed the point about `erw`s haha, especially about simp-normal form.