### PR TITLE
feat: define variational derivative

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -35,6 +35,9 @@ import PhysLean.Mathematics.RatComplexNum
 import PhysLean.Mathematics.SO3.Basic
 import PhysLean.Mathematics.SchurTriangulation
 import PhysLean.Mathematics.SpecialFunctions.PhysHermite
+import PhysLean.Mathematics.VariationalCalculus.HasVarAdjoint
+import PhysLean.Mathematics.VariationalCalculus.HasVarGradient
+import PhysLean.Mathematics.VariationalCalculus.IsTestFunction
 import PhysLean.Meta.AllFilePaths
 import PhysLean.Meta.Basic
 import PhysLean.Meta.Informal.Basic

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -6,6 +6,30 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 
 import PhysLean.Mathematics.VariationalCalculus.IsTestFunction
 
+/-! Variational adjoint
+
+Definition of adjoint of linear function between function spaces. It is inspired by the definition
+of distributional adjoint of linear maps between test functions as described here:
+https://en.wikipedia.org/wiki/Distribution_(mathematics) under 'Preliminaries: Transpose of a linear
+operator' but we require that the adjoint is function between test functions too.
+
+The key results are:
+  - variational adjoint of identity is identity, `HasVarAdjoint.id`
+  - variational adjoint of composition is composition of adjoint in reverse order,
+    `HasVarAdjoint.comp`
+  - variational adjoint of deriv is `- deriv`, `HasVarAdjoint.deriv`
+  - variational adjoint of algebraic operations is algebraic operation of adjoints,
+    `HasVarAdjoint.neg`, `HasVarAdjoint.add`, `HasVarAdjoint.sub`, `HasVarAdjoint.mul_left`,
+    `HasVarAdjoint.mul_right`, `HasVarAdjoint.smul_left`, `HasVarAdjoint.smul_right`
+
+The variational adjoint is not uniquelly defined, having `HasVarAdjoint F F'` and
+`HasVarAdjoint F G'` does not imply `F' = G'`. Further investigation needs to be done. Likely
+the adjoint is unique almost everywhere when applied to test functions. To extend it to
+other functions one would have to invoke continuity and density of test function in some
+appropriate function space.
+-/
+
+
 open InnerProductSpace MeasureTheory ContDiff
 
 variable

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -3,10 +3,11 @@ Copyright (c) 2025 Tomas Skrivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomas Skrivan, Joseph Tooby-Smith
 -/
-
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 import PhysLean.Mathematics.VariationalCalculus.IsTestFunction
-
-/-! Variational adjoint
+/-!
+# Variational adjoint
 
 Definition of adjoint of linear function between function spaces. It is inspired by the definition
 of distributional adjoint of linear maps between test functions as described here:
@@ -29,7 +30,6 @@ other functions one would have to invoke continuity and density of test function
 appropriate function space.
 -/
 
-
 open InnerProductSpace MeasureTheory ContDiff
 
 variable
@@ -50,7 +50,7 @@ such formal treatement is unnecessarily complicated for physics applications.
 -/
 structure HasVarAdjoint
     (F : (X → U) → (X → V)) (F' : (X → V) → (X → U)) (μ : Measure X := by volume_tac) where
-  test_fun_preserving  : ∀ φ, IsTestFunction φ → IsTestFunction (F φ)
+  test_fun_preserving : ∀ φ, IsTestFunction φ → IsTestFunction (F φ)
   test_fun_preserving' : ∀ φ, IsTestFunction φ → IsTestFunction (F' φ)
   adjoint : ∀ φ ψ, IsTestFunction φ → IsTestFunction ψ →
     ∫ x, ⟪F φ x, ψ x⟫_ℝ ∂μ = ∫ x, ⟪φ x, F' ψ x⟫_ℝ ∂μ
@@ -60,14 +60,14 @@ namespace HasVarAdjoint
 variable {μ : Measure X}
 
 lemma id : HasVarAdjoint (fun φ : X → U => φ) (fun φ => φ) μ where
-  test_fun_preserving  _ hφ := hφ
+  test_fun_preserving _ hφ := hφ
   test_fun_preserving' _ hφ := hφ
   adjoint _ _ _ _ := rfl
 
 lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
     HasVarAdjoint (fun φ => F (G φ)) (fun φ => G' (F' φ)) μ where
