### PR TITLE
feat(SU5-charges): Add maps of charges and charges in ZMod

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -113,6 +113,7 @@ import PhysLean.Particles.SuperSymmetry.MSSMNu.AnomalyCancellation.Y3
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.AllowsTerm
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Basic
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Completions
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.Map
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimalSuperSet
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.Basic
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.OfFinset
@@ -121,6 +122,7 @@ import PhysLean.Particles.SuperSymmetry.SU5.Charges.OfPotentialTerm
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.PhenoConstrained
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Tree
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.ZMod
 import PhysLean.Particles.SuperSymmetry.SU5.FieldLabels
 import PhysLean.Particles.SuperSymmetry.SU5.Potential
 import PhysLean.QFT.AnomalyCancellation.Basic

--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -122,6 +122,7 @@ import PhysLean.Particles.SuperSymmetry.SU5.Charges.OfFieldLabel
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.OfPotentialTerm
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.PhenoConstrained
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Tree
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.U1U1
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.ZMod
 import PhysLean.Particles.SuperSymmetry.SU5.FieldLabels

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean
@@ -49,6 +49,15 @@ lemma eq_of_parts {x y : Charges 𝓩} (h1 : x.1 = y.1) (h2 : x.2.1 = y.2.1)
   | (x1, x2, x3, x4), (y1, y2, y3, y4) =>
     simp_all
 
+lemma eq_iff {x y : Charges 𝓩} :
+    x = y ↔ x.1 = y.1 ∧ x.2.1 = y.2.1 ∧ x.2.2.1 = y.2.2.1 ∧ x.2.2.2 = y.2.2.2 := by
+  constructor
+  · intro h
+    subst h
+    simp
+  · rintro ⟨h1, h2, h3, h4⟩
+    exact eq_of_parts h1 h2 h3 h4
+
 /-!
 
 ## Basic instances on the type `Charges 𝓩`.
@@ -445,6 +454,11 @@ lemma ofFinset_subset_of_subset {S5 S5' S10 S10' : Finset 𝓩}
   intro x hx
   rw [mem_ofFinset_iff] at hx ⊢
   exact ⟨hx.1.trans h5, hx.2.1.trans h5, hx.2.2.1.trans h5, hx.2.2.2.trans h10⟩
+
+lemma ofFinset_univ [Fintype 𝓩] (x : Charges 𝓩) :
+    x ∈ ofFinset (Finset.univ : Finset 𝓩) (Finset.univ : Finset 𝓩) := by
+  rw [mem_ofFinset_iff]
+  simp
 
 end Charges
 

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
@@ -103,7 +103,7 @@ lemma map_ofPotentialTerm_toFinset [DecidableEq 𝓩]
       obtain ⟨q1, q1_mem, rfl⟩ := q1_mem
       obtain ⟨q2, q2_mem, rfl⟩ := q2_mem
       obtain ⟨q3, q3_mem, rfl⟩ := q3_mem
-    case' Λ | K2 | bottomYukawa  => use q1 + q2 + q3
+    case' Λ | K2 | bottomYukawa => use q1 + q2 + q3
     case' W3 => use - q1 - q1 + q2 + q3
     case' W4 => use q1 - q2 - q2 + q3
     case' K1 | topYukawa => use - q1 + q2 + q3
