### PR TITLE
feat: defining Laplacian and some related identities

### DIFF
--- a/PhysLean/ClassicalMechanics/Space/Basic.lean
+++ b/PhysLean/ClassicalMechanics/Space/Basic.lean
@@ -94,16 +94,16 @@ noncomputable def Laplacian (f : Space d → ℝ) :
   ∑ i, df2 i x
 
 @[inherit_doc Laplacian]
-scoped[Space] notation "∇²" => Laplacian
+scoped[Space] notation "Δ" => Laplacian
 
 /-- The vector `Laplacian_vec` operator. -/
 noncomputable def Laplacian_vec (f : Space d → EuclideanSpace ℝ (Fin d)) :
     Space d → EuclideanSpace ℝ (Fin d) := fun x i =>
   -- get i-th component of `f`
   let fi i x := coord i (f x)
-  ∇² (fi i) x
+  Δ (fi i) x
 
 @[inherit_doc Laplacian_vec]
-scoped[Space] notation "∇²" => Laplacian_vec
+scoped[Space] notation "Δ" => Laplacian_vec
 
 end Space

--- a/PhysLean/ClassicalMechanics/Space/Basic.lean
+++ b/PhysLean/ClassicalMechanics/Space/Basic.lean
@@ -85,25 +85,25 @@ noncomputable def div (f : Space d → EuclideanSpace ℝ (Fin d)) :
 @[inherit_doc div]
 macro (name := divNotation) "∇" "⬝" f:term:100  : term => `(div $f)
 
-/-- The scalar `Laplacian` operator. -/
-noncomputable def Laplacian (f : Space d → ℝ) :
+/-- The scalar `laplacian` operator. -/
+noncomputable def laplacian (f : Space d → ℝ) :
     Space d → ℝ := fun x =>
   -- second derivative of f in i-th coordinate
   -- ∂²f/∂xᵢ²
   let df2 i x := ∂[i] (∂[i] f) x
   ∑ i, df2 i x
 
-@[inherit_doc Laplacian]
-scoped[Space] notation "Δ" => Laplacian
+@[inherit_doc laplacian]
+scoped[Space] notation "Δ" => laplacian
 
-/-- The vector `Laplacian_vec` operator. -/
-noncomputable def Laplacian_vec (f : Space d → EuclideanSpace ℝ (Fin d)) :
+/-- The vector `laplacian_vec` operator. -/
+noncomputable def laplacian_vec (f : Space d → EuclideanSpace ℝ (Fin d)) :
     Space d → EuclideanSpace ℝ (Fin d) := fun x i =>
   -- get i-th component of `f`
   let fi i x := coord i (f x)
   Δ (fi i) x
 
-@[inherit_doc Laplacian_vec]
-scoped[Space] notation "Δ" => Laplacian_vec
+@[inherit_doc laplacian_vec]
+scoped[Space] notation "Δ" => laplacian_vec
 
 end Space

--- a/PhysLean/ClassicalMechanics/Space/Basic.lean
+++ b/PhysLean/ClassicalMechanics/Space/Basic.lean
@@ -70,19 +70,40 @@ noncomputable def curl (f : Space → EuclideanSpace ℝ (Fin 3)) :
     | 2 => df 1 0 x - df 0 1 x
 
 @[inherit_doc curl]
-scoped[Space] notation "∇×" => curl
+macro (name := curlNotation) "∇" "×" f:term:100  : term => `(curl $f)
 
 /-- The vector calculus operator `div`. -/
 noncomputable def div (f : Space d → EuclideanSpace ℝ (Fin d)) :
-  Space d → ℝ := fun x =>
+    Space d → ℝ := fun x =>
   -- get i-th component of `f`
   let fi i x := coord i (f x)
-  -- derivative of i-th component in j-th coordinate
+  -- derivative of i-th component in i-th coordinate
   -- ∂fᵢ/∂xⱼ
   let df i x := ∂[i] (fi i) x
   ∑ i, df i x
 
 @[inherit_doc div]
