### PR TITLE
refactor: use global Planck constant ℏ

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -197,6 +197,7 @@ import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.Eigenfunction
 import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.TISE
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Parity
+import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.Relativity.Bispinors.Basic
 import PhysLean.Relativity.CliffordAlgebra
 import PhysLean.Relativity.Lorentz.Algebra.Basic

--- a/PhysLean/QuantumMechanics/FiniteTarget/Basic.lean
+++ b/PhysLean/QuantumMechanics/FiniteTarget/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.CStarAlgebra.Classes
 import Mathlib.Analysis.Normed.Algebra.Exponential
 import Mathlib.LinearAlgebra.Matrix.Hermitian
 import PhysLean.Meta.TODO.Basic
+import PhysLean.QuantumMechanics.PlanckConstant
 /-!
 
 # Finite target quantum mechanics
@@ -19,32 +20,34 @@ Physical examples of such systems include:
 - Tight binding chains.
 
 -/
-
+open Constants
 namespace QuantumMechanics
 
+TODO "FXH5S" "Make `FiniteTarget` basis independent, i.e. use a linear map for
+  the hamiltonian instead of a matrix."
 /-- A finite target quantum mechanical system with hilbert-space of dimension `n`
   and Plank constant `ℏ` is described by a self-adjoint `n × n` matrix. -/
-structure FiniteTarget (n : ℕ) {ℏ : ℝ} (hℏ : 0 < ℏ) where
+structure FiniteTarget (n : ℕ)  where
   /-- The Hamiltonian, written with respect to the standard basis on `Fin n → ℂ`. -/
   H : Matrix (Fin n) (Fin n) ℂ
   H_selfAdjoint : Matrix.IsHermitian H
 
 namespace FiniteTarget
 
-variable {n : ℕ} {ℏ : ℝ} {hℏ : 0 < ℏ} (A : FiniteTarget n hℏ)
+variable {n : ℕ} (A : FiniteTarget n)
 
 /-- The Hilbert space associated with a finite target theory `A`. -/
 @[nolint unusedArguments]
-abbrev V (_ : FiniteTarget n hℏ) := Fin n → ℂ
+abbrev V (_ : FiniteTarget n) := Fin n → ℂ
 
 /-- Given a finite target QM system `A`, the time evolution matrix for a `t : ℝ`,
   `A.timeEvolutionMatrix t` is defined as `e ^ (- I t /ℏ * A.H)`. -/
-noncomputable def timeEvolutionMatrix (A : FiniteTarget n hℏ) (t : ℝ) : Matrix (Fin n) (Fin n) ℂ :=
+noncomputable def timeEvolutionMatrix (A : FiniteTarget n) (t : ℝ) : Matrix (Fin n) (Fin n) ℂ :=
   NormedSpace.exp ℂ (- (Complex.I * t / ℏ) • A.H)
 
 /-- Given a finite target QM system `A`, `timeEvolution` is the linear map from
   `A.V` to `A.V` obtained by multiplication with `timeEvolutionMatrix`. -/
-noncomputable def timeEvolution (A : FiniteTarget n hℏ) (t : ℝ) : A.V →ₗ[ℂ] A.V :=
+noncomputable def timeEvolution (A : FiniteTarget n) (t : ℝ) : A.V →ₗ[ℂ] A.V :=
   (LinearMap.toMatrix (Pi.basisFun ℂ (Fin n)) (Pi.basisFun ℂ (Fin n))).symm
   (timeEvolutionMatrix A t)
 

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
@@ -5,6 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Parity
 import PhysLean.Meta.TODO.Basic
+import PhysLean.QuantumMechanics.PlanckConstant
 /-!
 
 # 1d Harmonic Oscillator
@@ -59,39 +60,32 @@ namespace OneDimension
 structure HarmonicOscillator where
   /-- The mass of the particle. -/
   m : ℝ
-  /-- Reduced Planck's constant. -/
-  ℏ : ℝ
   /-- The angular frequency of the harmonic oscillator. -/
   ω : ℝ
-  hℏ : 0 < ℏ
   hω : 0 < ω
   hm : 0 < m
 
 namespace HarmonicOscillator
-
+open Constants
 open PhysLean HilbertSpace
 open MeasureTheory
 
 variable (Q : HarmonicOscillator)
 
 @[simp]
-lemma m_mul_ω_div_two_ℏ_pos : 0 < Q.m * Q.ω / (2 * Q.ℏ) := by
+lemma m_mul_ω_div_two_ℏ_pos : 0 < Q.m * Q.ω / (2 * ℏ) := by
   apply div_pos
   · exact mul_pos Q.hm Q.hω
-  · exact mul_pos (by norm_num) Q.hℏ
+  · exact mul_pos (by norm_num) ℏ_pos
 
 @[simp]
