### PR TITLE
feat: Space.grad equal gradient

### DIFF
--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -175,14 +175,13 @@ lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
 
 -/
 
-
 lemma grad_eq_sum {d} (f : Space d → ℝ) (x : Space d) :
     ∇ f x = ∑ i, deriv i f x • basis i := by
   funext i
   rw [grad, deriv_eq]
-  simp
+  simp only
   rw [Fintype.sum_apply]
-  simp
+  simp only [PiLp.smul_apply, smul_eq_mul]
   rw [Finset.sum_eq_single i]
   · simp [basis]
     rfl
@@ -197,9 +196,9 @@ lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
   funext x
   simp [grad, gradient, deriv_eq]
   have hx (y : Space d) : ⟪(InnerProductSpace.toDual ℝ (Space d)).symm (fderiv ℝ f x), y⟫_ℝ =
-      ⟪∇ f x, y⟫_ℝ  := by
+      ⟪∇ f x, y⟫_ℝ := by
     rw [toDual_symm_apply]
-    have hy : y = ∑ i, y i • basis  i  := by
+    have hy : y = ∑ i, y i • basis i := by
       conv_lhs => rw [← OrthonormalBasis.sum_repr basis y]
       dsimp [basis]
     rw [hy]
@@ -211,7 +210,7 @@ lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
     congr
     rw [grad_eq_sum]
     rw [← inner_conj_symm]
-    simp only [ conj_trivial, inner_sum]
+    simp only [conj_trivial, inner_sum]
     simp only [inner_smul_right]
     rw [Finset.sum_eq_single i]
     · have h1 : ⟪basis i, basis i⟫_ℝ = 1 := by

--- a/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
+++ b/PhysLean/ClassicalMechanics/Space/VectorIdentities.lean
@@ -6,7 +6,7 @@ Authors: Zhi Kai Pong
 import PhysLean.ClassicalMechanics.Space.Basic
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.Calculus.FDeriv.Symmetric
-
+import Mathlib.Analysis.Calculus.Gradient.Basic
 /-!
 
 # VectorIdentities
@@ -168,6 +168,71 @@ lemma deriv_coord_2nd_sub (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContD
     · apply differentiable_fderiv_coord
       exact hf
     · fun_prop
+
+/-!
+
+## Some properties of grad
+
+-/
+
+
+lemma grad_eq_sum {d} (f : Space d → ℝ) (x : Space d) :
+    ∇ f x = ∑ i, deriv i f x • basis i := by
+  funext i
+  rw [grad, deriv_eq]
+  simp
+  rw [Fintype.sum_apply]
+  simp
+  rw [Finset.sum_eq_single i]
+  · simp [basis]
+    rfl
+  · intro j hj
+    simp [basis]
+    exact fun a a_1 => False.elim (a (id (Eq.symm a_1)))
+  · simp
+
+open InnerProductSpace in
+lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
+    ∇ f = gradient f := by
+  funext x
+  simp [grad, gradient, deriv_eq]
+  have hx (y : Space d) : ⟪(InnerProductSpace.toDual ℝ (Space d)).symm (fderiv ℝ f x), y⟫_ℝ =
+      ⟪∇ f x, y⟫_ℝ  := by
+    rw [toDual_symm_apply]
+    have hy : y = ∑ i, y i • basis  i  := by
+      conv_lhs => rw [← OrthonormalBasis.sum_repr basis y]
+      dsimp [basis]
+    rw [hy]
+    conv_lhs => simp
+    conv_rhs => rw [inner_sum]
+    congr
+    funext i
+    rw [inner_smul_right]
+    congr
+    rw [grad_eq_sum]
+    rw [← inner_conj_symm]
+    simp only [ conj_trivial, inner_sum]
+    simp only [inner_smul_right]
+    rw [Finset.sum_eq_single i]
+    · have h1 : ⟪basis i, basis i⟫_ℝ = 1 := by
+        rw [real_inner_self_eq_norm_sq, basis.norm_eq_one]
+        simp
+      rw [h1]
+      simp only [mul_one]
+      rw [deriv_eq]
+      simp [basis]
+    · intro b hb h
+      rw [basis.inner_eq_zero]
+      simp only [mul_zero]
+      exact id (Ne.symm h)
+    · simp
+  have h1 : ∀ y, ⟪(toDual ℝ (Space d)).symm (fderiv ℝ f x) - ∇ f x, y⟫_ℝ = 0 := by
+    intro y
+    rw [inner_sub_left, hx y]
+    simp
+  have h2 := h1 ((toDual ℝ (Space d)).symm (fderiv ℝ f x) - ∇ f x)
+  rw [inner_self_eq_zero, sub_eq_zero] at h2
+  rw [h2]
 
 /-!
 


### PR DESCRIPTION
Proving the result:

```lean
lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
    ∇ f = gradient f := by ...
```

The latter has general API around it which may be useful.