### PR TITLE
feat: Position and parity operators in 1d QM

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -207,6 +207,7 @@ import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 import PhysLean.QuantumMechanics.OneDimension.Operators.Parity
+import PhysLean.QuantumMechanics.OneDimension.Operators.Position
 import PhysLean.QuantumMechanics.PlanckConstant
 import PhysLean.Relativity.Bispinors.Basic
 import PhysLean.Relativity.CliffordAlgebra

--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -204,6 +204,7 @@ import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.TISE
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Gaussians
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
 import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
 import PhysLean.QuantumMechanics.OneDimension.Operators.Parity

--- a/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/GeneralPotential/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ammar Husain
 -/
 import PhysLean.QuantumMechanics.OneDimension.Operators.Momentum
+import PhysLean.QuantumMechanics.OneDimension.Operators.Position
+
 /-!
 
 # The 1d QM system with general potential
@@ -56,11 +58,6 @@ lemma momentumOperator_sq_linear (a1 a2 : ℂ) (ψ1 ψ2 : ℝ → ℂ)
     a1 • (momentumOperator (momentumOperator ψ1)) +
     a2 • (momentumOperator (momentumOperator ψ2)) := by
   rw [momentumOperator_linear, momentumOperator_linear] <;> assumption
-
-/-- The position operator is defined as the map from `ℝ → ℂ` to `ℝ → ℂ` taking
-  `ψ` to `x ψ'`. -/
-noncomputable def positionOperator (ψ : ℝ → ℂ) : ℝ → ℂ :=
-  fun x ↦ x * ψ x
 
 /-- The potential operator is defined as the map from `ℝ → ℂ` to `ℝ → ℂ` taking
   `ψ` to `V(x) ψ`. -/

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Basic.lean
@@ -183,12 +183,12 @@ lemma schrodingerOperator_eq_ξ (ψ : ℝ → ℂ) : Q.schrodingerOperator ψ =
 
 /-- The Schrodinger operator commutes with the parity operator. -/
 lemma schrodingerOperator_parity (ψ : ℝ → ℂ) :
-    Q.schrodingerOperator (parity ψ) = parity (Q.schrodingerOperator ψ) := by
+    Q.schrodingerOperator (parityOperator ψ) = parityOperator (Q.schrodingerOperator ψ) := by
   funext x
   have (ψ : ℝ → ℂ) : (fun x => (deriv fun x => ψ (-x)) x) = fun x => - deriv ψ (-x) := by
     funext x
     rw [← deriv_comp_neg]
-  simp [schrodingerOperator, parity, this]
+  simp [schrodingerOperator, parityOperator, this]
 
 end HarmonicOscillator
 end OneDimension

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Completeness.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Completeness.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.Eigenfunction
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Gaussians
-import Mathlib.Analysis.Fourier.FourierTransform
 /-!
 
 # Completeness of the eigenfunctions of the Harmonic Oscillator

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
@@ -159,10 +159,10 @@ lemma eigenfunction_continuous (n : ℕ) : Continuous (Q.eigenfunction n) := by
 /-- The `n`th eigenfunction is an eigenfunction of the parity operator with
   the eigenvalue `(-1) ^ n`. -/
 lemma eigenfunction_parity (n : ℕ) :
-    parity (Q.eigenfunction n) = (-1) ^ n * Q.eigenfunction n := by
+    parityOperator (Q.eigenfunction n) = (-1) ^ n * Q.eigenfunction n := by
   funext x
   rw [eigenfunction_eq]
