### PR TITLE
feat: momentum operator as unbounded linear map

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -203,6 +203,7 @@ import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.Eigenfunction
 import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.TISE
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Parity
+import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.Relativity.Bispinors.Basic
 import PhysLean.Relativity.CliffordAlgebra

--- a/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import PhysLean.QuantumMechanics.PlanckConstant
+import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 /-!
 
 # The 1d QM system with general potential
@@ -19,13 +20,6 @@ namespace QuantumMechanics
 namespace OneDimension
 
 open PhysLean HilbertSpace Constants
-
-/-- The momentum operator is defined as the map from `ℝ → ℂ` to `ℝ → ℂ` taking
-  `ψ` to `- i ℏ ψ'`.
-
-  The notation `Pᵒᵖ` can be used for the momentum operator. -/
-noncomputable def momentumOperator (ψ : ℝ → ℂ) : ℝ → ℂ :=
-  fun x ↦ - Complex.I * ℏ * deriv ψ x
 
 private lemma fun_add {α : Type*} (f g : α → ℂ) :
   (fun x ↦ f x) + (fun x ↦ g x) = fun x ↦ f x + g x := by

--- a/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
@@ -3,11 +3,6 @@ Copyright (c) 2025 Ammar Husain. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ammar Husain
 -/
-import PhysLean.Meta.TODO.Basic
-import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.Analysis.Calculus.Deriv.Add
-import Mathlib.Analysis.Calculus.Deriv.Mul
-import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 /-!
 

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
@@ -114,7 +114,7 @@ lemma mk_smul {f : ℝ → ℂ} {c : ℂ} {hf : MemHS f} :
     mk (memHS_smul (c := c) hf) = c • mk hf := rfl
 
 lemma mk_eq_iff {f g : ℝ → ℂ} {hf : MemHS f} {hg : MemHS g} :
-    mk hf = mk hg  ↔ f =ᵐ[volume] g := by
+    mk hf = mk hg ↔ f =ᵐ[volume] g := by
   simp [mk]
 
 /-!

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean
@@ -44,6 +44,23 @@ lemma memHS_iff {f : ℝ → ℂ} : MemHS f ↔
     MeasureTheory.AEStronglyMeasurable.pow (continuous_norm.comp_aestronglyMeasurable h1) ..
   simp [h0, HasFiniteIntegral]
 
+@[simp]
+lemma zero_memHS : MemHS 0 := by
+  change MemHS (fun x => (0 : ℂ))
+  rw [memHS_iff]
+  simp only [norm_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, integrable_zero,
+    and_true]
+  fun_prop
+
+@[simp]
+lemma zero_fun_memHS : MemHS (fun _ : ℝ => (0 : ℂ)) := zero_memHS
+
+lemma memHS_add {f g : ℝ → ℂ} (hf : MemHS f) (hg : MemHS g) :
+    MemHS (f + g) := MeasureTheory.MemLp.add hf hg
+
+lemma memHS_smul {f : ℝ → ℂ} {c : ℂ} (hf : MemHS f) :
+    MemHS (c • f) := MeasureTheory.MemLp.const_smul hf c
+
 lemma aeEqFun_mk_mem_iff (f : ℝ → ℂ) (hf : AEStronglyMeasurable f volume) :
     AEEqFun.mk f hf ∈ HilbertSpace ↔ MemHS f := by
   simp only [Lp.mem_Lp_iff_memLp]
@@ -89,6 +106,16 @@ lemma mem_iff' {f : ℝ → ℂ} (hf : MeasureTheory.AEStronglyMeasurable f Meas
   have h0 : MeasureTheory.AEStronglyMeasurable (fun x => norm (f x) ^ 2) MeasureTheory.volume :=
     MeasureTheory.AEStronglyMeasurable.pow (continuous_norm.comp_aestronglyMeasurable hf) ..
   simp [h0, HasFiniteIntegral]
