### PR TITLE
refactor: finite canonical ensemble definitions

### DIFF
--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -461,7 +461,6 @@ lemma μProd_nsmul (n : ℕ) (T : Temperature) [IsFiniteMeasure (𝓒.μBolt T)]
 @[fun_prop]
 lemma integrable_energy_add (T : Temperature) [IsFiniteMeasure (𝓒.μBolt T)]
     [IsFiniteMeasure (𝓒1.μBolt T)]
-    [NeZero 𝓒.μ] [NeZero 𝓒1.μ]
     (h : Integrable 𝓒.energy (𝓒.μProd T)) (h1 : Integrable 𝓒1.energy (𝓒1.μProd T)) :
     Integrable (𝓒 + 𝓒1).energy ((𝓒 + 𝓒1).μProd T) := by
   rw [μProd_add]
@@ -494,7 +493,7 @@ lemma integrable_energy_congr (T : Temperature) (e : ι1 ≃ᵐ ι)
 
 @[fun_prop]
 lemma integrable_energy_nsmul (n : ℕ) (T : Temperature)
-    [IsFiniteMeasure (𝓒.μBolt T)] [NeZero 𝓒.μ]
+    [IsFiniteMeasure (𝓒.μBolt T)]
     (h : Integrable 𝓒.energy (𝓒.μProd T)) :
     Integrable (nsmul n 𝓒).energy ((nsmul n 𝓒).μProd T) := by
   induction n with

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -406,6 +406,10 @@ instance (T : Temperature) [IsFiniteMeasure (𝓒.μBolt T)]
   [NeZero 𝓒.μ] : IsProbabilityMeasure (𝓒.μProd T) := inferInstanceAs <|
   IsProbabilityMeasure ((𝓒.μBolt T Set.univ)⁻¹ • 𝓒.μBolt T)
 
+instance {T} : IsFiniteMeasure (𝓒.μProd T) := by
+  rw [μProd]
+  infer_instance
+
 lemma μProd_add {T : Temperature} [IsFiniteMeasure (𝓒.μBolt T)]
     [IsFiniteMeasure (𝓒1.μBolt T)] : (𝓒 + 𝓒1).μProd T = (𝓒.μProd T).prod (𝓒1.μProd T) := by
   rw [μProd, μProd, μProd, μBolt_add]

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -3,10 +3,7 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import PhysLean.StatisticalMechanics.Temperature
-import PhysLean.Meta.Informal.SemiFormal
-import PhysLean.Meta.Linters.Sorry
-import Mathlib.Analysis.SpecialFunctions.Log.Summable
+import PhysLean.StatisticalMechanics.CanonicalEnsemble.Basic
 /-!
 
 # Finite canonical ensemble
@@ -33,319 +30,118 @@ this file should be modified.
 
 -/
 
-/-- A Finite Canonical ensemble is described by a type `ι`, corresponding to the type of
-  microstates, and a map `ι → ℝ` which associates which each microstate an energy. -/
-def FiniteCanonicalEnsemble (ι : Type) : Type := ι → ℝ
+namespace CanonicalEnsemble
 
-namespace FiniteCanonicalEnsemble
-open Real Temperature
+open Real Temperature MeasureTheory
 
-variable {ι ι1 : Type} (𝓒 : FiniteCanonicalEnsemble ι) (𝓒1 : FiniteCanonicalEnsemble ι1)
+variable {ι : Type} [Fintype ι] [MeasurableSpace ι]
+  [MeasurableSingletonClass ι] (𝓒 : CanonicalEnsemble ι)
 
-/-- The addition of two `CanonicalEnsemble`. -/
-instance {ι1 ι2 : Type} : HAdd (FiniteCanonicalEnsemble ι1) (FiniteCanonicalEnsemble ι2)
-    (FiniteCanonicalEnsemble (ι1 × ι2)) where
-  hAdd := fun 𝓒1 𝓒2 => fun (i : ι1 × ι2) => 𝓒1 i.1 + 𝓒2 i.2
+variable {ι1 : Type} [Fintype ι1] [MeasurableSpace ι1]
+  [MeasurableSingletonClass ι1] (𝓒1 : CanonicalEnsemble ι1)
 
