### PR TITLE
docs: Temperature

### DIFF
--- a/PhysLean/StatisticalMechanics/BoltzmannConstant.lean
+++ b/PhysLean/StatisticalMechanics/BoltzmannConstant.lean
@@ -6,20 +6,24 @@ Authors: Joseph Tooby-Smith
 import Mathlib.Data.NNReal.Defs
 /-!
 
-## Boltzmann constant
+# Boltzmann constant
 
-In this file we define the Boltzmann constant `kB` as a non-negative real number.
-This is introduced as an axiom.
+The Boltzmann constant is a constant `kB` of dimension `m² kg s⁻² K⁻¹`, that is
+`Energy/Temperature`. It is named after Ludwig Boltzmann.
+
+In this module we axiomise the existence of the Boltzmann constant in a given (but arbitrary)
+set of units.
 
 -/
 open NNReal
 
 namespace Constants
 
-/-- The Boltzmann constant axiom. -/
+/-- The axiom introducing the Boltzmann constant in a given but arbitrary set of units. -/
 axiom kBAx : {p : ℝ | 0 < p}
 
-/-- The Boltzmann constant. -/
+/-- The Boltzmann constant in a given but arbitary set of units.
+  Boltzman's constant has dimension equivalent to `Energy/Temperature`.  -/
 noncomputable def kB : ℝ := kBAx.1
 
 /-- The Boltzmann constant is positive. -/

--- a/PhysLean/StatisticalMechanics/Temperature.lean
+++ b/PhysLean/StatisticalMechanics/Temperature.lean
@@ -3,13 +3,10 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
+import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.InnerProductSpace.Basic
 import PhysLean.StatisticalMechanics.BoltzmannConstant
 import PhysLean.Meta.TODO.Basic
-import Mathlib.Algebra.Lie.OfAssociative
-import Mathlib.Analysis.Calculus.LogDeriv
-import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.Analysis.SpecialFunctions.ExpDeriv
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
 /-!
 
 # Temperature
@@ -46,7 +43,8 @@ instance : TopologicalSpace Temperature := inferInstanceAs (TopologicalSpace ℝ
 
 instance : Zero Temperature := ⟨0, Preorder.le_refl 0⟩
 
-/-- The inverse temperature. -/
+/-- The inverse temperature defined as `1/(kB * T)` in a given, but arbitary set of units.
+  This has dimensions equivalent to `Energy`. -/
 noncomputable def β (T : Temperature) : ℝ≥0 := ⟨1 / (kB * T), by
   apply div_nonneg
   · exact zero_le_one' ℝ
@@ -120,8 +118,5 @@ lemma ofβ_differentiableOn :
     simp at hx
     left
     linarith
-
-TODO "EQTKM" "Define the function from `Temperature` to `ℝ` which gives the temperature in
-  Kelvin, based on axiomized constants. "
 
 end Temperature

--- a/PhysLean/StatisticalMechanics/Temperature.lean
+++ b/PhysLean/StatisticalMechanics/Temperature.lean
@@ -10,17 +10,25 @@ import Mathlib.Analysis.Calculus.LogDeriv
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
-
 /-!
 
 # Temperature
 
-In this module we define the type `Temperature`, and give basic properties thereof.
+In this module we define the type `Temperature`, corresponding to the temperature in a given
+(but arbitrary) set of units which have absolute zero at zero.
+
+This is the version of temperature most often used in undergraduate and
+non-mathematical physics.
+
+The choice of units can be made on a case-by-case basis, as long as they are done consistently.
 
 -/
 open NNReal
 
-/-- The type of temperatures. -/
+TODO "IOY4E" "Change the definition of `Temperature` to be a structure rather than a `def`."
+
+/-- The type `Temperature` represents the temperature in a given (but arbitary) set of units
+  (preserving zero). -/
 def Temperature : Type := ℝ≥0
 
 namespace Temperature


### PR DESCRIPTION
**Copilot summary** 

This pull request updates the documentation and definition of the `Temperature` type in the `PhysLean/StatisticalMechanics/Temperature.lean` file. The primary focus is on clarifying the purpose and usage of the `Temperature` type and adding a TODO comment for future improvements.

### Documentation improvements:
* Expanded the module docstring to provide a more detailed explanation of the `Temperature` type, emphasizing its use in undergraduate and non-mathematical physics and the flexibility of unit choice.

### Code improvements:
* Added a TODO comment suggesting that the definition of `Temperature` should be changed from a `def` to a structure for better clarity and extensibility.