### PR TITLE
feat: time to a structure & docs

### DIFF
--- a/PhysLean/ClassicalMechanics/EulerLagrange.lean
+++ b/PhysLean/ClassicalMechanics/EulerLagrange.lean
@@ -15,7 +15,7 @@ and prove the that the variational derivative of the action functional
 
 -/
 
-open MeasureTheory ContDiff InnerProductSpace
+open MeasureTheory ContDiff InnerProductSpace Time
 
 variable {X} [NormedAddCommGroup X] [InnerProductSpace ℝ X] [CompleteSpace X]
 
@@ -25,29 +25,29 @@ namespace ClassicalMechanics
   and a lagrangian `Time → X → X → ℝ`, the Euler-Lagrange operator is
     `∂L/∂q - dₜ(∂L/∂(dₜ q))`. -/
 noncomputable def eulerLagrangeOp (L : Time → X → X → ℝ) (q : Time → X) : Time → X := fun t =>
-  gradient (L t · (deriv q t)) (q t)
-      - deriv (fun t' => gradient (L t' (q t') ·) (deriv q t')) t
+  gradient (L t · (∂ₜ q t)) (q t) - ∂ₜ (fun t' => gradient (L t' (q t') ·) (∂ₜ q t')) t
 
 lemma eulerLagrangeOp_eq (L : Time → X → X → ℝ) (q : Time → X) :
-    eulerLagrangeOp L q = fun t => gradient (L t · (deriv q t)) (q t)
-    - deriv (fun t' => gradient (L t' (q t') ·) (deriv q t')) t := by rfl
+    eulerLagrangeOp L q = fun t => gradient (L t · (∂ₜ q t)) (q t)
+    - ∂ₜ (fun t' => gradient (L t' (q t') ·) (∂ₜ q t')) t := by rfl
 
 lemma eulerLagrangeOp_zero (q : Time → X) :
     eulerLagrangeOp (fun _ _ _ => 0) q = fun _ => 0 := by
-  simp [eulerLagrangeOp_eq]
+  simp [eulerLagrangeOp_eq, Time.deriv_eq]
 
 /- The variational derivative of `L t (q' t) (deriv q' t))` for a lagrangian `L`
   is equal to the `eulerLagrangeOp`. -/
 theorem euler_lagrange_varGradient
     (L : Time → X → X → ℝ) (q : Time → X)
     (hq : ContDiff ℝ ∞ q) (hL : ContDiff ℝ ∞ ↿L) :