+
+lemma mk_add {f g : ℝ → ℂ} {hf : MemHS f} {hg : MemHS g} :
+    mk (memHS_add hf hg) = mk hf + mk hg := rfl
+
+lemma mk_smul {f : ℝ → ℂ} {c : ℂ} {hf : MemHS f} :
+    mk (memHS_smul (c := c) hf) = c • mk hf := rfl
+
+lemma mk_eq_iff {f g : ℝ → ℂ} {hf : MemHS f} {hg : MemHS g} :
+    mk hf = mk hg  ↔ f =ᵐ[volume] g := by
+  simp [mk]
 
 /-!
 

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
+import Mathlib.LinearAlgebra.LinearPMap
+import PhysLean.QuantumMechanics.PlanckConstant
+import PhysLean.Meta.TODO.Basic
+/-!
+
+# Momentum operator
+
+In this module we define the momentum operator as an `LinearPMap`
+from the Hilbert space of square integrable functions to itself.
+This corresponds to `momentumOperatorLinearPMap`.
+
+We also define the momentum operator on functions `ℝ → ℂ`,
+which is `momentumOperator`.
+-/
+
+namespace QuantumMechanics
+
+namespace OneDimension
+noncomputable section
+open Constants
+open HilbertSpace
+
+/-- The domain of the momentum operator is square integrable functions
+  which are differentiable and which have a square integrable derivative. -/
+def momentumOperatorLinearPMap.domain' : Submodule ℂ HilbertSpace  where
+  carrier ψ := ∃ ψ', ψ =ᵐ[MeasureTheory.volume] ψ' ∧
+    Differentiable ℝ ψ' ∧ MemHS (fun x => - Complex.I * ℏ * deriv ψ' x)
+  zero_mem' := by
+    use 0
+    apply And.intro
+    · exact MeasureTheory.Lp.coeFn_zero ℂ 2 MeasureTheory.volume
+    · simp
+  add_mem' {ψ1 ψ2} h1 h2:= by
+    obtain ⟨ψ1', h1', h1diff, h1hs⟩ := h1
+    obtain ⟨ψ2', h2', h2diff, h2hs⟩ := h2
+    use ψ1' + ψ2'
+    refine ⟨?_, ?_, ?_⟩
+    · trans ψ1.1 + ψ2.1
+      · apply MeasureTheory.AEEqFun.coeFn_add
+      · apply Filter.EventuallyEq.add
+        · exact h1'
+        · exact h2'
+    · fun_prop
+    · have h1 :  (fun x => -Complex.I * ↑↑ℏ * deriv (ψ1' + ψ2') x)
+          =  fun x => -Complex.I * ↑↑ℏ * deriv (ψ1') x + (-Complex.I * ↑↑ℏ * deriv (ψ2') x) := by
+        funext x
+        simp
+        rw [deriv_add]
+        · ring
+        · exact h1diff x
+        · exact h2diff x
+      rw [h1]
+      exact memHS_add h1hs h2hs
+  smul_mem' c ψ h := by
+    obtain ⟨ψ', h', hdiff, hhs⟩ := h
+    use c • ψ'
+    refine ⟨?_, ?_, ?_⟩
+    · trans c • ψ
+      · apply MeasureTheory.AEEqFun.coeFn_smul
+      · change (fun x => c • ψ x) =ᵐ[MeasureTheory.volume] fun x => c • ψ' x
+        exact Filter.EventuallyEq.const_smul h' c
+    · fun_prop
+    · have h1 : (fun x => -Complex.I * ↑↑ℏ * deriv (c • ψ') x)
+          = c • fun x => (-Complex.I * ↑↑ℏ * deriv ψ' x) := by
+        funext x
+        rw [deriv_const_smul]
+        · simp
+          ring
+        · fun_prop
+      rw [h1]
+      exact memHS_smul hhs
+
+/-- The momentum operator as a linear map from it's domain to the Hilbert space. -/
+def momentumOperatorLinearPMap.toFun' :
+    momentumOperatorLinearPMap.domain' →ₗ[ℂ] HilbertSpace where
+  toFun := fun ψ => HilbertSpace.mk (Classical.choose_spec ψ.2).2.2
+  map_add' ψ1 ψ2 := by
+    rw [← mk_add, mk_eq_iff]
+    trans  (fun x => (-Complex.I * ↑↑ℏ) • (fun x => deriv (Classical.choose (ψ1 + ψ2).2) x) x)
+    · simp
+    symm
+    trans (fun x => (-Complex.I * ↑↑ℏ) • (fun x =>
+      deriv (Classical.choose ψ1.2) x + deriv (Classical.choose ψ2.2) x) x)
+    · apply Eq.eventuallyEq
+      funext x
+      simp
+      ring
+    apply Filter.EventuallyEq.const_smul
+    trans  (fun x => deriv (Classical.choose ψ1.2 + Classical.choose ψ2.2) x)
+    · apply Eq.eventuallyEq
+      funext x
+      simp
+      have h1 : deriv (Classical.choose ψ1.2) x + deriv (Classical.choose ψ2.2) x
+          = deriv (Classical.choose ψ1.2 + Classical.choose ψ2.2) x := by
+        rw [deriv_add]
+        · exact (Classical.choose_spec ψ1.2).2.1 x
+        · exact (Classical.choose_spec ψ2.2).2.1 x
+      trans deriv (Classical.choose ψ1.2) x + deriv (Classical.choose ψ2.2) x
+      · simp
+      rw [h1]
+      simp
+    apply Eq.eventuallyEq
+    funext x
+    rw [← fderiv_deriv, ← fderiv_deriv]
+    congr 1
+    apply Filter.EventuallyEq.fderiv_eq
+    refine Filter.EventuallyEq.symm (Eq.eventuallyEq ?_)
+    refine (Continuous.ae_eq_iff_eq MeasureTheory.volume ?_ ?_).mp ?_
+    · apply (Classical.choose_spec (ψ1 + ψ2).2).2.1.continuous
+    · have h1 := (Classical.choose_spec ψ1.2).2.1.continuous
+      have h2 := (Classical.choose_spec ψ2.2).2.1.continuous
+      exact Continuous.add h1 h2
+    trans (ψ1 + ψ2)
+    swap
+    · apply Filter.EventuallyEq.add
+      · exact (Classical.choose_spec ψ1.2).1
+      · exact (Classical.choose_spec ψ2.2).1
+    refine (Classical.choose_spec (ψ1 + ψ2).2).1.symm.trans ?_
+    apply (MeasureTheory.AEEqFun.coeFn_add)
+  map_smul' c ψ := by
+    rw [← mk_smul, mk_eq_iff]
+    apply Filter.EventuallyEq.symm (Eq.eventuallyEq ?_)
+    funext x
+    simp
+    trans (Complex.I * ↑↑ℏ * (c • deriv (Classical.choose ψ.2) x))
+    · simp
+      ring
+    trans (Complex.I * ↑↑ℏ * (deriv ( Classical.choose (c • ψ).2) x))
+    swap
+    · simp
+    congr
+    rw [← deriv_const_smul c ((Classical.choose_spec ψ.2).2.1 x)]
+    congr
+    refine (Continuous.ae_eq_iff_eq MeasureTheory.volume ?_ ?_).mp ?_
+    · have h1 := (Classical.choose_spec ψ.2).2.1.continuous
+      exact Continuous.const_smul h1 c
+    · exact (Classical.choose_spec (c • ψ).2).2.1.continuous
+    trans c • ψ
+    · change (fun x => c • Classical.choose ψ.2 x) =ᵐ[MeasureTheory.volume] fun x => c • ψ.1 x
+      apply Filter.EventuallyEq.const_smul
+      exact (Classical.choose_spec ψ.2).1.symm
+    symm
+    apply (Classical.choose_spec (c • ψ).2).1.symm.trans
+    simp
+    apply MeasureTheory.AEEqFun.coeFn_smul
+
+/-- The unbounded momentum operator, whose domain is square integrable functions
+  which are differentiable and which have a square integrable derivative. -/
+def momentumOperatorLinearPMap : HilbertSpace →ₗ.[ℂ] HilbertSpace where
+  domain := momentumOperatorLinearPMap.domain'
+  toFun := momentumOperatorLinearPMap.toFun'
+
+/-- The momentum operator is defined as the map from `ℝ → ℂ` to `ℝ → ℂ` taking
+  `ψ` to `- i ℏ ψ'`. -/
+def momentumOperator (ψ : ℝ → ℂ) : ℝ → ℂ :=
+  fun x ↦ - Complex.I * ℏ * deriv ψ x
+
+TODO "GPZWI" "Make API connecting the `momentumOperator` to `momentumOperatorLinearPMap`
+  for one-dimensional QM."
+
+end
+end OneDimension
+end QuantumMechanics

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
-import Mathlib.LinearAlgebra.LinearPMap
 import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.Meta.TODO.Basic
 /-!
@@ -28,7 +27,7 @@ open HilbertSpace
 
 /-- The domain of the momentum operator is square integrable functions
   which are differentiable and which have a square integrable derivative. -/
-def momentumOperatorLinearPMap.domain' : Submodule ℂ HilbertSpace  where
+def momentumOperatorLinearPMap.domain' : Submodule ℂ HilbertSpace where
   carrier ψ := ∃ ψ', ψ =ᵐ[MeasureTheory.volume] ψ' ∧
     Differentiable ℝ ψ' ∧ MemHS (fun x => - Complex.I * ℏ * deriv ψ' x)
   zero_mem' := by
@@ -47,10 +46,10 @@ def momentumOperatorLinearPMap.domain' : Submodule ℂ HilbertSpace  where
         · exact h1'
         · exact h2'
     · fun_prop
-    · have h1 :  (fun x => -Complex.I * ↑↑ℏ * deriv (ψ1' + ψ2') x)
-          =  fun x => -Complex.I * ↑↑ℏ * deriv (ψ1') x + (-Complex.I * ↑↑ℏ * deriv (ψ2') x) := by
+    · have h1 : (fun x => -Complex.I * ↑↑ℏ * deriv (ψ1' + ψ2') x)
+          = fun x => -Complex.I * ↑↑ℏ * deriv (ψ1') x + (-Complex.I * ↑↑ℏ * deriv (ψ2') x) := by
         funext x
