### PR TITLE
feat: Length units

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -302,6 +302,7 @@ import PhysLean.Relativity.Tensors.Tensorial
 import PhysLean.Relativity.Tensors.UnitTensor
 import PhysLean.SpaceAndTime.Space.Basic
 import PhysLean.SpaceAndTime.Space.Distributions
+import PhysLean.SpaceAndTime.Space.LengthUnit
 import PhysLean.SpaceAndTime.Space.VectorIdentities
 import PhysLean.SpaceAndTime.SpaceTime.Basic
 import PhysLean.SpaceAndTime.SpaceTime.TimeSlice

--- a/PhysLean/SpaceAndTime/Space/LengthUnit.lean
+++ b/PhysLean/SpaceAndTime/Space/LengthUnit.lean
@@ -25,7 +25,10 @@ existence of the length unit of meters, and construct all other length units fro
 
 /-- The choices of translationally-invariant metrics on the space-manifold.
   Such a choice corresponds to a choice of units for length. -/
-def LengthUnit : Type := {x : ℝ | 0 < x}
+structure LengthUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
 
 namespace LengthUnit
 

--- a/PhysLean/SpaceAndTime/Space/LengthUnit.lean
+++ b/PhysLean/SpaceAndTime/Space/LengthUnit.lean
@@ -154,6 +154,9 @@ noncomputable def kilometers : LengthUnit := scale ((10) ^ (3)) meters
 /-- The length unit of a mile (1609.344 meters). -/
 noncomputable def miles : LengthUnit := scale (1609.344) meters
 
+/-- The length unit of a nautical mile (1852 meters). -/
+noncomputable def nauticalMiles : LengthUnit := scale (1852) meters
+
 /-- The length unit of an astronomical unit (149,597,870,700 meters). -/
 noncomputable def astronomicalUnits : LengthUnit := scale (149597870700) meters
 

