### PR TITLE
refactor: make `σ0` an abbrev for `1`

### DIFF
--- a/PhysLean/Relativity/PauliMatrices/AsTensor.lean
+++ b/PhysLean/Relativity/PauliMatrices/AsTensor.lean
@@ -43,7 +43,7 @@ lemma asTensor_expand_complexContrBasis : asTensor =
 lemma leftRightToMatrix_σSA_inl_0_expand : leftRightToMatrix.symm (σSA (Sum.inl 0)) =
     leftBasis 0 ⊗ₜ rightBasis 0 + leftBasis 1 ⊗ₜ rightBasis 1 := by
   rw [leftRightToMatrix_symm_expand_tmul]
-  simp only [σSA, Fin.isValue, Basis.coe_mk, σSA', σ0, of_apply, cons_val', empty_val',
+  simp only [σSA, Fin.isValue, Basis.coe_mk, σSA', σ0, one_fin_two, of_apply, cons_val', empty_val',
     cons_val_fin_one, Fin.sum_univ_two, cons_val_zero, cons_val_one, head_cons, one_smul, zero_smul,
     add_zero, head_fin_const, zero_add, CategoryTheory.Equivalence.symm_inverse,
     Action.functorCategoryEquivalence_functor, Action.FunctorCategoryEquivalence.functor_obj_obj]

--- a/PhysLean/Relativity/PauliMatrices/Matrix.lean
+++ b/PhysLean/Relativity/PauliMatrices/Matrix.lean
@@ -18,8 +18,10 @@ open Complex
 open Matrix
 
 /-- The zeroth Pauli-matrix as a `2 x 2` complex matrix.
-  That is the matrix `!![1, 0; 0, 1]`. -/
-def σ0 : Matrix (Fin 2) (Fin 2) ℂ := !![1, 0; 0, 1]
+  That is the matrix `!![1, 0; 0, 1]`, which in Lean is more conveniently written `1`. -/
+abbrev σ0 : Matrix (Fin 2) (Fin 2) ℂ := 1
+
+lemma σ0_eq : σ0 = !![1, 0; 0, 1] := one_fin_two
 
 /-- The first Pauli-matrix as a `2 x 2` complex matrix.
   That is, the matrix `!![0, 1; 1, 0]`. -/
@@ -34,10 +36,7 @@ def σ2 : Matrix (Fin 2) (Fin 2) ℂ := !![0, -I; I, 0]
 def σ3 : Matrix (Fin 2) (Fin 2) ℂ := !![1, 0; 0, -1]
 
 /-- The conjugate transpose of `σ0` is equal to `σ0`. -/
-@[simp]
-lemma σ0_selfAdjoint : σ0ᴴ = σ0 := by
-  rw [eta_fin_two σ0ᴴ]
-  simp [σ0]
+lemma σ0_selfAdjoint : σ0ᴴ = σ0 := by simp
 
 /-- The conjugate transpose of `σ1` is equal to `σ1`. -/
 @[simp]
@@ -77,33 +76,24 @@ We skip `σ0` since it's just `1` anyway.
 
 -/
 
+@[simp] lemma trace_σ1 : Matrix.trace σ1 = 0 := by simp [σ1]
+@[simp] lemma trace_σ2 : Matrix.trace σ2 = 0 := by simp [σ2]
+@[simp] lemma trace_σ3 : Matrix.trace σ3 = 0 := by simp [σ3]
+
 /-- The trace of `σ0` multiplied by `σ0` is equal to `2`. -/
-@[simp]
-lemma σ0_σ0_trace : Matrix.trace (σ0 * σ0) = 2 := by
-  simp only [σ0, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons, one_smul,
-    tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul, Equiv.symm_apply_apply,
-    trace_fin_two_of]
-  norm_num
+lemma σ0_σ0_trace : Matrix.trace (σ0 * σ0) = 2 := by simp
 
 /-- The trace of `σ0` multiplied by `σ1` is equal to `0`. -/
-@[simp]
-lemma σ0_σ1_trace : Matrix.trace (σ0 * σ1) = 0 := by
-  simp [σ0, σ1]
+lemma σ0_σ1_trace : Matrix.trace (σ0 * σ1) = 0 := by simp
 
 /-- The trace of `σ0` multiplied by `σ2` is equal to `0`. -/
-@[simp]
-lemma σ0_σ2_trace : Matrix.trace (σ0 * σ2) = 0 := by
-  simp [σ0, σ2]
+lemma σ0_σ2_trace : Matrix.trace (σ0 * σ2) = 0 := by simp
 
 /-- The trace of `σ0` multiplied by `σ3` is equal to `0`. -/
-@[simp]
-lemma σ0_σ3_trace : Matrix.trace (σ0 * σ3) = 0 := by
-  simp [σ0, σ3]
+lemma σ0_σ3_trace : Matrix.trace (σ0 * σ3) = 0 := by simp
 
 /-- The trace of `σ1` multiplied by `σ0` is equal to `0`. -/
-@[simp]
-lemma σ1_σ0_trace : Matrix.trace (σ1 * σ0) = 0 := by
-  simp [σ1, σ0]
+lemma σ1_σ0_trace : Matrix.trace (σ1 * σ0) = 0 := by simp
 
 /-- The trace of `σ1` multiplied by `σ1` is equal to `2`. -/
 lemma σ1_σ1_trace : Matrix.trace (σ1 * σ1) = 2 := by simp
@@ -119,9 +109,7 @@ lemma σ1_σ3_trace : Matrix.trace (σ1 * σ3) = 0 := by
   simp [σ1, σ3]
 
 /-- The trace of `σ2` multiplied by `σ0` is equal to `0`. -/
-@[simp]
-lemma σ2_σ0_trace : Matrix.trace (σ2 * σ0) = 0 := by
-  simp [σ2, σ0]
+lemma σ2_σ0_trace : Matrix.trace (σ2 * σ0) = 0 := by simp
 
 /-- The trace of `σ2` multiplied by `σ1` is equal to `0`. -/
 lemma σ2_σ1_trace : Matrix.trace (σ2 * σ1) = 0 := by
@@ -136,9 +124,7 @@ lemma σ2_σ3_trace : Matrix.trace (σ2 * σ3) = 0 := by
   simp [σ2, σ3]
 
 /-- The trace of `σ3` multiplied by `σ0` is equal to `0`. -/
-@[simp]
-lemma σ3_σ0_trace : Matrix.trace (σ3 * σ0) = 0 := by
-  simp [σ3, σ0]
+lemma σ3_σ0_trace : Matrix.trace (σ3 * σ0) = 0 := by simp
 
 /-- The trace of `σ3` multiplied by `σ1` is equal to `0`. -/
 lemma σ3_σ1_trace : Matrix.trace (σ3 * σ1) = 0 := by simp

--- a/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
+++ b/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
@@ -22,65 +22,20 @@ lemma selfAdjoint_trace_σ0_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) 
 /-- The trace of `σ1` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ1_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
     (Matrix.trace (σ1 * A.1)).re = Matrix.trace (σ1 * A.1) := by