-        simp
+        simp only [neg_mul]
         rw [deriv_add]
         · ring
         · exact h1diff x
@@ -82,20 +81,20 @@ def momentumOperatorLinearPMap.toFun' :
   toFun := fun ψ => HilbertSpace.mk (Classical.choose_spec ψ.2).2.2
   map_add' ψ1 ψ2 := by
     rw [← mk_add, mk_eq_iff]
-    trans  (fun x => (-Complex.I * ↑↑ℏ) • (fun x => deriv (Classical.choose (ψ1 + ψ2).2) x) x)
+    trans (fun x => (-Complex.I * ↑↑ℏ) • (fun x => deriv (Classical.choose (ψ1 + ψ2).2) x) x)
     · simp
     symm
     trans (fun x => (-Complex.I * ↑↑ℏ) • (fun x =>
       deriv (Classical.choose ψ1.2) x + deriv (Classical.choose ψ2.2) x) x)
     · apply Eq.eventuallyEq
       funext x
-      simp
+      simp only [neg_mul, Pi.add_apply, smul_eq_mul]
       ring
     apply Filter.EventuallyEq.const_smul
-    trans  (fun x => deriv (Classical.choose ψ1.2 + Classical.choose ψ2.2) x)
+    trans (fun x => deriv (Classical.choose ψ1.2 + Classical.choose ψ2.2) x)
     · apply Eq.eventuallyEq
       funext x