@@ -244,7 +244,8 @@ lemma map_ofYukawaTermsNSum_toFinset {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {n
     rw [Finset.image_union]
     congr 1
     ext i
-    simp
+    simp only [Multiset.mem_toFinset, Multiset.mem_bind, Multiset.mem_map, Finset.mem_image,
+      exists_exists_and_exists_and_eq_and, map_add]
     constructor
     · intro h
       obtain ⟨a, a_mem, b, b_mem, h⟩ := h
@@ -260,12 +261,12 @@ lemma map_ofYukawaTermsNSum_toFinset {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {n
       use f a
       apply And.intro
       · rw [← Multiset.mem_toFinset, ih]
-        simp
+        simp only [Finset.mem_image, Multiset.mem_toFinset]
         use a
       use f b
       apply And.intro
       · rw [mem_map_ofYukawaTerms_iff]
-        simp
+        simp only [Multiset.mem_map]
         use b
       exact h
 
@@ -324,9 +325,9 @@ lemma preimageOfFinset_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Char
   simp [map]
   constructor
   · intro ⟨⟨h1, rfl⟩, ⟨h2, rfl⟩, ⟨h3, rfl⟩, ⟨h4, rfl⟩⟩
-    simp
+    simp only [true_and]
     rw [mem_ofFinset_iff]
-    simp
+    simp only
     refine ⟨?_, ?_, ?_, ?_⟩
     · match yHd with
       | some a => simpa using h1
@@ -339,7 +340,7 @@ lemma preimageOfFinset_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Char
   · rw [eq_iff]
     simp only
     intro ⟨⟨rfl, rfl, rfl, rfl⟩, h2⟩
-    simp
+    simp only [and_true, Finset.mem_image]
     rw [mem_ofFinset_iff] at h2
     simp at h2
     refine ⟨?_, ?_, ?_, ?_⟩
@@ -355,12 +356,12 @@ lemma preimageOfFinset_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Char
       | none => simp
     · refine Finset.subset_iff.mpr ?_
       intro x hx
-      simp
+      simp only [Finset.mem_filter]
       refine ⟨h2.2.2.1 hx, ?_⟩
       use x
     · refine Finset.subset_iff.mpr ?_
       intro x hx
-      simp
+      simp only [Finset.mem_filter]
       refine ⟨h2.2.2.2 hx, ?_⟩
       use x
 
@@ -382,7 +383,7 @@ lemma preimageOfFinset_card_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x :
     preimageOfFinsetCard S5 S10 f x =
     (preimageOfFinset S5 S10 f x).card := by
   rw [preimageOfFinset]
-  simp
+  simp only [Option.map_eq_map, Finset.product_eq_sprod]
   repeat rw [Finset.card_product]
   simp [preimageOfFinsetCard, mul_assoc]
 

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
@@ -1,0 +1,392 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
+import Mathlib.Tactic.FinCases
+/-!
+
+# Mapping charges from different sets
+
+In this module we define a function `map` which takes an additive monoid homomorphism
+`f : 𝓩 →+ 𝓩1` and a charge `x : Charges 𝓩`, and returns the charge
+`x.map f : Charges 𝓩1` obtained by mapping the elements of `x` by `f`.
+
+We prove that various properties of charges are preserved under this mapping.
+
+We define the preimage of this mapping within a subset `ofFinset S5 S10` of `Charges 𝓩` in
+a computationaly efficient way.
+
+-/
+
+namespace SuperSymmetry
+
+namespace SU5
+namespace Charges
+
+variable {𝓩 𝓩1 𝓩2 : Type} [AddCommGroup 𝓩] [AddCommGroup 𝓩1] [DecidableEq 𝓩1]
+  [AddCommGroup 𝓩2] [DecidableEq 𝓩2]
+
+/-- Given an additive monoid homomorphisms `f : 𝓩 →+ 𝓩1`, for a charge
+  `x : Charges 𝓩`, `x.map f` is the charge of `Charges 𝓩1` obtained by mapping the elements
+  of `x` by `f`. -/
+def map (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩) : Charges 𝓩1 :=
+  (f <$> x.1, f <$> x.2.1, x.2.2.1.image f, x.2.2.2.image f)
+
+@[simp]
+lemma map_empty (f : 𝓩 →+ 𝓩1) : map f (∅ : Charges 𝓩) = ∅ := by
+  simp only [map, empty_qHd, Option.map_eq_map, Option.map_none, empty_qHu, empty_Q5,
+    Finset.image_empty, empty_Q10]
+  rfl
+
+lemma map_map (f : 𝓩 →+ 𝓩1) (g : 𝓩1 →+ 𝓩2) (x : Charges 𝓩) :
+    map g (map f x) = map (g.comp f) x := by
+  simp [map, Function.comp, Option.map_map, Finset.image_image]
+
+@[simp]
+lemma map_id [DecidableEq 𝓩] (x : Charges 𝓩) : map (AddMonoidHom.id 𝓩) x = x := by
+  simp [map, Option.map_id, Finset.image_id]
+
+lemma map_ofFieldLabel (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩) (F : FieldLabel) :
+    ofFieldLabel (map f x) F = (ofFieldLabel x F).image f := by
+  simp [ofFieldLabel, map]
+  match x with
+  | (qHd, qHu, Q5, Q10) =>
+  fin_cases F
+  all_goals simp
+  case «0» | «1» =>
+    match qHu with
+    | some a => simp
+    | none => simp
+  case «2» | «3» =>
+    match qHd with
+    | some a => simp
+    | none => simp
+  · trans (Finset.image (⇑f) Q5).image Neg.neg
+    · ext a
+      simp
+    · rw [Finset.image_image]
+      symm
+      trans Finset.image (⇑f ∘ Neg.neg) (Q5)
+      · ext a
+        simp
+      congr
+      funext a
+      simp
+
+lemma map_ofPotentialTerm_toFinset [DecidableEq 𝓩]
+    (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩) (T : PotentialTerm) :
+    (ofPotentialTerm (map f x) T).toFinset = (ofPotentialTerm x T).toFinset.image f := by
+  ext i
+  simp [Multiset.mem_toFinset]
+  rw [mem_ofPotentialTerm_iff_mem_ofPotentialTerm]
+  conv_rhs =>
+    enter [1, a]
+    rw [mem_ofPotentialTerm_iff_mem_ofPotentialTerm]
+  constructor
+  · intro h
+    cases T
+    all_goals
+      simp [ofPotentialTerm'] at h
+      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product] at h
+    case' μ | β =>
+      obtain ⟨q1, q2, ⟨q1_mem, q2_mem⟩, q_sum⟩ := h
+      simp [map] at q1_mem q2_mem
+      obtain ⟨q1, q1_mem, rfl⟩ := q1_mem
+      obtain ⟨q2, q2_mem, rfl⟩ := q2_mem
+    case' μ => use q1 - q2
+    case' β => use -q1 + q2
+    case' Λ | W3 | W4 | K1 | K2 | topYukawa | bottomYukawa =>
+      obtain ⟨q1, q2, q3, ⟨q1_mem, q2_mem, q3_mem⟩, q_sum⟩ := h
+      simp [map] at q1_mem q2_mem q3_mem
+      obtain ⟨q1, q1_mem, rfl⟩ := q1_mem
+      obtain ⟨q2, q2_mem, rfl⟩ := q2_mem
+      obtain ⟨q3, q3_mem, rfl⟩ := q3_mem
+    case' Λ | K2 | bottomYukawa  => use q1 + q2 + q3
+    case' W3 => use - q1 - q1 + q2 + q3
+    case' W4 => use q1 - q2 - q2 + q3
+    case' K1 | topYukawa => use - q1 + q2 + q3
+    case' W1 | W2 =>
+      obtain ⟨q1, q2, q3, q4, ⟨q1_mem, q2_mem, q3_mem, q4_mem⟩, q_sum⟩ := h
+      simp [map] at q1_mem q2_mem q3_mem q4_mem
+      obtain ⟨q1, q1_mem, rfl⟩ := q1_mem
+      obtain ⟨q2, q2_mem, rfl⟩ := q2_mem
+      obtain ⟨q3, q3_mem, rfl⟩ := q3_mem
+      obtain ⟨q4, q4_mem, rfl⟩ := q4_mem
+      use q1 + q2 + q3 + q4
+    all_goals
+      subst i
+      simp [ofPotentialTerm']
+      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product]
+      use q1, q2
+      simp_all
+    · use q3, q4
+    · use q3, q4
+  · intro h
+    obtain ⟨a, h, rfl⟩ := h
+    cases T
+    all_goals
+      simp [ofPotentialTerm'] at h
+      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product] at h
+      simp [ofPotentialTerm']
+    case' μ | β =>
+      obtain ⟨q1, q2, ⟨q1_mem, q2_mem⟩, q_sum⟩ := h
+      use f q1, f q2
+    case' Λ | W3 | W4 | K1 | K2 | topYukawa | bottomYukawa =>
+      obtain ⟨q1, q2, q3, ⟨q1_mem, q2_mem, q3_mem⟩, q_sum⟩ := h
+      use f q1, f q2, f q3
+    case' W1 | W2 =>
+      obtain ⟨q1, q2, q3, q4, ⟨q1_mem, q2_mem, q3_mem, q4_mem⟩, q_sum⟩ := h
+      use f q1, f q2, f q3, f q4
+    all_goals
+      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product, map ]
+      subst a
+      simp_all
+    case W1 => refine ⟨⟨q1, q1_mem, rfl⟩, ⟨q2, q2_mem, rfl⟩, ⟨q3, q3_mem, rfl⟩, ⟨q4, q4_mem, rfl⟩⟩
+    case W2 => refine ⟨⟨q2, q2_mem, rfl⟩, ⟨q3, q3_mem, rfl⟩, ⟨q4, q4_mem, rfl⟩⟩
+    case Λ | K1 => refine ⟨⟨q1, q1_mem, rfl⟩, ⟨q2, q2_mem, rfl⟩, ⟨q3, q3_mem, rfl⟩⟩
+    case W3 | topYukawa | bottomYukawa => refine ⟨⟨q2, q2_mem, rfl⟩, ⟨q3, q3_mem, rfl⟩⟩
+    case W4 | K2 => refine ⟨q3, q3_mem, rfl⟩
+    case β => refine ⟨q2, q2_mem, rfl⟩
+
+lemma mem_map_ofPotentialTerm_iff [DecidableEq 𝓩]
+    (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩) (T : PotentialTerm) :
+    i ∈ (ofPotentialTerm (map f x) T) ↔ i ∈ (ofPotentialTerm x T).map f := by
+  trans i ∈ (ofPotentialTerm (map f x) T).toFinset
+  · simp
+  rw [map_ofPotentialTerm_toFinset]
+  simp
+
+lemma map_subset {f : 𝓩 →+ 𝓩1} {x y : Charges 𝓩} (h : x ⊆ y) :
+    map f x ⊆ map f y := by
+  simp [map, subset_def] at *
+  obtain ⟨hHd, hHu, hQ5, hQ10⟩ := h
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · match x, y with
+    | (a, _, _, _), (b, _, _, _) =>
+      cases a
+      all_goals cases b
+      all_goals simp [hHd]
+      all_goals simp at hHd
+      subst hHd
+      rfl
+  · match x, y with
+    | (_, a, _, _), (_, b, _, _) =>
+      cases a
+      all_goals cases b
+      all_goals simp [hHu]
+      all_goals simp at hHu
+      subst hHu
+      rfl
+  · exact Finset.image_subset_image hQ5
+  · exact Finset.image_subset_image hQ10
+
+variable [DecidableEq 𝓩]
+
+lemma allowsTermForm_map {T} {f : 𝓩 →+ 𝓩1} {a b c : 𝓩} :
+    (allowsTermForm a b c T).map f = allowsTermForm (f a) (f b) (f c) T := by
+  cases T
+  all_goals simp [allowsTermForm, map]
+
+lemma map_allowsTerm {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {T : PotentialTerm}
+    (h : x.AllowsTerm T) : (map f x).AllowsTerm T := by
+  rw [allowsTerm_iff_subset_allowsTermForm] at ⊢ h
+  obtain ⟨a, b, c, h1⟩ := h
+  use f a, f b, f c
+  rw [← allowsTermForm_map]
+  exact map_subset h1
+
+lemma map_isPhenoConstrained (f : 𝓩 →+ 𝓩1) {x : Charges 𝓩}
+    (h : x.IsPhenoConstrained) : (map f x).IsPhenoConstrained := by
+  simp [IsPhenoConstrained] at ⊢ h
+  rcases h with h | h | h | h | h | h | h | h
+  · exact Or.inl (map_allowsTerm h)
+  · exact Or.inr (Or.inl (map_allowsTerm h))
+  · exact Or.inr (Or.inr (Or.inl (map_allowsTerm h)))
+  · exact Or.inr (Or.inr (Or.inr (Or.inl (map_allowsTerm h))))
+  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl (map_allowsTerm h)))))
+  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl (map_allowsTerm h))))))
+  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl (map_allowsTerm h)))))))
+  · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr ((map_allowsTerm h))))))))
+
+lemma not_isPhenoConstrained_of_map {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩}
+    (h : ¬ (map f x).IsPhenoConstrained) : ¬ x.IsPhenoConstrained :=
+  fun hn => h (map_isPhenoConstrained f hn)
+
+omit [DecidableEq 𝓩] in
+lemma map_isComplete_iff {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} :
+    (map f x).IsComplete ↔ x.IsComplete := by
+  simp [IsComplete, map]
+
+lemma map_ofYukawaTerms_toFinset {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} :
+    (map f x).ofYukawaTerms.toFinset = x.ofYukawaTerms.toFinset.image f := by
+  simp [ofYukawaTerms]
+  ext i
+  rw [Finset.image_union]
+  simp only [Finset.mem_union, Multiset.mem_toFinset]
+  rw [mem_map_ofPotentialTerm_iff, mem_map_ofPotentialTerm_iff]
+  simp [Multiset.mem_map]
+
+lemma mem_map_ofYukawaTerms_iff {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {i} :
+    i ∈ (map f x).ofYukawaTerms ↔ i ∈ x.ofYukawaTerms.map f := by
+  trans i ∈ (map f x).ofYukawaTerms.toFinset
+  · simp
+  rw [map_ofYukawaTerms_toFinset]
+  simp
+
+lemma map_ofYukawaTermsNSum_toFinset {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {n : ℕ}:
+    ((map f x).ofYukawaTermsNSum n).toFinset = (x.ofYukawaTermsNSum n).toFinset.image f:= by
+  induction n with
+  | zero => simp [ofYukawaTermsNSum, map]
+  | succ n ih =>
+    simp [ofYukawaTermsNSum]
+    rw [Finset.image_union]
+    congr 1
+    ext i
+    simp
+    constructor
+    · intro h
+      obtain ⟨a, a_mem, b, b_mem, h⟩ := h
+      have a_mem' : a ∈ ((map f x).ofYukawaTermsNSum n).toFinset := by simpa using a_mem
+      rw [ih] at a_mem'
+      rw [mem_map_ofYukawaTerms_iff] at b_mem
+      simp at a_mem' b_mem
+      obtain ⟨a, a_mem', rfl⟩ := a_mem'
+      obtain ⟨b, b_mem', rfl⟩ := b_mem
+      exact ⟨a, a_mem', b, b_mem', h⟩
+    · intro h
+      obtain ⟨a, a_mem, b, b_mem, h⟩ := h
+      use f a
+      apply And.intro
+      · rw [← Multiset.mem_toFinset, ih]
+        simp
+        use a
+      use f b
+      apply And.intro
+      · rw [mem_map_ofYukawaTerms_iff]
+        simp
+        use b
+      exact h
+
+lemma mem_map_ofYukawaTermsNSum_iff {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} {n i} :
+    i ∈ (map f x).ofYukawaTermsNSum n ↔ i ∈ (x.ofYukawaTermsNSum n).map f := by
+  trans i ∈ ((map f x).ofYukawaTermsNSum n).toFinset
+  · simp
+  rw [map_ofYukawaTermsNSum_toFinset]
+  simp
+
+lemma map_phenoConstrainingChargesSP_toFinset {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩} :
+    (map f x).phenoConstrainingChargesSP.toFinset =
+    x.phenoConstrainingChargesSP.toFinset.image f := by
+  simp [phenoConstrainingChargesSP, map_ofPotentialTerm_toFinset, Finset.image_union]
+
+lemma map_yukawaGeneratesDangerousAtLevel (f : 𝓩 →+ 𝓩1) {x : Charges 𝓩} (n : ℕ)
+    (h : x.YukawaGeneratesDangerousAtLevel n) : (map f x).YukawaGeneratesDangerousAtLevel n := by
+  rw [YukawaGeneratesDangerousAtLevel]
+  rw [map_phenoConstrainingChargesSP_toFinset, map_ofYukawaTermsNSum_toFinset]
+  rw [← Finset.nonempty_iff_ne_empty, ← Finset.not_disjoint_iff_nonempty_inter]
+  apply Disjoint.of_image_finset.mt
+  rw [Finset.not_disjoint_iff_nonempty_inter, Finset.nonempty_iff_ne_empty]
+  exact h
+
+lemma not_yukawaGeneratesDangerousAtLevel_of_map {f : 𝓩 →+ 𝓩1} {x : Charges 𝓩}
+    (n : ℕ) (h : ¬ (map f x).YukawaGeneratesDangerousAtLevel n) :
+    ¬ x.YukawaGeneratesDangerousAtLevel n :=
+  fun hn => h (map_yukawaGeneratesDangerousAtLevel f n hn)
+
+/-!
+
+## Preimage
+
+-/
+
+/-- The preimage of a charge `Charges 𝓩1` in `ofFinset S5 S10 ⊆ Charges 𝓩` under
+  mapping charges through `f : 𝓩 →+ 𝓩1`. -/
+def preimageOfFinset (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩1) : Finset (Charges 𝓩) :=
+  let SHd := (S5.map ⟨Option.some, Option.some_injective 𝓩⟩ ∪ {none} : Finset (Option 𝓩)).filter
+    fun y => f <$> y = x.1
+  let SHu := (S5.map ⟨Option.some, Option.some_injective 𝓩⟩ ∪ {none} : Finset (Option 𝓩)).filter
+    fun y => f <$> y = x.2.1
+  let SQ5' := S5.filter fun y => f y ∈ x.2.2.1
+  let SQ5 : Finset (Finset 𝓩) := SQ5'.powerset.filter fun y => y.image f = x.2.2.1
+  let SQ10' := S10.filter fun y => f y ∈ x.2.2.2
+  let SQ10 : Finset (Finset 𝓩) := SQ10'.powerset.filter fun y => y.image f = x.2.2.2
+  SHd.product <| SHu.product <| SQ5.product SQ10
+
+lemma preimageOfFinset_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩1) :
+    preimageOfFinset S5 S10 f x = {y : Charges 𝓩 | y.map f = x ∧ y ∈ ofFinset S5 S10} := by
+  ext y
+  match y, x with
+  | (yHd, yHu, y5, y10), (xHd, xHu, x5, x10) =>
+  simp [preimageOfFinset]
+  repeat rw [Finset.mem_product]
+  simp [map]
+  constructor
+  · intro ⟨⟨h1, rfl⟩, ⟨h2, rfl⟩, ⟨h3, rfl⟩, ⟨h4, rfl⟩⟩
+    simp
+    rw [mem_ofFinset_iff]
+    simp
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · match yHd with
+      | some a => simpa using h1
+      | none => simp
+    · match yHu with
+      | some a => simpa using h2
+      | none => simp
+    · exact h3.trans <| Finset.filter_subset (fun y => f y ∈ Finset.image (⇑f) y5) S5
+    · apply h4.trans <| Finset.filter_subset (fun y => f y ∈ Finset.image (⇑f) y10) S10
+  · rw [eq_iff]
+    simp only
+    intro ⟨⟨rfl, rfl, rfl, rfl⟩, h2⟩
+    simp
+    rw [mem_ofFinset_iff] at h2
+    simp at h2
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · match yHd with
+      | some a =>
+        simp at h2
+        simpa using h2.1
+      | none => simp
+    · match yHu with
+      | some a =>
+        simp at h2
+        simpa using h2.2.1
+      | none => simp
+    · refine Finset.subset_iff.mpr ?_
+      intro x hx
+      simp
+      refine ⟨h2.2.2.1 hx, ?_⟩
+      use x
+    · refine Finset.subset_iff.mpr ?_
+      intro x hx
+      simp
+      refine ⟨h2.2.2.2 hx, ?_⟩
+      use x
+
+/-- The cardiniality of the
+  preimage of a charge `Charges 𝓩1` in `ofFinset S5 S10 ⊆ Charges 𝓩` under
+  mapping charges through `f : 𝓩 →+ 𝓩1`. -/
+def preimageOfFinsetCard (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩1) : ℕ :=
+  let SHd := (S5.map ⟨Option.some, Option.some_injective 𝓩⟩ ∪ {none} : Finset (Option 𝓩)).filter
+    fun y => f <$> y = x.1
+  let SHu := (S5.map ⟨Option.some, Option.some_injective 𝓩⟩ ∪ {none} : Finset (Option 𝓩)).filter
+    fun y => f <$> y = x.2.1
+  let SQ5' := S5.filter fun y => f y ∈ x.2.2.1
+  let SQ5 : Finset (Finset 𝓩) := SQ5'.powerset.filter fun y => y.image f = x.2.2.1
+  let SQ10' := S10.filter fun y => f y ∈ x.2.2.2
+  let SQ10 : Finset (Finset 𝓩) := SQ10'.powerset.filter fun y => y.image f = x.2.2.2
+  SHd.card * SHu.card * SQ5.card * SQ10.card
+
+lemma preimageOfFinset_card_eq (S5 S10 : Finset 𝓩) (f : 𝓩 →+ 𝓩1) (x : Charges 𝓩1) :
+    preimageOfFinsetCard S5 S10 f x =
+    (preimageOfFinset S5 S10 f x).card := by
+  rw [preimageOfFinset]
+  simp
+  repeat rw [Finset.card_product]
+  simp [preimageOfFinsetCard, mul_assoc]
+
+end Charges
+end SU5
+
+end SuperSymmetry

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import PhysLean.Particles.SuperSymmetry.SU5.Charges.AllowsTerm
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.PhenoConstrained
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.Basic
 import Mathlib.Tactic.FinCases
@@ -107,7 +106,7 @@ lemma mem_minTopBottom_of_minimallyAllowsFinsetTerms
   rw [mem_ofFinset_iff] at hx
   simp at hx
   refine ⟨⟨hx.1, hx.2.1, hx.2.2.1 h5.1, hx.2.2.2 (h10 (Finset.mem_insert_self _ _))⟩, ?_⟩
-  refine  (h _ ?_).mpr ?_
+  refine (h _ ?_).mpr ?_
   · simp [subset_def]
     refine ⟨h5.1, ?_⟩
     refine Finset.insert_subset h5.2 ?_

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/U1U1.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/U1U1.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.ZMod.Defs
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
+import Mathlib.Tactic.FinCases
+import PhysLean.Meta.Linters.Sorry
+/-!
+
+# U(1) x U(1) charges
+
+The aim of this module is to investigate the possible U(1) x U(1) charges that one can assign
+to particles in the SU(5) model, whilst ensuring a phenomenologically viable theory.
+
+The aim is to put an upper bound on the number of such charges, when the `U(1)` charges
+are constrained to sit in certain finite sets.
+
+## Note
+
+This file is currently a stub.
+-/

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.ZMod.Defs
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
 import Mathlib.Tactic.FinCases
+import PhysLean.Meta.Linters.Sorry
 /-!
 
 # ZMod charges
@@ -33,14 +34,18 @@ lemma ZModCharges_one_eq : ZModCharges 1 = ∅:= by decide
 
 lemma ZModCharges_two_eq : ZModCharges 2 = ∅ := by decide
 
+@[pseudo]
 lemma ZModCharges_three_eq : ZModCharges 3 = ∅ := by native_decide
 
+@[pseudo]
 lemma ZModCharges_four_eq : ZModCharges 4 = {(some 0, some 2, {1}, {3}),
     (some 0, some 2, {3}, {1}), (some 1, some 2, {0}, {3}), (some 3, some 2, {0}, {1})} := by
   native_decide
 
+@[pseudo]
 lemma ZModCharges_five_eq : ZModCharges 5 = ∅ := by native_decide
 
+@[pseudo]
 lemma ZModCharges_six_eq : ZModCharges 6 = {(some 0, some 2, {5}, {1}),
     (some 0, some 4, {1}, {5}), (some 1, some 0, {2}, {3}), (some 1, some 2, {4}, {1}),
     (some 1, some 4, {0}, {5}), (some 1, some 4, {3}, {2}), (some 2, some 0, {1}, {3}),

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.ZMod.Defs
+import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
+import Mathlib.Tactic.FinCases
+/-!
+
+# ZMod charges
+
+In this module we investigate the possible ℤ₂ charges that one can assign
+to charges associated with ℤ₂ we can assign to particles in the SU(5) model, whilst
+keeping charges anomaly free.
+
+-/
+
+namespace SuperSymmetry
+
+namespace SU5
+namespace Charges
+
+/-- The finite set of `ZMod n` valued charges which are complete,
+  not pheno-constrained and don't regenerate dangerous couplings
+  with the Yukawa term up-to 4-inserstions of singlets. -/
+def ZModCharges (n : ℕ) [NeZero n] : Finset (Charges (ZMod n)) :=
+  let S : Finset (Charges (ZMod n)) := ofFinset (Finset.univ) Finset.univ
+  S.filter (fun x => IsComplete x ∧ ¬ x.IsPhenoConstrained ∧ ¬ x.YukawaGeneratesDangerousAtLevel 4)
+
+lemma ZModCharges_one_eq : ZModCharges 1 = ∅:= by decide
+
+lemma ZModCharges_two_eq : ZModCharges 2 = ∅ := by decide
+
+lemma ZModCharges_three_eq : ZModCharges 3 = ∅ := by native_decide
+
+lemma ZModCharges_four_eq : ZModCharges 4 = {(some 0, some 2, {1}, {3}),
+    (some 0, some 2, {3}, {1}), (some 1, some 2, {0}, {3}), (some 3, some 2, {0}, {1})} := by
+  native_decide
+
+lemma ZModCharges_five_eq : ZModCharges 5 = ∅ := by native_decide
+
+lemma ZModCharges_six_eq : ZModCharges 6 = {(some 0, some 2, {5}, {1}),
+    (some 0, some 4, {1}, {5}), (some 1, some 0, {2}, {3}), (some 1, some 2, {4}, {1}),
+    (some 1, some 4, {0}, {5}), (some 1, some 4, {3}, {2}), (some 2, some 0, {1}, {3}),
+    (some 2, some 4, {5}, {5}), (some 3, some 2, {5}, {4}), (some 3, some 4, {1}, {2}),
+    (some 4, some 0, {5}, {3}), (some 4, some 2, {1}, {1}), (some 5, some 0, {4}, {3}),
+    (some 5, some 2, {0}, {1}), (some 5, some 2, {3}, {4}), (some 5, some 4, {2}, {5})} := by
+  native_decide
+
+/-- The finite set of `ZMod n × ZMod m` valued charges which are complete,
+  not pheno-constrained and don't regenerate dangerous couplings
+  with the Yukawa term up-to 4-inserstions of singlets. -/
+def ZModZModCharges (n m : ℕ) [NeZero n] [NeZero m] : Finset (Charges (ZMod n × ZMod m)) :=
+  let S : Finset (Charges (ZMod n × ZMod m)) := ofFinset (Finset.univ) Finset.univ
+  S.filter (fun x => IsComplete x ∧
+  ¬ x.IsPhenoConstrained ∧ ¬ x.YukawaGeneratesDangerousAtLevel 4)
+
+/-- The additive monoid homomorphism from `ℤ` to `ZMod n` obtained by
+  taking the modulo. -/
+def intToZMod (n : ℕ) : ℤ →+ ZMod n where
+  toFun := Int.cast
+  map_zero' := Int.cast_zero
+  map_add' := Int.cast_add
+
+/-- The non-trivial additive monoid homomorphism from `ZMod 4` to `ZMod 2`. -/
+def zModFourToZModTwo:
+    ZMod 4 →+ ZMod 2 where
+  toFun x :=
+    match x with
+    | 0 => 0
+    | 1 => 1
+    | 2 => 0
+    | 3 => 1
+  map_zero' := by simp
+  map_add' := by
+    intros x y
+    fin_cases x
+    all_goals fin_cases y
+    all_goals decide
+
+end Charges
+end SU5
+
+end SuperSymmetry

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean
@@ -30,10 +30,16 @@ def ZModCharges (n : ℕ) [NeZero n] : Finset (Charges (ZMod n)) :=
   let S : Finset (Charges (ZMod n)) := ofFinset (Finset.univ) Finset.univ
   S.filter (fun x => IsComplete x ∧ ¬ x.IsPhenoConstrained ∧ ¬ x.YukawaGeneratesDangerousAtLevel 4)
 
+/-- This lemma corresponds to the statement that there are no choices of `ℤ₁` representations
+  which give a phenomenologically viable theory. -/
 lemma ZModCharges_one_eq : ZModCharges 1 = ∅:= by decide
 
+/-- This lemma corresponds to the statement that there are no choices of `ℤ₂` representations
+  which give a phenomenologically viable theory. -/
 lemma ZModCharges_two_eq : ZModCharges 2 = ∅ := by decide
 
+/-- This lemma corresponds to the statement that there are no choices of `ℤ₃` representations
+  which give a phenomenologically viable theory. -/
 @[pseudo]
 lemma ZModCharges_three_eq : ZModCharges 3 = ∅ := by native_decide
 
@@ -42,6 +48,8 @@ lemma ZModCharges_four_eq : ZModCharges 4 = {(some 0, some 2, {1}, {3}),
     (some 0, some 2, {3}, {1}), (some 1, some 2, {0}, {3}), (some 3, some 2, {0}, {1})} := by
   native_decide
 
+/-- This lemma corresponds to the statement that there are no choices of `ℤ₅` representations
+  which give a phenomenologically viable theory. -/
 @[pseudo]
 lemma ZModCharges_five_eq : ZModCharges 5 = ∅ := by native_decide
 


### PR DESCRIPTION
***Copilot summary***

This pull request introduces several significant updates to the `PhysLean` codebase, focusing on expanding functionality for handling charges in the SU(5) supersymmetry model. Key changes include the addition of new modules (`Map` and `ZMod`) for charge mapping and modular arithmetic operations, as well as enhancements to existing functionality in `Charges`. These updates improve modularity, extend mathematical capabilities, and streamline charge-related computations.

### New Modules and Features

* **`PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean`**: Introduced a new module defining a `map` function for mapping charges via additive monoid homomorphisms. Includes lemmas proving preservation of charge properties and efficient computation of preimages.
* **`PhysLean/Particles/SuperSymmetry/SU5/Charges/ZMod.lean`**: Added a new module for working with `ZMod` charges, including definitions for sets of valid charges (`ZModCharges` and `ZModZModCharges`) and related lemmas.

### Enhancements to Existing Functionality

* **`PhysLean/Particles/SuperSymmetry/SU5/Charges/Basic.lean`**:
  - Added a new lemma `eq_iff` for equivalence of `Charges` based on their components.
  - Introduced `ofFinset_univ` lemma for universal membership in finite sets of charges.

### Dependency and Import Updates

* **`PhysLean.lean`**:
  - Added imports for `PhysLean.Particles.SuperSymmetry.SU5.Charges.Map` and `PhysLean.Particles.SuperSymmetry.SU5.Charges.ZMod` to incorporate new modules. [[1]](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R116) [[2]](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R126)
* **`PhysLean/Particles/SuperSymmetry/SU5/Charges/MinimallyAllowsTerm/FinsetTerms.lean`**:
  - Removed an unused import of `PhysLean.Particles.SuperSymmetry.SU5.Charges.AllowsTerm`.