-  rw [eta_fin_two A.1]
-  simp only [σ1, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons,
-    one_smul, tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul,
-    Equiv.symm_apply_apply, trace_fin_two_of, Complex.add_re, Complex.ofReal_add]
-  have hA : IsSelfAdjoint A.1 := A.2
-  rw [isSelfAdjoint_iff, star_eq_conjTranspose] at hA
-  rw [eta_fin_two (A.1)ᴴ] at hA
-  simp only [Fin.isValue, conjTranspose_apply, RCLike.star_def] at hA
-  have h01 := congrArg (fun f => f 0 1) hA
-  simp only [Fin.isValue, of_apply, cons_val', cons_val_one, head_cons, empty_val',
-    cons_val_fin_one, cons_val_zero] at h01
-  rw [← h01]
-  simp only [Fin.isValue, Complex.conj_re]
-  rw [Complex.add_conj]
-  simp only [Fin.isValue, Complex.ofReal_mul, Complex.ofReal_ofNat]
-  ring
+  rw [← Complex.conj_eq_iff_re, starRingEnd_apply, ← trace_conjTranspose, conjTranspose_mul,
+    σ1_selfAdjoint, ← star_eq_conjTranspose, A.2, trace_mul_comm]
 
 /-- The trace of `σ2` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ2_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
     (Matrix.trace (σ2 * A.1)).re = Matrix.trace (σ2 * A.1) := by