-      simp
+      simp only [neg_mul]
       have h1 : deriv (Classical.choose ψ1.2) x + deriv (Classical.choose ψ2.2) x
           = deriv (Classical.choose ψ1.2 + Classical.choose ψ2.2) x := by
         rw [deriv_add]
@@ -127,11 +126,12 @@ def momentumOperatorLinearPMap.toFun' :
     rw [← mk_smul, mk_eq_iff]
     apply Filter.EventuallyEq.symm (Eq.eventuallyEq ?_)
     funext x
-    simp
+    simp only [RingHom.id_apply, neg_mul, Pi.smul_apply, smul_eq_mul, mul_neg, SetLike.val_smul,
+      neg_inj]
     trans (Complex.I * ↑↑ℏ * (c • deriv (Classical.choose ψ.2) x))
     · simp
       ring
-    trans (Complex.I * ↑↑ℏ * (deriv ( Classical.choose (c • ψ).2) x))
+    trans (Complex.I * ↑↑ℏ * (deriv (Classical.choose (c • ψ).2) x))
     swap
     · simp
     congr
@@ -147,7 +147,7 @@ def momentumOperatorLinearPMap.toFun' :
       exact (Classical.choose_spec ψ.2).1.symm
     symm
     apply (Classical.choose_spec (c • ψ).2).1.symm.trans
-    simp
+    simp only [SetLike.val_smul]
     apply MeasureTheory.AEEqFun.coeFn_smul
 
 /-- The unbounded momentum operator, whose domain is square integrable functions

