### PR TITLE
feat: Add derivatives of distributions

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -297,6 +297,7 @@ import PhysLean.Relativity.Tensors.TensorSpecies.Basic
 import PhysLean.Relativity.Tensors.Tensorial
 import PhysLean.Relativity.Tensors.UnitTensor
 import PhysLean.SpaceAndTime.Space.Basic
+import PhysLean.SpaceAndTime.Space.Distributions
 import PhysLean.SpaceAndTime.Space.VectorIdentities
 import PhysLean.SpaceAndTime.SpaceTime.Basic
 import PhysLean.SpaceAndTime.SpaceTime.TimeSlice

--- a/PhysLean/Mathematics/Distribution/Basic.lean
+++ b/PhysLean/Mathematics/Distribution/Basic.lean
@@ -47,7 +47,7 @@ abbrev Distribution (𝕜 E F : Type) [RCLike 𝕜] [NormedAddCommGroup E] [Norm
     [NormedSpace ℝ E] [NormedSpace 𝕜 F] : Type :=
   𝓢(E, 𝕜) →L[𝕜] F
 
-@[inherit_doc] notation:25 E:arg "→d[" 𝕜:25 "] " F:arg => Distribution 𝕜 E F
+@[inherit_doc] notation:25 E:arg "→d[" 𝕜:25 "] " F:0 => Distribution 𝕜 E F
 
 variable (𝕜 : Type) {E F : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]
 
@@ -127,6 +127,81 @@ def derivative : (ℝ →d[𝕜] 𝕜) →ₗ[𝕜] (ℝ →d[𝕜] 𝕜) where
   rfl
 
 end RCLike
+
+section fderiv
+
+variable [NormedAddCommGroup E]
+  [NormedSpace ℝ E] [NormedAddCommGroup F] [NormedSpace ℝ F] [RCLike 𝕜]
+  [NormedSpace 𝕜 F] [SMulCommClass ℝ 𝕜 F]
+
+/-- The Fréchet derivative of a distribution.
+
+Informally, for a distribution `u : E →d[𝕜] F`,
+the Fréchet derivative `fderiv u x v` corresponds to the dervative of `u` at the
+point `x` in the direction `v`. For example, if `F = ℝ³`
+then `fderiv u x v` is a vector in `ℝ³` corrsponding to
+`(v₁ ∂u₁/∂x₁ + v₂ ∂u₁/∂x₂ + v₃ ∂u₁/∂x₃, v₁ ∂u₂/∂x₁ + v₂ ∂u₂/∂x₂ + v₃ ∂u₂/∂x₃,...)`.
+
+Formally, for a distribution `u : E →d[𝕜] F`, this is actually defined
+the distribution which takes test function `η : E → 𝕜` to
+`- u (SchwartzMap.evalCLM v (SchwartzMap.fderivCLM 𝕜 η))`.
+
+Note that, unlike for functions, the Fréchet derivative of a distribution always exists.
+-/
+def fderivD [FiniteDimensional ℝ E] : (E →d[𝕜] F) →ₗ[𝕜] (E →d[𝕜] (E →L[ℝ] F)) where
+  toFun u := {
+    toFun η := LinearMap.toContinuousLinearMap {
+      toFun v := ContinuousLinearEquiv.neg 𝕜 <| u <|
+        SchwartzMap.evalCLM (𝕜 := 𝕜) v <|
+        SchwartzMap.fderivCLM 𝕜 (E := E) (F := 𝕜) η
+      map_add' v1 v2 := by
+        simp only [ContinuousLinearEquiv.neg_apply]
+        trans -u ((SchwartzMap.evalCLM (𝕜 := 𝕜) v1) ((fderivCLM 𝕜) η) +
+          (SchwartzMap.evalCLM (𝕜 := 𝕜) v2) ((fderivCLM 𝕜) η))
+        swap
+        · simp only [map_add, neg_add_rev]
+          abel
+        congr
+        ext x
+        simp only [SchwartzMap.evalCLM, mkCLM, mkLM, map_add, ContinuousLinearMap.coe_mk',
+          LinearMap.coe_mk, AddHom.coe_mk, fderivCLM_apply, add_apply]
+        rfl
+      map_smul' a v1 := by
+        simp only [ContinuousLinearEquiv.neg_apply, RingHom.id_apply, smul_neg, neg_inj]
+        trans u (a • (SchwartzMap.evalCLM (𝕜 := 𝕜) v1) ((fderivCLM 𝕜) η))
+        swap
+        · simp
+        congr
+        ext x
+        simp only [SchwartzMap.evalCLM, mkCLM, mkLM, map_smul, ContinuousLinearMap.coe_mk',
+          LinearMap.coe_mk, AddHom.coe_mk, fderivCLM_apply, smul_apply]
+        rfl}
+    map_add' η1 η2 := by
+      ext x
+      simp only [map_add, ContinuousLinearEquiv.neg_apply, neg_add_rev,
+        LinearMap.coe_toContinuousLinearMap', LinearMap.coe_mk, AddHom.coe_mk,
+        ContinuousLinearMap.add_apply]
+    map_smul' a η := by
+      ext x
+      simp
+    cont := by
+      refine continuous_clm_apply.mpr ?_
+      intro y
+      simp only [ContinuousLinearEquiv.neg_apply, LinearMap.coe_toContinuousLinearMap',
+        LinearMap.coe_mk, AddHom.coe_mk]
+      fun_prop
+  }
+  map_add' u₁ u₂ := by
+    ext η
+    simp only [ContinuousLinearMap.add_apply, ContinuousLinearEquiv.neg_apply, neg_add_rev,
+      ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk,
+      LinearMap.coe_toContinuousLinearMap']
+    abel
+  map_smul' c u := by
+    ext
+    simp
+
+end fderiv
 
 section Complex
 

--- a/PhysLean/SpaceAndTime/Space/Distributions.lean
+++ b/PhysLean/SpaceAndTime/Space/Distributions.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2025 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+import PhysLean.SpaceAndTime.Space.Basic
+import PhysLean.Mathematics.Distribution.Basic
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Analysis.Calculus.FDeriv.Symmetric
+import Mathlib.Analysis.Calculus.Gradient.Basic
+/-!
+
+# Distributions on space
+
+In this module we define the derivatives, gradient, divergence and curl of distributions
+on `Space`.
+
+Contrary to the usual definition of derivatives on functions, when working with
+distributions one does not need to check that the function is differentiable to perform
+basic operations. This has the consequence that in a lot of cases, distributions are in fact
+somewhat easier to work with than functions.
+
+## Examples of distributions
+
+Distributions cover a wide range of objects that we use in physics.
+
+- The dirac delta function.
+- The potential 1/r (which is not defined at the origin).
+- The Heaviside step function.
+- Interfaces between materials, such as a charged sphere.
+
+-/
+
+namespace Space
+
+open Distribution
+open SchwartzMap
+/-!
+
+## Derivatives
+
+-/
+
+/-- Given a distribution (function) `f : Space d →d[ℝ] M` the derivative
+  of `f` in direction `μ`. -/
+noncomputable def derivD {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (μ : Fin d) : ((Space d) →d[ℝ] M) →ₗ[ℝ] (Space d) →d[ℝ] M where
+  toFun f :=
+    let ev : (Space d →L[ℝ] M) →L[ℝ] M := {
+      toFun v := v (basis μ)
+      map_add' v1 v2 := by
+        simp only [LinearMap.add_apply, ContinuousLinearMap.add_apply]
+      map_smul' a v := by
+        simp
+    }
+    ev.comp (Distribution.fderivD ℝ f)
+  map_add' f1 f2 := by
+    simp
+  map_smul' a f := by simp
+
+lemma derivD_comm {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (μ ν : Fin d) (f : (Space d) →d[ℝ] M) :
+    (derivD ν (derivD μ f)) = (derivD μ (derivD ν f)) := by
+  ext η
+  simp [derivD, Distribution.fderivD]
+  congr 1
+  ext x
+  have h1 := η.smooth
+  have h2 := h1 2
+  change fderiv ℝ (fun x => fderiv ℝ η x (basis ν)) x (basis μ) =
+    fderiv ℝ (fun x => fderiv ℝ η x (basis μ)) x (basis ν)
+  rw [fderiv_clm_apply, fderiv_clm_apply]
+  simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
+    ContinuousLinearMap.flip_apply]
+  rw [IsSymmSndFDerivAt.eq]
+  apply ContDiffAt.isSymmSndFDerivAt (n := 2)
+  · refine ContDiff.contDiffAt ?_
+    exact h2
+  · simp
+  · fun_prop
+  · exact differentiableAt_const (basis μ)
+  · fun_prop
+  · exact differentiableAt_const (basis ν)
+
+/-!
+
+## The gradient
+
+-/
+
+open InnerProductSpace
+
+/-- The gradient of a distribution `(Space d) →d[ℝ] ℝ` as a distribution
+  `(Space d) →d[ℝ] (EuclideanSpace ℝ (Fin d))`. -/
+noncomputable def gradD {d} :
+    ((Space d) →d[ℝ] ℝ) →ₗ[ℝ] (Space d) →d[ℝ] (EuclideanSpace ℝ (Fin d)) where
+  toFun f :=
+    ((InnerProductSpace.toDual ℝ (Space d)).symm.toContinuousLinearMap).comp (fderivD ℝ f)
+  map_add' f1 f2 := by
+    ext x
+    simp
+  map_smul' a f := by
+    ext x
+    simp
+
+/-!
+
+## The divergence
+
+-/
+
+/-- The divergence of a distribution `(Space d) →d[ℝ] (EuclideanSpace ℝ (Fin d))` as a distribution
+  `(Space d) →d[ℝ] ℝ`. -/
+noncomputable def divD {d} :
+    ((Space d) →d[ℝ] (EuclideanSpace ℝ (Fin d))) →ₗ[ℝ] (Space d) →d[ℝ] ℝ where
+  toFun f :=
+    let trace : (Space d →L[ℝ] (EuclideanSpace ℝ (Fin d))) →L[ℝ] ℝ := {
+      toFun v := ∑ i, ⟪v (basis i), basis i⟫_ℝ
+      map_add' v1 v2 := by
+        simp
+        rw [Finset.sum_add_distrib]
+      map_smul' a v := by
+        simp
+        rw [Finset.mul_sum]
+      cont := by fun_prop}
+    trace.comp (Distribution.fderivD ℝ f)
+  map_add' f1 f2 := by
+    ext x
+    simp
+  map_smul' a f := by
+    ext x
+    simp
+
+/-!
+
+## The curl
+
+-/
+
+/-- The curl of a distribution `Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))` as a distribution
+  `Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))`. -/
+noncomputable def curlD : (Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) →ₗ[ℝ]
+    (Space) →d[ℝ] (EuclideanSpace ℝ (Fin 3)) where
+  toFun f :=
+    let curl : (Space →L[ℝ] (EuclideanSpace ℝ (Fin 3))) →L[ℝ] (EuclideanSpace ℝ (Fin 3)) := {
+      toFun dfdx:= fun i =>
+        match i with
+        | 0 => dfdx (basis 2) 1 - dfdx (basis 1) 2
+        | 1 => dfdx (basis 0) 2 - dfdx (basis 2) 0
+        | 2 => dfdx (basis 1) 0 - dfdx (basis 0) 1
+      map_add' v1 v2 := by
+        ext i
+        fin_cases i
+        all_goals
+          simp
+          ring
+      map_smul' a v := by
+        ext i
+        fin_cases i
+        all_goals
+          simp
+          ring
+      cont := by
+        rw [continuous_pi_iff]
+        intro i
+        fin_cases i
+        all_goals
+          fun_prop
+        }
+    curl.comp (Distribution.fderivD ℝ f)
+  map_add' f1 f2 := by
+    ext x
+    simp
+  map_smul' a f := by
+    ext x
+    simp
+
+end Space

--- a/PhysLean/SpaceAndTime/Space/Distributions.lean
+++ b/PhysLean/SpaceAndTime/Space/Distributions.lean
@@ -117,10 +117,11 @@ noncomputable def divD {d} :
     let trace : (Space d →L[ℝ] (EuclideanSpace ℝ (Fin d))) →L[ℝ] ℝ := {
       toFun v := ∑ i, ⟪v (basis i), basis i⟫_ℝ
       map_add' v1 v2 := by
-        simp
+        simp only [ContinuousLinearMap.add_apply, inner_basis, PiLp.add_apply]
         rw [Finset.sum_add_distrib]
       map_smul' a v := by
-        simp
+        simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, inner_basis, PiLp.smul_apply,
+          smul_eq_mul, RingHom.id_apply]
         rw [Finset.mul_sum]
       cont := by fun_prop}
     trace.comp (Distribution.fderivD ℝ f)
@@ -152,13 +153,14 @@ noncomputable def curlD : (Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) →ₗ[
         ext i
         fin_cases i
         all_goals
-          simp
+          simp only [Fin.isValue, ContinuousLinearMap.add_apply, PiLp.add_apply, Fin.zero_eta]
           ring
       map_smul' a v := by
         ext i
         fin_cases i
         all_goals
-          simp
+          simp only [Fin.isValue, ContinuousLinearMap.coe_smul', Pi.smul_apply, PiLp.smul_apply,
+            smul_eq_mul, RingHom.id_apply, Fin.reduceFinMk]
           ring
       cont := by
         rw [continuous_pi_iff]


### PR DESCRIPTION
**Copilot summary**

This pull request introduces significant enhancements to the `PhysLean` library, focusing on distributions and their derivatives in the context of mathematical physics. The changes include new functionality for defining derivatives, gradient, divergence, and curl of distributions, as well as improvements to existing notation and imports.

### Additions to distributions and their derivatives:
* Introduced a new module `PhysLean.SpaceAndTime.Space.Distributions` to define derivatives, gradient, divergence, and curl of distributions on space. This includes new definitions like `derivD`, `gradD`, `divD`, and `curlD`, which provide linear maps for these operations.
* Added the `fderivD` function in `PhysLean/Mathematics/Distribution/Basic.lean` to compute the Fréchet derivative of a distribution. This formalizes the derivative operation for distributions, ensuring it always exists.

### Improvements to notation and imports:
* Updated the notation for `Distribution` in `PhysLean/Mathematics/Distribution/Basic.lean` to improve clarity by adjusting the formatting of the `F` argument.
* Added an import for `PhysLean.SpaceAndTime.Space.Distributions` in `PhysLean.lean` to integrate the new module into the broader library.