### PR TITLE
feat: setting up homogeneous media for EM

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -12,6 +12,7 @@ import PhysLean.Cosmology.FLRW.Basic
 import PhysLean.Electromagnetism.Basic
 import PhysLean.Electromagnetism.FieldStrength.Basic
 import PhysLean.Electromagnetism.FieldStrength.Derivative
+import PhysLean.Electromagnetism.Homogeneous
 import PhysLean.Electromagnetism.LorentzAction
 import PhysLean.Electromagnetism.MaxwellEquations
 import PhysLean.Mathematics.FDerivCurry

--- a/PhysLean/Electromagnetism/Basic.lean
+++ b/PhysLean/Electromagnetism/Basic.lean
@@ -28,4 +28,35 @@ open realLorentzTensor
 /-- The vector potential of an electromagnetic field-/
 abbrev VectorPotential (d : ℕ := 3) := SpaceTime d → ℝT[d, .up]
 
+/-- The electric permittivity and the magnetic permeability of free space. -/
+structure EMSystem where
+  /-- The permittivity of free space. -/
+  ε₀ : ℝ
+  /-- The permeability of free space. -/
+  μ₀ : ℝ
+
+TODO "6V2UZ" "Charge density and current density should be generalized to signed measures,
+  in such a way
+  that they are still easy to work with and can be integrated with with tensor notation.
+  See here:
+  https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLean/topic/Maxwell's.20Equations"
+
+/-- The charge density. -/
+abbrev ChargeDensity := Time → Space → ℝ
+
+/-- Current density. -/
+abbrev CurrentDensity := Time → Space → EuclideanSpace ℝ (Fin 3)
+
+namespace EMSystem
+variable (𝓔 : EMSystem)
+open SpaceTime
+
+/-- The speed of light. -/
+noncomputable def c : ℝ := 1/(√(𝓔.μ₀ * 𝓔.ε₀))
+
+/-- Coulomb's constant. -/
+noncomputable def coulombConstant : ℝ := 1/(4 * Real.pi * 𝓔.ε₀)
+
+end EMSystem
+
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -63,39 +63,35 @@ variable (OM : OpticalMedium)
 local notation "ε" => OM.ε
 local notation "μ" => OM.μ
 
-/-- An optical medium which is charge and current free. -/
-def IsFree (OM : OpticalMedium)
+/-- The Maxwell equations for charge and current free medium. -/
+def OpticalMedium.FreeMaxwellEquations (OM : OpticalMedium)
     (E : ElectricField) (B : MagneticField) : Prop :=
-    OM.free.ρ = 0 ∧ OM.free.J = 0 ∧
-    MaxwellEquations OM OM.free.ρ OM.free.J E B
+  MaxwellEquations OM OM.free.ρ OM.free.J E B
 
-/-- Maxwell's equations for charge and current free medium. -/
 theorem OpticalMedium.gaussLawElectric_of_free (E : ElectricField) (B : MagneticField)
-    (h : IsFree OM E B) :
+    (h : OM.FreeMaxwellEquations E B) :
     ε * (∇ ⬝ E t) x = 0 := by