-/-- Scalar multiplication of `CanonicalEnsemble`, defined such that
-  `nsmul n 𝓒` is `n` coppies of the canonical ensemble `𝓒`. -/
-def nsmul (n : ℕ) (𝓒1 : FiniteCanonicalEnsemble ι) : FiniteCanonicalEnsemble (Fin n → ι) :=
-  fun f => ∑ i, 𝓒1 (f i)
+/-- A finite `CanonicalEnsemble` is one which has a finite
+  type of microstates and the counting measure on them. -/
+class IsFinite [Fintype ι] : Prop where
+  μ_eq_count : 𝓒.μ = Measure.count
 
-lemma nsmul_eq (n : ℕ) (𝓒1 : FiniteCanonicalEnsemble ι) : nsmul n 𝓒1 = fun f => ∑ i, 𝓒1 (f i) := rfl
+instance [IsFinite 𝓒] [IsFinite 𝓒1] : IsFinite (𝓒 + 𝓒1) where
+  μ_eq_count := by
+    rw [μ_add]
+    rw [IsFinite.μ_eq_count, IsFinite.μ_eq_count]
+    refine Measure.prod_eq ?_
+    intro s t hs ht
+    rw [Measure.count_apply, Measure.count_apply, Measure.count_apply]
+    rw [← ENat.toENNReal_mul]
+    congr
+    simp [Set.encard, ENat.card_congr (Equiv.Set.prod ..)]
+    · exact ht
+    · exact hs
+    · exact MeasurableSet.prod hs ht
 
-set_option linter.unusedVariables false in
-/-- The microstates of a the canonical ensemble -/
-@[nolint unusedArguments]
-abbrev microstates {ι : Type} (𝓒 : FiniteCanonicalEnsemble ι) : Type := ι
+instance [IsFinite 𝓒] (e : ι1 ≃ᵐ ι) : IsFinite (congr 𝓒 e) where
+  μ_eq_count := by
+    simp [congr]
+    rw [IsFinite.μ_eq_count]
+    refine Measure.ext_iff.mpr ?_
+    intro s hs
+    rw [@MeasurableEquiv.map_apply]
+    rw [Measure.count_apply, Measure.count_apply]
+    simp
 
-/-!
+    rw [@MeasurableEquiv.preimage_symm]
+    rw [← Set.Finite.cast_ncard_eq, ← Set.Finite.cast_ncard_eq,]
+    congr 1
+    change (e.toEmbedding '' s).ncard = _
+    rw [Set.ncard_map]
+    · exact Set.toFinite s
+    · exact Set.toFinite (⇑e '' s)
+    · exact hs
+    · exact (MeasurableEquiv.measurableSet_preimage e.symm).mpr hs
 
-## The energy of the microstates
+instance [IsFinite 𝓒] (n : ℕ) : IsFinite (nsmul n 𝓒) where
+  μ_eq_count := by
+    induction n with
+    | zero =>
+      rw [@Measure.ext_iff_singleton]
+      simp [nsmul]
+      rw [← Set.univ_pi_singleton]
+      simp
+    | succ n ih =>
+      rw [nsmul_succ]
+      haveI : IsFinite (nsmul n 𝓒) := ⟨ih⟩
+      rw [IsFinite.μ_eq_count]
+      exact Pi.instFintype
 
--/
-/-- The energy of associated with a mircrostate of the canonical ensemble. -/
-abbrev energy (𝓒 : FiniteCanonicalEnsemble ι) : microstates 𝓒 → ℝ := 𝓒
+instance [IsFinite 𝓒] : IsFiniteMeasure (𝓒.μ) := by
+  rw [IsFinite.μ_eq_count]
+  infer_instance
+
+lemma partitionFunction_of_fintype [IsFinite 𝓒] (T : Temperature) :
+    𝓒.partitionFunction T = ∑ i, exp (- β T * 𝓒.energy i) := by
+  rw [partitionFunction_eq_integral]
+  rw [MeasureTheory.integral_fintype]
+  simp [IsFinite.μ_eq_count]
+  · rw [IsFinite.μ_eq_count]
+    exact Integrable.of_finite
 
 @[simp]
-lemma energy_add_apply (i : microstates (𝓒 + 𝓒1)) :
-    (𝓒 + 𝓒1).energy i = 𝓒.energy i.1 + 𝓒1.energy i.2 := by
-  simp [energy]
+lemma μBolt_of_fintype (T : Temperature) [IsFinite 𝓒] (i : ι) :
+    (𝓒.μBolt T).real {i} = Real.exp (- β T * 𝓒.energy i) := by
+  rw [μBolt]
+  simp only [neg_mul]
+  rw [@measureReal_def]
+  simp [IsFinite.μ_eq_count]
+  exact Real.exp_nonneg _
+
+instance {T} [IsFinite 𝓒] : IsFiniteMeasure (𝓒.μBolt T) := by
+  rw [μBolt]
+  refine isFiniteMeasure_withDensity_ofReal ?_
+  exact HasFiniteIntegral.of_finite
+
+@[simp]
+lemma μProd_of_fintype (T : Temperature) [IsFinite 𝓒] (i : ι) :
+    (𝓒.μProd T).real {i} = 𝓒.probability T i := by
+  rw [μProd]
+  simp [probability]
+  ring_nf
+  rw [mul_comm]
   rfl
 