--- a/PhysLean/Relativity/LorentzGroup/Boosts/Generalized.lean
+++ b/PhysLean/Relativity/LorentzGroup/Boosts/Generalized.lean
@@ -234,7 +234,7 @@ lemma generalizedBoost_apply (u v : Velocity d) (x : Vector d) :
 lemma generalizedBoost_apply_mul_one_plus_contr (u v : Velocity d) (x : Vector d) :
     (1 + ⟪u, v.1⟫ₘ) • generalizedBoost u v • x = (1 + ⟪u, v.1⟫ₘ) • x +
     (2 * ⟪x, u⟫ₘ * (1 + ⟪u, v.1⟫ₘ)) • v - ⟪x, u + v⟫ₘ • (u + v) := by
-  rw [generalizedBoost_apply, _root_.smul_add,  _root_.smul_add]
+  rw [generalizedBoost_apply, _root_.smul_add, _root_.smul_add]
   trans (1 + ⟪u, v.1⟫ₘ) • x + (2 * ⟪x, u⟫ₘ * (1 + ⟪u, v.1⟫ₘ)) • v
     + (- ⟪x, u + v⟫ₘ) • (u + v)
   · congr 1
@@ -259,7 +259,7 @@ lemma generalizedBoost_apply_expand (u v : Velocity d) (x : Vector d) :
   apply (smul_right_inj (Velocity.one_add_minkowskiProduct_neq_zero u v)).mp
   rw [generalizedBoost_apply_mul_one_plus_contr]
   conv_rhs =>
-    rw [ _root_.smul_sub,  _root_.smul_add, smul_smul, smul_smul]
+    rw [_root_.smul_sub, _root_.smul_add, smul_smul, smul_smul]
   congr 1
   · ring_nf
   · congr

--- a/PhysLean/Relativity/PauliMatrices/ToTensor.lean
+++ b/PhysLean/Relativity/PauliMatrices/ToTensor.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import PhysLean.Relativity.PauliMatrices.Basic
 import PhysLean.Relativity.Tensors.ComplexTensor.Metrics.Basic
 import PhysLean.Relativity.PauliMatrices.AsTensor
 import PhysLean.Relativity.Tensors.ComplexTensor.Metrics.Basic


### PR DESCRIPTION

Copilot summary: 

This pull request introduces significant changes to the implementation of the momentum operator in the `PhysLean` library. The momentum operator, previously defined directly as a function, has been refactored into a dedicated module with a more rigorous mathematical structure, including its definition as a `LinearPMap` for Hilbert spaces. Additionally, helper lemmas for Hilbert space membership have been added to support the new implementation. The most important changes are summarized below.

### Refactoring the Momentum Operator

* **Momentum operator module**: Created a new module `PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean` to define the momentum operator rigorously as a `LinearPMap` from the Hilbert space of square-integrable functions to itself. This includes defining its domain (`momentumOperatorLinearPMap.domain'`) and its action as a linear map (`momentumOperatorLinearPMap.toFun'`).
* **Momentum operator function**: Reintroduced the momentum operator as a function `momentumOperator` mapping `ℝ → ℂ` to `ℝ → ℂ`, now within the new module.

### Cleanup and Removal of Redundant Code

* **Removed direct definition**: Deleted the earlier definition of the momentum operator (`momentumOperator`) from `PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean`. The new module supersedes this implementation.

### Enhancements to Hilbert Space Membership Lemmas

* **Hilbert space helper lemmas**: Added new lemmas in `PhysLean/QuantumMechanics/OneDimension/HilbertSpace/Basic.lean` to simplify operations on Hilbert space elements, including `zero_memHS`, `memHS_add`, and `memHS_smul`. These lemmas support the new momentum operator implementation.
* **Additional lemmas for `mk`**: Introduced lemmas (`mk_add`, `mk_smul`, and `mk_eq_iff`) to streamline manipulations of `mk` for Hilbert space elements.

### Dependency Updates

* **Updated imports**: Added imports for the new momentum operator module in files where it is used (`PhysLean.lean` and `PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean`). [[1]](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R206) [[2]](diffhunk://#diff-14aae18c36605c7a0d47b107dfdf660d8698bc77d2d327d4da84bea10b58427cR11)