--- a/PhysLean/SpaceAndTime/Space/LengthUnit.lean
+++ b/PhysLean/SpaceAndTime/Space/LengthUnit.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Geometry.Manifold.Diffeomorph
+import PhysLean.SpaceAndTime.Time.Basic
+/-!
+
+# Units on Length
+
+A unit of length corresponds to a choice of translationally-invariant
+metric on the space manifold (to be defined). Such a choice is (non-canonically) equivalent to a
+choice of positive real number. We define the type `LengthUnit` to be equivalent to the
+positive reals.
+
+On `LengthUnit` there is an instance of division giving a real number, corresponding to the
+ratio of the two scales of length unit.
+
+To define specific length units, we first axiomise the existence of a
+a given length unit, and then construct all other length units from it. We choose to axiomise the
+existence of the length unit of meters, and construct all other length units from that.
+
+-/
+
+/-- The choices of translationally-invariant metrics on the space-manifold.
+  Such a choice corresponds to a choice of units for length. -/
+def LengthUnit : Type := {x : ℝ | 0 < x}
+
+namespace LengthUnit
+
+@[simp]
+lemma val_neq_zero (x : LengthUnit) : x.val ≠ 0 := by
+  exact Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : LengthUnit) : 0 < x.val := x.property
+
+instance : Inhabited LengthUnit where
+  default := ⟨1, by norm_num⟩
+
+/-!
+
+## Division of LengthUnit
+
+-/
+
+noncomputable instance : HDiv LengthUnit LengthUnit ℝ where
+  hDiv x t := x.val / t.val
+
+lemma div_eq_val (x y : LengthUnit) :
+    x / y = x.val / y.val := rfl
+
+@[simp]
+lemma div_pos (x y : LengthUnit) :
+    (0 : ℝ) < x / y := by
+  simpa [div_eq_val] using _root_.div_pos x.val_pos y.val_pos
+
+@[simp]
+lemma div_self (x : LengthUnit) :
+    x / x = (1 : ℝ) := by
+  simp [div_eq_val, x.val_neq_zero]
+
+lemma div_symm (x y : LengthUnit) :
+    x / y = (y / x)⁻¹ := by
+  rw [div_eq_val, inv_eq_one_div, div_eq_val]
+  simp
+
+/-!
+
+## The scaling of a length unit
+
+-/
+
+/-- The scaling of a length unit by a positive real. -/
+def scale (r : ℝ) (x : LengthUnit) (hr : 0 < r := by norm_num) : LengthUnit :=
+  ⟨r * x.val, mul_pos hr x.val_pos⟩
+
+@[simp]
+lemma scale_div_self (x : LengthUnit) (r : ℝ) (hr : 0 < r) :
+    scale r x hr / x = r := by
+  simp [scale, div_eq_val]
+
+@[simp]
+lemma scale_one (x : LengthUnit) : scale 1 x = x := by
+  simp [scale, mul_one]
+
+@[simp]
+lemma scale_div_scale (x1 x2 : LengthUnit) {r1 r2 : ℝ} (hr1 : 0 < r1) (hr2 : 0 < r2) :
+    scale r1 x1 hr1 / scale r2 x2 hr2 = r1 / r2 * (x1 / x2) := by
+  simp [scale, div_eq_val]
+  field_simp
+
+/-!
+
+## Specific choices of Length units
+
+To define a specific length units, we must first axiomise the existence of a
+a given length unit, and then construct all other length units from it.
+We choose to axiomise the existence of the length unit of meters.
+
+We need an axiom since this relates something to something in the physical world.
+
+-/
+
+/-- The axiom corresponding to the definition of a length unit of meters. -/
+axiom meters : LengthUnit
+
+/-- The length unit of femtometers (10⁻¹⁵ of a meter). -/
+noncomputable def femtometers : LengthUnit := scale ((1/10) ^ (15)) meters
+
+/-- The length unit of picometers (10⁻¹² of a meter). -/
+noncomputable def picometers : LengthUnit := scale ((1/10) ^ (12)) meters
+
+/-- The length unit of nanometers (10⁻⁹ of a meter). -/
+noncomputable def nanometers : LengthUnit := scale ((1/10) ^ (9)) meters
+
+/-- The length unit of micrometers (10⁻⁶ of a meter). -/
+noncomputable def micrometers : LengthUnit := scale ((1/10) ^ (6)) meters
+
+/-- The length unit of millimeters (10⁻³ of a meter). -/
+noncomputable def millimeters : LengthUnit := scale ((1/10) ^ (3)) meters
+
+/-- The length unit of centimeters (10⁻² of a meter). -/
+noncomputable def centimeters : LengthUnit := scale ((1/10) ^ (2)) meters
+
+/-- The length unit of inch (0.0254 meters). -/
+noncomputable def inches : LengthUnit := scale (0.0254) meters
+
+/-- The length unit of link (0.201168 meters). -/
+noncomputable def links : LengthUnit := scale (0.201168) meters
+
+/-- The length unit of feet (0.3048 meters) -/
+noncomputable def feet : LengthUnit := scale (0.3048) meters
+
+/-- The length unit of a yard (0.9144 meters) -/
+noncomputable def yards : LengthUnit := scale (0.9144) meters
+
+/-- The length unit of a rod (5.0292 meters) -/
+noncomputable def rods : LengthUnit := scale (5.0292) meters
+
+/-- The length unit of a chain (20.1168 meters) -/
+noncomputable def chains : LengthUnit := scale (20.1168) meters
+
+/-- The length unit of a furlong (201.168 meters) -/
+noncomputable def furlongs : LengthUnit := scale (201.168) meters
+
+/-- The length unit of kilometers (10³ meters). -/
+noncomputable def kilometers : LengthUnit := scale ((10) ^ (3)) meters
+
+/-- The length unit of a mile (1609.344 meters). -/
+noncomputable def miles : LengthUnit := scale (1609.344) meters
+
+/-- The length unit of an astronomical unit (149,597,870,700 meters). -/
+noncomputable def astronomicalUnits : LengthUnit := scale (149597870700) meters
+
+/-- The length unit of a light year (9,460,730,472,580,800 meters). -/
+noncomputable def lightYears : LengthUnit := scale (9460730472580800) meters
+
+/-- The length unit of a parsec (648,000/π astronomicalUnits). -/
+noncomputable def parsecs : LengthUnit := scale (648000/Real.pi) astronomicalUnits
+  (by norm_num; exact Real.pi_pos)
+
+/-!
+
+## Relations between length units
+
+-/
+
+/-- There are exactly 1760 yards in a mile. -/
+lemma miles_div_yards : miles / yards = (1760 : ℝ) := by simp [miles, yards]; norm_num
+
+/-- There are exactly 220 yards in a furlong. -/
+lemma furlongs_div_yards : furlongs / yards = (220 : ℝ) := by simp [furlongs, yards]; norm_num
+
+end LengthUnit

--- a/PhysLean/SpaceAndTime/Space/LengthUnit.lean
+++ b/PhysLean/SpaceAndTime/Space/LengthUnit.lean
@@ -5,6 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 import Mathlib.Geometry.Manifold.Diffeomorph
 import PhysLean.SpaceAndTime.Time.Basic
+import PhysLean.Meta.TODO.Basic
 /-!
 
 # Units on Length
@@ -162,6 +163,9 @@ noncomputable def lightYears : LengthUnit := scale (9460730472580800) meters
 /-- The length unit of a parsec (648,000/π astronomicalUnits). -/
 noncomputable def parsecs : LengthUnit := scale (648000/Real.pi) astronomicalUnits
   (by norm_num; exact Real.pi_pos)
+
+TODO "ITXJV" "For each unit of charge give the reference the literature where it's definition
+  is defined."
 
 /-!
 

