### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# This is simply to add an extra level of security around pull-requests.
+# It says nothing about who `owns` the code.
+*       @HepLean/physlean-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This is simply to add an extra level of security around pull-requests.
 # It says nothing about who `owns` the code.
-*       @HepLean/physlean-maintainers
+*       @HEPLean/physlean-maintainers


### PR DESCRIPTION
This file is simply here to make pull-requests safer. Despite its name, it says nothing about who owns the files etc.