-  rw [eta_fin_two A.1]
-  simp only [σ2, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons,
-    one_smul, tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul,
-    Equiv.symm_apply_apply, trace_fin_two_of, Complex.add_re, Complex.ofReal_add]
-  have hA : IsSelfAdjoint A.1 := A.2
-  rw [isSelfAdjoint_iff, star_eq_conjTranspose, eta_fin_two (A.1)ᴴ] at hA
-  simp only [Fin.isValue, conjTranspose_apply, RCLike.star_def] at hA
-  have h10 := congrArg (fun f => f 1 0) hA
-  simp only [Fin.isValue, of_apply, cons_val', cons_val_zero, empty_val', cons_val_fin_one,
-    cons_val_one, head_fin_const] at h10
-  rw [← h10]
-  simp only [Fin.isValue, neg_smul, smul_cons, smul_eq_mul, smul_empty, neg_cons, neg_empty,
-    trace_fin_two_of, Complex.add_re, Complex.neg_re, Complex.mul_re, Complex.I_re, Complex.conj_re,
-    zero_mul, Complex.I_im, Complex.conj_im, mul_neg, one_mul, sub_neg_eq_add, zero_add, zero_sub,
-    Complex.ofReal_add, Complex.ofReal_neg]
-  trans Complex.I * (A.1 0 1 - (starRingEnd ℂ) (A.1 0 1))
-  · rw [Complex.sub_conj]
-    ring_nf
-    simp
-  · ring
+  rw [← Complex.conj_eq_iff_re, starRingEnd_apply, ← trace_conjTranspose, conjTranspose_mul,
+    σ2_selfAdjoint, ← star_eq_conjTranspose, A.2, trace_mul_comm]
 
 /-- The trace of `σ3` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ3_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
     (Matrix.trace (σ3 * A.1)).re = Matrix.trace (σ3 * A.1) := by
-  rw [eta_fin_two A.1]
-  simp only [σ3, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons,
-    one_smul, tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul,
-    Equiv.symm_apply_apply, trace_fin_two_of, Complex.add_re, Complex.ofReal_add]
-  have hA : IsSelfAdjoint A.1 := A.2
-  rw [isSelfAdjoint_iff, star_eq_conjTranspose, eta_fin_two (A.1)ᴴ] at hA
-  simp only [Fin.isValue, conjTranspose_apply, RCLike.star_def] at hA
-  have h00 := congrArg (fun f => f 0 0) hA
-  have h11 := congrArg (fun f => f 1 1) hA
-  have hA00 : A.1 0 0 = (A.1 0 0).re := Eq.symm ((fun {z} => Complex.conj_eq_iff_re.mp) h00)
-  have hA11 : A.1 1 1 = (A.1 1 1).re := Eq.symm ((fun {z} => Complex.conj_eq_iff_re.mp) h11)
-  simp only [Fin.isValue, neg_smul, one_smul, neg_cons, neg_empty, trace_fin_two_of, Complex.add_re,
-    Complex.neg_re, Complex.ofReal_add, Complex.ofReal_neg]
-  rw [hA00, hA11]
-  simp
+  rw [← Complex.conj_eq_iff_re, starRingEnd_apply, ← trace_conjTranspose, conjTranspose_mul,
+    σ3_selfAdjoint, ← star_eq_conjTranspose, A.2, trace_mul_comm]
 
 open Complex
 

--- a/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
+++ b/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
@@ -16,25 +16,9 @@ open Matrix
 /-- The trace of `σ0` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ0_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
     (Matrix.trace (σ0 * A.1)).re = Matrix.trace (σ0 * A.1) := by