-scoped[Space] notation "∇⬝" => div
+macro (name := divNotation) "∇" "⬝" f:term:100  : term => `(div $f)
+
+/-- The scalar `Laplacian` operator. -/
+noncomputable def Laplacian (f : Space d → ℝ) :
+    Space d → ℝ := fun x =>
+  -- second derivative of f in i-th coordinate
+  -- ∂²f/∂xᵢ²
+  let df2 i x := ∂[i] (∂[i] f) x
+  ∑ i, df2 i x
+
+@[inherit_doc Laplacian]
+scoped[Space] notation "∇²" => Laplacian
+
+/-- The vector `Laplacian_vec` operator. -/
+noncomputable def Laplacian_vec (f : Space d → EuclideanSpace ℝ (Fin d)) :
+    Space d → EuclideanSpace ℝ (Fin d) := fun x i =>
+  -- get i-th component of `f`
+  let fi i x := coord i (f x)
+  ∇² (fi i) x
+
+@[inherit_doc Laplacian_vec]
+scoped[Space] notation "∇²" => Laplacian_vec
 
 end Space

--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -173,9 +173,9 @@ lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
 
 -/
 
-lemma Laplacian_eq_div_of_grad (f : Space → ℝ) :
+lemma laplacian_eq_div_of_grad (f : Space → ℝ) :
     Δ f = ∇ ⬝ ∇ f := by
-  unfold Laplacian div grad Finset.sum
+  unfold laplacian div grad Finset.sum
   simp only [Fin.univ_val_map, List.ofFn_succ, Fin.isValue, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, List.ofFn_zero, Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero,
     coord, basis, EuclideanSpace.basisFun_apply, PiLp.inner_apply, EuclideanSpace.single_apply,
@@ -202,7 +202,7 @@ lemma div_of_curl_eq_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
 
 lemma curl_of_curl (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
     ∇ × (∇ × f) = ∇ (∇ ⬝ f) - Δ f := by
-  unfold Laplacian_vec Laplacian div grad curl Finset.sum
+  unfold laplacian_vec laplacian div grad curl Finset.sum
   simp only [Fin.isValue, coord, basis, EuclideanSpace.basisFun_apply, PiLp.inner_apply,
     EuclideanSpace.single_apply, RCLike.inner_apply, conj_trivial, ite_mul, one_mul, zero_mul,
     Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fin.univ_val_map, List.ofFn_succ,

--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -173,7 +173,7 @@ lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
 -/
 
 lemma Laplacian_eq_div_of_grad (f : Space → ℝ) :
-    ∇² f = ∇ ⬝ ∇ f := by
+    Δ f = ∇ ⬝ ∇ f := by
   unfold Laplacian div grad Finset.sum
   simp only [Fin.univ_val_map, List.ofFn_succ, Fin.isValue, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, List.ofFn_zero, Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero,
@@ -200,7 +200,7 @@ lemma div_of_curl_eq_zero (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
     exact hf
 
 lemma curl_of_curl (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
-    ∇ × (∇ × f) = ∇ (∇ ⬝ f) - ∇² f := by
+    ∇ × (∇ × f) = ∇ (∇ ⬝ f) - Δ f := by
   unfold Laplacian_vec Laplacian div grad curl Finset.sum
   simp only [Fin.isValue, coord, basis, EuclideanSpace.basisFun_apply, PiLp.inner_apply,
     EuclideanSpace.single_apply, RCLike.inner_apply, conj_trivial, ite_mul, one_mul, zero_mul,

--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -133,10 +133,11 @@ lemma differentiable_fderiv_coord (f : Space → EuclideanSpace ℝ (Fin 3)) (hf
   · apply ContDiff.differentiable_fderiv
     exact hf
 
-/-- Second derivatives on space distiribute coordinate-wise over addition (all three components for div). -/
+/-- Second derivatives distiribute coordinate-wise over addition (all three components for div). -/
 lemma deriv_coord_2nd_add (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
     ∂[i] (fun x => ∂[u] (fun x => f x u) x + (∂[v] (fun x => f x v) x + ∂[w] (fun x => f x w) x)) =
-    (∂[i] (∂[u] (fun x => f x u))) + (∂[i] (∂[v] (fun x => f x v))) + (∂[i] (∂[w] (fun x => f x w))) := by
+    (∂[i] (∂[u] (fun x => f x u))) + (∂[i] (∂[v] (fun x => f x v))) +
+    (∂[i] (∂[w] (fun x => f x w))) := by
   unfold deriv
   ext x
   rw [fderiv_add, fderiv_add]
@@ -150,7 +151,7 @@ lemma deriv_coord_2nd_add (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
       exact hf
     · fun_prop
 
-/-- Second derivatives on space distiribute coordinate-wise over subtraction (two components for curl). -/
+/-- Second derivatives distiribute coordinate-wise over subtraction (two components for curl). -/
 lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
     ∂[u] (fun x => ∂[v] (fun x => f x w) x - ∂[w]  (fun x => f x v) x) =
     (∂[u] (∂[v] (fun x => f x w))) - (∂[u] (∂[w] (fun x => f x v))) := by


### PR DESCRIPTION
1. changed div and curl notation according to [this suggestion](https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLean/topic/Vector.20calculus/near/512317216)
2. defining scalar and vector versions of the Laplacian operator
3. related identities
 3.1 Δ f = ∇ ⬝ ∇ f
 3.2  ∇ × (∇ × f) = ∇ (∇ ⬝ f) - Δ f