-    (δ (q':=q), ∫ t, L t (q' t) (deriv q' t)) = eulerLagrangeOp L q := by
+    (δ (q':=q), ∫ t, L t (q' t) (fderiv ℝ q' t 1)) = eulerLagrangeOp L q := by
   rw [eulerLagrangeOp_eq]
+  simp only [Time.deriv_eq]
   apply HasVarGradientAt.varGradient
   apply HasVarGradientAt.intro _
   · apply HasVarAdjDerivAt.comp
-      (F := fun (φ : ℝ → X × X) t => L t (φ t).fst (φ t).snd)
-      (G := fun (φ : ℝ → X) t => (φ t, deriv φ t))
+      (F := fun (φ : Time → X × X) t => L t (φ t).fst (φ t).snd)
+      (G := fun (φ : Time → X) t => (φ t, fderiv ℝ φ t 1))
     · apply HasVarAdjDerivAt.fmap (f := fun t => ↿(L t))
       · fun_prop
       · fun_prop
@@ -57,9 +57,9 @@ theorem euler_lagrange_varGradient
       apply ContDiff.differentiable
       fun_prop
       simp
-    · apply HasVarAdjDerivAt.prod (F:=fun φ => φ) (G:=fun φ => deriv φ)
+    · apply HasVarAdjDerivAt.prod (F:=fun φ => φ)
       · apply HasVarAdjDerivAt.id _ hq
-      · apply HasVarAdjDerivAt.deriv'
+      · apply HasVarAdjDerivAt.fderiv
         · exact hq
   case hgrad =>
     funext t

--- a/PhysLean/ClassicalMechanics/HarmonicOscillator/Basic.lean
+++ b/PhysLean/ClassicalMechanics/HarmonicOscillator/Basic.lean
@@ -3,14 +3,9 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith, Lode Vermeulen
 -/
-import PhysLean.Meta.TODO.Basic
 import PhysLean.Meta.Informal.SemiFormal
 import PhysLean.SpaceAndTime.Space.VectorIdentities
-import PhysLean.Meta.Linters.Sorry
 import PhysLean.SpaceAndTime.Time.Basic
-import Mathlib.Analysis.Calculus.Deriv.Add
-import Mathlib.Analysis.Calculus.Deriv.Mul
-import Mathlib.Analysis.Calculus.Deriv.Pow
 /-!
 
 # The Classical Harmonic Oscillator
@@ -97,9 +92,10 @@ lemma inverse_ω_sq : (S.ω ^ 2)⁻¹ = S.m/S.k := by
   rw [ω_sq]
   field_simp
 
+open Time
 /-- The kinetic energy of the harmonic oscillator is `1/2 m ‖dx/dt‖^2`. -/
 noncomputable def kineticEnergy (xₜ : Time → Space 1) : Time → ℝ := fun t =>
-  (1 / (2 : ℝ)) * S.m * ⟪deriv xₜ t, deriv xₜ t⟫_ℝ
+  (1 / (2 : ℝ)) * S.m * ⟪∂ₜ xₜ t, ∂ₜ xₜ t⟫_ℝ
 
 /-- The potential energy of the harmonic oscillator is `1/2 k x ^ 2` -/
 noncomputable def potentialEnergy (x : Space 1) : ℝ :=
@@ -124,7 +120,7 @@ lemma lagrangian_parity (xₜ : Time → Space 1) :
     inner_neg_neg, sub_left_inj, mul_eq_mul_left_iff, mul_eq_zero, inv_eq_zero, OfNat.ofNat_ne_zero,
     false_or]
   left
-  rw [show deriv (- xₜ) t = - deriv xₜ t from deriv.neg]
+  rw [show ∂ₜ (- xₜ) t = - ∂ₜ xₜ t by rw [Time.deriv_neg]]
   simp only [inner_neg_neg]
 
 /-- The force of the classical harmonic oscillator defined as `- dU(x)/dx` where `U(x)`

--- a/PhysLean/ClassicalMechanics/VectorFields.lean
+++ b/PhysLean/ClassicalMechanics/VectorFields.lean
@@ -109,7 +109,7 @@ lemma differentiableAt_fderiv_coord_single
       ext w
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply, ContinuousLinearMap.inr_apply]
       rw [fderiv_uncurry]
-      simp only [fderiv_eq_smul_deriv, smul_eq_mul, zero_mul, zero_add]
+      simp only [map_zero, zero_add]
       fun_prop
     conv =>
       enter [2, y]
@@ -160,7 +160,7 @@ infixl:70 " ⨯ₑ₃ " => fun a b => (WithLp.equiv 2 (Fin 3 → ℝ)).symm
     (WithLp.equiv 2 (Fin 3 → ℝ) a ×₃ WithLp.equiv 2 (Fin 3 → ℝ) b)
 
 /-- Cross product and fderiv commute. -/
-lemma fderiv_cross_commute {u : ℝ} {s : Space} {f : ℝ → EuclideanSpace ℝ (Fin 3)}
+lemma fderiv_cross_commute {u : Time} {s : Space} {f : Time → EuclideanSpace ℝ (Fin 3)}
     (hf : Differentiable ℝ f) :
     s ⨯ₑ₃ (fderiv ℝ (fun u => f u) u) 1
     =
@@ -177,13 +177,14 @@ lemma fderiv_cross_commute {u : ℝ} {s : Space} {f : ℝ → EuclideanSpace ℝ
   rw [crossProduct]
   ext i
   fin_cases i <;>
-  · simp only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, WithLp.equiv_apply,
+  · simp [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, WithLp.equiv_apply,
       LinearMap.mk₂_apply, PiLp.ofLp_apply, Fin.reduceFinMk, WithLp.equiv_symm_apply,
       PiLp.toLp_apply, cons_val]
     rw [h]
-    simp only [Fin.isValue, fderiv_eq_smul_deriv, smul_eq_mul, one_mul, PiLp.smul_apply]
-    rw [deriv_pi]
-    simp only [Fin.isValue, WithLp.equiv_symm_apply, PiLp.toLp_apply, cons_val]
+    simp [Fin.isValue, fderiv_eq_smul_deriv, smul_eq_mul, one_mul, PiLp.smul_apply]
+    rw [fderiv_pi]
+    simp [Fin.isValue, WithLp.equiv_symm_apply, PiLp.toLp_apply, cons_val]
+    rfl
     · intro i
       fin_cases i <;>
       · simp

--- a/PhysLean/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/PhysLean/ClassicalMechanics/WaveEquation/Basic.lean
@@ -30,10 +30,10 @@ noncomputable def planeWave (f₀ : ℝ → EuclideanSpace ℝ (Fin d))
 lemma wave_dt {s : Direction d} {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace ℝ (Fin d)}
     (h' : ∀ x, HasFDerivAt f₀ (f₀' x) x) :
     ∂ₜ (fun t => f₀ (inner ℝ x s.unit - c * t)) =
-    fun t => -c • (f₀' (inner ℝ x s.unit - c * t)) 1 := by
+    fun t : Time => -c • (f₀' (inner ℝ x s.unit - c * t)) 1 := by
   unfold Time.deriv
   ext t i
-  change fderiv ℝ (f₀ ∘ fun t => (inner ℝ x s.unit - c * t)) t 1 i = _
+  change fderiv ℝ (f₀ ∘ fun t : Time => (inner ℝ x s.unit - c * t)) t 1 i = _
   rw [fderiv_comp, fderiv_const_sub, fderiv_const_mul]
   simp only [fderiv_id', ContinuousLinearMap.comp_neg, ContinuousLinearMap.comp_smulₛₗ,
     RingHom.id_apply, ContinuousLinearMap.comp_id, ContinuousLinearMap.neg_apply,
@@ -41,7 +41,8 @@ lemma wave_dt {s : Direction d} {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace �
     neg_mul, neg_inj, mul_eq_mul_left_iff]
   rw [HasFDerivAt.fderiv (h' (inner ℝ x s.unit - c * t))]
   left
-  rfl
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, ContinuousLinearMap.coe_comp',
+    Function.comp_apply, fderiv_val]
   repeat fun_prop
 
 lemma wave_dt2 {s : Direction d} {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace ℝ (Fin d)}
@@ -53,7 +54,7 @@ lemma wave_dt2 {s : Direction d} {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace �
   rw [Time.deriv_smul]
   unfold Time.deriv
   ext i
-  change -c • fderiv ℝ ((fun x' => f₀' x' 1) ∘ (fun t => inner ℝ x s.unit - c * t)) t 1 i = _
+  change -c • fderiv ℝ ((fun x' => f₀' x' 1) ∘ (fun t : Time => inner ℝ x s.unit - c * t)) t 1 i = _
   rw [fderiv_comp, fderiv_const_sub, fderiv_const_mul]
   simp only [fderiv_id', ContinuousLinearMap.comp_neg, ContinuousLinearMap.comp_smulₛₗ,
     RingHom.id_apply, ContinuousLinearMap.comp_id, ContinuousLinearMap.neg_apply,
@@ -61,8 +62,10 @@ lemma wave_dt2 {s : Direction d} {f₀' : ℝ → ℝ →L[ℝ] EuclideanSpace �
     mul_neg, neg_mul, neg_neg]
   rw [← mul_assoc, ← pow_two]
   rw [HasFDerivAt.fderiv (h'' (inner ℝ x s.unit - c * t))]
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, ContinuousLinearMap.coe_comp',
+    Function.comp_apply, fderiv_val]
   repeat fun_prop
-  · change Differentiable ℝ ((fun t' => f₀' t' 1) ∘ (fun t => (inner ℝ x s.unit - c * t)))
+  · change Differentiable ℝ ((fun t' => f₀' t' 1) ∘ (fun t : Time => (inner ℝ x s.unit - c * t)))
     apply Differentiable.comp
     · intro x
       exact HasFDerivAt.differentiableAt (h'' x)
@@ -217,7 +220,8 @@ theorem planeWave_isWave (c : ℝ) (s : Direction d)
 /-- If `f₀` is a function of `(inner ℝ x s - c * t)`, the fderiv of its components
 with respect to spatial coordinates is equal to the corresponding component of
 the propagation direction `s` times time derivative. -/
-lemma space_fderiv_of_inner_product_wave_eq_space_fderiv {f₀ : ℝ → EuclideanSpace ℝ (Fin d)}
+lemma space_fderiv_of_inner_product_wave_eq_space_fderiv
+    {t : Time} {f₀ : ℝ → EuclideanSpace ℝ (Fin d)}
     {s : Direction d} {u v : Fin d} (h' : Differentiable ℝ f₀) :
     c * ((fun x' => (fderiv ℝ (fun x => inner ℝ (f₀ (inner ℝ x s.unit - c * t))
     (EuclideanSpace.single v 1)) x') (EuclideanSpace.single u 1)) x)
@@ -314,7 +318,7 @@ lemma differentiable_uncurry_of_eq_planewave {s : Direction d}
     (h' : Differentiable ℝ f₀) : Differentiable ℝ ↿f := by
   rw [hf]
   unfold planeWave
-  change Differentiable ℝ (f₀ ∘ fun (t, x) => (inner ℝ x s.unit - c * t))
+  change Differentiable ℝ (f₀ ∘ fun ((t : Time), x) => (inner ℝ x s.unit - c * t))
   apply Differentiable.comp
   · fun_prop
   · apply Differentiable.sub

--- a/PhysLean/Electromagnetism/Wave.lean
+++ b/PhysLean/Electromagnetism/Wave.lean
@@ -303,20 +303,31 @@ lemma electricPlaneWave_eq_cross_magneticPlaneWave_upto_space_fun
     simp only [smul_eq_mul, neg_smul, neg_add_cancel]
     · exact time_differentiable_of_eq_planewave h' hBwave
   unfold Time.deriv at h
-  have hderiv : ∀ t x, _root_.deriv (fun t => (E t x) +
-      (√(μ • ε))⁻¹ • (s.unit ⨯ₑ₃ (B t x))) t = 0 := by
+  have hderiv' : ∀ t x, fderiv ℝ (fun t => (E t x) +
+      (√(μ • ε))⁻¹ • (s.unit ⨯ₑ₃ (B t x))) t 1 = 0 := by
     intro t x
-    rw [_root_.deriv_fun_add, _root_.deriv_fun_smul]
+    rw [fderiv_fun_add, fderiv_fun_smul]
     simp_all
     · fun_prop
     · exact crossProduct_time_differentiable_of_right_eq_planewave h' hBwave
     · exact function_differentiableAt_fst (hf := by fun_prop) ..
     · apply DifferentiableAt.fun_const_smul
       exact crossProduct_time_differentiable_of_right_eq_planewave h' hBwave
+  have hderiv : ∀ t x, fderiv ℝ (fun t => (E t x) +
+      (√(μ • ε))⁻¹ • (s.unit ⨯ₑ₃ (B t x))) t = 0 := by
+    intro t x
+    ext1 r
+    conv_lhs =>
+      enter [2]
+      rw [Time.eq_one_smul r]
+    simp only [smul_eq_mul, WithLp.equiv_apply, WithLp.equiv_symm_apply, map_smul,
+      ContinuousLinearMap.zero_apply, smul_eq_zero, val_eq_zero]
+    right
+    exact hderiv' t x
   use fun x => (E 0 x) + (√(μ • ε))⁻¹ • (s.unit ⨯ₑ₃ B 0 x)
   intro t x
   have ht' := fun t => hderiv t x
-  apply is_const_of_deriv_eq_zero at ht'
+  apply is_const_of_fderiv_eq_zero at ht'
   simp only
   rw [ht' 0 t]
   simp only [smul_eq_mul, neg_smul, neg_add_cancel_comm_assoc]
@@ -346,13 +357,18 @@ lemma magneticPlaneWave_eq_cross_electricPlaneWave_upto_space_fun
   have hderiv : ∀ t x, fderiv ℝ (fun t => (B t x) -
       (√(μ • ε)) • (s.unit ⨯ₑ₃ (E t x))) t = 0 := by
     intro t x
-    ext1
+    ext1 r
+    conv_lhs =>
+      enter [2]
+      rw [Time.eq_one_smul r]
+    simp only [smul_eq_mul, WithLp.equiv_apply, WithLp.equiv_symm_apply, map_smul,
+      ContinuousLinearMap.zero_apply, smul_eq_zero, val_eq_zero]
+    right
     rw [fderiv_fun_sub]
     rw [fderiv_fun_const_smul]
     change (fderiv ℝ (fun t => B t x) t 1) -
         ((√(μ • ε)) • fderiv ℝ (fun t => (s.unit ⨯ₑ₃ (E t x))) t 1) = _
     rw [h]
-    simp only [PiLp.zero_apply, ContinuousLinearMap.zero_apply]
     · exact crossProduct_time_differentiable_of_right_eq_planewave h' hEwave
     · exact function_differentiableAt_fst (hf := by fun_prop) ..
     · apply DifferentiableAt.fun_const_smul
@@ -467,7 +483,7 @@ lemma electricField_add_cross_magneticField_eq_const_of_planeWave
   have hu : inner ℝ x s.unit - c * (c⁻¹ * inner ℝ x s.unit) = 0 := by
     rw [← mul_assoc]
     simp [hc_non_zero]
-  rw [← hu, ← hcuE (c⁻¹ * inner ℝ x s.unit) x, hcxE]
+  rw [← hu, ← hcuE _ x, hcxE]
 
 /-- `B - s ⨯ₑ₃ E` is constant for an EMwave. -/
 lemma magneticField_sub_cross_electricField_eq_const_of_planeWave
@@ -500,7 +516,7 @@ lemma magneticField_sub_cross_electricField_eq_const_of_planeWave
   have hu : inner ℝ x s.unit - c * (c⁻¹ * inner ℝ x s.unit) = 0 := by
     rw [← mul_assoc]
     simp [hc_non_zero]
-  rw [← hu, ← hcuB (c⁻¹ * inner ℝ x s.unit) x, hcxB]
+  rw [← hu, ← hcuB _ x, hcxB]
 
 /-- Unit vectors in the direciton of `B`, `E` and `s` form an orthonormal traid for an EMwave
 after subtracting the appropriate constant fields. -/

--- a/PhysLean/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
+++ b/PhysLean/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
@@ -666,6 +666,15 @@ protected lemma fderiv (u : X → U) (dx : X) (hu : ContDiff ℝ ∞ u)
   · exact hu
   · exact HasVarAdjoint.fderiv_apply
 
+omit [OpensMeasurableSpace X] [IsFiniteMeasureOnCompacts (@volume X _)] in
+protected lemma fderiv' (F : (X → U) → (X → V)) (F') (u) (dx : X)
+    (hF : HasVarAdjDerivAt F F' u)[ProperSpace X] [BorelSpace X]
+    [FiniteDimensional ℝ X] [(@volume X _).IsAddHaarMeasure] :
+    HasVarAdjDerivAt (fun φ : X → U => fun x => fderiv ℝ (F φ) x dx)
+    (fun ψ x => F' (fun x' => - fderiv ℝ ψ x' dx) x) u := by
+  have hG := HasVarAdjDerivAt.fderiv (F u) dx (hF.apply_smooth_self)
+  exact comp hG hF
+
 protected lemma gradient {d} (u : Space d → ℝ) (hu : ContDiff ℝ ∞ u) :
     HasVarAdjDerivAt
       (fun (φ : Space d → ℝ) x => gradient φ x)

--- a/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
+++ b/PhysLean/Particles/SuperSymmetry/SU5/Charges/Map.lean
@@ -140,7 +140,7 @@ lemma map_ofPotentialTerm_toFinset [DecidableEq 𝓩]
       obtain ⟨q1, q2, q3, q4, ⟨q1_mem, q2_mem, q3_mem, q4_mem⟩, q_sum⟩ := h
       use f q1, f q2, f q3, f q4
     all_goals
-      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product, map ]
+      simp only [SProd.sprod, Multiset.instSProd, Multiset.mem_product, map]
       subst a
       simp_all
     case W1 => refine ⟨⟨q1, q1_mem, rfl⟩, ⟨q2, q2_mem, rfl⟩, ⟨q3, q3_mem, rfl⟩, ⟨q4, q4_mem, rfl⟩⟩

--- a/PhysLean/SpaceAndTime/SpaceTime/Basic.lean
+++ b/PhysLean/SpaceAndTime/SpaceTime/Basic.lean
@@ -62,15 +62,17 @@ informal_lemma space_equivariant where
 
 /-- The time part of spacetime. -/
 def time {d : ℕ} : SpaceTime d →ₗ[ℝ] Time where
-  toFun x := Lorentz.Vector.timeComponent x
+  toFun x := ⟨Lorentz.Vector.timeComponent x⟩
   map_add' x1 x2 := by
+    ext
     simp [Lorentz.Vector.timeComponent]
   map_smul' c x := by
+    ext
     simp [Lorentz.Vector.timeComponent]
 
 @[simp]
-lemma time_toCoord_symm {d : ℕ} (f : Fin 1 ⊕ Fin d → ℝ) :
-    time f =f (Sum.inl 0) := by
+lemma time_val_toCoord_symm {d : ℕ} (f : Fin 1 ⊕ Fin d → ℝ) :
+    (time f).val = f (Sum.inl 0) := by
   simp [time, Lorentz.Vector.timeComponent]
 
 /-- A continuous linear equivalence between `SpaceTime d` and
@@ -80,7 +82,7 @@ def toTimeAndSpace {d : ℕ} : SpaceTime d ≃L[ℝ] Time × Space d :=
     toFun x := (x.time, x.space)
     invFun tx := (fun i =>
       match i with
-      | Sum.inl _ => tx.1
+      | Sum.inl _ => tx.1.val
       | Sum.inr i => tx.2 i)
     left_inv x := by
       simp only [Nat.succ_eq_add_one, Nat.reduceAdd, time, LinearMap.coe_mk,
@@ -93,8 +95,11 @@ def toTimeAndSpace {d : ℕ} : SpaceTime d ≃L[ℝ] Time × Space d :=
       simp only [Nat.succ_eq_add_one, Nat.reduceAdd, time, Lorentz.Vector.timeComponent,
         Fin.isValue, LinearMap.coe_mk, AddHom.coe_mk, LinearEquiv.apply_symm_apply, space]
     map_add' x y := by
-      simp only [time_toCoord_symm, Fin.isValue, Lorentz.Vector.apply_add, space_toCoord_symm,
+      simp only [time_val_toCoord_symm, Fin.isValue, Lorentz.Vector.apply_add, space_toCoord_symm,
         Prod.mk_add_mk, Prod.mk.injEq, true_and]
+      constructor
+      · ext
+        simp
       funext i
       simp
     map_smul' := by
@@ -107,7 +112,8 @@ lemma toTimeAndSpace_basis_inr {d : ℕ} (i : Fin d) :
   simp only [Nat.succ_eq_add_one, Nat.reduceAdd, toTimeAndSpace, time, LinearMap.coe_mk,
     AddHom.coe_mk, LinearEquiv.coe_toContinuousLinearEquiv', LinearEquiv.coe_mk, Prod.mk.injEq]
   rw [Lorentz.Vector.timeComponent_basis_sum_inr]
-  simp only [true_and]
+  constructor
+  · rfl
   funext j
   simp [Space.basis_apply]
 
@@ -116,7 +122,8 @@ lemma toTimeAndSpace_basis_inl {d : ℕ} :
   simp only [Nat.succ_eq_add_one, Nat.reduceAdd, toTimeAndSpace, time, LinearMap.coe_mk,
     AddHom.coe_mk, LinearEquiv.coe_toContinuousLinearEquiv', LinearEquiv.coe_mk, Prod.mk.injEq]
   rw [Lorentz.Vector.timeComponent_basis_sum_inl]
-  simp only [true_and]
+  constructor
+  · rfl
   funext j
   simp [space]
 

--- a/PhysLean/SpaceAndTime/Time/Basic.lean
+++ b/PhysLean/SpaceAndTime/Time/Basic.lean
@@ -3,36 +3,299 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
 import PhysLean.Meta.Informal.Basic
 import Mathlib.Analysis.Calculus.FDeriv.Add
+import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 /-!
 # Time
 
-In this file we define the time worldvolume as a real line.
+In this module we define the type `Time`, corresponding to time in a given
+(but arbitary) set of units, with a given (but arbitary) choice of origin (time zero),
+and a choice of orientation (i.e. a positive time direction).
 
-## Note on implementation
+We note that this is the version of time most often used in undergraduate and
+non-mathematical physics.
 
-The definition of `Time` currently inherits all instances of
-`ℝ`.
+The choice of units or origin can be made on a case-by-case basis, as
+long as they are done consistently. However, since the choice of units and origin is
+left implicit, Lean will not catch inconsistencies in the choice of units or origin when
+working with `Time`.
 
-This, in particular, automatically equips `Time` with a
-norm. This norm induces a metric on `Time` which is the standard
-flat metric. Thus `Time` automatically corresponds to
-flat time.
+For example, for the classical mechanics system corresponding to the harmonic oscillator,
+one can take the origin of time to be the time at which the initial conditions are specified,
+and the units can be taken as anything as long as the units chosen for time `t` and
+the angular frequency `ω` are consistent.
 
-The definition of `deriv` through `fderiv` explicitly uses this metric.
+With this notion of `Time`, becomes a 1d vector space over `ℝ` with an inner product.
 
-`Time` also inherits instances of `ℝ` such as
-a zero vector, the ability to add two time positions etc, which
-are not really allowed operations on `Time`.
+Within other modules e.g. `TopTime.Basic`, we define versions of time with less choices made.
 
 -/
 
-/-- The type `Time` represents the time manifold. -/
-abbrev Time := ℝ
+/-- The type `Time` represents the time in a given (but arbitary) set of units, and
+  with a given (but arbitary) choice of origin. -/
+structure Time where
+  /-- The underlying real number associated with a point in time. -/
+  val : ℝ
 
 namespace Time
+open MeasureTheory InnerProductSpace
+
+/-- The map `Time.val` taking an element of `Time` to it's underlying real number
+  is injective. -/
+lemma val_injective : Function.Injective Time.val := by
+  intro t1 t2 h
+  cases t1
+  cases t2
+  simp_all
+
+@[ext]
+lemma ext_of {t1 t2 : Time} (h : t1.val = t2.val) :
+    t1 = t2 := by
+  cases t1; cases t2; simp_all
+
+/-!
+
+## The choice of zero, units and orientation
+
+-/
+
+/-- The zero point in `Time`. -/
+instance : Zero Time where
+  zero := ⟨0⟩
+
+@[simp]
+lemma zero_val : (0 : Time).val = 0 := rfl
+
+@[simp]
+lemma val_eq_zero (t : Time) : t.val = 0 ↔ t = 0 := by
+  constructor
+  · intro h
+    ext
+    exact h
+  · rintro rfl
+    rfl
+
+/-- The choice of a norm on `Time`, corresponding to the choice of units. -/
+instance : Norm Time where
+  norm t := ‖t.val‖
+
+/-- The choice of a one on `Time`, corresponding, with the choice of norm,
+  to the choice of units. -/
+instance : One Time where
+  one := ⟨1⟩
+
+@[simp]
+lemma one_val : (1 : Time).val = 1 := rfl
+
+/-- The choice of an orientation on `Time`. -/
+instance : LE Time where
+  le t1 t2 := t1.val ≤ t2.val
+
+lemma le_def (t1 t2 : Time) :
+    t1 ≤ t2 ↔ t1.val ≤ t2.val := Iff.rfl
+
+/-!
+
+## Basic operations on `Time`.
+
+-/
+
+instance : Add Time where
+  add t1 t2 := ⟨t1.val + t2.val⟩
+
+@[simp]
+lemma add_val (t1 t2 : Time) :
+    (t1 + t2).val = t1.val + t2.val := rfl
+
+instance : Neg Time where
+  neg t := ⟨-t.val⟩
+
+@[simp]
+lemma neg_val (t : Time) :
+    (-t).val = -t.val := rfl
+
+instance : Sub Time where
+  sub t1 t2 := ⟨t1.val - t2.val⟩
+
+@[simp]
+lemma sub_val (t1 t2 : Time) :
+    (t1 - t2).val = t1.val - t2.val := rfl
+
+instance : SMul ℝ Time where
+  smul k t := ⟨k * t.val⟩
+
+@[simp]
+lemma smul_real_val (k : ℝ) (t : Time) :
+    (k • t).val = k * t.val := rfl
+
+instance : Dist Time where
+  dist t1 t2 := ‖t1 - t2‖
+
+lemma dist_eq_val (t1 t2 : Time) :
+    dist t1 t2 = ‖t1.val - t2.val‖ := rfl
+
+lemma dist_eq_real_dist (t1 t2 : Time) :
+    dist t1 t2 = dist t1.val t2.val := by rfl
+
+instance : Inner ℝ Time where
+  inner := fun t1 t2 => t1.val * t2.val
+
+@[simp]
+lemma inner_def (t1 t2 : Time) :
+    ⟪t1, t2⟫_ℝ = t1.val * t2.val := rfl
+
+/-!
+
+## Instances on `Time`.
+
+-/
+
+instance : AddGroup Time where
+  add_assoc := by intros; ext; simp [add_assoc]
+  zero_add := by intros; ext; simp [zero_add]
+  add_zero := by intros; ext; simp [add_zero]
+  neg_add_cancel := by intros; ext; simp [neg_add_cancel]
+  nsmul n t := ⟨n • t.val⟩
+  zsmul n t := ⟨n • t.val⟩
+
+instance : AddCommMonoid Time where
+  add_comm := by intros; ext; simp [add_comm]
+
+instance : AddCommGroup Time where
+
+instance : Module ℝ Time where
+  one_smul t := by ext; simp [one_smul]
+  smul_add k t1 t2 := by ext; simp [mul_add]
+  smul_zero k := by ext; simp [mul_zero]
+  add_smul k1 k2 t := by ext; simp [add_mul]
+  mul_smul k1 k2 t := by ext; simp [mul_assoc]
+  zero_smul t := by ext; simp [zero_smul]
+
+instance : SeminormedAddCommGroup Time where
+  dist_self := by intros; simp [dist_eq_real_dist]
+  dist_comm := by intros; simp [dist_eq_real_dist, dist_comm]
+  dist_triangle := by intros; simp [dist_eq_real_dist, dist_triangle]
+
+instance : NormedAddCommGroup Time where
+  eq_of_dist_eq_zero := by
+    intro a b h
+    simp [dist, norm] at h
+    rw [Time.ext_of_iff]
+    rw [sub_eq_zero] at h
+    exact h
+
+instance : NormedSpace ℝ Time where
+  norm_smul_le := by intros; simp [abs_mul, norm]
+
+instance : PartialOrder Time where
+  le_refl := by intros; simp [le_def]
+  le_trans := by intro _ _ _; simp [le_def]; exact le_trans
+  le_antisymm := by intro _ _; simp [le_def, Time.ext_of_iff]; exact le_antisymm
+
+lemma lt_def (t1 t2 : Time) :
+    t1 < t2 ↔ t1.val < t2.val := by
+  constructor
+  · intro h
+    exact lt_iff_le_not_ge.mpr h
+  · intro h
+    apply lt_iff_le_not_ge.mpr
+    simp_all [le_def]
+    apply le_of_lt h
+
+noncomputable instance : DecidableEq Time := fun t1 t2 =>
+  decidable_of_iff (t1.val = t2.val) Time.ext_of_iff.symm
+
+instance : MeasurableSpace Time := borel Time
+
+instance : BorelSpace Time where
+  measurable_eq := by rfl
+
+instance : FiniteDimensional ℝ Time := by
+  refine Module.finite_of_rank_eq_one ?_
+  rw [@rank_eq_one_iff]
+  use ⟨1⟩
+  constructor
+  · simp [Time.ext_of_iff]
+  · intro v
+    use v.val
+    ext
+    simp
+
+noncomputable instance : InnerProductSpace ℝ Time where
+  norm_sq_eq_re_inner := by intros; simp [norm]; ring
+  conj_inner_symm := by intros; simp [inner_def]; ring
+  add_left := by intros; simp [inner_def, add_mul]
+  smul_left := by intros; simp [inner_def]; ring
+
+/-!
+
+## Maps from `Time` to `ℝ`.
+
+-/
+
+open MeasureTheory
+
+/-- The continuous linear map from `Time` to `ℝ`. -/
+noncomputable def toRealCLM : Time →L[ℝ] ℝ := LinearMap.toContinuousLinearMap
+  {
+  toFun := Time.val
+  map_add' := by simp
+  map_smul' := by simp }
+
+/-- The continuous linear equivalence from `Time` to `ℝ`. -/
+noncomputable def toRealCLE : Time ≃L[ℝ] ℝ := LinearEquiv.toContinuousLinearEquiv
+  {
+  toFun := Time.val
+  invFun := fun x => ⟨x⟩
+  left_inv x := by rfl
+  right_inv x := by rfl
+  map_add' := by simp
+  map_smul' := by simp
+  }
+
+/-- The linear isomentry equivalence from `Time` to `ℝ`. -/
+noncomputable def toRealLIE : Time ≃ₗᵢ[ℝ] ℝ where
+  toFun := Time.val
+  invFun := fun x => ⟨x⟩
+  left_inv x := by rfl
+  right_inv x := by rfl
+  map_add' := by simp
+  map_smul' := by simp
+  norm_map' x := by
+    simp
+    rfl
+
+instance : Coe Time ℝ where
+  coe := Time.val
+
+lemma eq_one_smul (t : Time) :
+    t = t.val • 1 := by
+  ext
+  simp [one_val]
+
+@[fun_prop]
+lemma val_measurable : Measurable Time.val := by
+  change Measurable toRealCLE
+  fun_prop
+
+lemma val_measurableEmbedding : MeasurableEmbedding Time.val where
+  injective := val_injective
+  measurable := by fun_prop
+  measurableSet_image' := by
+    intro s hs
+    change MeasurableSet (⇑toRealCLE '' s)
+    rw [ContinuousLinearEquiv.image_eq_preimage]
+    exact toRealCLE.symm.continuous.measurable hs
+
+lemma val_measurePreserving : MeasurePreserving Time.val volume volume :=
+  LinearIsometryEquiv.measurePreserving toRealLIE
+
+/-!
+
+## Derivatives
+
+-/
 
 /-- Given a function `f : Time → M` the derivative of `f`. -/
 noncomputable def deriv [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
@@ -42,11 +305,30 @@ noncomputable def deriv [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
 @[inherit_doc deriv]
 scoped notation "∂ₜ" => deriv
 
+lemma deriv_eq [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
+    (f : Time → M) (t : Time) : Time.deriv f t = fderiv ℝ f t 1 := rfl
+
 lemma deriv_smul (f : Time → EuclideanSpace ℝ (Fin d)) (k : ℝ)
     (hf : Differentiable ℝ f) :
     ∂ₜ (fun t => k • f t) t = k • ∂ₜ (fun t => f t) t := by
   rw [deriv, fderiv_fun_const_smul]
   rfl
   fun_prop
+
+lemma deriv_neg [NormedAddCommGroup M] [NormedSpace ℝ M] (f : Time → M) :
+    ∂ₜ (-f) t = -∂ₜ f t := by
+  rw [deriv, fderiv_neg]
+  rfl
+
+@[fun_prop]
+lemma val_differentiable : Differentiable ℝ Time.val := by
+  change Differentiable ℝ toRealCLM
+  fun_prop
+
+@[simp]
+lemma fderiv_val (t : Time) : fderiv ℝ Time.val t 1 = 1 := by
+  change (fderiv ℝ toRealCLM t 1) = 1
+  simp
+  rfl
 
 end Time


### PR DESCRIPTION
This PR changes the type `Time` to be a structure rather than an abbreviation of `Real`. This prevents casting when not allowed. Also improvements to the doc-string of the Time file, to make it clear what `Time` represents in PhysLean.