--- a/PhysLean/SpaceAndTime/Time/TimeUnit.lean
+++ b/PhysLean/SpaceAndTime/Time/TimeUnit.lean
@@ -28,7 +28,10 @@ existence of the time unit of seconds, and construct all other time units from t
 
 /-- The choices of translationally-invariant metrics on the manifold `TimeTransMan`.
   Such a choice corresponds to a choice of units for time. -/
-def TimeUnit : Type := {x : ℝ | 0 < x}
+structure TimeUnit : Type where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
 
 namespace TimeUnit
 

--- a/PhysLean/SpaceAndTime/Time/TimeUnit.lean
+++ b/PhysLean/SpaceAndTime/Time/TimeUnit.lean
@@ -56,7 +56,7 @@ lemma div_eq_val (x y : TimeUnit) :
 @[simp]
 lemma div_pos (x y : TimeUnit) :
     (0 : ℝ) < x / y := by
-  simpa [div_eq_val] using  _root_.div_pos x.val_pos y.val_pos
+  simpa [div_eq_val] using _root_.div_pos x.val_pos y.val_pos
 
 @[simp]
 lemma div_self (x : TimeUnit) :
@@ -75,7 +75,7 @@ lemma div_symm (x y : TimeUnit) :
 -/
 
 /-- The scaling of a time unit by a positive real. -/
-def scale  (r : ℝ) (x : TimeUnit) (hr : 0 < r := by norm_num) : TimeUnit :=
+def scale (r : ℝ) (x : TimeUnit) (hr : 0 < r := by norm_num) : TimeUnit :=
   ⟨r * x.val, mul_pos hr x.val_pos⟩
 
 @[simp]

--- a/PhysLean/StatisticalMechanics/BoltzmannConstant.lean
+++ b/PhysLean/StatisticalMechanics/BoltzmannConstant.lean
@@ -23,7 +23,7 @@ namespace Constants
 axiom kBAx : {p : ℝ | 0 < p}
 
 /-- The Boltzmann constant in a given but arbitary set of units.
-  Boltzman's constant has dimension equivalent to `Energy/Temperature`.  -/
+  Boltzman's constant has dimension equivalent to `Energy/Temperature`. -/
 noncomputable def kB : ℝ := kBAx.1
 
 /-- The Boltzmann constant is positive. -/

--- a/PhysLean/Units/Mass.lean
+++ b/PhysLean/Units/Mass.lean
@@ -3,8 +3,6 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import PhysLean.Meta.TODO.Basic
 import PhysLean.Units.Basic
 /-!
 # Mass

--- a/PhysLean/Units/Momentum/Basic.lean
+++ b/PhysLean/Units/Momentum/Basic.lean
@@ -3,9 +3,6 @@ Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
-import PhysLean.Meta.TODO.Basic
-import PhysLean.Units.Basic
 import PhysLean.Units.Velocity
 import PhysLean.Units.Mass
 /-!


### PR DESCRIPTION
**Copilot summary**

This pull request introduces a new module, `LengthUnit`, to represent and manipulate units of length in a mathematically rigorous way. It defines the `LengthUnit` type, implements operations like division and scaling, and provides predefined length units ranging from femtometers to parsecs. Additionally, it adds documentation and axioms for specific length units.

### New `LengthUnit` module:

* **Definition and basic properties**:
  - Introduced the `LengthUnit` type, representing positive real numbers corresponding to translationally-invariant metrics on a space manifold. (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)
  - Added lemmas for basic properties, such as `val_neq_zero` and `val_pos`, and defined a default instance for `LengthUnit`. (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)

* **Operations on `LengthUnit`**:
  - Implemented division for `LengthUnit`, yielding a real number representing the ratio of two units. Added lemmas like `div_eq_val`, `div_self`, and `div_symm`. (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)
  - Defined a `scale` operation to scale a `LengthUnit` by a positive real number, with supporting lemmas like `scale_div_self` and `scale_div_scale`. (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)

* **Predefined length units**:
  - Axiomatised the existence of the `meters` unit and defined derived units such as `femtometers`, `kilometers`, `miles`, `lightYears`, and `parsecs`. (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)

* **Relations between units**:
  - Added lemmas to describe relationships between units, e.g., `miles_div_yards` (1760 yards in a mile) and `furlongs_div_yards` (220 yards in a furlong). (`[PhysLean/SpaceAndTime/Space/LengthUnit.leanR1-R175](diffhunk://#diff-d303d36967197e83cf29b2b1e26766f4e2058eb7348b7b5c4b7f0933d7a499d5R1-R175)`)

### Import adjustment:
* Added the new `PhysLean.SpaceAndTime.Space.LengthUnit` module to the imports in `PhysLean.lean`. (`[PhysLean.leanR305](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R305)`)