### PR TITLE
refactor: remove `erw`s from PauliMatrices folder

### DIFF
--- a/PhysLean/Relativity/PauliMatrices/Basic.lean
+++ b/PhysLean/Relativity/PauliMatrices/Basic.lean
@@ -74,7 +74,6 @@ lemma pauliContr_eq_fromTripleT : σ^^^ = fromTripleT PauliMatrix.asTensor := by
   rw [pauliContr_eq_fromConstTriple, fromConstTriple,
     congrArg fromTripleT PauliMatrix.asConsTensor_apply_one]
 
-set_option maxHeartbeats 0 in
 lemma pauliContr_eq_basis : pauliContr =
     Tensor.basis ![Color.up, Color.upL, Color.upR] (fun | 0 => 0 | 1 => 0 | 2 => 0)
     + Tensor.basis ![Color.up, Color.upL, Color.upR] (fun | 0 => 0 | 1 => 1 | 2 => 1)
@@ -91,9 +90,38 @@ lemma pauliContr_eq_basis : pauliContr =
   rw [show complexContrBasis (Sum.inr 0) = complexContrBasisFin4 1 by {simp}]
   rw [show complexContrBasis (Sum.inr 1) = complexContrBasisFin4 2 by {simp}]
   rw [show complexContrBasis (Sum.inr 2) = complexContrBasisFin4 3 by {simp}]