-  simp only [parity, LinearMap.coe_mk, AddHom.coe_mk, mul_neg, Pi.mul_apply, Pi.pow_apply,
+  simp only [parityOperator, LinearMap.coe_mk, AddHom.coe_mk, mul_neg, Pi.mul_apply, Pi.pow_apply,
     Pi.neg_apply, Pi.one_apply]
   rw [show -x / Q.ξ = - (x / Q.ξ) by ring]
   rw [← physHermite_eq_aeval, physHermite_parity]

--- a/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HarmonicOscillator/Eigenfunction.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.QuantumMechanics.OneDimension.HarmonicOscillator.Basic
-import Mathlib.Topology.Algebra.Polynomial
 import PhysLean.Mathematics.SpecialFunctions.PhysHermite
 /-!
 

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/PositionStates.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/PositionStates.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.SchwartzSubmodule
+/-!
+
+# Position states
+
+We define plane waves as a member of the dual of the
+Schwartz submodule of the Hilbert space.
+
+-/
+namespace QuantumMechanics
+
+namespace OneDimension
+
+noncomputable section
+
+namespace HilbertSpace
+open MeasureTheory
+
+/-- Position state as a member of the dual of the
+  Schwartz submodule of the Hilbert space. -/
+def positionState (x : ℝ) : Module.Dual ℂ Φ := by
+  refine (?_ : SchwartzMap ℝ ℂ →ₗ[ℂ] ℂ) ∘ₗ schwartzSubmoduleEquiv
+  exact
+  { toFun ψ := ψ x,
+    map_add' ψ1 ψ2 := by simp
+    map_smul' a ψ := by simp
+  }
+
+lemma positionState_apply (x : ℝ) (ψ : schwartzSubmodule) :
+    positionState x ψ = schwartzSubmoduleEquiv ψ x := rfl
+
+/-- Two elements of the `schwartzSubmodule` are equal if they
+  are equal on all position states. -/
+lemma eq_of_eq_positionState {ψ1 ψ2 : schwartzSubmodule}
+    (h : ∀ x, positionState x ψ1 = positionState x ψ2) :
+    ψ1 = ψ2 := by
+  apply schwartzSubmoduleEquiv.injective
+  ext x
+  exact h x
+
+end HilbertSpace
+end
+end OneDimension
+end QuantumMechanics

--- a/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/HilbertSpace/SchwartzSubmodule.lean
@@ -68,6 +68,12 @@ def schwartzSubmoduleEquiv : schwartzSubmodule ≃ₗ[ℂ] SchwartzMap ℝ ℂ w
     rw [(Classical.choose_spec (a • ψ).2).2, (Classical.choose_spec ψ.2).2]
     rfl
 
+@[simp]
+lemma schwartzMap_toLpCLM_mem_schwartzSubmodule (ψ : SchwartzMap ℝ ℂ) :
+    ψ.toLp 2 volume ∈ schwartzSubmodule := by
+  use ψ
+  simp
+
 /-- The inclusion of the Hilbert space into the dual of the submodule
   of Schwartz maps. -/
 def inclDualSchwartzSubmodule: HilbertSpace →ₛₗ[starRingEnd ℂ] Module.Dual ℂ Φ :=

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -73,6 +73,8 @@ lemma momentumOperator_add {ψ1 ψ2 : ℝ → ℂ}
 
 -/
 
+/-- The momentum operator on the Schwartz submodule is defined as the linear map from
+  `schwartzSubmodule` to itself, such that `ψ` is taken to `fun x => - I ℏ ψ' (x)`. -/
 def momentumOperatorSchwartz : Φ →ₗ[ℂ] Φ where
   toFun ψ := schwartzSubmoduleEquiv.symm <|
     (- Complex.I * ℏ) • SchwartzMap.derivCLM ℂ (schwartzSubmoduleEquiv ψ)

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -73,39 +73,45 @@ lemma momentumOperator_add {ψ1 ψ2 : ℝ → ℂ}
 
 -/
 
-/-- The unbounded momentum operator, whose domain is square integrable functions
-  which are differentiable and which have a square integrable derivative. -/
-def momentumOperatorSchwartz : HilbertSpace →ₗ.[ℂ] HilbertSpace where
+def momentumOperatorSchwartz : Φ →ₗ[ℂ] Φ where
+  toFun ψ := schwartzSubmoduleEquiv.symm <|
+    (- Complex.I * ℏ) • SchwartzMap.derivCLM ℂ (schwartzSubmoduleEquiv ψ)
+  map_add' ψ1 ψ2 := by
+    simp only [neg_mul, map_add, smul_add, neg_smul]
+  map_smul' a ψ := by
+    simp only [neg_mul, map_smul, neg_smul, RingHom.id_apply]
+    rw [smul_comm]
+    simp
+
+lemma schwartzSubmoduleEquiv_momentumOperatorSchwartz (ψ : schwartzSubmodule) :
+    schwartzSubmoduleEquiv (momentumOperatorSchwartz ψ) =
+      (- Complex.I * ℏ) • (SchwartzMap.derivCLM ℂ (schwartzSubmoduleEquiv ψ)) := by
+  change schwartzSubmoduleEquiv (schwartzSubmoduleEquiv.symm _) = _
+  simp [momentumOperatorSchwartz]
+
+/-- The unbounded momentum operator, whose domain is Schwartz maps. -/
+def momentumOperatorUnbounded : HilbertSpace →ₗ.[ℂ] HilbertSpace where
   domain := schwartzSubmodule
-  toFun := {
-    toFun ψ := ((- Complex.I * ℏ) • SchwartzMap.derivCLM ℂ
-      (schwartzSubmoduleEquiv ψ)).toLp 2 MeasureTheory.volume
-    map_add' ψ1 ψ2 := by
-      simp only [neg_mul, map_add, smul_add, neg_smul]
-      rfl
-    map_smul' a ψ := by
-      simp only [neg_mul, map_smul, neg_smul, RingHom.id_apply]
-      rw [smul_comm]
-      change _ = (a • -((Complex.I * ↑↑ℏ) •
-        (SchwartzMap.derivCLM ℂ) (schwartzSubmoduleEquiv ψ))).toLp 2 MeasureTheory.volume
-      simp}
+  toFun := SchwartzMap.toLpCLM ℂ (E := ℝ) ℂ 2 MeasureTheory.volume ∘ₗ
+    schwartzSubmoduleEquiv.toLinearMap ∘ₗ momentumOperatorSchwartz
 
-lemma momentumOperatorSchwartz_apply (ψ : schwartzSubmodule) :
-    momentumOperatorSchwartz ψ =
+lemma momentumOperatorUnbounded_apply (ψ : schwartzSubmodule) :
+    momentumOperatorUnbounded ψ =
       ((- Complex.I * ℏ) • SchwartzMap.derivCLM ℂ
-      (schwartzSubmoduleEquiv ψ)).toLp 2 MeasureTheory.volume := by rfl
+      (schwartzSubmoduleEquiv ψ)).toLp 2 MeasureTheory.volume := by
+  simp [momentumOperatorUnbounded, momentumOperatorSchwartz]
 
