### PR TITLE
feat(SU5-SUSY): Add minimally allows finite set of terms

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -115,6 +115,7 @@ import PhysLean.Particles.SuperSymmetry.SU5.Charges.Basic
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Completions
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimalSuperSet
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.Basic
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.FinsetTerms
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.OfFinset
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.OfFieldLabel
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.OfPotentialTerm

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/AllowsTerm.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/AllowsTerm.lean
@@ -312,6 +312,16 @@ lemma allowsTermForm_subset_allowsTerm_of_allowsTerm {T : PotentialTerm} {x : Ch
     rw [← sub_zero f2, ← f1_add_f2_eq_zero]
     abel
 
+lemma allowsTerm_iff_subset_allowsTermForm {T : PotentialTerm} {x : Charges 𝓩} :
+    x.AllowsTerm T ↔ ∃ a b c, allowsTermForm a b c T ⊆ x := by
+  constructor
+  · intro h
+    obtain ⟨a, b, c, h1, h2⟩ := allowsTermForm_subset_allowsTerm_of_allowsTerm h
+    use a, b, c
+  · intro h
+    obtain ⟨a, b, c, h1⟩ := h
+    apply allowsTerm_mono h1 allowsTermForm_allowsTerm
+
 lemma subset_card_le_degree_allowsTerm_of_allowsTerm {T : PotentialTerm} {x : Charges 𝓩}
     (h : x.AllowsTerm T) : ∃ y ∈ x.powerset, y.card ≤ T.degree ∧ y.AllowsTerm T := by
   obtain ⟨a, b, c, h1, h2⟩ := allowsTermForm_subset_allowsTerm_of_allowsTerm h

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/Basic.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/Basic.lean
@@ -9,7 +9,7 @@ import PhysLean.Particles.SuperSymmetry.SU5.Charges.AllowsTerm
 # Minimally allows terms
 
 Given a set of charges `x : Charges` corresponding to charges of the representations
-present in the thoery, and a potential term `T : PotentialTerm`, we say that `x`
+present in the theory, and a potential term `T : PotentialTerm`, we say that `x`
 minimally allows `T` if it allows the term `T` and no proper subset of `x` allows `T`.
 
 -/

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
@@ -120,7 +120,7 @@ lemma mem_minTopBottom_of_minimallyAllowsFinsetTerms
     · rw [allowsTerm_iff_subset_allowsTermForm]
       simp [allowsTermForm, subset_def]
       use -qHu
-      simp
+      simp only [neg_neg, true_and]
       use q10
       simp
     · rw [allowsTerm_iff_subset_allowsTermForm]

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.AllowsTerm
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.PhenoConstrained
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.Basic
+import Mathlib.Tactic.FinCases
+/-!
+
+# Minimally allows a finite set of terms
+
+Given a set of charges `x : Charges` corresponding to charges of the representations
+present in the theory, and a finite set of
+potential terms `Ts : Finset PotentialTerm`, we say that `x`
+minimally allows `Ts` if it allows each term in `Ts` and no proper subset of `x` allows
+each term in `Ts`.
+
+-/
+
+namespace SuperSymmetry
+namespace SU5
+
+namespace Charges
+
+variable {𝓩 : Type} [AddCommGroup 𝓩] [DecidableEq 𝓩]
+open SuperSymmetry.SU5
+open PotentialTerm
+
+/-- A collection of charges `x : Charges` is said to minimally allow
+  a finite set of potential terms `Ts` if it allows
+  all terms in `Ts` and no strict subset of it allows all terms in `Ts`. -/
+def MinimallyAllowsFinsetTerms (x : Charges 𝓩) (Ts : Finset PotentialTerm) : Prop :=
+  ∀ y ∈ x.powerset, y = x ↔ ∀ T ∈ Ts, y.AllowsTerm T
+
+instance (x : Charges 𝓩) (Ts : Finset PotentialTerm) :
+    Decidable (x.MinimallyAllowsFinsetTerms Ts) :=
+  inferInstanceAs (Decidable (∀ y ∈ powerset x, y = x ↔ ∀ T ∈ Ts, y.AllowsTerm T))
+
+variable {Ts : Finset PotentialTerm} {x : Charges 𝓩}
+
+lemma allowsTerm_of_minimallyAllowsFinsetTerms {T : PotentialTerm}
+    (h : x.MinimallyAllowsFinsetTerms Ts) (hT : T ∈ Ts) : x.AllowsTerm T :=
+  (h x (self_mem_powerset x)).mp rfl T hT
+
+@[simp]
+lemma minimallyAllowsFinsetTerms_singleton {T : PotentialTerm} :
+    x.MinimallyAllowsFinsetTerms {T} ↔ x.MinimallyAllowsTerm T := by
+  simp [MinimallyAllowsFinsetTerms, MinimallyAllowsTerm]
+
+/-!
+
+## Minimally allows top and bottom Yukawa
+
+-/
+
+/-- The set of charges of the form `(qHd, qHu, {q5}, {-qHd-q5, q10, qHu - q10})`
+  This includes every charge which minimally allows for the top and bottom Yukawas. -/
+def minTopBottom (S5 S10 : Finset 𝓩) : Multiset (Charges 𝓩) := Multiset.dedup <|
+  (S5.val.product <| S5.val.product <| S5.val.product <| S10.val).map
+    (fun x => (x.1, x.2.1, {x.2.2.1}, {- x.1 - x.2.2.1, x.2.2.2, x.2.1 - x.2.2.2}))
+
+lemma allowsTerm_topYukawa_of_mem_minTopBottom {S5 S10 : Finset 𝓩}
+    {x : Charges 𝓩} (h : x ∈ minTopBottom S5 S10) :
+    x.AllowsTerm topYukawa := by
+  simp [minTopBottom] at h
+  obtain ⟨qHd, qHu, q5, q10, ⟨hHd, hHu, h5, h10⟩, rfl⟩ := h
+  rw [allowsTerm_iff_subset_allowsTermForm]
+  simp [allowsTermForm]
+  use -qHu, q10
+  rw [subset_def]
+  simp
+
+lemma allowsTerm_bottomYukawa_of_mem_minTopBottom {S5 S10 : Finset 𝓩}
+    {x : Charges 𝓩} (h : x ∈ minTopBottom S5 S10) :
+    x.AllowsTerm bottomYukawa := by
+  simp [minTopBottom] at h
+  obtain ⟨qHd, qHu, q5, q10, ⟨hHd, hHu, h5, h10⟩, rfl⟩ := h
+  rw [allowsTerm_iff_subset_allowsTermForm]
+  simp [allowsTermForm]
+  use qHd, q5
+  rw [subset_def]
+  simp
+
+lemma mem_minTopBottom_of_minimallyAllowsFinsetTerms
+    {x : Charges 𝓩} {S5 S10 : Finset 𝓩}
+    (h : x.MinimallyAllowsFinsetTerms {topYukawa, bottomYukawa})
+    (hx : x ∈ ofFinset S5 S10) :
+    x ∈ minTopBottom S5 S10 := by
+  simp [minTopBottom]
+  have hTop : x.AllowsTerm topYukawa := allowsTerm_of_minimallyAllowsFinsetTerms h (by simp)
+  have hBottom : x.AllowsTerm bottomYukawa := allowsTerm_of_minimallyAllowsFinsetTerms h (by simp)
+  match x with
+  | (none, qHu, Q5, Q10) =>
+    rw [allowsTerm_iff_subset_allowsTermForm] at hBottom
+    simp [allowsTermForm, subset_def] at hBottom
+  | (qHd, none, Q5, Q10) =>
+    rw [allowsTerm_iff_subset_allowsTermForm] at hTop
+    simp [allowsTermForm, subset_def] at hTop
+  | (some qHd, some qHu, Q5, Q10) =>
+  rw [allowsTerm_iff_subset_allowsTermForm] at hTop hBottom
+  simp [allowsTermForm, subset_def] at hTop hBottom
+  obtain ⟨n, hn, q10, h10⟩ := hTop
+  obtain ⟨q5, h5⟩ := hBottom
+  use qHd, qHu, q5, q10
+  rw [mem_ofFinset_iff] at hx
+  simp at hx
+  refine ⟨⟨hx.1, hx.2.1, hx.2.2.1 h5.1, hx.2.2.2 (h10 (Finset.mem_insert_self _ _))⟩, ?_⟩
+  refine  (h _ ?_).mpr ?_
+  · simp [subset_def]
+    refine ⟨h5.1, ?_⟩
+    refine Finset.insert_subset h5.2 ?_
+    refine Finset.insert_subset (h10 ?_) ?_
+    · simp
+    · refine Finset.singleton_subset_iff.mpr (h10 ?_)
+      simp [hn]
+  · intro T hT
+    fin_cases hT
+    · rw [allowsTerm_iff_subset_allowsTermForm]
+      simp [allowsTermForm, subset_def]
+      use -qHu
+      simp
+      use q10
+      simp
+    · rw [allowsTerm_iff_subset_allowsTermForm]
+      simp [allowsTermForm, subset_def]
+
+end Charges
+
+end SU5
+end SuperSymmetry

--- a/PhysLean/StringTheory/FTheory/SU5/Fluxes/NoExotics/Elems.lean
+++ b/PhysLean/StringTheory/FTheory/SU5/Fluxes/NoExotics/Elems.lean
@@ -63,6 +63,11 @@ lemma toFinset_card_le_four_mem_elemsNoExotics (F : FluxesFive) (h : F ∈ elems
   revert F h
   decide
 
+lemma card_le_six_mem_elemsNoExotics (F : FluxesFive) (h : F ∈ elemsNoExotics) :
+    F.card ≤ 6 := by
+  revert F h
+  decide
+
 lemma sum_of_mem_elemsNoExotics (F : FluxesFive) (h : F ∈ elemsNoExotics) :
     F.sum = (3, 0) := by
   revert F h

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/AnomalyCancellation.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/AnomalyCancellation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.FromParts
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.FinsetTerms
 /-!
 
 # Anomaly cancellation


### PR DESCRIPTION
Introduces `MinimallyAllowsFinsetTerms` and related lemmas for handling minimal allowance of finite sets of potential terms in SU(5) charges. Also adds utility for top and bottom Yukawa terms, updates documentation, fixes a typo, and adds a card bound lemma for fluxes with no exotics. Imports the new module where relevant.