### PR TITLE
feat: Add energy and pressure units

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -351,7 +351,9 @@ import PhysLean.Thermodynamics.Temperature.Basic
 import PhysLean.Thermodynamics.Temperature.TemperatureUnits
 import PhysLean.Units.Area
 import PhysLean.Units.Basic
+import PhysLean.Units.Energy
 import PhysLean.Units.Mass
 import PhysLean.Units.Momentum.Basic
+import PhysLean.Units.Pressure
 import PhysLean.Units.Speed
 import PhysLean.Units.Velocity

--- a/PhysLean/Units/Energy.lean
+++ b/PhysLean/Units/Energy.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Units.Basic
+/-!
+
+# Energy
+
+In this module we define the dimensionful type corresponding to an energy.
+We define specific insances of energy.
+
+-/
+open Dimension
+open NNReal
+
+/-- Energy as a dimensional quantity with dimension `MLT⁻2`.. -/
+abbrev DimEnergy : Type := Dimensionful (M𝓭 * L𝓭 * L𝓭 * T𝓭⁻¹ * T𝓭⁻¹) ℝ
+
+namespace DimEnergy
+open UnitChoices Dimensionful
+
+/-- The dimensional energy corresponding to 1 joule, J. -/
+noncomputable def joule : DimEnergy := ofUnit _ 1 SI
+
+/-- The dimensional energy corresponding to 1 electron volt, 1.602176634×10−19 J. -/
+noncomputable def electronVolt : DimEnergy := ofUnit _ (1.602176634e-19) SI
+
+/-- The dimensional energy corresponding to 1 calorie, 4.184 J. -/
+noncomputable def calorie : DimEnergy := ofUnit _ 4.184 SI
+
+/-- The dimensional energy corresponding to 1 kilowatt-hours, (3,600,000 J). -/
+noncomputable def kilowattHour : DimEnergy := ofUnit _ 3600000 SI
+
+end DimEnergy

--- a/PhysLean/Units/Pressure.lean
+++ b/PhysLean/Units/Pressure.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Units.Basic
+/-!
+
+# Pressure
+
+In this module we define the dimensionful type corresponding to an pressure.
+We define specific insances of pressure.
+
+-/
+open Dimension
+open NNReal
+
+/-- Pressure as a dimensional quantity with dimension `ML⁻¹T⁻2`.. -/
+abbrev DimPressure : Type := Dimensionful (M𝓭 * L𝓭⁻¹ * T𝓭⁻¹ * T𝓭⁻¹) ℝ
+
+namespace DimPressure
+open UnitChoices Dimensionful
+
+/-- The dimensional pressure corresponding to 1 pascal, Pa. -/
+noncomputable def pascal : DimPressure := ofUnit _ 1 SI
+
+/-- The dimensional pressure corresponding to 1 millimeter of mercury (133.322387415 pascals). -/
+noncomputable def millimeterOfMercury : DimPressure := ofUnit _ (133.322387415) SI
+
+/-- The dimensional pressure corresponding to 1 bar (100,000 pascals). -/
+noncomputable def bar : DimPressure := ofUnit _ 100000 SI
+
+/-- The dimensional pressure corresponding to 1 standard atmosphere (101,325 pascals). -/
+noncomputable def standardAtmosphere : DimPressure := ofUnit _ (101325) SI
+
+/-- The dimensional pressure corresponding to 1 torr (1/760 of standard atmosphere pressure). -/
+noncomputable def torr : DimPressure := (1/760) • standardAtmosphere
+
+/-- The dimensional pressure corresponding to 1 pound per square inch. -/
+noncomputable def psi : DimPressure := ofUnit _ 1 ({SI with
+  mass := MassUnit.pounds,
+  length := LengthUnit.inches} : UnitChoices)
+
+end DimPressure


### PR DESCRIPTION
**Copilot summary** 

This pull request introduces two new modules, `Energy` and `Pressure`, to the `PhysLean` library, defining their respective dimensional types and common unit representations. Additionally, the imports in `Temperature.Basic` were updated to include these new modules.

### New Modules Added:

* **Energy Module (`PhysLean/Units/Energy.lean`):**
  - Introduced `DimEnergy`, representing energy as a dimensional quantity with dimension `MLT⁻2`.
  - Defined common energy units:
    - `joule` (1 J).
    - `electronVolt` (1.602176634×10⁻¹⁹ J).
    - `calorie` (4.184 J).
    - `kilowattHour` (3,600,000 J).

* **Pressure Module (`PhysLean/Units/Pressure.lean`):**
  - Introduced `DimPressure`, representing pressure as a dimensional quantity with dimension `ML⁻¹T⁻2`.
  - Defined common pressure units:
    - `pascal` (1 Pa).
    - `millimeterOfMercury` (133.322387415 Pa).
    - `bar` (100,000 Pa).
    - `standardAtmosphere` (101,325 Pa).
    - `torr` (1/760 of standard atmosphere pressure).
    - `psi` (pounds per square inch).

### Import Updates:

* **`Temperature.Basic` (`PhysLean.lean`):**
  - Added imports for the newly introduced `Energy` and `Pressure` modules.