-lemma momentumOperatorSchwartz_mem_schwartzSubmodule (ψ : schwartzSubmodule) :
-    momentumOperatorSchwartz ψ ∈ schwartzSubmodule := by
-  rw [momentumOperatorSchwartz_apply]
+lemma momentumOperatorUnbounded_mem_schwartzSubmodule (ψ : schwartzSubmodule) :
+    momentumOperatorUnbounded ψ ∈ schwartzSubmodule := by
+  rw [momentumOperatorUnbounded_apply]
   use (- Complex.I * ℏ) • SchwartzMap.derivCLM ℂ (schwartzSubmoduleEquiv ψ)
   simp
 
-lemma schwartzSubmoduleEquiv_momentumOperatorSchwartz (ψ : schwartzSubmodule) :
-    schwartzSubmoduleEquiv ⟨momentumOperatorSchwartz ψ,
-      momentumOperatorSchwartz_mem_schwartzSubmodule ψ⟩ =
-      (- Complex.I * ℏ) • (SchwartzMap.derivCLM ℂ (schwartzSubmoduleEquiv ψ)) := by
-  change schwartzSubmoduleEquiv (schwartzSubmoduleEquiv.symm _) = _
+lemma momentumOperatorSchwartz_apply_eq_momentumOperatorUnbounded (ψ : schwartzSubmodule) :
+    momentumOperatorSchwartz ψ = ⟨momentumOperatorUnbounded ψ,
+      momentumOperatorUnbounded_mem_schwartzSubmodule ψ⟩  := by
+  ext1
+  change _ = (schwartzSubmoduleEquiv.symm (schwartzSubmoduleEquiv (momentumOperatorSchwartz ψ))).1
   simp
 
 /-!
