### PR TITLE
feat: Mass units

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -3,6 +3,7 @@ import PhysLean.ClassicalMechanics.EulerLagrange
 import PhysLean.ClassicalMechanics.HamiltonsEquations
 import PhysLean.ClassicalMechanics.HarmonicOscillator.Basic
 import PhysLean.ClassicalMechanics.HarmonicOscillator.Solution
+import PhysLean.ClassicalMechanics.Mass.MassUnit
 import PhysLean.ClassicalMechanics.VectorFields
 import PhysLean.ClassicalMechanics.WaveEquation.Basic
 import PhysLean.ClassicalMechanics.WaveEquation.HarmonicWave

--- a/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
+++ b/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import Mathlib.Geometry.Manifold.Diffeomorph
+import PhysLean.SpaceAndTime.Time.Basic
+import PhysLean.Meta.TODO.Basic
+/-!
+
+# Units on Mass
+
+A unit of mass corresponds to a choice of translationally-invariant
+metric on the mass manifold (to be defined diffeomorphic to `ℝ≥0`).
+Such a choice is (non-canonically) equivalent to a
+choice of positive real number. We define the type `MassUnit` to be equivalent to the
+positive reals.
+
+On `MassUnit` there is an instance of division giving a real number, corresponding to the
+ratio of the two scales of mass unit.
+
+To define specific mass units, we first axiomise the existence of a
+a given mass unit, and then construct all other mass units from it. We choose to axiomise the
+existence of the mass unit of kilograms, and construct all other mass units from that.
+
+-/
+
+/-- The choices of translationally-invariant metrics on the mass-manifold.
+  Such a choice corresponds to a choice of units for mass. -/
+structure MassUnit where
+  /-- The underlying scale of the unit. -/
+  val : ℝ
+  property : 0 < val
+
+namespace MassUnit
+
+@[simp]
+lemma val_neq_zero (x : MassUnit) : x.val ≠ 0 := by
+  exact Ne.symm (ne_of_lt x.property)
+
+lemma val_pos (x : MassUnit) : 0 < x.val := x.property
+
+instance : Inhabited MassUnit where
+  default := ⟨1, by norm_num⟩
+
+/-!
+
+## Division of LengthUnit
+
+-/
+
+noncomputable instance : HDiv MassUnit MassUnit ℝ where
+  hDiv x t := x.val / t.val
+
+lemma div_eq_val (x y : MassUnit) :
+    x / y = x.val / y.val := rfl
+
+@[simp]
+lemma div_pos (x y : MassUnit) :
+    (0 : ℝ) < x / y := by
+  simpa [div_eq_val] using _root_.div_pos x.val_pos y.val_pos
+
+@[simp]
+lemma div_self (x : MassUnit) :
+    x / x = (1 : ℝ) := by
+  simp [div_eq_val, x.val_neq_zero]
+
+lemma div_symm (x y : MassUnit) :
+    x / y = (y / x)⁻¹ := by
+  rw [div_eq_val, inv_eq_one_div, div_eq_val]
+  simp
+
+/-!
+
+## The scaling of a length unit
+
+-/
+
+/-- The scaling of a mass unit by a positive real. -/
+def scale (r : ℝ) (x : MassUnit) (hr : 0 < r := by norm_num) : MassUnit :=
+  ⟨r * x.val, mul_pos hr x.val_pos⟩
+
+@[simp]
+lemma scale_div_self (x : MassUnit) (r : ℝ) (hr : 0 < r) :
+    scale r x hr / x = r := by
+  simp [scale, div_eq_val]
+
+@[simp]
+lemma scale_one (x : MassUnit) : scale 1 x = x := by
+  simp [scale, mul_one]
+
+@[simp]
+lemma scale_div_scale (x1 x2 : MassUnit) {r1 r2 : ℝ} (hr1 : 0 < r1) (hr2 : 0 < r2) :
+    scale r1 x1 hr1 / scale r2 x2 hr2 = r1 / r2 * (x1 / x2) := by
+  simp [scale, div_eq_val]
+  field_simp
+
+@[simp]
+lemma scale_scale (x : MassUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
+    scale r1 (scale r2 x hr2) hr1 = scale (r1 * r2) x (mul_pos hr1 hr2) := by
+  simp [scale]
+  ring
+
+/-!
+
+## Specific choices of mass units
+
+To define a specific mass units, we must first axiomise the existence of a
+a given mass unit, and then construct all other mass units from it.
+We choose to axiomise the existence of the mass unit of kilographs.
+
+We need an axiom since this relates something to something in the physical world.
+
+-/
+
+/-- The axiom corresponding to the definition of a mass unit of kilograms. -/
+axiom kilograms : MassUnit
+
+/-- The mass unit of a microgram (10^(-9) of a kilogram). -/
+noncomputable def micrograms : MassUnit := scale ((1/10) ^ 9) kilograms
+
+/-- The mass unit of milligram (10^(-6) of a kilogram). -/
+noncomputable def milligrams : MassUnit := scale ((1/10) ^ 6) kilograms
+
+/-- The mass unit of grams (10^(-3) of a kilogram). -/
+noncomputable def grams : MassUnit := scale ((1/10) ^ 3) kilograms
+
+/-- The mass unit of (avoirdupois) ounces (0.028 349 523 125 of a kilogram). -/
+noncomputable def ounces : MassUnit := scale (0.028349523125) kilograms
+
+/-- The mass unit of (avoirdupois) pounds (0.453 592 37 of a kilogram). -/
+noncomputable def pounds : MassUnit := scale (0.45359237) kilograms
+
+/-- The mass unit of stones (14 pounds). -/
+noncomputable def stones : MassUnit := scale (14) pounds
+
+/-- The mass unit of a quarter (28 pounds). -/
+noncomputable def quarters : MassUnit := scale (28) pounds
+
+/-- The mass unit of hundredweights (112 pounds). -/
+noncomputable def hundredweights : MassUnit := scale (112) pounds
+
+/-- The mass unit of short tons (2000 pounds). -/
+noncomputable def shortTons : MassUnit := scale (2000) pounds
+
+/-- The mass unit of metric tons (1000 kilograms). -/
+noncomputable def metricTons : MassUnit := scale (1000) kilograms
+
+/-- The mass unit of long tons (2240 pounds). Also called shortweight tons. -/
+noncomputable def longTons : MassUnit := scale (2240) pounds
+
+/-- The mass unit of nominal solar masses (1.988416 × 10 ^ 30 kilograms).
+  See: https://iopscience.iop.org/article/10.3847/0004-6256/152/2/41 -/
+noncomputable def nominalSolarMasses : MassUnit := scale (1.988416e30) kilograms
+
+/-!
+
+## Relations between mass units
+
+-/
+
+lemma pounds_div_ounces : pounds / ounces = (16 : ℝ) := by simp [pounds, ounces]; norm_num
+
+lemma shortTons_div_kilograms : shortTons / kilograms = (907.18474 : ℝ) := by
+  simp [shortTons, kilograms, pounds]; norm_num
+
+lemma longTons_div_kilograms : longTons / kilograms = (1016.0469088 : ℝ) := by
+  simp [longTons, kilograms, pounds]; norm_num
+
+end MassUnit

--- a/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
+++ b/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
@@ -45,7 +45,7 @@ instance : Inhabited MassUnit where
 
 /-!
 
-## Division of LengthUnit
+## Division of MassUnit
 
 -/
 
@@ -72,7 +72,7 @@ lemma div_symm (x y : MassUnit) :
 
 /-!
 
-## The scaling of a length unit
+## The scaling of a mass unit
 
 -/
 

--- a/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
+++ b/PhysLean/ClassicalMechanics/Mass/MassUnit.lean
@@ -107,7 +107,7 @@ lemma scale_scale (x : MassUnit) (r1 r2 : ℝ) (hr1 : 0 < r1) (hr2 : 0 < r2) :
 
 To define a specific mass units, we must first axiomise the existence of a
 a given mass unit, and then construct all other mass units from it.
-We choose to axiomise the existence of the mass unit of kilographs.
+We choose to axiomise the existence of the mass unit of kilograms.
 
 We need an axiom since this relates something to something in the physical world.
 


### PR DESCRIPTION
**Copilot summary**

This pull request introduces a new module for handling units of mass in the `PhysLean` library. The most significant changes include the addition of the `MassUnit` structure, its associated operations, and predefined mass units. Additionally, the module is imported into the main `PhysLean` library.

### New module: `MassUnit`

* **Definition of `MassUnit`:** A structure representing a unit of mass, defined as a positive real number with operations for division and scaling. (`PhysLean/ClassicalMechanics/Mass/MassUnit.lean`, [PhysLean/ClassicalMechanics/Mass/MassUnit.leanR1-R170](diffhunk://#diff-9ea87c2c80a4b1b8b5a1bffcf5db50a33d7a7ca67c648faa634b31fbb52aa935R1-R170))
* **Operations on `MassUnit`:** Added support for division between mass units, scaling by positive real numbers, and properties such as `div_self`, `scale_one`, and `scale_scale`. (`PhysLean/ClassicalMechanics/Mass/MassUnit.lean`, [PhysLean/ClassicalMechanics/Mass/MassUnit.leanR1-R170](diffhunk://#diff-9ea87c2c80a4b1b8b5a1bffcf5db50a33d7a7ca67c648faa634b31fbb52aa935R1-R170))
* **Predefined mass units:** Introduced standard mass units like kilograms, grams, pounds, stones, metric tons, and nominal solar masses, along with relations between them. (`PhysLean/ClassicalMechanics/Mass/MassUnit.lean`, [PhysLean/ClassicalMechanics/Mass/MassUnit.leanR1-R170](diffhunk://#diff-9ea87c2c80a4b1b8b5a1bffcf5db50a33d7a7ca67c648faa634b31fbb52aa935R1-R170))

### Integration into `PhysLean`

* **Import statement added:** The new `MassUnit` module is imported into the main library to enable its usage in other parts of the system. (`PhysLean.lean`, [PhysLean.leanR6](diffhunk://#diff-8a561d40bcedb4a7f8b13be53cda0743215b195a87659e0b81192e64cb1a06c5R6))