-  have h' := h.2.2.1
-  unfold GaussLawElectric at h'
-  rw [h.1] at h'
-  simp_all
+  have h' := h.1
+  rw [h']
+  rfl
 
-theorem OpticalMedium.gaussLawMagnetic_of_isfree (E : ElectricField) (B : MagneticField)
-    (h : IsFree OM E B) :
+theorem OpticalMedium.gaussLawMagnetic_of_free (E : ElectricField) (B : MagneticField)
+    (h : OM.FreeMaxwellEquations E B) :
     (∇ ⬝ B t) x = 0 := by
-  have h' := h.2.2.2.1
-  unfold GaussLawMagnetic at h'
+  have h' := h.2.1
   rw [h']
 
-theorem OpticalMedium.ampereLaw_of_isfree (E : ElectricField) (B : MagneticField)
-    (h : IsFree OM E B) :
+theorem OpticalMedium.ampereLaw_of_free (E : ElectricField) (B : MagneticField)
+    (h : OM.FreeMaxwellEquations E B) :
     (∇ × B t) x = μ • ε • ∂ₜ (fun t => E t x) t := by
-  have h' := h.2.2.2.2.1
-  unfold AmpereLaw at h'
-  rw [h.2.1] at h'
+  have h' := h.2.2.1
+  rw [h']
   simp_all
+  right
+  rfl
 
-theorem OpticalMedium.faradayLaw_of_isfree (E : ElectricField) (B : MagneticField)
-    (h : IsFree OM E B) :
+theorem OpticalMedium.faradayLaw_of_free (E : ElectricField) (B : MagneticField)
+    (h : OM.FreeMaxwellEquations E B) :
     (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
-  have h' := h.2.2.2.2.2
-  unfold FaradayLaw at h'
+  have h' := h.2.2.2
   rw [h']

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -17,12 +17,6 @@ PhysLean.Electromagnetism.MaxwellEquations.
 
 namespace Electromagnetism
 
-namespace Homogeneous
-/-- Optical Medium has scalar electric permittivity as a function of space. -/
-structure OpticalMedium extends EMSystem where
-  /-- The electric permittivity of the material. -/
-  ε : Space → ℝ
-
 /-- Charged Medium is defined as Optical Medium with charge and current. -/
 structure ChargedMedium extends OpticalMedium where
   /-- The charge density. -/
@@ -33,86 +27,67 @@ structure ChargedMedium extends OpticalMedium where
 open Space
 open Time
 
-/-- Gauss's law for the Electric field in homogeneous medium. -/
-def GaussLawElectricHomogeneous (CM : ChargedMedium) (E : ElectricField) : Prop :=
-  ∀ t : Time, ∀ x : Space, CM.ε₀ * (∇ ⬝ E t) x = CM.ρ t x
-
-/-- Gauss's law for the Magnetic field in homogeneous medium. -/
-def GaussLawMagneticHomogeneous (B : MagneticField) : Prop :=
-  ∀ t : Time, ∀ x : Space, (∇ ⬝ B t) x = 0
-
-/-- Ampère's law in homogeneous medium. -/
-def AmpereLawHomogeneous (CM : ChargedMedium)
-    (E : ElectricField) (B : MagneticField) : Prop :=
-  ∀ t : Time, ∀ x : Space, (∇ × B t) x =
-  CM.μ₀ • (CM.J t x + CM.ε₀ • ∂ₜ (fun t => E t x) t)
-
-/-- Faraday's law in homogeneous medium. -/
-def FaradayLawHomogeneous (E : ElectricField) (B : MagneticField) : Prop :=
-  ∀ t : Time, ∀ x : Space, (∇ × E t) x = - ∂ₜ (fun t => B t x) t
-
-/-!
-## Equivalence of bundled and unbundled versions of Maxwell's Equations.
--/
-def ChargedMedium.𝓔 (CM : ChargedMedium) : EMSystem where
-  μ₀ := CM.μ₀
-  ε₀ := CM.ε₀
-
 variable (CM : ChargedMedium)
 
-lemma GaussLawElectricHomogeneousEquiv :
-    GaussLawElectricHomogeneous CM = GaussLawElectric CM.𝓔 CM.ρ := by
-  rfl
+/-- Gauss's law for the Electric field in homogeneous medium. -/
+abbrev ChargedMedium.GaussLawElectric (E : ElectricField) : Prop :=
+  Electromagnetism.GaussLawElectric CM.toOpticalMedium CM.ρ E
 
-lemma GaussLawMagneticHomogeneousEquiv :
-    GaussLawMagneticHomogeneous = GaussLawMagnetic := by
-  rfl
+/-- Gauss's law for the Magnetic field in homogeneous medium. -/
+abbrev ChargedMedium.GaussLawMagnetic (CM : ChargedMedium)
+    (B : MagneticField) : Prop :=
+  Electromagnetism.GaussLawMagnetic B
 
-lemma AmpereLawHomogeneousEquiv :
-    AmpereLawHomogeneous CM = AmpereLaw CM.𝓔 CM.J := by
-  rfl
+/-- Ampère's law in homogeneous medium. -/
+abbrev ChargedMedium.AmpereLaw (CM : ChargedMedium)
+    (E : ElectricField) (B : MagneticField) : Prop :=
+  Electromagnetism.AmpereLaw CM.toOpticalMedium CM.J E B
 
-lemma FaradayLawHomogeneousEquiv :
-    FaradayLawHomogeneous = FaradayLaw := by
-  rfl
+/-- Faraday's law in homogeneous medium. -/
+abbrev ChargedMedium.FaradayLaw (CM : ChargedMedium)
+    (E : ElectricField) (B : MagneticField) : Prop :=
+  Electromagnetism.FaradayLaw E B
 
 /-!
-## Maxwell's equations for optical medium
+## Maxwell's equations for charge and current free medium
 -/
 /-- Optical medium defined as charge and current free charged medium. -/
 def OpticalMedium.free (OM : OpticalMedium) : ChargedMedium where
-  μ₀ := OM.μ₀
-  ε₀ := OM.ε₀
+  μ := OM.μ
   ε := OM.ε
   ρ := fun _ _ => 0
   J := fun _ _ => 0
 
 variable (OM : OpticalMedium)
 
-local notation "ε₀" => OM.free.ε₀
-local notation "μ₀" => OM.free.μ₀
+local notation "ε" => OM.free.ε
+local notation "μ" => OM.free.μ
 
 /-- Maxwell's equations for free space. -/
-theorem GaussLawElectricFree (E : ElectricField)
-    (h : GaussLawElectricHomogeneous OM.free E) :
-    ε₀ * (∇ ⬝ E t) x = 0 := by
+theorem ChargedMedium.gaussLawElectric_of_free (E : ElectricField)
+    (h : OM.free.GaussLawElectric E) :
+    ε x * (∇ ⬝ E t) x = 0 := by
   rw [h]
   rfl
 
-theorem GaussLawMagneticFree (B : MagneticField)
-    (h : GaussLawMagneticHomogeneous B) :
+theorem ChargedMedium.gaussLawMagnetic_of_free (B : MagneticField)
+    (h : OM.free.GaussLawMagnetic B) :
     (∇ ⬝ B t) x = 0 := by
   rw [h]
 
-theorem AmpereLawFree (E : ElectricField) (B : MagneticField)
-    (h : AmpereLawHomogeneous OM.free E B) :
-    (∇ × B t) x = μ₀ • ε₀ • ∂ₜ (fun t => E t x) t := by
+theorem ChargedMedium.ampereLaw_of_free (E : ElectricField) (B : MagneticField)
+    (h : OM.free.AmpereLaw E B) :
+    (∇ × B t) x = μ x • ε x • ∂ₜ (fun t => E t x) t := by
   rw [h]
   simp only [smul_add, add_eq_right, smul_eq_zero]
   right
   rfl
 
-theorem FaradayLawFree (E : ElectricField) (B : MagneticField)
-    (h : FaradayLawHomogeneous E B) :
+theorem ChargedMedium.faradayLaw_of_free (E : ElectricField) (B : MagneticField)
+    (h : OM.free.FaradayLaw E B) :
     (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
   rw [h]
+
+def OpticalMedium.isFree (E : ElectricField) (B : MagneticField) : Prop :=
+    OM.free.GaussLawElectric E ∧ OM.free.GaussLawMagnetic B ∧
+    OM.free.AmpereLaw E B ∧ OM.free.FaradayLaw E B

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -88,6 +88,6 @@ theorem ChargedMedium.faradayLaw_of_free (E : ElectricField) (B : MagneticField)
     (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
   rw [h]
 
-def OpticalMedium.isFree (E : ElectricField) (B : MagneticField) : Prop :=
+def IsFree (OM : OpticalMedium) (E : ElectricField) (B : MagneticField) : Prop :=
     OM.free.GaussLawElectric E ∧ OM.free.GaussLawMagnetic B ∧
     OM.free.AmpereLaw E B ∧ OM.free.FaradayLaw E B

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -34,7 +34,7 @@ abbrev ChargedMedium.GaussLawElectric (E : ElectricField) : Prop :=
   Electromagnetism.GaussLawElectric CM.toOpticalMedium CM.ρ E
 
 /-- Gauss's law for the Magnetic field in homogeneous medium. -/
-abbrev ChargedMedium.GaussLawMagnetic (CM : ChargedMedium)
+abbrev ChargedMedium.GaussLawMagnetic
     (B : MagneticField) : Prop :=
   Electromagnetism.GaussLawMagnetic B
 
@@ -44,7 +44,7 @@ abbrev ChargedMedium.AmpereLaw (CM : ChargedMedium)
   Electromagnetism.AmpereLaw CM.toOpticalMedium CM.J E B
 
 /-- Faraday's law in homogeneous medium. -/
-abbrev ChargedMedium.FaradayLaw (CM : ChargedMedium)
+abbrev ChargedMedium.FaradayLaw
     (E : ElectricField) (B : MagneticField) : Prop :=
   Electromagnetism.FaradayLaw E B
 
@@ -60,34 +60,42 @@ def OpticalMedium.free (OM : OpticalMedium) : ChargedMedium where
 
 variable (OM : OpticalMedium)
 
-local notation "ε" => OM.free.ε
-local notation "μ" => OM.free.μ
+local notation "ε" => OM.ε
+local notation "μ" => OM.μ
 
-/-- Maxwell's equations for free space. -/
-theorem ChargedMedium.gaussLawElectric_of_free (E : ElectricField)
-    (h : OM.free.GaussLawElectric E) :
-    ε x * (∇ ⬝ E t) x = 0 := by
-  rw [h]
-  rfl
+/-- An optical medium which is charge and current free. -/
+def IsFree (OM : OpticalMedium)
+    (E : ElectricField) (B : MagneticField) : Prop :=
+    OM.free.ρ = 0 ∧ OM.free.J = 0 ∧
+    MaxwellEquations OM OM.free.ρ OM.free.J E B
 
-theorem ChargedMedium.gaussLawMagnetic_of_free (B : MagneticField)
-    (h : OM.free.GaussLawMagnetic B) :
+/-- Maxwell's equations for charge and current free medium. -/
+theorem OpticalMedium.gaussLawElectric_of_free (E : ElectricField) (B : MagneticField)
+    (h : IsFree OM E B) :
+    ε * (∇ ⬝ E t) x = 0 := by
+  have h' := h.2.2.1
+  unfold GaussLawElectric at h'
+  rw [h.1] at h'
+  simp_all
+
+theorem OpticalMedium.gaussLawMagnetic_of_isfree (E : ElectricField) (B : MagneticField)
+    (h : IsFree OM E B) :
     (∇ ⬝ B t) x = 0 := by
-  rw [h]
+  have h' := h.2.2.2.1
+  unfold GaussLawMagnetic at h'
+  rw [h']
 
-theorem ChargedMedium.ampereLaw_of_free (E : ElectricField) (B : MagneticField)
-    (h : OM.free.AmpereLaw E B) :
-    (∇ × B t) x = μ x • ε x • ∂ₜ (fun t => E t x) t := by
-  rw [h]
-  simp only [smul_add, add_eq_right, smul_eq_zero]
-  right
-  rfl
+theorem OpticalMedium.ampereLaw_of_isfree (E : ElectricField) (B : MagneticField)
+    (h : IsFree OM E B) :
+    (∇ × B t) x = μ • ε • ∂ₜ (fun t => E t x) t := by
+  have h' := h.2.2.2.2.1
+  unfold AmpereLaw at h'
+  rw [h.2.1] at h'
+  simp_all
 
-theorem ChargedMedium.faradayLaw_of_free (E : ElectricField) (B : MagneticField)
-    (h : OM.free.FaradayLaw E B) :
+theorem OpticalMedium.faradayLaw_of_isfree (E : ElectricField) (B : MagneticField)
+    (h : IsFree OM E B) :
     (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
-  rw [h]
-
-def IsFree (OM : OpticalMedium) (E : ElectricField) (B : MagneticField) : Prop :=
-    OM.free.GaussLawElectric E ∧ OM.free.GaussLawMagnetic B ∧
-    OM.free.AmpereLaw E B ∧ OM.free.FaradayLaw E B
+  have h' := h.2.2.2.2.2
+  unfold FaradayLaw at h'
+  rw [h']

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -17,7 +17,7 @@ PhysLean.Electromagnetism.MaxwellEquations.
 
 namespace Electromagnetism
 
-namespace HomogeneousEM
+namespace Homogeneous
 /-- Optical Medium has scalar electric permittivity as a function of space. -/
 structure OpticalMedium extends EMSystem where
   /-- The electric permittivity of the material. -/
@@ -87,14 +87,14 @@ def OpticalMedium.free (OM : OpticalMedium) : ChargedMedium where
   ρ := fun _ _ => 0
   J := fun _ _ => 0
 
-variable (FS : OpticalMedium)
+variable (OM : OpticalMedium)
 
-local notation "ε₀" => FS.free.ε₀
-local notation "μ₀" => FS.free.μ₀
+local notation "ε₀" => OM.free.ε₀
+local notation "μ₀" => OM.free.μ₀
 
 /-- Maxwell's equations for free space. -/
 theorem GaussLawElectricFree (E : ElectricField)
-    (h : GaussLawElectricHomogeneous FS.free E) :
+    (h : GaussLawElectricHomogeneous OM.free E) :
     ε₀ * (∇ ⬝ E t) x = 0 := by
   rw [h]
   rfl
@@ -105,7 +105,7 @@ theorem GaussLawMagneticFree (B : MagneticField)
   rw [h]
 
 theorem AmpereLawFree (E : ElectricField) (B : MagneticField)
-    (h : AmpereLawHomogeneous FS.free E B) :
+    (h : AmpereLawHomogeneous OM.free E B) :
     (∇ × B t) x = μ₀ • ε₀ • ∂ₜ (fun t => E t x) t := by
   rw [h]
   simp only [smul_add, add_eq_right, smul_eq_zero]

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2025 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+import PhysLean.ClassicalMechanics.VectorFields
+import PhysLean.Electromagnetism.MaxwellEquations
+/-!
+# Electromagnetism in Homogeneous medium
+
+Basic properties for homogeneous medium and free space.
+
+Variables are bundled in structure, for unbundled version use
+PhysLean.Electromagnetism.MaxwellEquations.
+
+-/
+
+namespace Electromagnetism
+
+namespace HomogeneousEM
+/-- Optical Medium has scalar electric permittivity as a function of space. -/
+structure OpticalMedium extends EMSystem where
+  /-- The electric permittivity of the material. -/
+  ε : Space → ℝ
+
+/-- Charged Medium is defined as Optical Medium with charge and current. -/
+structure ChargedMedium extends OpticalMedium where
+  /-- The charge density. -/
+  ρ : ChargeDensity
+  /-- The current density. -/
+  J : CurrentDensity
+
+open Space
+open Time
+
+/-- Gauss's law for the Electric field in homogeneous medium. -/
+def GaussLawElectricHomogeneous (CM : ChargedMedium) (E : ElectricField) : Prop :=
+  ∀ t : Time, ∀ x : Space, CM.ε₀ * (∇ ⬝ E t) x = CM.ρ t x
+
+/-- Gauss's law for the Magnetic field in homogeneous medium. -/
+def GaussLawMagneticHomogeneous (B : MagneticField) : Prop :=
+  ∀ t : Time, ∀ x : Space, (∇ ⬝ B t) x = 0
+
+/-- Ampère's law in homogeneous medium. -/
+def AmpereLawHomogeneous (CM : ChargedMedium)
+    (E : ElectricField) (B : MagneticField) : Prop :=
+  ∀ t : Time, ∀ x : Space, (∇ × B t) x =
+  CM.μ₀ • (CM.J t x + CM.ε₀ • ∂ₜ (fun t => E t x) t)
+
+/-- Faraday's law in homogeneous medium. -/
+def FaradayLawHomogeneous (E : ElectricField) (B : MagneticField) : Prop :=
+  ∀ t : Time, ∀ x : Space, (∇ × E t) x = - ∂ₜ (fun t => B t x) t
+
+/-!
+## Equivalence of bundled and unbundled versions of Maxwell's Equations.
+-/
+def ChargedMedium.𝓔 (CM : ChargedMedium) : EMSystem where
+  μ₀ := CM.μ₀
+  ε₀ := CM.ε₀
+
+variable (CM : ChargedMedium)
+
+lemma GaussLawElectricHomogeneousEquiv :
+    GaussLawElectricHomogeneous CM = GaussLawElectric CM.𝓔 CM.ρ := by
+  rfl
+
+lemma GaussLawMagneticHomogeneousEquiv :
+    GaussLawMagneticHomogeneous = GaussLawMagnetic := by
+  rfl
+
+lemma AmpereLawHomogeneousEquiv :
+    AmpereLawHomogeneous CM = AmpereLaw CM.𝓔 CM.J := by
+  rfl
+
+lemma FaradayLawHomogeneousEquiv :
+    FaradayLawHomogeneous = FaradayLaw := by
+  rfl
+
+/-!
+## Maxwell's equations for optical medium
+-/
+/-- Optical medium defined as charge and current free charged medium. -/
+def OpticalMedium.free (OM : OpticalMedium) : ChargedMedium where
+  μ₀ := OM.μ₀
+  ε₀ := OM.ε₀
+  ε := OM.ε
+  ρ := fun _ _ => 0
+  J := fun _ _ => 0
+
+variable (FS : OpticalMedium)
+
+local notation "ε₀" => FS.free.ε₀
+local notation "μ₀" => FS.free.μ₀
+
+/-- Maxwell's equations for free space. -/
+theorem GaussLawElectricFree (E : ElectricField)
+    (h : GaussLawElectricHomogeneous FS.free E) :
+    ε₀ * (∇ ⬝ E t) x = 0 := by
+  rw [h]
+  rfl
+
+theorem GaussLawMagneticFree (B : MagneticField)
+    (h : GaussLawMagneticHomogeneous B) :
+    (∇ ⬝ B t) x = 0 := by
+  rw [h]
+
+theorem AmpereLawFree (E : ElectricField) (B : MagneticField)
+    (h : AmpereLawHomogeneous FS.free E B) :
+    (∇ × B t) x = μ₀ • ε₀ • ∂ₜ (fun t => E t x) t := by
+  rw [h]
+  simp only [smul_add, add_eq_right, smul_eq_zero]
+  right
+  rfl
+
+theorem FaradayLawFree (E : ElectricField) (B : MagneticField)
+    (h : FaradayLawHomogeneous E B) :
+    (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
+  rw [h]

--- a/PhysLean/Electromagnetism/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/MaxwellEquations.lean
@@ -19,9 +19,9 @@ namespace Electromagnetism
   and the magnetic permeability. -/
 structure OpticalMedium where
   /-- The permittivity. -/
-  ε : Space → ℝ
+  ε : ℝ
   /-- The permeability. -/
-  μ : Space → ℝ
+  μ : ℝ
 
 variable (𝓔 : OpticalMedium) (ρ : ChargeDensity) (J : CurrentDensity)
 open SpaceTime
@@ -32,7 +32,7 @@ open Time
 
 /-- Gauss's law for the Electric field. -/
 def GaussLawElectric (E : ElectricField) : Prop :=
-  ∀ t : Time, ∀ x : Space, ε x * (∇ ⬝ E t) x = ρ t x
+  ∀ t : Time, ∀ x : Space, ε * (∇ ⬝ E t) x = ρ t x
 
 /-- Gauss's law for the Magnetic field. -/
 def GaussLawMagnetic (B : MagneticField) : Prop :=
@@ -40,7 +40,7 @@ def GaussLawMagnetic (B : MagneticField) : Prop :=
 
 /-- Ampère's law. -/
 def AmpereLaw (E : ElectricField) (B : MagneticField) : Prop :=
-  ∀ t : Time, ∀ x : Space, (∇ × B t) x = μ x • (J t x + ε x • ∂ₜ (fun t => E t x) t)
+  ∀ t : Time, ∀ x : Space, (∇ × B t) x = μ • (J t x + ε • ∂ₜ (fun t => E t x) t)
 
 /-- Faraday's law. -/
 def FaradayLaw (E : ElectricField) (B : MagneticField) : Prop :=
@@ -49,7 +49,7 @@ def FaradayLaw (E : ElectricField) (B : MagneticField) : Prop :=
 /-- Maxwell's equations. -/
 def MaxwellEquations (E : ElectricField) (B : MagneticField) : Prop :=
   GaussLawElectric 𝓔 ρ E ∧ GaussLawMagnetic B ∧
-  FaradayLaw E B ∧ AmpereLaw 𝓔 J E B
+  AmpereLaw 𝓔 J E B ∧ FaradayLaw E B
 
 TODO "6V2VD" "Show that if the charge density is spherically symmetric,
   then the electric field is also spherically symmetric."

--- a/PhysLean/Electromagnetism/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/MaxwellEquations.lean
@@ -14,7 +14,6 @@ Note that currently OpticalMedium is assumed to be isotropic.
 
 namespace Electromagnetism
 
-
 /-- An optcial medium consists of the electric permittivity
   and the magnetic permeability. -/
 structure OpticalMedium where

--- a/PhysLean/Electromagnetism/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/MaxwellEquations.lean
@@ -8,52 +8,31 @@ import PhysLean.Electromagnetism.Basic
 
 # Maxwell's equations
 
+Note that currently OpticalMedium is assumed to be isotropic.
+
 -/
 
 namespace Electromagnetism
 
-/-- An electromagnetic system consists of the electric permittivity
+
+/-- An optcial medium consists of the electric permittivity
   and the magnetic permeability. -/
-structure EMSystem where
+structure OpticalMedium where
   /-- The permittivity. -/
-  ε₀ : ℝ
+  ε : Space → ℝ
   /-- The permeability. -/
-  μ₀ : ℝ
+  μ : Space → ℝ
 
-TODO "6V2UZ" "Charge density and current density should be generalized to signed measures,
-  in such a way
-  that they are still easy to work with and can be integrated with with tensor notation.
-  See here:
-  https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLean/topic/Maxwell's.20Equations"
-
-/-- The charge density. -/
-abbrev ChargeDensity := Time → Space → ℝ
-
-/-- Current density. -/
-abbrev CurrentDensity := Time → Space → EuclideanSpace ℝ (Fin 3)
-
-namespace EMSystem
-variable (𝓔 : EMSystem)
+variable (𝓔 : OpticalMedium) (ρ : ChargeDensity) (J : CurrentDensity)
 open SpaceTime
 
-/-- The speed of light. -/
-noncomputable def c : ℝ := 1/(√(𝓔.μ₀ * 𝓔.ε₀))
-
-/-- Coulomb's constant. -/
-noncomputable def coulombConstant : ℝ := 1/(4 * Real.pi * 𝓔.ε₀)
-
-end EMSystem
-
-variable (𝓔 : EMSystem) (ρ : ChargeDensity) (J : CurrentDensity)
-open SpaceTime
-
-local notation "ε₀" => 𝓔.ε₀
-local notation "μ₀" => 𝓔.μ₀
+local notation "ε" => 𝓔.ε
+local notation "μ" => 𝓔.μ
 open Time
 
 /-- Gauss's law for the Electric field. -/
 def GaussLawElectric (E : ElectricField) : Prop :=
-  ∀ t : Time, ∀ x : Space, ε₀ * (∇ ⬝ E t) x = ρ t x
+  ∀ t : Time, ∀ x : Space, ε x * (∇ ⬝ E t) x = ρ t x
 
 /-- Gauss's law for the Magnetic field. -/
 def GaussLawMagnetic (B : MagneticField) : Prop :=
@@ -61,7 +40,7 @@ def GaussLawMagnetic (B : MagneticField) : Prop :=
 
 /-- Ampère's law. -/
 def AmpereLaw (E : ElectricField) (B : MagneticField) : Prop :=
-  ∀ t : Time, ∀ x : Space, (∇ × B t) x = μ₀ • (J t x + ε₀ • ∂ₜ (fun t => E t x) t)
+  ∀ t : Time, ∀ x : Space, (∇ × B t) x = μ x • (J t x + ε x • ∂ₜ (fun t => E t x) t)
 
 /-- Faraday's law. -/
 def FaradayLaw (E : ElectricField) (B : MagneticField) : Prop :=

--- a/PhysLean/Electromagnetism/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/MaxwellEquations.lean
@@ -12,13 +12,13 @@ import PhysLean.Electromagnetism.Basic
 
 namespace Electromagnetism
 
-/-- An electromagnetic system consists of charge density, a current density,
-  the speed of light and the electric permittivity. -/
+/-- An electromagnetic system consists of the electric permittivity
+  and the magnetic permeability. -/
 structure EMSystem where
-  /-- The speed of light. -/
-  c : ℝ
   /-- The permittivity. -/
   ε₀ : ℝ
+  /-- The permeability. -/
+  μ₀ : ℝ
 
 TODO "6V2UZ" "Charge density and current density should be generalized to signed measures,
   in such a way
@@ -36,8 +36,8 @@ namespace EMSystem
 variable (𝓔 : EMSystem)
 open SpaceTime
 
-/-- The permeability. -/
-noncomputable def μ₀ : ℝ := 1/(𝓔.c^2 * 𝓔.ε₀)
+/-- The speed of light. -/
+noncomputable def c : ℝ := 1/(√(𝓔.μ₀ * 𝓔.ε₀))
 
 /-- Coulomb's constant. -/
 noncomputable def coulombConstant : ℝ := 1/(4 * Real.pi * 𝓔.ε₀)

--- a/PhysLean/Electromagnetism/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/MaxwellEquations.lean
@@ -8,13 +8,15 @@ import PhysLean.Electromagnetism.Basic
 
 # Maxwell's equations
 
-Note that currently OpticalMedium is assumed to be isotropic.
+Note that currently the equations are defined for isotropic and homogeneous domains.
 
 -/
 
 namespace Electromagnetism
 
-/-- An optcial medium consists of the electric permittivity
+/-- An optcial medium refers to an isotropic medium
+  (which may or may not be free space)
+  which consists of the electric permittivity
   and the magnetic permeability. -/
 structure OpticalMedium where
   /-- The permittivity. -/


### PR DESCRIPTION
attempt at setting this up.  thought process is as follows:

1. redefine Maxwell's with respect to bundled `ChargedMedium` structure as `GaussLawElectricHomogeneous`, `GaussLawMagneticHomogeneous` etc.
2. show that this is equivalent to original formulation with the variables from bundled structure
3. we can then "embed" (not sure what's the right word) optical medium into charged medium and obtain charge and current free Maxwell's equations

Please check if this makes sense and feel free to make suggestions :)