@@ -116,8 +122,7 @@ lemma schwartzSubmoduleEquiv_momentumOperatorSchwartz (ψ : schwartzSubmodule) :
 
 lemma planeWaveFunctional_generalized_eigenvector_momentumOperatorSchwartz
     (k : ℝ) (ψ : schwartzSubmodule) :
-    planewaveFunctional k ⟨momentumOperatorSchwartz ψ,
-      momentumOperatorSchwartz_mem_schwartzSubmodule ψ⟩ =
+    planewaveFunctional k (momentumOperatorSchwartz ψ) =
     (2 * Real.pi * ℏ * k) • (planewaveFunctional k ψ) := by
   conv_lhs =>
     rw [planewaveFunctional]

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -109,7 +109,7 @@ lemma momentumOperatorUnbounded_mem_schwartzSubmodule (ψ : schwartzSubmodule) :
 
 lemma momentumOperatorSchwartz_apply_eq_momentumOperatorUnbounded (ψ : schwartzSubmodule) :
     momentumOperatorSchwartz ψ = ⟨momentumOperatorUnbounded ψ,
-      momentumOperatorUnbounded_mem_schwartzSubmodule ψ⟩  := by
+      momentumOperatorUnbounded_mem_schwartzSubmodule ψ⟩ := by
   ext1
   change _ = (schwartzSubmoduleEquiv.symm (schwartzSubmoduleEquiv (momentumOperatorSchwartz ψ))).1
   simp

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
 /-!
 
@@ -50,12 +49,12 @@ def parityOperatorSchwartz : schwartzSubmodule →ₗ[ℂ] schwartzSubmodule := 
     schwartzSubmoduleEquiv.toLinearMap
   · fun_prop
   · intro n
-    simp
+    simp only [Real.norm_eq_abs]
     use 1, 1
     intro x
-    simp
+    simp only [pow_one, one_mul]
     erw [iteratedFDeriv_neg_apply]
-    simp
+    simp only [norm_neg]
     match n with
     | 0 => simp
     | 1 =>
@@ -63,9 +62,10 @@ def parityOperatorSchwartz : schwartzSubmodule →ₗ[ℂ] schwartzSubmodule := 
       simp
     | .succ (.succ n) =>
       rw [iteratedFDeriv_succ_eq_comp_right]
-      simp
+      simp only [Nat.succ_eq_add_one, fderiv_id', Function.comp_apply, LinearIsometryEquiv.norm_map,
+        ge_iff_le]
       rw [iteratedFDeriv_const_of_ne]
-      simp
+      simp only [Pi.zero_apply, norm_zero]
       apply add_nonneg
       · exact zero_le_one' ℝ
       · exact abs_nonneg x