-  rw [eta_fin_two A.1]
-  simp only [σ0, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons,
-    one_smul, tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul,
-    Equiv.symm_apply_apply, trace_fin_two_of, Complex.add_re, Complex.ofReal_add]
-  have hA : IsSelfAdjoint A.1 := A.2
-  rw [isSelfAdjoint_iff, star_eq_conjTranspose] at hA
-  rw [eta_fin_two (A.1)ᴴ] at hA
-  simp only [Fin.isValue, conjTranspose_apply, RCLike.star_def, of_apply, cons_val', cons_val_zero,
-    empty_val', cons_val_fin_one, cons_val_one, head_cons, head_fin_const] at hA
-  have h00 := congrArg (fun f => f 0 0) hA
-  simp only [Fin.isValue, of_apply, cons_val', cons_val_zero, empty_val', cons_val_fin_one] at h00
-  have hA00 : A.1 0 0 = (A.1 0 0).re := by
-    exact Eq.symm ((fun {z} => Complex.conj_eq_iff_re.mp) h00)
-  rw [hA00]
-  simp only [Fin.isValue, Complex.ofReal_re, add_right_inj]
-  have h11 := congrArg (fun f => f 1 1) hA
-  simp only [Fin.isValue, of_apply, cons_val', cons_val_one, head_cons, empty_val',
-    cons_val_fin_one, head_fin_const] at h11
-  exact Complex.conj_eq_iff_re.mp h11
+  have hi (i) : star (A.1 i i) = A.1 i i := by simpa using congrArg (fun f => f i i) A.2
+  simp_rw [← starRingEnd_apply, Complex.conj_eq_iff_re] at hi
+  simp_rw [Matrix.trace, Fin.sum_univ_two, one_mul, diag, Complex.add_re, Complex.ofReal_add, hi]
 
 /-- The trace of `σ1` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ1_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
@@ -110,7 +94,7 @@ lemma selfAdjoint_ext_complex {A B : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)}
     (h3 : Matrix.trace (PauliMatrix.σ3 * A.1) = Matrix.trace (PauliMatrix.σ3 * B.1)) : A = B := by
   ext i j
   rw [eta_fin_two A.1, eta_fin_two B.1] at h0 h1 h2 h3