-@[simp]
-lemma energy_nsmul_apply (n : ℕ) (f : Fin n → microstates 𝓒) :
-    (nsmul n 𝓒).energy f = ∑ i, 𝓒.energy (f i) := by
-  simp [energy, nsmul]
-
-/-!
-
-## The partition function of the canonical ensemble
-
--/
-
-TODO "G5AM2" "Generalize the parition function to non-finite types of
-  microstates."
-
-/-- The partition function of the canonical ensemble. -/
-noncomputable def partitionFunction [Fintype ι] (T : Temperature) : ℝ :=
-  ∑ i, exp (- β T * 𝓒.energy i)
-
-lemma partitionFunction_add [Fintype ι] [Fintype ι1] :
-    (𝓒 + 𝓒1).partitionFunction T = 𝓒.partitionFunction T * 𝓒1.partitionFunction T := by
-  simp [partitionFunction]
-  rw [Fintype.sum_prod_type]
-  rw [Finset.sum_mul]
-  congr
-  funext i
-  rw [Finset.mul_sum]
-  congr
-  funext j
-  rw [← Real.exp_add]
-  congr
-  simp [energy]
-  ring
-
-/-- The partition function of `n` copies of a canonical ensemble. -/
-@[simp]
-lemma partitionFunction_nsmul [Fintype ι] (n : ℕ) (T : Temperature) :
-    (nsmul n 𝓒).partitionFunction T = (𝓒.partitionFunction T) ^ n := by
-  simp only [partitionFunction, energy_nsmul_apply, neg_mul]
-  rw [Fintype.sum_pow]
-  congr
-  funext f
-  rw [← Real.exp_sum]
-  congr
-  simp [Finset.mul_sum]
-
-lemma partitionFunction_pos [Fintype ι] [Nonempty ι] (T : Temperature) :
-    0 < partitionFunction 𝓒 T := by
-  rw [partitionFunction]
-  apply Finset.sum_pos
-  · intro i hi
-    exact exp_pos (-T.β * 𝓒.energy i)
-  · simp
-
-@[simp]
-lemma partitionFunction_neq_zero [Fintype ι] [Nonempty ι] (T : Temperature) :
-    partitionFunction 𝓒 T ≠ 0:= by
-  have h1 := partitionFunction_pos 𝓒 T
-  exact Ne.symm (ne_of_lt h1)
-
-/-- The partition function of the canonical ensemble as a function of `β` -/
-noncomputable def partitionFunctionβ [Fintype ι] (β : ℝ) : ℝ :=
-  ∑ i, exp (- β * 𝓒.energy i)
-
-lemma partitionFunctionβ_def [Fintype ι]:
-    partitionFunctionβ 𝓒 = fun β => ∑ i, exp (- β * 𝓒.energy i) := by rfl
-
-@[fun_prop]
-lemma partitionFunctionβ_differentiable [Fintype ι] :
-    Differentiable ℝ 𝓒.partitionFunctionβ := by
-  rw [partitionFunctionβ_def]
-  fun_prop
-
-lemma partitionFunction_eq_partitionFunctionβ [Fintype ι] (T : Temperature) :
-    partitionFunction 𝓒 T = partitionFunctionβ 𝓒 (β T) := by
-  simp [partitionFunction, partitionFunctionβ, β]
-
-/-!
-
-## The probability of being in a given microstate
--/
-
-/-- The probability of been in a given microstate. -/
-noncomputable def probability [Fintype ι] (i : microstates 𝓒) (T : Temperature) : ℝ :=
-  exp (- β T * 𝓒.energy i) / partitionFunction 𝓒 T
-
-/-- Probability of a microstate in a canonical ensemble is less then or equal to `1`. -/
-lemma probability_le_one [Fintype ι] [Nonempty ι] (i : microstates 𝓒) (T : Temperature) :
-    𝓒.probability i T ≤ 1 := by
-  rw [probability]
-  rw [div_le_one]
-  · simp [partitionFunction]
-    apply Finset.single_le_sum (f := fun x => exp (-(T.β * 𝓒.energy x)))
-    · intro i _
-      exact exp_nonneg (-(T.β * 𝓒.energy i))
-    · simp
-  · exact partitionFunction_pos 𝓒 T
-
-/-- Probability of a microstate in a canonical ensemble is non-negative. -/
-lemma probability_nonneg [Fintype ι] [Nonempty ι] (i : microstates 𝓒) (T : Temperature) :
-    0 ≤ 𝓒.probability i T := by
-  rw [probability]
-  apply div_nonneg
-  · exact exp_nonneg (-T.β * 𝓒.energy i)
-  · exact le_of_lt (partitionFunction_pos 𝓒 T)
-
-lemma probability_neq_zero [Fintype ι] [Nonempty ι] (i : microstates 𝓒) (T : Temperature) :
-    probability 𝓒 i T ≠ 0 := by
-  rw [probability]
-  field_simp
-
-@[simp]
-lemma probability_add [Fintype ι] [Fintype ι1]
-    (i : microstates (𝓒 + 𝓒1)) (T : Temperature) :
-    (𝓒 + 𝓒1).probability i T = 𝓒.probability i.1 T * 𝓒1.probability i.2 T := by
-  simp [probability]
-  rw [partitionFunction_add 𝓒 𝓒1]
-  field_simp
-  congr
-  rw [← Real.exp_add]
-  ring_nf
-
-/-- The probability of a microstate in `n` copies of a canonical ensemble is
-  equal to the product of the probability of the corresponding individual microstates. -/
-@[simp]
-lemma probability_nsmul [Fintype ι] (n : ℕ)
-    (f : microstates (nsmul n 𝓒)) (T : Temperature) :
-    (nsmul n 𝓒).probability f T = ∏ i, 𝓒.probability (f i) T := by
-  simp [probability, nsmul]
-  congr
-  rw [← Real.exp_sum]
-  congr
-  simp [Finset.mul_sum]
-
-@[simp]
-lemma sum_probability_eq_one [Fintype ι] [Nonempty ι] (T : Temperature) :
-    ∑ i, probability 𝓒 i T = 1 := by
-  simp [probability]
-  rw [← Finset.sum_div]
-  field_simp
-  rw [partitionFunction]
-  ring_nf
-
-/-!
-
-## The mean energy of the canonical ensemble
-
--/
-
-/-- The mean energy of the canonical ensemble. -/
-noncomputable def meanEnergy [Fintype ι] (T : Temperature) : ℝ :=
-  ∑ i, 𝓒.energy i * probability 𝓒 i T
-
-@[simp]
-lemma meanEnergy_add [Fintype ι] [Nonempty ι] (𝓒1 : FiniteCanonicalEnsemble ι1) [Fintype ι1]
-    [Nonempty ι1]
-    (T : Temperature) :
-    (𝓒 + 𝓒1).meanEnergy T = 𝓒.meanEnergy T + 𝓒1.meanEnergy T := by
+lemma meanEnergy_of_fintype [IsFinite 𝓒] (T : Temperature) :
+    𝓒.meanEnergy T = ∑ i, 𝓒.energy i * 𝓒.probability T i := by
   simp [meanEnergy]
