### PR TITLE
chore: Add missing ends

### DIFF
--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -396,3 +396,5 @@ lemma curl_linear_map (f : W → Space 3 → EuclideanSpace ℝ (Fin 3))
     rw [hf'.map_smul]
     rw [curl_smul]
     fun_prop
+
+end Space

--- a/PhysLean/ClassicalMechanics/VectorFields.lean
+++ b/PhysLean/ClassicalMechanics/VectorFields.lean
@@ -211,3 +211,5 @@ lemma inner_self_cross (v w : EuclideanSpace ℝ (Fin 3)) :
   cases w using WithLp.rec with | _ w =>
   simp only [Equiv.apply_symm_apply, EuclideanSpace.inner_piLp_equiv_symm, star_trivial]
   rw [dotProduct_comm, dot_self_cross]
+
+end ClassicalMechanics

--- a/PhysLean/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/PhysLean/ClassicalMechanics/WaveEquation/Basic.lean
@@ -321,3 +321,5 @@ lemma differentiable_uncurry_of_eq_planewave {s : Direction d}
     · apply Differentiable.inner
       repeat fun_prop
     · fun_prop
+
+end ClassicalMechanics

--- a/PhysLean/ClassicalMechanics/WaveEquation/HarmonicWave.lean
+++ b/PhysLean/ClassicalMechanics/WaveEquation/HarmonicWave.lean
@@ -85,3 +85,5 @@ lemma transverseHarmonicPlaneWave_eq_planeWave {c : ℝ} {k : WaveVector} {f₀x
 
 TODO "EGU3E" "Show that any disturbance (subject to certian conditions) can be expressed
     as a superposition of harmonic plane waves via Fourier integral."
+
+end ClassicalMechanics

--- a/PhysLean/CondensedMatter/TightBindingChain/Basic.lean
+++ b/PhysLean/CondensedMatter/TightBindingChain/Basic.lean
@@ -364,3 +364,4 @@ lemma hamiltonian_energyEigenstate (k : T.QuantaWaveNumber) :
   ring_nf
 
 end TightBindingChain
+end CondensedMatter

--- a/PhysLean/Electromagnetism/Homogeneous.lean
+++ b/PhysLean/Electromagnetism/Homogeneous.lean
@@ -96,3 +96,5 @@ theorem OpticalMedium.faradayLaw_of_free {t : Time} {x : Space}
     (E : ElectricField) (B : MagneticField) (h : OM.FreeMaxwellEquations E B) :
     (∇ × E t) x = - ∂ₜ (fun t => B t x) t := by
   rw [h.2.2.2]
+
+end Electromagnetism

--- a/PhysLean/Electromagnetism/Wave.lean
+++ b/PhysLean/Electromagnetism/Wave.lean
@@ -556,3 +556,5 @@ theorem orthonormal_triad_of_electromagneticplaneWave {s : Direction}
     rw [real_inner_comm, inner_self_cross]
     simp
   · exact s.norm
+
+end Electromagnetism

--- a/PhysLean/Mathematics/Geometry/Metric/PseudoRiemannian/Defs.lean
+++ b/PhysLean/Mathematics/Geometry/Metric/PseudoRiemannian/Defs.lean
@@ -615,3 +615,7 @@ lemma cotangentToBilinForm_nondegenerate (g : PseudoRiemannianMetric E H M n I) 
   exact hω v
 
 end Cotangent
+
+end PseudoRiemannianMetric
+end
+end PseudoRiemannianMetric

--- a/PhysLean/Mathematics/Geometry/Metric/Riemannian/Defs.lean
+++ b/PhysLean/Mathematics/Geometry/Metric/Riemannian/Defs.lean
@@ -212,3 +212,6 @@ def curveLength (g : RiemannianMetric I n M) (γ : ℝ → M) (t₀ t₁ : ℝ)
 end Curve
 
 end RiemannianMetric
+end
+end RiemannianMetric
+end PseudoRiemannianMetric

--- a/PhysLean/Optics/Polarization/Basic.lean
+++ b/PhysLean/Optics/Polarization/Basic.lean
@@ -111,3 +111,5 @@ theorem polarizationEllipse (hx : E₀x ≠ 0) (hy : E₀y ≠ 0) (h : τ = ω *
   trans (cos τ ^ 2 + sin τ ^ 2) * sin (δy - δx) ^ 2
   · ring
   simp
+
+end Optics

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
@@ -268,3 +268,6 @@ lemma exp_abs_mul_abs_mul_gaussian_integrable (f : ℝ → ℂ) (hf : MemHS f) (
       rw [abs_mul, abs_of_nonneg hx]
 
 end HilbertSpace
+end
+end OneDimension
+end QuantumMechanics

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Parity.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Parity.lean
@@ -41,3 +41,6 @@ lemma memHS_of_parity (ψ : ℝ → ℂ) (hψ : MemHS ψ) : MemHS (parity ψ) :=
       (fun x => ‖ψ (x)‖ ^ 2) (R := (-1 : ℝ)) (by simp)).mpr hψ.right
 
 end HilbertSpace
+end
+end OneDimension
+end QuantumMechanics


### PR DESCRIPTION
Found by adding: 

```
[leanOptions]
weak.linter.style.missingEnd = true
```

to `lakefile.toml` and building physlean.