@@ -91,6 +91,15 @@ lemma parityOperatorUnbounded_apply_eq_parityOperatorUnbounded (ψ : schwartzSub
   ext1
   change _ = (schwartzSubmoduleEquiv.symm (schwartzSubmoduleEquiv (parityOperatorSchwartz ψ))).1
   simp
+
+@[simp]
+lemma parityOperatorSchwartz_parityOperatorSchwartz (ψ : schwartzSubmodule) :
+    parityOperatorSchwartz (parityOperatorSchwartz ψ) = ψ := by
+  apply schwartzSubmoduleEquiv.injective
+  ext x
+  simp [parityOperatorSchwartz]
+
+open InnerProductSpace
 
 end HilbertSpace
 end

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Parity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.Basic
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
 /-!
 
 # Parity operator
@@ -18,9 +19,15 @@ noncomputable section
 namespace HilbertSpace
 open MeasureTheory
 
+/-!
+
+## The parity operator on functions
+
+-/
+
 /-- The parity operator is defined as linear map from `ℝ → ℂ` to itself, such that
   `ψ` is taken to `fun x => ψ (-x)`. -/
-def parity : (ℝ → ℂ) →ₗ[ℂ] (ℝ → ℂ) where
+def parityOperator : (ℝ → ℂ) →ₗ[ℂ] (ℝ → ℂ) where
   toFun ψ := fun x => ψ (-x)
   map_add' ψ1 ψ2 := by
     funext x
@@ -29,16 +36,61 @@ def parity : (ℝ → ℂ) →ₗ[ℂ] (ℝ → ℂ) where
     funext x
     simp
 
-/-- The parity operator acting on a member of the Hilbert space is in Hilbert space. -/
-lemma memHS_of_parity (ψ : ℝ → ℂ) (hψ : MemHS ψ) : MemHS (parity ψ) := by
-  simp only [parity, LinearMap.coe_mk, AddHom.coe_mk]
-  rw [memHS_iff] at hψ ⊢
-  apply And.intro
-  · rw [show (fun x => ψ (-x)) = ψ ∘ (λ x => -x) by funext x; simp]
-    exact MeasureTheory.AEStronglyMeasurable.comp_quasiMeasurePreserving hψ.left <|
-      quasiMeasurePreserving_neg_of_right_invariant volume
-  · simpa using (integrable_comp_mul_left_iff
-      (fun x => ‖ψ (x)‖ ^ 2) (R := (-1 : ℝ)) (by simp)).mpr hψ.right
+/-!
+
+## The parity operator on Schwartz maps
+
+-/
+
+/-- The parity operator on the Schwartz submodule is defined as the linear map from
+  `schwartzSubmodule` to itself, such that `ψ` is taken to `fun x => ψ (-x)`. -/
+def parityOperatorSchwartz : schwartzSubmodule →ₗ[ℂ] schwartzSubmodule := by
+  refine schwartzSubmoduleEquiv.symm.toLinearMap ∘ₗ
+    (SchwartzMap.compCLM ℂ (g := (fun x => - x : ℝ → ℝ)) ⟨?_, ?_⟩ ?_).toLinearMap ∘ₗ
+    schwartzSubmoduleEquiv.toLinearMap
+  · fun_prop
+  · intro n
+    simp
+    use 1, 1
+    intro x
+    simp
+    erw [iteratedFDeriv_neg_apply]
+    simp
+    match n with
+    | 0 => simp
+    | 1 =>
+      rw [iteratedFDeriv_succ_eq_comp_right]
+      simp
+    | .succ (.succ n) =>
+      rw [iteratedFDeriv_succ_eq_comp_right]
+      simp
+      rw [iteratedFDeriv_const_of_ne]
+      simp
+      apply add_nonneg
+      · exact zero_le_one' ℝ
+      · exact abs_nonneg x
+      simp
+  · simp
+    use 1, 1
+    intro x
+    simp
+
+/-- The unbounded parity operator, whose domain is Schwartz maps. -/
+def parityOperatorUnbounded : HilbertSpace →ₗ.[ℂ] HilbertSpace where
+  domain := schwartzSubmodule
+  toFun := SchwartzMap.toLpCLM ℂ (E := ℝ) ℂ 2 MeasureTheory.volume ∘ₗ
+    schwartzSubmoduleEquiv.toLinearMap ∘ₗ parityOperatorSchwartz
+
+lemma parityOperatorUnbounded_mem_schwartzSubmodule (ψ : schwartzSubmodule) :
+    parityOperatorUnbounded ψ ∈ schwartzSubmodule := by
+  simp [parityOperatorUnbounded]
+
+lemma parityOperatorUnbounded_apply_eq_parityOperatorUnbounded (ψ : schwartzSubmodule) :
+    parityOperatorSchwartz ψ = ⟨parityOperatorUnbounded ψ,
+      parityOperatorUnbounded_mem_schwartzSubmodule ψ⟩ := by
+  ext1
+  change _ = (schwartzSubmoduleEquiv.symm (schwartzSubmoduleEquiv (parityOperatorSchwartz ψ))).1
+  simp
 
 end HilbertSpace
 end

--- a/PhysLean/QuantumMechanics/OneDimension/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/OneDimension/Operators/Position.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PlaneWaves
+import PhysLean.QuantumMechanics.OneDimension.HilbertSpace.PositionStates
+import PhysLean.QuantumMechanics.PlanckConstant
+import PhysLean.Meta.TODO.Basic
+/-!
+
+# Position operator
+
+In this module we define:
+- The momentum operator on functions `ℝ → ℂ`
+- The momentum operator on Schwartz maps as an unbounded operator on the Hilbert space.
+
+We show that plane waves are generalized eigenvectors of the momentum operator.
+
+-/
+
+namespace QuantumMechanics
+
+namespace OneDimension
+noncomputable section
+open Constants
+open HilbertSpace
+
+/-!
+
+## The position operator on functions `ℝ → ℂ`
+
+-/
+
+/-- The position operator is defined as the linear map from `ℝ → ℂ` to `ℝ → ℂ` taking
+  `ψ` to `x * ψ`. -/
+def positionOperator :  (ℝ → ℂ) →ₗ[ℂ] ℝ → ℂ where
+  toFun ψ := fun x ↦ x * ψ x
+  map_add' ψ1 ψ2 := by
+    funext x
+    simp
+    ring
+  map_smul' a ψ1 := by
+    funext x
+    simp
+    ring
+/-!
+
+## The position operator on Schwartz maps
+
+-/
+
+private lemma norm_iteratedFDeriv_ofRealCLM {x} (i : ℕ) :
+   ‖iteratedFDeriv ℝ i Complex.ofRealCLM x‖ = if i = 0 then |x| else if i = 1 then 1 else 0  := by
+  match i with
+  | 0 =>
+    simp [iteratedFDeriv_zero_eq_comp]
+  | .succ i =>
+    induction i with
+    | zero =>
+      simp [iteratedFDeriv_succ_eq_comp_right]
+      rw [@ContinuousLinearMap.norm_def]
+      apply ContinuousLinearMap.opNorm_eq_of_bounds
+      · simp
+      · intro x
+        simp
+      · intro N hN h
+        simpa using h 1
+    | succ i ih =>
+
+      rw [iteratedFDeriv_succ_eq_comp_right]
+      simp
+      rw [iteratedFDeriv_succ_eq_comp_right]
+
+      conv_lhs =>
+        enter [1, 2, 3, y]
+        rw [fderiv_const_apply Complex.ofRealCLM]
+      conv_lhs =>
+        enter [1, 2]
+        change iteratedFDeriv ℝ i 0
+      simp
+      have h1 : iteratedFDeriv ℝ i (0 : ℝ → ℝ →L[ℝ] ℝ →L[ℝ] ℂ) x = 0 := by
+        change iteratedFDeriv ℝ i (fun x => 0) x = 0
+        rw [iteratedFDeriv_zero_fun ]
+        rfl
+      rw [h1]
+      exact ContinuousMultilinearMap.opNorm_zero
+
+open ContDiff
+
+/-- The position operator on the Schwartz submodule is defined as the linear map from
+  `schwartzSubmodule` to itself, such that `ψ` is taken to `fun x => x * ψ (x)`. -/
+def positionOperatorSchwartz : schwartzSubmodule →ₗ[ℂ] schwartzSubmodule where
+  toFun ψ := schwartzSubmoduleEquiv.symm ⟨fun x => x * (schwartzSubmoduleEquiv ψ x),
+      by
+        apply ContDiff.mul
+        · change ContDiff ℝ _ Complex.ofRealCLM
+          fun_prop
+        · exact SchwartzMap.smooth (schwartzSubmoduleEquiv ψ) ⊤
+        , by
+        intro k n
+        obtain ⟨C1, hC1⟩ := (schwartzSubmoduleEquiv ψ).decay' k (n - 1)
+        obtain ⟨C2, hC2⟩ := (schwartzSubmoduleEquiv ψ).decay' (k + 1) n
+        use  n * C1 + C2
+        intro x
+        trans ‖x‖ ^ k * ∑ i ∈ Finset.range (n + 1), ↑(n.choose i) * ‖iteratedFDeriv ℝ i (fun (x : ℝ) => (x : ℂ)) x‖ *
+            ‖iteratedFDeriv ℝ (n - i) (fun x => schwartzSubmoduleEquiv ψ x) x‖
+        apply mul_le_mul_of_nonneg'
+        · exact Preorder.le_refl (‖x‖ ^ k)
+        · apply norm_iteratedFDeriv_mul_le  (N := ∞)
+          · change ContDiff ℝ ∞ Complex.ofRealCLM
+            fun_prop
+          · exact SchwartzMap.smooth (schwartzSubmoduleEquiv ψ) ⊤
+          · exact right_eq_inf.mp rfl
+        · exact ContinuousMultilinearMap.opNorm_nonneg _
+        · refine pow_nonneg ?_ k
+          exact norm_nonneg x
+        conv_lhs =>
+          enter [2, 2, i, 1, 2]
+          change ‖iteratedFDeriv ℝ i Complex.ofRealCLM x‖
+          rw [norm_iteratedFDeriv_ofRealCLM i]
+        match n with
+        | 0 =>
+          simp
+          have hC3x := hC2 x
+          simp at hC3x
+          refine le_trans ?_ hC3x
+          apply le_of_eq
+          ring_nf
+          rfl
+        | .succ n =>
+          rw [Finset.sum_range_succ', Finset.sum_range_succ']
+          simp
+          trans (↑n + 1) * (|x| ^ k * ‖iteratedFDeriv ℝ n (fun x => (schwartzSubmoduleEquiv ψ) x) x‖)
+            + (|x| ^ (k + 1) * ‖iteratedFDeriv ℝ (n + 1) (fun x => (schwartzSubmoduleEquiv ψ) x) x‖)
+          · apply le_of_eq
+            ring
+          apply add_le_add _ (hC2 x)
+          apply mul_le_mul_of_nonneg_left (hC1 x)
+          refine Left.add_nonneg ?_ ?_
+          · exact Nat.cast_nonneg' n
+          · exact zero_le_one' ℝ⟩
+  map_add' ψ1 ψ2 := by
+    simp [mul_add]
+    rfl
+  map_smul' a ψ := by
+    simp only [neg_mul, map_smul, neg_smul, RingHom.id_apply]
+    conv_lhs =>
+      enter [2, 1, x]
+      change  ↑x • a • ( schwartzSubmoduleEquiv ψ) x
+      rw [smul_comm]
+    rfl
+
+/-- The unbounded position operator, whose domain is Schwartz maps. -/
+def positionOperatorUnbounded : HilbertSpace →ₗ.[ℂ] HilbertSpace where
+  domain := schwartzSubmodule
+  toFun := SchwartzMap.toLpCLM ℂ (E := ℝ) ℂ 2 MeasureTheory.volume ∘ₗ
+    schwartzSubmoduleEquiv.toLinearMap ∘ₗ positionOperatorSchwartz
+
+lemma positionOperatorUnbounded_mem_schwartzSubmodule (ψ : schwartzSubmodule) :
+    positionOperatorUnbounded ψ ∈ schwartzSubmodule := by
+  simp [positionOperatorUnbounded]
+
+lemma positionOperatorSchwartz_apply_eq_positionOperatorUnbounded (ψ : schwartzSubmodule) :
+    positionOperatorSchwartz ψ = ⟨positionOperatorUnbounded ψ,
+      positionOperatorUnbounded_mem_schwartzSubmodule ψ⟩ := by
+  ext1
+  change _ = (schwartzSubmoduleEquiv.symm (schwartzSubmoduleEquiv (positionOperatorSchwartz ψ))).1
+  simp
+
+/-!
+
+## Generalized eigenvectors of the momentum operator
+
+-/
+
+lemma positionStates_generalized_eigenvector_positionOperatorSchwartz
+    (x : ℝ) (ψ : schwartzSubmodule) :
+    positionState x (positionOperatorSchwartz ψ) = x * positionState x ψ := by
+  simp only [positionOperatorSchwartz, LinearPMap.mk_apply, LinearMap.coe_mk, AddHom.coe_mk,
+    positionState_apply]
+  change (schwartzSubmoduleEquiv (schwartzSubmoduleEquiv.symm _)) x = _
+  simp only [LinearEquiv.apply_symm_apply]
+  rfl
+
+end
+end OneDimension
+end QuantumMechanics


### PR DESCRIPTION

**Copilot summary:**

This pull request introduces significant updates to the `PhysLean` library, primarily focusing on the addition and refinement of operators and states in quantum mechanics, specifically within one-dimensional systems. The most notable changes include the introduction of the position operator and position states, enhancements to the parity operator, and modifications to the momentum operator. These updates aim to improve the mathematical rigor and expand the functionality of the library.

### Additions and Enhancements to Operators:

* **Position Operator**:
  - Added a new module `PhysLean/QuantumMechanics/OneDimension/Operators/Position.lean` defining the position operator on functions (`ℝ → ℂ`) and Schwartz maps. This includes the unbounded position operator on the Hilbert space.
  - Defined generalized eigenvectors for the position operator, showing that position states are eigenvectors.

* **Parity Operator**:
  - Refactored the parity operator to `parityOperator` for clarity and introduced its definition on Schwartz maps and as an unbounded operator on the Hilbert space. [[1]](diffhunk://#diff-ce9d80b7a7b5041d783cb0d61a2ac8dc8da0431b71a7dcf394f887b33b3b899cR22-R30) [[2]](diffhunk://#diff-ce9d80b7a7b5041d783cb0d61a2ac8dc8da0431b71a7dcf394f887b33b3b899cL32-R93)
  - Updated references to `parity` throughout the library to use the new `parityOperator`. [[1]](diffhunk://#diff-6048e56831246ee7c271e13a43ca080941ac0c7d837d7625387fd9c85855c0aaL186-R191) [[2]](diffhunk://#diff-e6c7768f117d0460c0cc1025954232ab5e8e02b89c72b8e09f38bacb988ad19eL162-R165)

### Refinements to Momentum Operator:

* **Momentum Operator**:
  - Replaced the previous `momentumOperatorSchwartz` with a more rigorous definition (`momentumOperatorUnbounded`) and updated its application and membership in the Schwartz submodule.
  - Simplified and clarified the relationship between the Schwartz submodule and the momentum operator.

### Introduction of Position States:

* **Position States**:
  - Added a new module `PhysLean/QuantumMechanics/OneDimension/HilbertSpace/PositionStates.lean` defining position states as elements of the dual of the Schwartz submodule.
  - Introduced lemmas establishing the properties of position states and their equivalence.

### Miscellaneous Updates:

* **Imports**:
  - Added necessary imports to support the new modules and operators, such as `PhysLean.QuantumMechanics.OneDimension.Operators.Position`. [[1]](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R210) [[2]](diffhunk://#diff-14aae18c36605c7a0d47b107dfdf660d8698bc77d2d327d4da84bea10b58427cR7-R8) [[3]](diffhunk://#diff-ce9d80b7a7b5041d783cb0d61a2ac8dc8da0431b71a7dcf394f887b33b3b899cR7)
* **Schwartz Submodule**:
  - Added a lemma to simplify membership checks for Schwartz maps in the submodule.

These changes collectively enhance the theoretical foundation and computational capabilities of the `PhysLean` library, enabling more robust handling of quantum mechanical operators and states.