-  conv_lhs =>
-    enter [2, x]
-    rw [add_mul]
-  rw [Finset.sum_add_distrib]
-  congr 1
-  · rw [Fintype.sum_prod_type]
-    simp only
-    congr
-    funext i
-    rw [← Finset.mul_sum, ← Finset.mul_sum]
-    simp
-  · rw [Fintype.sum_prod_type]
-    rw [Finset.sum_comm]
-    simp only
-    congr
-    funext i
-    rw [← Finset.mul_sum, ← Finset.sum_mul]
-    simp
-
-/-- The mean energy of `n` copies of a canonical ensemble is equal
-  to `n` times the mean energy of the canonical ensemble.
-
-  Note, can't make this `SMul` since the target type depends on the
-  value of `n`. -/
-@[sorryful]
-lemma meanEnergy_nsmul [Fintype ι] (n : ℕ) (T : Temperature) :
-    (nsmul n 𝓒).meanEnergy T = n * 𝓒.meanEnergy T := by
-  sorry
-
-lemma meanEnergy_eq_logDeriv_partitionFunctionβ [Fintype ι] (T : Temperature) :
-    meanEnergy 𝓒 T = - logDeriv (partitionFunctionβ 𝓒) (β T) := by
-  rw [logDeriv_apply]
-  nth_rewrite 1 [partitionFunctionβ_def]
-  rw [deriv_fun_sum]
-  · simp [meanEnergy]
-    rw [@neg_div]
-    simp only [neg_neg]
-    rw [Finset.sum_div]
-    congr
-    funext i
-    simp [probability]
-    rw [partitionFunction_eq_partitionFunctionβ 𝓒 T]
-    ring
-  · intro i
-    fun_prop
+  rw [MeasureTheory.integral_fintype]
+  simp [mul_comm]
+  exact Integrable.of_finite
 
 open Constants
 