-  repeat rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
-  rw [← basis_up_eq, ← basis_up_eq]
-  repeat rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 1, 1, 1, 1, 1]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 1, 1, 1, 1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 1, 1, 1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 1, 1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [1, 2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
+  conv_lhs =>
+    enter [2]
+    rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+    rw [fromTripleT_apply_basis]
   rfl
 
 lemma pauliContr_eq_ofRat : pauliContr = ofRat (fun b =>

--- a/PhysLean/Relativity/PauliMatrices/Basic.lean
+++ b/PhysLean/Relativity/PauliMatrices/Basic.lean
@@ -93,30 +93,7 @@ lemma pauliContr_eq_basis : pauliContr =
   rw [show complexContrBasis (Sum.inr 2) = complexContrBasisFin4 3 by {simp}]
   repeat rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
   rw [← basis_up_eq, ← basis_up_eq]
-  conv_lhs =>
-    enter [1, 1, 1, 1, 1, 1, 1]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 1, 1, 1, 1, 1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 1, 1, 1, 1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 1, 1, 1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 1, 1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [1, 2]
-    rw [fromTripleT_apply_basis]
-  conv_lhs =>
-    enter [2]
-    rw [fromTripleT_apply_basis]
+  repeat rw [fromTripleT_apply_basis]
   rfl
 
 lemma pauliContr_eq_ofRat : pauliContr = ofRat (fun b =>

--- a/PhysLean/Relativity/PauliMatrices/Basic.lean
+++ b/PhysLean/Relativity/PauliMatrices/Basic.lean
@@ -74,6 +74,7 @@ lemma pauliContr_eq_fromTripleT : σ^^^ = fromTripleT PauliMatrix.asTensor := by
   rw [pauliContr_eq_fromConstTriple, fromConstTriple,
     congrArg fromTripleT PauliMatrix.asConsTensor_apply_one]
 
+set_option maxHeartbeats 0 in
 lemma pauliContr_eq_basis : pauliContr =
     Tensor.basis ![Color.up, Color.upL, Color.upR] (fun | 0 => 0 | 1 => 0 | 2 => 0)
     + Tensor.basis ![Color.up, Color.upL, Color.upR] (fun | 0 => 0 | 1 => 1 | 2 => 1)
@@ -90,30 +91,32 @@ lemma pauliContr_eq_basis : pauliContr =
   rw [show complexContrBasis (Sum.inr 0) = complexContrBasisFin4 1 by {simp}]
   rw [show complexContrBasis (Sum.inr 1) = complexContrBasisFin4 2 by {simp}]
   rw [show complexContrBasis (Sum.inr 2) = complexContrBasisFin4 3 by {simp}]
+  repeat rw [← basis_up_eq, ← basis_upL_eq, ← basis_upR_eq]
+  rw [← basis_up_eq, ← basis_up_eq]
   conv_lhs =>
     enter [1, 1, 1, 1, 1, 1, 1]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 1, 1, 1, 1, 1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 1, 1, 1, 1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 1, 1, 1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 1, 1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [1, 2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   conv_lhs =>
     enter [2]
-    erw [fromTripleT_apply_basis]
+    rw [fromTripleT_apply_basis]
   rfl
 
 lemma pauliContr_eq_ofRat : pauliContr = ofRat (fun b =>

--- a/PhysLean/Relativity/PauliMatrices/Basic.lean
+++ b/PhysLean/Relativity/PauliMatrices/Basic.lean
@@ -71,8 +71,8 @@ lemma pauliContr_eq_fromConstTriple : σ^^^ = fromConstTriple PauliMatrix.asCons
   rfl
 
 lemma pauliContr_eq_fromTripleT : σ^^^ = fromTripleT PauliMatrix.asTensor := by
-  rw [pauliContr_eq_fromConstTriple, fromConstTriple]
-  erw [PauliMatrix.asConsTensor_apply_one]
+  rw [pauliContr_eq_fromConstTriple, fromConstTriple,
+    congrArg fromTripleT PauliMatrix.asConsTensor_apply_one]
 
 lemma pauliContr_eq_basis : pauliContr =
     Tensor.basis ![Color.up, Color.upL, Color.upR] (fun | 0 => 0 | 1 => 0 | 2 => 0)

--- a/PhysLean/Relativity/PauliMatrices/Relations.lean
+++ b/PhysLean/Relativity/PauliMatrices/Relations.lean
@@ -46,7 +46,8 @@ lemma pauliCo_contr_pauliContr :
     simp only [Nat.reduceAdd, Nat.succ_eq_add_one, Fin.isValue, Fin.succAbove_zero,
       Function.comp_apply, cons_val_zero, cons_val_one, head_cons, ofRat_basis_repr_apply]
     rw [← PhysLean.RatComplexNum.toComplexNum.map_mul]
-    erw [PhysLean.RatComplexNum.ofNat_mul_toComplexNum 2]
+    change (2 : ℕ) * _
+    rw [PhysLean.RatComplexNum.ofNat_mul_toComplexNum 2]
   rw [contrT_basis_repr_apply]
   conv_lhs =>
     enter [2, x]

--- a/PhysLean/Relativity/PauliMatrices/Relations.lean
+++ b/PhysLean/Relativity/PauliMatrices/Relations.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 import PhysLean.Relativity.PauliMatrices.Basic
 /-!
 
-## Contractiong of indices of Pauli matrix.
+## Contracting of indices of Pauli matrix.
 
 The main result of this file is `pauliMatrix_contract_pauliMatrix` which states that
 `η_{μν} σ^{μ α dot β} σ^{ν α' dot β'} = 2 ε^{αα'} ε^{dot β dot β'}`.

--- a/PhysLean/Relativity/PauliMatrices/Relations.lean
+++ b/PhysLean/Relativity/PauliMatrices/Relations.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 import PhysLean.Relativity.PauliMatrices.Basic
 /-!
 
-## Contracting of indices of Pauli matrix.
+## Contraction of indices of Pauli matrix.
 
 The main result of this file is `pauliMatrix_contract_pauliMatrix` which states that
 `η_{μν} σ^{μ α dot β} σ^{ν α' dot β'} = 2 ε^{αα'} ε^{dot β dot β'}`.

--- a/PhysLean/Relativity/Tensors/ComplexTensor/Basic.lean
+++ b/PhysLean/Relativity/Tensors/ComplexTensor/Basic.lean
@@ -290,5 +290,30 @@ instance {n m : ℕ} {c : Fin n → complexLorentzTensor.C}
     Decidable (σ = σ') :=
   decidable_of_iff _ (OverColor.Hom.ext_iff σ σ')
 
+
+/-!
+
+## Relating basis
+
+-/
+
+lemma basis_up_eq {i : Fin 4} :
+    complexLorentzTensor.basis Color.up i = Lorentz.complexContrBasisFin4 i := rfl
+
+lemma basis_down_eq {i : Fin 4} :
+    complexLorentzTensor.basis Color.down i = Lorentz.complexCoBasisFin4 i := rfl
+
+lemma basis_upL_eq {i : Fin 2} :
+    complexLorentzTensor.basis Color.upL i = Fermion.leftBasis i := rfl
+
+lemma basis_downL_eq {i : Fin 2} :
+    complexLorentzTensor.basis Color.downL i = Fermion.altLeftBasis i := rfl
+
+lemma basis_upR_eq {i : Fin 2} :
+    complexLorentzTensor.basis Color.upR i = Fermion.rightBasis i := rfl
+
+lemma basis_downR_eq {i : Fin 2} :
+    complexLorentzTensor.basis Color.downR i = Fermion.altRightBasis i := rfl
+
 end complexLorentzTensor
 end


### PR DESCRIPTION
Toward https://github.com/HEPLean/PhysLean/issues/385