### PR TITLE
feat(Strings): Remove some unnecessary have's

### DIFF
--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean
@@ -347,12 +347,6 @@ def ofFinset (S5 S10 : Finset ℤ) : Finset Charges :=
 lemma qHd_mem_ofFinset (S5 S10 : Finset ℤ) (z : ℤ) (x2 : Option ℤ × Finset ℤ × Finset ℤ)
     (hsub : (some z, x2) ∈ ofFinset S5 S10) :
     z ∈ S5 := by
-  have hoption (x : Option ℤ) (S : Finset ℤ) :
-      x ∈ ({none} : Finset (Option ℤ)) ∪ S.map ⟨Option.some, Option.some_injective ℤ⟩ ↔
-      x.toFinset ⊆ S := by
-    match x with
-    | none => simp
-    | some x => simp
   rw [ofFinset] at hsub
   cases x2
   repeat rw [Finset.product_eq_sprod, Finset.mem_product] at hsub
@@ -363,12 +357,6 @@ lemma qHd_mem_ofFinset (S5 S10 : Finset ℤ) (z : ℤ) (x2 : Option ℤ × Finse
 lemma qHu_mem_ofFinset (S5 S10 : Finset ℤ) (z : ℤ) (x1 : Option ℤ) (x2 : Finset ℤ × Finset ℤ)
     (hsub : (x1, some z, x2) ∈ ofFinset S5 S10) :
     z ∈ S5 := by
-  have hoption (x : Option ℤ) (S : Finset ℤ) :
-      x ∈ ({none} : Finset (Option ℤ)) ∪ S.map ⟨Option.some, Option.some_injective ℤ⟩ ↔
-      x.toFinset ⊆ S := by
-    match x with
-    | none => simp
-    | some x => simp
   rw [ofFinset] at hsub
   cases x2
   repeat rw [Finset.product_eq_sprod, Finset.mem_product] at hsub


### PR DESCRIPTION
**Copilot summary** 

This pull request simplifies the `qHd_mem_ofFinset` and `qHu_mem_ofFinset` lemmas in the `PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean` file by removing redundant helper code. The changes streamline the logic and improve code readability.

### Simplification of lemmas:

* [`qHd_mem_ofFinset`](diffhunk://#diff-91dbc36f4b4c34965f0326f95284853d1e25b04704ec99bca8160087bb1180a8L350-L355): Removed the `hoption` helper lemma, which was unnecessary for the proof, simplifying the logic.
* [`qHu_mem_ofFinset`](diffhunk://#diff-91dbc36f4b4c34965f0326f95284853d1e25b04704ec99bca8160087bb1180a8L366-L371): Similarly, removed the `hoption` helper lemma, reducing redundancy and improving clarity.