-  simp only [PauliMatrix.σ0, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons,
+  simp only [one_mul, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons,
     head_cons, one_smul, tail_cons, zero_smul, empty_vecMul, add_zero, zero_add, empty_mul,
     Equiv.symm_apply_apply, trace_fin_two_of] at h0
   simp only [σ1, Fin.isValue, cons_mul, Nat.succ_eq_add_one, Nat.reduceAdd, vecMul_cons, head_cons,

--- a/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
+++ b/PhysLean/Relativity/PauliMatrices/SelfAdjoint.lean
@@ -16,9 +16,8 @@ open Matrix
 /-- The trace of `σ0` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ0_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :
     (Matrix.trace (σ0 * A.1)).re = Matrix.trace (σ0 * A.1) := by
-  have hi (i) : star (A.1 i i) = A.1 i i := by simpa using congrArg (fun f => f i i) A.2
-  simp_rw [← starRingEnd_apply, Complex.conj_eq_iff_re] at hi
-  simp_rw [Matrix.trace, Fin.sum_univ_two, one_mul, diag, Complex.add_re, Complex.ofReal_add, hi]
+  rw [one_mul, ← Complex.conj_eq_iff_re, starRingEnd_apply, ← trace_conjTranspose,
+    ← star_eq_conjTranspose, A.2]
 
 /-- The trace of `σ1` multiplied by a self-adjoint `2×2` matrix is real. -/
 lemma selfAdjoint_trace_σ1_real (A : selfAdjoint (Matrix (Fin 2) (Fin 2) ℂ)) :

--- a/PhysLean/Relativity/SL2C/Basic.lean
+++ b/PhysLean/Relativity/SL2C/Basic.lean
@@ -85,7 +85,8 @@ lemma toSelfAdjointMap_apply_σSAL_inl (M : SL(2, ℂ)) :
       PauliMatrix.σSAL (Sum.inr 2) := by
   simp only [toSelfAdjointMap, PauliMatrix.σSAL, Fin.isValue, Basis.coe_mk, PauliMatrix.σSAL',
     PauliMatrix.σ0, LinearMap.coe_mk, AddHom.coe_mk, neg_add_rev, PauliMatrix.σ1,
-    neg_of, neg_cons, neg_zero, neg_empty, neg_mul, PauliMatrix.σ2, neg_neg, PauliMatrix.σ3]
+    neg_of, neg_cons, neg_zero, neg_empty, neg_mul, PauliMatrix.σ2, neg_neg, PauliMatrix.σ3,
+    one_fin_two]
   ext1
   simp only [Fin.isValue, AddSubgroup.coe_add, selfAdjoint.val_smul, smul_of, smul_cons, real_smul,
     ofReal_div, ofReal_add, ofReal_pow, ofReal_ofNat, mul_one, smul_zero, smul_empty, smul_neg,

--- a/PhysLean/Relativity/Tensors/RealTensor/Vector/Pre/Contraction.lean
+++ b/PhysLean/Relativity/Tensors/RealTensor/Vector/Pre/Contraction.lean
@@ -426,17 +426,17 @@ lemma matrix_apply_stdBasis (ν μ : Fin 1 ⊕ Fin d) :
 
 lemma same_eq_det_toSelfAdjoint (x : ContrMod 3) :
     ⟪x, x⟫ₘ = det (ContrMod.toSelfAdjoint x).1 := by
-  rw [ContrMod.toSelfAdjoint_apply_coe]
-  simp only [Fin.isValue, as_sum_toSpace,
-    PiLp.inner_apply, Function.comp_apply, RCLike.inner_apply, conj_trivial, Fin.sum_univ_three,
-    ofReal_sub, ofReal_mul, ofReal_add]
-  simp only [Fin.isValue, PauliMatrix.σ0, smul_of, smul_cons, real_smul, mul_one, smul_zero,
-    smul_empty, PauliMatrix.σ1, of_sub_of, sub_cons, head_cons, sub_zero, tail_cons, zero_sub,
-    sub_self, zero_empty, PauliMatrix.σ2, smul_neg, sub_neg_eq_add, PauliMatrix.σ3, det_fin_two_of]
+  rw [ContrMod.toSelfAdjoint_apply_coe, as_sum_toSpace, det_fin_two,
+    PauliMatrix.σ1, PauliMatrix.σ2, PauliMatrix.σ3, ContrMod.toSpace,
+    ContrMod.toFin1dℝ_eq_val]
+  simp [Fin.sum_univ_three] says
+    simp only [Fin.isValue, PiLp.inner_apply, Function.comp_apply, RCLike.inner_apply, conj_trivial,
+      Fin.sum_univ_three, ofReal_sub, ofReal_mul, ofReal_add, smul_of, smul_cons, smul_zero,
+      real_smul, mul_one, smul_empty, smul_neg, sub_apply, smul_apply, one_apply_eq, of_apply,
+      cons_val', cons_val_zero, cons_val_fin_one, sub_zero, cons_val_one, sub_neg_eq_add, ne_eq,
+      zero_ne_one, not_false_eq_true, one_apply_ne, zero_sub, one_ne_zero]
   ring_nf
-  simp only [Fin.isValue, ContrMod.toFin1dℝ_eq_val, I_sq, mul_neg, mul_one, ContrMod.toSpace,
-    Function.comp_apply]
-  ring
+  simp
 
 end contrContrContractField
 

--- a/PhysLean/Relativity/Tensors/RealTensor/Vector/Pre/Contraction.lean
+++ b/PhysLean/Relativity/Tensors/RealTensor/Vector/Pre/Contraction.lean
@@ -429,7 +429,7 @@ lemma same_eq_det_toSelfAdjoint (x : ContrMod 3) :
   rw [ContrMod.toSelfAdjoint_apply_coe, as_sum_toSpace, det_fin_two,
     PauliMatrix.σ1, PauliMatrix.σ2, PauliMatrix.σ3, ContrMod.toSpace,
     ContrMod.toFin1dℝ_eq_val]
-  simp [Fin.sum_univ_three] says
+  simp? [Fin.sum_univ_three] says
     simp only [Fin.isValue, PiLp.inner_apply, Function.comp_apply, RCLike.inner_apply, conj_trivial,
       Fin.sum_univ_three, ofReal_sub, ofReal_mul, ofReal_add, smul_of, smul_cons, smul_zero,
       real_smul, mul_one, smul_empty, smul_neg, sub_apply, smul_apply, one_apply_eq, of_apply,


### PR DESCRIPTION
This also adds a few new `simp` lemmas to keep things simp-normal.