-  test_fun_preserving  _ hφ := hF.test_fun_preserving _ (hG.test_fun_preserving _ hφ)
+  test_fun_preserving _ hφ := hF.test_fun_preserving _ (hG.test_fun_preserving _ hφ)
   test_fun_preserving' _ hφ := hG.test_fun_preserving' _ (hF.test_fun_preserving' _ hφ)
   adjoint φ ψ hφ hψ := by
     rw [hF.adjoint _ _ (hG.test_fun_preserving φ hφ) hψ]
@@ -75,7 +75,7 @@ lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
 
 protected lemma deriv :
     HasVarAdjoint (fun φ : ℝ → ℝ => deriv φ) (fun φ => - deriv φ) where
-  test_fun_preserving  _ hφ := by
+  test_fun_preserving _ hφ := by
     have ⟨h,h'⟩ := hφ
     constructor
     · fun_prop
@@ -91,7 +91,7 @@ protected lemma deriv :
     trans ∫ (x : ℝ), ψ x * deriv φ x
     · congr
     rw [MeasureTheory.integral_mul_deriv_eq_deriv_mul_of_integrable (u := ψ) (v := φ)
-      (u' := deriv ψ) ]
+      (u' := deriv ψ)]
     · simp
       rw [@MeasureTheory.integral_neg]
     · intro x
@@ -112,7 +112,7 @@ protected lemma deriv :
 lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint G F' μ) (h' : ∀ φ, IsTestFunction φ → F φ = G φ) :
     HasVarAdjoint F F' μ where
-  test_fun_preserving  φ hφ := by
+  test_fun_preserving φ hφ := by
     rw[h' _ hφ]
     exact h.test_fun_preserving φ hφ
   test_fun_preserving' φ hφ := h.test_fun_preserving' φ hφ
@@ -123,7 +123,7 @@ lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {
 lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
     HasVarAdjoint F F' μ where
-  test_fun_preserving  φ hφ := h.test_fun_preserving φ hφ
+  test_fun_preserving φ hφ := h.test_fun_preserving φ hφ
   test_fun_preserving' φ hφ := by
     rw [h' φ hφ]
     exact h.test_fun_preserving' φ hφ
@@ -132,10 +132,10 @@ lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)}
     exact h.adjoint φ ψ hφ hψ
 
 lemma neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
-    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    {μ : Measure X}
     (hF : HasVarAdjoint F F' μ) :
     HasVarAdjoint (fun φ x => - F φ x) (fun φ x => - F' φ x) μ where
-  test_fun_preserving  _ hφ := by
+  test_fun_preserving _ hφ := by
     have ⟨h,h'⟩ := hφ
     constructor
     · apply ContDiff.neg
@@ -157,7 +157,7 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
     HasVarAdjoint (fun φ x => F φ x + G φ x) (fun φ x => F' φ x + G' φ x) μ where
-  test_fun_preserving  _ hφ := by
+  test_fun_preserving _ hφ := by
     have ⟨h,h'⟩ := hφ
     constructor
     · apply ContDiff.add
@@ -166,7 +166,7 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     · apply HasCompactSupport.add
       apply (hF.test_fun_preserving _ hφ).supp
       apply (hG.test_fun_preserving _ hφ).supp
-  test_fun_preserving' _ hφ :=  by
+  test_fun_preserving' _ hφ := by
     have ⟨h,h'⟩ := hφ
     constructor
     · apply ContDiff.add
@@ -177,8 +177,8 @@ lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
       apply (hG.test_fun_preserving' _ hφ).supp
   adjoint _ _ _ _ := by
     simp[inner_add_left,inner_add_right]
-    rw[MeasureTheory.integral_add ]
-    rw[MeasureTheory.integral_add ]
+    rw[MeasureTheory.integral_add]
+    rw[MeasureTheory.integral_add]
     rw[hF.adjoint _ _ (by assumption) (by assumption)]
     rw[hG.adjoint _ _ (by assumption) (by assumption)]
     · apply IsTestFunction.integrable
@@ -206,10 +206,10 @@ lemma sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
   apply add hF (neg hG)
 
 lemma mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
-    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    {μ : Measure X}
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x * F φ x) (fun φ x => F' (fun x => ψ x * φ x) x) μ where
-  test_fun_preserving  φ hφ := by
+  test_fun_preserving φ hφ := by
     apply IsTestFunction.mul_left
     · exact hψ
     · exact hF.test_fun_preserving φ hφ
@@ -227,10 +227,10 @@ lemma mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → �
       · exact hψ'
 
 lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
-    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    {μ : Measure X}
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => F φ x * ψ x) (fun φ x => F' (fun x => φ x * ψ x) x) μ where
-  test_fun_preserving  φ hφ := by
+  test_fun_preserving φ hφ := by
     apply IsTestFunction.mul_right
     · exact hF.test_fun_preserving φ hφ
     · exact hψ
@@ -248,10 +248,10 @@ lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → 
       · exact hψ
 
 lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
-    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    {μ : Measure X}
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where
-  test_fun_preserving  φ hφ := by
+  test_fun_preserving φ hφ := by
     have := hF.test_fun_preserving φ hφ
     fun_prop
   test_fun_preserving' φ hφ := by
@@ -265,10 +265,10 @@ lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) �
     · simp; fun_prop
 
 lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
-    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    {μ : Measure X}
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where
-  test_fun_preserving  φ hφ := by
+  test_fun_preserving φ hφ := by
     have := hF.test_fun_preserving φ hφ
     fun_prop
   test_fun_preserving' φ hφ := by

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -59,12 +59,12 @@ namespace HasVarAdjoint
 
 variable {μ : Measure X}
 
-theorem id : HasVarAdjoint (fun φ : X → U => φ) (fun φ => φ) μ where
+lemma id : HasVarAdjoint (fun φ : X → U => φ) (fun φ => φ) μ where
   test_fun_preserving  _ hφ := hφ
   test_fun_preserving' _ hφ := hφ
   adjoint _ _ _ _ := rfl
 
-theorem comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
+lemma comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
     HasVarAdjoint (fun φ => F (G φ)) (fun φ => G' (F' φ)) μ where
   test_fun_preserving  _ hφ := hF.test_fun_preserving _ (hG.test_fun_preserving _ hφ)
@@ -73,7 +73,7 @@ theorem comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
     rw [hF.adjoint _ _ (hG.test_fun_preserving φ hφ) hψ]
     rw [hG.adjoint _ _ hφ (hF.test_fun_preserving' _ hψ)]
 
-protected theorem deriv :
+protected lemma deriv :
     HasVarAdjoint (fun φ : ℝ → ℝ => deriv φ) (fun φ => - deriv φ) where
   test_fun_preserving  _ hφ := by
     have ⟨h,h'⟩ := hφ
@@ -109,7 +109,7 @@ protected theorem deriv :
     · refine IsTestFunction.integrable ?_ _
       exact IsTestFunction.mul hψ hφ
 
-theorem congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
+lemma congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint G F' μ) (h' : ∀ φ, IsTestFunction φ → F φ = G φ) :
     HasVarAdjoint F F' μ where
   test_fun_preserving  φ hφ := by
@@ -120,7 +120,7 @@ theorem congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
     rw [h' φ hφ]
     exact h.adjoint φ ψ hφ hψ
 
-theorem congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
+lemma congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
     (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
     HasVarAdjoint F F' μ where
   test_fun_preserving  φ hφ := h.test_fun_preserving φ hφ
@@ -131,7 +131,7 @@ theorem congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U
     rw [h' ψ hψ]
     exact h.adjoint φ ψ hφ hψ
 
-theorem neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
+lemma neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) :
     HasVarAdjoint (fun φ x => - F φ x) (fun φ x => - F' φ x) μ where
@@ -153,7 +153,7 @@ theorem neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
     simp [integral_neg]
     rw[hF.adjoint _ _ (by assumption) (by assumption)]
 
-theorem add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
+lemma add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
     HasVarAdjoint (fun φ x => F φ x + G φ x) (fun φ x => F' φ x + G' φ x) μ where
@@ -198,14 +198,14 @@ theorem add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
       · (expose_names; exact hG.test_fun_preserving x h)
       · (expose_names; exact h_1)
 
-theorem sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
+lemma sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
     HasVarAdjoint (fun φ x => F φ x - G φ x) (fun φ x => F' φ x - G' φ x) μ := by
   simp [sub_eq_add_neg]
   apply add hF (neg hG)
 
-theorem mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
+lemma mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x * F φ x) (fun φ x => F' (fun x => ψ x * φ x) x) μ where
@@ -226,7 +226,7 @@ theorem mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X →
       · exact hψ
       · exact hψ'
 
-theorem mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
+lemma mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => F φ x * ψ x) (fun φ x => F' (fun x => φ x * ψ x) x) μ where
@@ -247,7 +247,7 @@ theorem mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X �
       · exact hψ'
       · exact hψ
 
-theorem smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
+lemma smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where
@@ -264,7 +264,7 @@ theorem smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V)
     · exact hφ
     · simp; fun_prop
 
-theorem smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
+lemma smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
     {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
     (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
     HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2025 Tomas Skrivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomas Skrivan, Joseph Tooby-Smith
+-/
+
+import PhysLean.Mathematics.VariationalCalculus.IsTestFunction
+
+open InnerProductSpace MeasureTheory ContDiff
+
+variable
+  {X} [NormedAddCommGroup X] [NormedSpace ℝ X] [MeasurableSpace X]
+  {U} [NormedAddCommGroup U] [InnerProductSpace ℝ U]
+  {V} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+  {W} [NormedAddCommGroup W] [InnerProductSpace ℝ W]
+
+/-- Map `F` from `(X → U)` to `(X → V)` has a variational adjoint `F'` if it preserves
+test functions and satisfies the adjoint relation `⟪F φ, ψ⟫ = ⟪φ, F' ψ⟫`for all test functions
+`φ` and `ψ` for `⟪φ, ψ⟫ = ∫ x, ⟪φ x, ψ x⟫_ℝ ∂μ`.
+
+The canonical example is the function `F = deriv` that has adjoint `F' = - deriv`.
+
+This notion of adjoint allows us to do formally variational calculus as often encountered in physics
+textbooks. In mathematical literature, the adjoint is often defined for unbounded operators, but
+such formal treatement is unnecessarily complicated for physics applications.
+-/
+structure HasVarAdjoint
+    (F : (X → U) → (X → V)) (F' : (X → V) → (X → U)) (μ : Measure X := by volume_tac) where
+  test_fun_preserving  : ∀ φ, IsTestFunction φ → IsTestFunction (F φ)
+  test_fun_preserving' : ∀ φ, IsTestFunction φ → IsTestFunction (F' φ)
+  adjoint : ∀ φ ψ, IsTestFunction φ → IsTestFunction ψ →
+    ∫ x, ⟪F φ x, ψ x⟫_ℝ ∂μ = ∫ x, ⟪φ x, F' ψ x⟫_ℝ ∂μ
+
+namespace HasVarAdjoint
+
+variable {μ : Measure X}
+
+theorem id : HasVarAdjoint (fun φ : X → U => φ) (fun φ => φ) μ where
+  test_fun_preserving  _ hφ := hφ
+  test_fun_preserving' _ hφ := hφ
+  adjoint _ _ _ _ := rfl
+
+theorem comp {F : (X → V) → (X → W)} {G : (X → U) → (X → V)} {F' G'}
+    (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
+    HasVarAdjoint (fun φ => F (G φ)) (fun φ => G' (F' φ)) μ where
+  test_fun_preserving  _ hφ := hF.test_fun_preserving _ (hG.test_fun_preserving _ hφ)
+  test_fun_preserving' _ hφ := hG.test_fun_preserving' _ (hF.test_fun_preserving' _ hφ)
+  adjoint φ ψ hφ hψ := by
+    rw [hF.adjoint _ _ (hG.test_fun_preserving φ hφ) hψ]
+    rw [hG.adjoint _ _ hφ (hF.test_fun_preserving' _ hψ)]
+
+protected theorem deriv :
+    HasVarAdjoint (fun φ : ℝ → ℝ => deriv φ) (fun φ => - deriv φ) where
+  test_fun_preserving  _ hφ := by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · fun_prop
+    · exact HasCompactSupport.deriv h'
+  test_fun_preserving' _ hφ := by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · eta_expand; dsimp; fun_prop
+    · apply HasCompactSupport.neg'
+      apply HasCompactSupport.deriv h'
+  adjoint φ ψ hφ hψ := by
+    dsimp
+    trans ∫ (x : ℝ), ψ x * deriv φ x
+    · congr
+    rw [MeasureTheory.integral_mul_deriv_eq_deriv_mul_of_integrable (u := ψ) (v := φ)
+      (u' := deriv ψ) ]
+    · simp
+      rw [@MeasureTheory.integral_neg]
+    · intro x
+      simpa using hψ.1.differentiable (by exact ENat.LEInfty.out) x
+    · intro x
+      simpa using hφ.1.differentiable (by exact ENat.LEInfty.out) x
+    · refine IsTestFunction.integrable ?_ _
+      apply IsTestFunction.mul
+      · exact hψ
+      · exact IsTestFunction.deriv hφ
+    · refine IsTestFunction.integrable ?_ _
+      apply IsTestFunction.mul
+      · exact IsTestFunction.deriv hψ
+      · exact hφ
+    · refine IsTestFunction.integrable ?_ _
+      exact IsTestFunction.mul hψ hφ
+
+theorem congr_fun {F G : (X → U) → (X → V)} {F' : (X → V) → (X → U)} {μ : Measure X}
+    (h : HasVarAdjoint G F' μ) (h' : ∀ φ, IsTestFunction φ → F φ = G φ) :
+    HasVarAdjoint F F' μ where
+  test_fun_preserving  φ hφ := by
+    rw[h' _ hφ]
+    exact h.test_fun_preserving φ hφ
+  test_fun_preserving' φ hφ := h.test_fun_preserving' φ hφ
+  adjoint φ ψ hφ hψ := by
+    rw [h' φ hφ]
+    exact h.adjoint φ ψ hφ hψ
+
+theorem congr_adjoint {F : (X → U) → (X → V)} {G' : (X → V) → (X → U)} {μ : Measure X}
+    (h : HasVarAdjoint F G' μ) (h' : ∀ φ, IsTestFunction φ → F' φ = G' φ) :
+    HasVarAdjoint F F' μ where
+  test_fun_preserving  φ hφ := h.test_fun_preserving φ hφ
+  test_fun_preserving' φ hφ := by
+    rw [h' φ hφ]
+    exact h.test_fun_preserving' φ hφ
+  adjoint φ ψ hφ hψ := by
+    rw [h' ψ hψ]
+    exact h.adjoint φ ψ hφ hψ
+
+theorem neg {F : (X → U) → (X → V)} {F' : (X → V) → (X → U)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) :
+    HasVarAdjoint (fun φ x => - F φ x) (fun φ x => - F' φ x) μ where
+  test_fun_preserving  _ hφ := by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · apply ContDiff.neg
+      apply (hF.test_fun_preserving _ hφ).smooth
+    · apply HasCompactSupport.neg'
+      apply (hF.test_fun_preserving _ hφ).supp
+  test_fun_preserving' _ hφ := by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · apply ContDiff.neg
+      apply (hF.test_fun_preserving' _ hφ).smooth
+    · apply HasCompactSupport.neg'
+      apply (hF.test_fun_preserving' _ hφ).supp
+  adjoint _ _ _ _ := by
+    simp [integral_neg]
+    rw[hF.adjoint _ _ (by assumption) (by assumption)]
+
+theorem add {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
+    HasVarAdjoint (fun φ x => F φ x + G φ x) (fun φ x => F' φ x + G' φ x) μ where
+  test_fun_preserving  _ hφ := by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · apply ContDiff.add
+      apply (hF.test_fun_preserving _ hφ).smooth
+      apply (hG.test_fun_preserving _ hφ).smooth
+    · apply HasCompactSupport.add
+      apply (hF.test_fun_preserving _ hφ).supp
+      apply (hG.test_fun_preserving _ hφ).supp
+  test_fun_preserving' _ hφ :=  by
+    have ⟨h,h'⟩ := hφ
+    constructor
+    · apply ContDiff.add
+      apply (hF.test_fun_preserving' _ hφ).smooth
+      apply (hG.test_fun_preserving' _ hφ).smooth
+    · apply HasCompactSupport.add
+      apply (hF.test_fun_preserving' _ hφ).supp
+      apply (hG.test_fun_preserving' _ hφ).supp
+  adjoint _ _ _ _ := by
+    simp[inner_add_left,inner_add_right]
+    rw[MeasureTheory.integral_add ]
+    rw[MeasureTheory.integral_add ]
+    rw[hF.adjoint _ _ (by assumption) (by assumption)]
+    rw[hG.adjoint _ _ (by assumption) (by assumption)]
+    · apply IsTestFunction.integrable
+      apply IsTestFunction.inner
+      · (expose_names; exact h)
+      · (expose_names; exact hF.test_fun_preserving' x_1 h_1)
+    · apply IsTestFunction.integrable
+      apply IsTestFunction.inner
+      · (expose_names; exact h)
+      · (expose_names; exact hG.test_fun_preserving' x_1 h_1)
+    · apply IsTestFunction.integrable
+      apply IsTestFunction.inner
+      · (expose_names; exact hF.test_fun_preserving x h)
+      · (expose_names; exact h_1)
+    · apply IsTestFunction.integrable
+      apply IsTestFunction.inner
+      · (expose_names; exact hG.test_fun_preserving x h)
+      · (expose_names; exact h_1)
+
+theorem sub {F G : (X → U) → (X → V)} {F' G' : (X → V) → (X → U)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hG : HasVarAdjoint G G' μ) :
+    HasVarAdjoint (fun φ x => F φ x - G φ x) (fun φ x => F' φ x - G' φ x) μ := by
+  simp [sub_eq_add_neg]
+  apply add hF (neg hG)
+
+theorem mul_left {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
+    HasVarAdjoint (fun φ x => ψ x * F φ x) (fun φ x => F' (fun x => ψ x * φ x) x) μ where
+  test_fun_preserving  φ hφ := by
+    apply IsTestFunction.mul_left
+    · exact hψ
+    · exact hF.test_fun_preserving φ hφ
+  test_fun_preserving' φ hφ := by
+    apply hF.test_fun_preserving'
+    apply IsTestFunction.mul_left
+    · exact hψ
+    · exact hφ
+  adjoint φ ψ' hφ hψ' := by
+    rw [← hF.adjoint]
+    · congr; funext x; simp; ring
+    · exact hφ
+    · apply IsTestFunction.mul_left
+      · exact hψ
+      · exact hψ'
+
+theorem mul_right {F : (X → ℝ) → (X → ℝ)} {ψ : X → ℝ} {F' : (X → ℝ) → (X → ℝ)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
+    HasVarAdjoint (fun φ x => F φ x * ψ x) (fun φ x => F' (fun x => φ x * ψ x) x) μ where
+  test_fun_preserving  φ hφ := by
+    apply IsTestFunction.mul_right
+    · exact hF.test_fun_preserving φ hφ
+    · exact hψ
+  test_fun_preserving' φ hφ := by
+    apply hF.test_fun_preserving'
+    apply IsTestFunction.mul_right
+    · exact hφ
+    · exact hψ
+  adjoint φ ψ' hφ hψ' := by
+    rw [← hF.adjoint]
+    · congr; funext x; simp; ring
+    · exact hφ
+    · apply IsTestFunction.mul_right
+      · exact hψ'
+      · exact hψ
+
+theorem smul_left {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
+    HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where
+  test_fun_preserving  φ hφ := by
+    have := hF.test_fun_preserving φ hφ
+    fun_prop
+  test_fun_preserving' φ hφ := by
+    apply hF.test_fun_preserving' _ _
+    fun_prop
+  adjoint φ ψ hφ hψ := by
+    simp_rw[inner_smul_left, ← inner_smul_right]
+    rw [hF.adjoint]
+    · rfl
+    · exact hφ
+    · simp; fun_prop
+
+theorem smul_right {F : (X → U) → (X → V)} {ψ : X → ℝ} {F' : (X → V) → (X → U)}
+    {μ : Measure X} [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts μ]
+    (hF : HasVarAdjoint F F' μ) (hψ : ContDiff ℝ ∞ ψ) :
+    HasVarAdjoint (fun φ x => ψ x • F φ x) (fun φ x => F' (fun x' => ψ x' • φ x') x) μ where
+  test_fun_preserving  φ hφ := by
+    have := hF.test_fun_preserving φ hφ
+    fun_prop
+  test_fun_preserving' φ hφ := by
+    apply hF.test_fun_preserving' _ _
+    fun_prop
+  adjoint φ ψ hφ hψ := by
+    simp_rw[inner_smul_left, ← inner_smul_right]
+    rw [hF.adjoint]
+    · rfl
+    · exact hφ
+    · simp; fun_prop

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
@@ -3,10 +3,11 @@ Copyright (c) 2025 Tomas Skrivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomas Skrivan, Joseph Tooby-Smith
 -/
-
 import PhysLean.Mathematics.VariationalCalculus.HasVarAdjoint
+import Mathlib.Tactic.FunProp.Differentiable
+/-!
 
-/-! Variational gradient
+# Variational gradient
 
 Definition of variational gradient that allows for formal treatement of variational calculus
 as used in physics textbooks.
@@ -17,7 +18,6 @@ open MeasureTheory ContDiff InnerProductSpace
 variable
   {X} [NormedAddCommGroup X] [NormedSpace ℝ X] [MeasurableSpace X]
   {U} [NormedAddCommGroup U] [InnerProductSpace ℝ U]
-
 
 /-- Function `grad` is variational gradient of functional `S` at point `u`.
 
@@ -64,9 +64,6 @@ inductive HasVarGradientAt (S' : (X → U) → (X → ℝ)) (grad : X → U) (u 
       (adjoint : HasVarAdjoint (fun δu t => deriv (fun s : ℝ => S' (u + s • δu) t) 0) F' μ)
       (eq : F' (fun _ => 1) = grad)
 
-
-
-
 /-- Variation of `S(x) = ∫ 1/2*m*‖ẋ‖² - V(x)` gives Newton's law of motion `δS(x) = - m*ẍ - V'(x)`-/
 example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff ℝ ∞ V) :
     HasVarGradientAt
@@ -78,7 +75,6 @@ example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff �
     eta_expand
     have := hu.differentiable ENat.LEInfty.out
     have := hV.differentiable ENat.LEInfty.out
-
     apply HasVarAdjoint.congr_fun
     case h' =>
       intro δu hδu; funext t
@@ -93,13 +89,11 @@ example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff �
         lhs
         simp (disch:=fun_prop (config:={maxTransitionDepth:=2}) (disch:=simp)) [deriv_add,hd]
         ring_nf
-
     case h =>
-     apply HasVarAdjoint.sub
-     · apply HasVarAdjoint.mul_left (hψ:=by fun_prop)
-       apply HasVarAdjoint.deriv
-     · apply HasVarAdjoint.mul_left (hψ:=by fun_prop)
-       apply HasVarAdjoint.id
-
+      apply HasVarAdjoint.sub
+      · apply HasVarAdjoint.mul_left (ψ := fun x => m * deriv u x) (hψ := by fun_prop)
+        apply HasVarAdjoint.deriv
+      · apply HasVarAdjoint.mul_left (hψ := by fun_prop)
+        apply HasVarAdjoint.id
   case eq =>
-    simp
+    simp only [mul_one, deriv_const_mul_field', Pi.neg_apply, neg_mul]

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Tomas Skrivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomas Skrivan, Joseph Tooby-Smith
+-/
+
+import PhysLean.Mathematics.VariationalCalculus.HasVarAdjoint
+
+open MeasureTheory ContDiff InnerProductSpace
+
+variable
+  {X} [NormedAddCommGroup X] [NormedSpace ℝ X] [MeasurableSpace X]
+  {U} [NormedAddCommGroup U] [InnerProductSpace ℝ U]
+
+
+/-- Function `grad` is variational gradient of functional `S` at point `u`.
+
+This formalizes the notion of variational gradient `δS/δu` of a functional `S` at a point `u`.
+
+However, it is not defined for a functional `S : (X → U) → ℝ` but rather for the function
+`S' : (X → U) → (X → ℝ)` which is related to the usual functional as `S u = ∫ x, S' (u x) x ∂μ`.
+For example for action integral, `S u = ∫ t, L (u t) (deriv u t)` we have
+`S' u t = L (u t) (deriv u t)`. Working with `S'` rather than with `S` allows us to ignore certain
+technicalities with integrability.
+
+Examples:
+
+Euler-Lagrange equations:
+```
+δ/δx ∫ L(x,ẋ) dt = ∂L/∂ x - d/dt (∂L/∂ẋ)
+```
+can be expressed as
+```
+HasVarGradientAt
+  (fun u t => L (u t) (deriv u t))
+  (fun t =>
+    deriv (L · (deriv u t)) ((u t))
+    -
+    deriv (fun t' => deriv (L (u t') ·) (deriv u t')) t)
+  u
+```
+
+Laplace equation is variational gradient of Dirichlet energy:
+```
+δ/δu ∫ 1/2*‖∇u‖² = - Δu
+```
+can be expressed as
+```
+HasVarGradientAt
+  (fun u t => 1/2 * deriv u t^2)
+  (fun t => - deriv (deriv u) t)
+  u
+```
+-/
+inductive HasVarGradientAt (S' : (X → U) → (X → ℝ)) (grad : X → U) (u : X → U)
+    (μ : Measure X := by volume_tac) : Prop
+  | intro (F')
+      (adjoint : HasVarAdjoint (fun δu t => deriv (fun s : ℝ => S' (u + s • δu) t) 0) F' μ)
+      (eq : F' (fun _ => 1) = grad)
+
+
+
+
+/-- Variation of `S(x) = ∫ 1/2*m*‖ẋ‖² - V(x)` gives Newton's law of motion `δS(x) = - m*ẍ - V'(x)` -/
+example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff ℝ ∞ V) : HasVarGradientAt
+    (fun (u : ℝ → ℝ) (t : ℝ) => 1/2 * m * deriv u t ^ 2 - V (u t))
+    (fun t => - m * deriv (deriv u) t - deriv V (u t))
+    u := by
+  apply HasVarGradientAt.intro
+  case adjoint =>
+    eta_expand
+    have := hu.differentiable ENat.LEInfty.out
+    have := hV.differentiable ENat.LEInfty.out
+
+    apply HasVarAdjoint.congr_fun
+    case h' =>
+      intro δu hδu; funext t
+      have := hδu.differentiable
+      have hd : deriv (fun y => V (u t + y * δu t)) 0
+                =
+                deriv V (u t) * δu t := by
+        have h := deriv_comp (h₂:=V) (h:=fun y => u t + y * δu t) 0 (by fun_prop) (by fun_prop)
+        simp +unfoldPartialApp [Function.comp] at h
+        exact h
+      conv =>
+        lhs
+        simp (disch:=fun_prop (config:={maxTransitionDepth:=2}) (disch:=simp)) [deriv_add,hd]
+        ring_nf
+
+    case h =>
+     apply HasVarAdjoint.sub
+     · apply HasVarAdjoint.mul_left (hψ:=by fun_prop)
+       apply HasVarAdjoint.deriv
+     · apply HasVarAdjoint.mul_left (hψ:=by fun_prop)
+       apply HasVarAdjoint.id
+
+  case eq =>
+    simp

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarGradient.lean
@@ -6,6 +6,12 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 
 import PhysLean.Mathematics.VariationalCalculus.HasVarAdjoint
 
+/-! Variational gradient
+
+Definition of variational gradient that allows for formal treatement of variational calculus
+as used in physics textbooks.
+-/
+
 open MeasureTheory ContDiff InnerProductSpace
 
 variable
@@ -61,11 +67,12 @@ inductive HasVarGradientAt (S' : (X → U) → (X → ℝ)) (grad : X → U) (u 
 
 
 
-/-- Variation of `S(x) = ∫ 1/2*m*‖ẋ‖² - V(x)` gives Newton's law of motion `δS(x) = - m*ẍ - V'(x)` -/
-example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff ℝ ∞ V) : HasVarGradientAt
-    (fun (u : ℝ → ℝ) (t : ℝ) => 1/2 * m * deriv u t ^ 2 - V (u t))
-    (fun t => - m * deriv (deriv u) t - deriv V (u t))
-    u := by
+/-- Variation of `S(x) = ∫ 1/2*m*‖ẋ‖² - V(x)` gives Newton's law of motion `δS(x) = - m*ẍ - V'(x)`-/
+example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff ℝ ∞ V) :
+    HasVarGradientAt
+      (fun (u : ℝ → ℝ) (t : ℝ) => 1/2 * m * deriv u t ^ 2 - V (u t))
+      (fun t => - m * deriv (deriv u) t - deriv V (u t))
+      u := by
   apply HasVarGradientAt.intro
   case adjoint =>
     eta_expand

--- a/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2025 Tomas Skrivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomas Skrivan, Joseph Tooby-Smith
+-/
+
+import Mathlib
+
+section IsTestFunction
+variable
+  {X} [NormedAddCommGroup X] [NormedSpace ℝ X]
+  {U} [NormedAddCommGroup U] [NormedSpace ℝ U]
+  {V} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+open ContDiff InnerProductSpace MeasureTheory
+/-- A test function is a smooth function with compact support. -/
+@[fun_prop]
+structure IsTestFunction (f : X → U) where
+  smooth : ContDiff ℝ ∞ f
+  supp : HasCompactSupport f
+
+@[fun_prop]
+theorem IsTestFunction.integrable [MeasurableSpace X] [OpensMeasurableSpace X]
+    {f : X → U} (hf : IsTestFunction f)
+    (μ : Measure X) [IsFiniteMeasureOnCompacts μ] :
+    MeasureTheory.Integrable f μ :=
+  Continuous.integrable_of_hasCompactSupport (continuous hf.smooth) hf.supp
+
+@[fun_prop]
+theorem IsTestFunction.differentiable {f : X → U} (hf : IsTestFunction f) :
+    Differentiable ℝ f := hf.1.differentiable ENat.LEInfty.out
+
+@[fun_prop]
+theorem IsTestFunction.contDiff {f : X → U} (hf : IsTestFunction f) :
+    ContDiff ℝ ∞ f := hf.1
+
+@[fun_prop]
+theorem IsTestFunction.deriv {f : ℝ → U} (hf : IsTestFunction f) :
+    IsTestFunction (fun x => deriv f x) where
+  smooth := deriv' hf.smooth
+  supp := HasCompactSupport.deriv hf.supp
+
+
+@[fun_prop]
+theorem IsTestFunction.mul {f g : X → ℝ} (hf : IsTestFunction f) (hg : IsTestFunction g) :
+    IsTestFunction (fun x => f x * g x) where
+  smooth := ContDiff.mul hf.smooth hg.smooth
+  supp := HasCompactSupport.mul_left hg.supp
+
+@[fun_prop]
+theorem IsTestFunction.inner {f g : X → V} (hf : IsTestFunction f) (hg : IsTestFunction g) :
+    IsTestFunction (fun x => ⟪f x, g x⟫_ℝ) where
+  smooth := ContDiff.inner ℝ hf.smooth hg.smooth
+  supp := by
+    have hf := hg.supp
+    rw [hasCompactSupport_iff_eventuallyEq] at hf ⊢
+    exact hf.mono fun x hx => by simp [hx]
+
+@[fun_prop]
+theorem IsTestFunction.mul_left {f g : X → ℝ} (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) :
+    IsTestFunction (fun x => f x * g x) where
+  smooth := ContDiff.mul hf hg.smooth
+  supp := HasCompactSupport.mul_left hg.supp
+
+@[fun_prop]
+theorem IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg : ContDiff ℝ ∞  g) :
+    IsTestFunction (fun x => f x * g x) where
+  smooth := ContDiff.mul hf.smooth hg
+  supp := HasCompactSupport.mul_right hf.supp
+
+
+@[fun_prop]
+theorem IsTestFunction.smul_left {f : X → ℝ} {g : X → U}
+   (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) : IsTestFunction (fun x => f x • g x) where
+  smooth := ContDiff.smul hf hg.smooth
+  supp := HasCompactSupport.smul_left hg.supp
+
+@[fun_prop]
+theorem IsTestFunction.smul_right {f : X → ℝ} {g : X → U}
+   (hf : IsTestFunction f) (hg : ContDiff ℝ ∞ g) : IsTestFunction (fun x => f x • g x) where
+  smooth := ContDiff.smul hf.smooth hg
+  supp := HasCompactSupport.smul_right hf.supp

--- a/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
@@ -3,13 +3,17 @@ Copyright (c) 2025 Tomas Skrivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomas Skrivan, Joseph Tooby-Smith
 -/
+import Mathlib.Analysis.Calculus.Deriv.Support
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Geometry.Manifold.IsManifold.Basic
+import Mathlib.MeasureTheory.Function.LocallyIntegrable
+/-!
 
-import Mathlib
-
-/-! Test function
+# Test functions
 
 Definition of test function, smooth and compactly supported function, and theorems about them.
 -/
+
 section IsTestFunction
 variable
   {X} [NormedAddCommGroup X] [NormedSpace ℝ X]
@@ -44,7 +48,6 @@ lemma IsTestFunction.deriv {f : ℝ → U} (hf : IsTestFunction f) :
   smooth := deriv' hf.smooth
   supp := HasCompactSupport.deriv hf.supp
 
-
 @[fun_prop]
 lemma IsTestFunction.mul {f g : X → ℝ} (hf : IsTestFunction f) (hg : IsTestFunction g) :
     IsTestFunction (fun x => f x * g x) where
@@ -67,11 +70,10 @@ lemma IsTestFunction.mul_left {f g : X → ℝ} (hf : ContDiff ℝ ∞ f) (hg : 
   supp := HasCompactSupport.mul_left hg.supp
 
 @[fun_prop]
-lemma IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg : ContDiff ℝ ∞  g) :
+lemma IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg : ContDiff ℝ ∞ g) :
     IsTestFunction (fun x => f x * g x) where
   smooth := ContDiff.mul hf.smooth hg
   supp := HasCompactSupport.mul_right hf.supp
-
 
 @[fun_prop]
 lemma IsTestFunction.smul_left {f : X → ℝ} {g : X → U}

--- a/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
@@ -24,35 +24,35 @@ structure IsTestFunction (f : X → U) where
   supp : HasCompactSupport f
 
 @[fun_prop]
-theorem IsTestFunction.integrable [MeasurableSpace X] [OpensMeasurableSpace X]
+lemma IsTestFunction.integrable [MeasurableSpace X] [OpensMeasurableSpace X]
     {f : X → U} (hf : IsTestFunction f)
     (μ : Measure X) [IsFiniteMeasureOnCompacts μ] :
     MeasureTheory.Integrable f μ :=
   Continuous.integrable_of_hasCompactSupport (continuous hf.smooth) hf.supp
 
 @[fun_prop]
-theorem IsTestFunction.differentiable {f : X → U} (hf : IsTestFunction f) :
+lemma IsTestFunction.differentiable {f : X → U} (hf : IsTestFunction f) :
     Differentiable ℝ f := hf.1.differentiable ENat.LEInfty.out
 
 @[fun_prop]
-theorem IsTestFunction.contDiff {f : X → U} (hf : IsTestFunction f) :
+lemma IsTestFunction.contDiff {f : X → U} (hf : IsTestFunction f) :
     ContDiff ℝ ∞ f := hf.1
 
 @[fun_prop]
-theorem IsTestFunction.deriv {f : ℝ → U} (hf : IsTestFunction f) :
+lemma IsTestFunction.deriv {f : ℝ → U} (hf : IsTestFunction f) :
     IsTestFunction (fun x => deriv f x) where
   smooth := deriv' hf.smooth
   supp := HasCompactSupport.deriv hf.supp
 
 
 @[fun_prop]
-theorem IsTestFunction.mul {f g : X → ℝ} (hf : IsTestFunction f) (hg : IsTestFunction g) :
+lemma IsTestFunction.mul {f g : X → ℝ} (hf : IsTestFunction f) (hg : IsTestFunction g) :
     IsTestFunction (fun x => f x * g x) where
   smooth := ContDiff.mul hf.smooth hg.smooth
   supp := HasCompactSupport.mul_left hg.supp
 
 @[fun_prop]
-theorem IsTestFunction.inner {f g : X → V} (hf : IsTestFunction f) (hg : IsTestFunction g) :
+lemma IsTestFunction.inner {f g : X → V} (hf : IsTestFunction f) (hg : IsTestFunction g) :
     IsTestFunction (fun x => ⟪f x, g x⟫_ℝ) where
   smooth := ContDiff.inner ℝ hf.smooth hg.smooth
   supp := by
@@ -61,26 +61,26 @@ theorem IsTestFunction.inner {f g : X → V} (hf : IsTestFunction f) (hg : IsTes
     exact hf.mono fun x hx => by simp [hx]
 
 @[fun_prop]
-theorem IsTestFunction.mul_left {f g : X → ℝ} (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) :
+lemma IsTestFunction.mul_left {f g : X → ℝ} (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) :
     IsTestFunction (fun x => f x * g x) where
   smooth := ContDiff.mul hf hg.smooth
   supp := HasCompactSupport.mul_left hg.supp
 
 @[fun_prop]
-theorem IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg : ContDiff ℝ ∞  g) :
+lemma IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg : ContDiff ℝ ∞  g) :
     IsTestFunction (fun x => f x * g x) where
   smooth := ContDiff.mul hf.smooth hg
   supp := HasCompactSupport.mul_right hf.supp
 
 
 @[fun_prop]
-theorem IsTestFunction.smul_left {f : X → ℝ} {g : X → U}
+lemma IsTestFunction.smul_left {f : X → ℝ} {g : X → U}
     (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) : IsTestFunction (fun x => f x • g x) where
   smooth := ContDiff.smul hf hg.smooth
   supp := HasCompactSupport.smul_left hg.supp
 
 @[fun_prop]
-theorem IsTestFunction.smul_right {f : X → ℝ} {g : X → U}
+lemma IsTestFunction.smul_right {f : X → ℝ} {g : X → U}
     (hf : IsTestFunction f) (hg : ContDiff ℝ ∞ g) : IsTestFunction (fun x => f x • g x) where
   smooth := ContDiff.smul hf.smooth hg
   supp := HasCompactSupport.smul_right hf.supp

--- a/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/IsTestFunction.lean
@@ -6,6 +6,10 @@ Authors: Tomas Skrivan, Joseph Tooby-Smith
 
 import Mathlib
 
+/-! Test function
+
+Definition of test function, smooth and compactly supported function, and theorems about them.
+-/
 section IsTestFunction
 variable
   {X} [NormedAddCommGroup X] [NormedSpace ℝ X]
@@ -71,12 +75,12 @@ theorem IsTestFunction.mul_right {f g : X → ℝ} (hf : IsTestFunction f) (hg :
 
 @[fun_prop]
 theorem IsTestFunction.smul_left {f : X → ℝ} {g : X → U}
-   (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) : IsTestFunction (fun x => f x • g x) where
+    (hf : ContDiff ℝ ∞ f) (hg : IsTestFunction g) : IsTestFunction (fun x => f x • g x) where
   smooth := ContDiff.smul hf hg.smooth
   supp := HasCompactSupport.smul_left hg.supp
 
 @[fun_prop]
 theorem IsTestFunction.smul_right {f : X → ℝ} {g : X → U}
-   (hf : IsTestFunction f) (hg : ContDiff ℝ ∞ g) : IsTestFunction (fun x => f x • g x) where
+    (hf : IsTestFunction f) (hg : ContDiff ℝ ∞ g) : IsTestFunction (fun x => f x • g x) where
   smooth := ContDiff.smul hf.smooth hg
   supp := HasCompactSupport.smul_right hf.supp


### PR DESCRIPTION
This PR defines variational gradient which allows us to state many physical laws in the form `δS = 0` and then show it is equivalent to the corresponding differential equation.

In particular there is 
```
inductive HasVarGradientAt (S' : (X → U) → (X → ℝ)) (grad : X → U) (u : X → U)  (μ : Measure X) : Prop := ...
```
which is saying that `grad` is variational gradient of `∫ x, S' u x ∂μ`. 

One potentially surprising thing with `HasVarGradientAt` is that you have to provide the unintegrated action `S'` rather than the full action `S u = ∫ x, S' u x ∂μ`. 

---

For example the statement that the variation of 1d pacticle's action gives Newton's law i.e. for
```
S(x) = ∫ 1/2*m*‖ẋ(t)‖² - V(x(t)) dt
```
we have
```
δS/δx(t) = - m*ẍ(t) - V'(x(t))`
```
is stated as
```
example (m : ℝ) (u V : ℝ → ℝ) (hu : ContDiff ℝ ∞ u) (hV : ContDiff ℝ ∞ V) : 
    HasVarGradientAt
      (fun (u : ℝ → ℝ) (t : ℝ) => 1/2 * m * deriv u t ^ 2 - V (u t))
      (fun t => - m * deriv (deriv u) t - deriv V (u t))
      u := ...
```