-lemma m_mul_ω_div_ℏ_pos : 0 < Q.m * Q.ω / Q.ℏ := by
+lemma m_mul_ω_div_ℏ_pos : 0 < Q.m * Q.ω / ℏ := by
   apply div_pos
   · exact mul_pos Q.hm Q.hω
-  · exact Q.hℏ
+  · exact ℏ_pos
 
 lemma m_ne_zero : Q.m ≠ 0 := by
   have h1 := Q.hm
-  linarith
-
-lemma ℏ_ne_zero : Q.ℏ ≠ 0 := by
-  have h1 := Q.hℏ
   linarith
 
 /-!
@@ -102,7 +96,7 @@ lemma ℏ_ne_zero : Q.ℏ ≠ 0 := by
 
 /-- The characteristic length `ξ` of the harmonic oscillator is defined
   as `√(ℏ /(m ω))`. -/
-noncomputable def ξ : ℝ := √(Q.ℏ / (Q.m * Q.ω))
+noncomputable def ξ : ℝ := √(ℏ / (Q.m * Q.ω))
 
 lemma ξ_nonneg : 0 ≤ Q.ξ := Real.sqrt_nonneg _
 
@@ -111,31 +105,31 @@ lemma ξ_pos : 0 < Q.ξ := by
   rw [ξ]
   apply Real.sqrt_pos.mpr
   apply div_pos
-  · exact Q.hℏ
+  · exact ℏ_pos
   · exact mul_pos Q.hm Q.hω
 
 @[simp]
 lemma ξ_ne_zero : Q.ξ ≠ 0 := Ne.symm (_root_.ne_of_lt Q.ξ_pos)
 
-lemma ξ_sq : Q.ξ^2 = Q.ℏ / (Q.m * Q.ω) := by
+lemma ξ_sq : Q.ξ^2 = ℏ / (Q.m * Q.ω) := by
   rw [ξ]
   apply Real.sq_sqrt
   apply div_nonneg
-  · exact le_of_lt Q.hℏ
+  · exact ℏ_nonneg
   · exact mul_nonneg (le_of_lt Q.hm) (le_of_lt Q.hω)
 
 @[simp]
 lemma ξ_abs : abs Q.ξ = Q.ξ := abs_of_nonneg Q.ξ_nonneg
 
-lemma one_over_ξ : 1/Q.ξ = √(Q.m * Q.ω / Q.ℏ) := by
-  have := Q.hℏ
+lemma one_over_ξ : 1/Q.ξ = √(Q.m * Q.ω / ℏ) := by
+  have := ℏ_pos
   field_simp [ξ]
 
-lemma ξ_inverse : Q.ξ⁻¹ = √(Q.m * Q.ω / Q.ℏ) := by
+lemma ξ_inverse : Q.ξ⁻¹ = √(Q.m * Q.ω / ℏ) := by
   rw [inv_eq_one_div]
   exact one_over_ξ Q
 
-lemma one_over_ξ_sq : (1/Q.ξ)^2 = Q.m * Q.ω / Q.ℏ := by
+lemma one_over_ξ_sq : (1/Q.ξ)^2 = Q.m * Q.ω / ℏ := by
   rw [one_over_ξ]
   refine Real.sq_sqrt (le_of_lt Q.m_mul_ω_div_ℏ_pos)
 
@@ -146,7 +140,7 @@ TODO "6VZH3" "The momentum operator should be moved to a more general file."
 
   The notation `Pᵒᵖ` can be used for the momentum operator. -/
 noncomputable def momentumOperator (ψ : ℝ → ℂ) : ℝ → ℂ :=
-  fun x => - Complex.I * Q.ℏ * deriv ψ x
+  fun x => - Complex.I * ℏ * deriv ψ x
 
 @[inherit_doc momentumOperator]
 scoped[QuantumMechanics.OneDimension.HarmonicOscillator] notation "Pᵒᵖ" => momentumOperator
@@ -166,10 +160,10 @@ scoped[QuantumMechanics.OneDimension.HarmonicOscillator] notation "Xᵒᵖ" => p
 
   `ψ ↦ - ℏ^2 / (2 * m) * ψ'' + 1/2 * m * ω^2 * x^2 * ψ`. -/
 noncomputable def schrodingerOperator (ψ : ℝ → ℂ) : ℝ → ℂ :=
-  fun x => - Q.ℏ ^ 2 / (2 * Q.m) * (deriv (deriv ψ) x) + 1/2 * Q.m * Q.ω^2 * x^2 * ψ x
+  fun x => - ℏ ^ 2 / (2 * Q.m) * (deriv (deriv ψ) x) + 1/2 * Q.m * Q.ω^2 * x^2 * ψ x
 
 lemma schrodingerOperator_eq (ψ : ℝ → ℂ) :