-/-!
-
-## Entropy
-
--/
-
-/-- The entropy of the canonical ensemble. -/
-noncomputable def entropy [Fintype ι] (T : Temperature) : ℝ :=
-  - kB * ∑ i, probability 𝓒 i T * log (probability 𝓒 i T)
-
-/-- Entropy is addative on adding canonical ensembles. -/
-@[simp]
-lemma entropy_add [Fintype ι] [Nonempty ι] (𝓒1 : FiniteCanonicalEnsemble ι1) [Fintype ι1]
-    [Nonempty ι1] (T : Temperature) :
-    (𝓒 + 𝓒1).entropy T = 𝓒.entropy T + 𝓒1.entropy T := by
+lemma entropy_of_fintype [IsFinite 𝓒] (T : Temperature) :
+    𝓒.entropy T = - kB * ∑ i, 𝓒.probability T i * log (𝓒.probability T i) := by
   simp [entropy]
-  conv_lhs =>
-    enter [1, 2, 2, x]
-    rw [log_mul (probability_neq_zero 𝓒 x.1 T) (probability_neq_zero 𝓒1 x.2 T)]
-    rw [mul_add]
-  rw [Finset.sum_add_distrib, mul_add, neg_add]
-  congr 1
-  · simp
-    left
-    rw [Fintype.sum_prod_type]
-    simp only
-    congr
-    funext i
-    rw [← Finset.sum_mul, ← Finset.mul_sum]
-    simp
-  · rw [Fintype.sum_prod_type]
-    rw [Finset.sum_comm]
-    simp only [neg_inj, mul_eq_mul_left_iff, NNReal.coe_eq_zero]
-    left
-    congr
-    funext i
-    rw [← Finset.sum_mul, ← Finset.sum_mul]
-    simp
+  rw [MeasureTheory.integral_fintype]
+  simp [mul_comm]
+  exact Integrable.of_finite
 
-/-- The entropy of `n` copies of a canonical ensemble is equal
-  to `n` times the entropy of the canonical ensemble. -/
-@[sorryful]
-lemma entropy_nsmul [Fintype ι] (n : ℕ) (T : Temperature) :
-    (nsmul n 𝓒).entropy T = n * 𝓒.entropy T := sorry
-
-/-!
-
-## Helmholtz free energy
-
--/
-
-/-- The (Helmholtz) free energy of the canonical ensemble. -/
-noncomputable def helmholtzFreeEnergy [Fintype ι] (T : Temperature) : ℝ :=
-  𝓒.meanEnergy T - T * 𝓒.entropy T
-
-/-- The Helmholtz free energy is addative. -/
-@[simp]
-lemma helmholtzFreeEnergy_add [Fintype ι] [Nonempty ι]
-    [Fintype ι1] [Nonempty ι1] (T : Temperature) :
-    (𝓒 + 𝓒1).helmholtzFreeEnergy T = 𝓒.helmholtzFreeEnergy T + 𝓒1.helmholtzFreeEnergy T := by
-  simp [helmholtzFreeEnergy]
-  ring
-
-/-- The free energy of `n` copies of a canonical ensemble is equal
-  to `n` times the entropy of the canonical ensemble. -/
-@[sorryful]
-lemma helmholtzFreeEnergy_nsmul [Fintype ι] (n : ℕ) (T : Temperature) :
-    (nsmul n 𝓒).helmholtzFreeEnergy T = n * 𝓒.helmholtzFreeEnergy T := sorry
-
-end FiniteCanonicalEnsemble
+end CanonicalEnsemble


### PR DESCRIPTION
Replaces FiniteCanonicalEnsemble with CanonicalEnsemble using typeclasses for finiteness, updates measure and probability definitions, and generalizes two-state system results. Simplifies imports and improves integration with measure-theoretic framework.