-    Q.schrodingerOperator ψ = (- Q.ℏ ^ 2 / (2 * Q.m)) •
+    Q.schrodingerOperator ψ = (- ℏ ^ 2 / (2 * Q.m)) •
     (deriv (deriv ψ)) + (1/2 * Q.m * Q.ω^2) • ((fun x => Complex.ofReal x ^2) * ψ) := by
   funext x
   simp only [schrodingerOperator, one_div, Pi.add_apply, Pi.smul_apply, Complex.real_smul,
@@ -179,11 +173,11 @@ lemma schrodingerOperator_eq (ψ : ℝ → ℂ) :
 
 /-- The schrodinger operator written in terms of `ξ`. -/
 lemma schrodingerOperator_eq_ξ (ψ : ℝ → ℂ) : Q.schrodingerOperator ψ =
-    fun x => (Q.ℏ ^2 / (2 * Q.m)) * (- (deriv (deriv ψ) x) + (1/Q.ξ^2)^2 * x^2 * ψ x) := by
+    fun x => (ℏ ^2 / (2 * Q.m)) * (- (deriv (deriv ψ) x) + (1/Q.ξ^2)^2 * x^2 * ψ x) := by
   funext x
   simp [schrodingerOperator_eq, ξ_sq, ξ_inverse, ξ_ne_zero, ξ_pos, ξ_abs, ← Complex.ofReal_pow]
   have := Complex.ofReal_ne_zero.mpr Q.m_ne_zero
-  have := Complex.ofReal_ne_zero.mpr Q.ℏ_ne_zero
+  have := Complex.ofReal_ne_zero.mpr ℏ_ne_zero
   field_simp
   ring
 

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
@@ -19,10 +19,7 @@ namespace HarmonicOscillator
 
 variable (Q : HarmonicOscillator)
 
-open Nat
-open PhysLean
-open HilbertSpace
-open MeasureTheory
+open Nat PhysLean HilbertSpace MeasureTheory Constants
 
 /-- The `n`th eigenfunction of the Harmonic oscillator is defined as the function `ℝ → ℂ`
   taking `x : ℝ` to

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/TISE.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/TISE.lean
@@ -17,12 +17,10 @@ namespace HarmonicOscillator
 
 variable (Q : HarmonicOscillator)
 
-open Nat
-open PhysLean
-open HilbertSpace
+open Nat PhysLean HilbertSpace Constants
 
 /-- The `n`th eigenvalues for a Harmonic oscillator is defined as `(n + 1/2) * ℏ * ω`. -/
-noncomputable def eigenValue (n : ℕ) : ℝ := (n + 1/2) * Q.ℏ * Q.ω
+noncomputable def eigenValue (n : ℕ) : ℝ := (n + 1/2) * ℏ * Q.ω
 
 /-!
 
@@ -258,7 +256,7 @@ lemma schrodingerOperator_eigenfunction (n : ℕ) (x : ℝ) :
   simp only [schrodingerOperator_eq_ξ, one_div]
   rw [Q.deriv_deriv_eigenfunction]
   have hm' := Complex.ofReal_ne_zero.mpr (Ne.symm (_root_.ne_of_lt Q.hm))
-  have hℏ' := Complex.ofReal_ne_zero.mpr (Ne.symm (_root_.ne_of_lt Q.hℏ))
+  have hℏ' := Complex.ofReal_ne_zero.mpr ℏ_ne_zero
   rw [eigenValue]
   simp only [← Complex.ofReal_pow, ξ_sq]
   field_simp

--- a/PhysLean/QuantumMechanics/PlanckConstant.lean
+++ b/PhysLean/QuantumMechanics/PlanckConstant.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Data.NNReal.Defs
+/-!
+
+# Planck's constant
+
+In this module we define the Planck's constant `ℏ` as a positive real number.
+This is introduced as an axiom.
+
+-/
+open NNReal
+
+namespace Constants
+
+/-- Planck's constant. -/
+axiom ℏ : Subtype fun x : ℝ => 0 < x
+
+/-- Planck's constant is positive. -/
+lemma ℏ_pos : 0 < (ℏ : ℝ) := ℏ.2
+
+/-- Planck's constant is non-negative. -/
+lemma ℏ_nonneg : 0 ≤ (ℏ : ℝ) := le_of_lt ℏ.2
+
+/-- Planck's constant is not equal to zero. -/
+lemma ℏ_ne_zero : (ℏ : ℝ) ≠ 0 := ne_of_gt ℏ.2
+
+end Constants


### PR DESCRIPTION
Copilot: Introduced PhysLean.QuantumMechanics.PlanckConstant.lean defining ℏ as a global constant. Updated all quantum mechanics modules to use this global ℏ instead of passing it as a parameter or storing it in structures. Simplified related proofs and imports accordingly.