### PR TITLE
refactor LieTrace with BlockTriangular API

### DIFF
--- a/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -5,6 +5,7 @@ Authors: Matteo Cipollina
 -/
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+import Mathlib.LinearAlgebra.Matrix.Block
 import PhysLean.Mathematics.SchurTriangulation
 
 /-!
@@ -13,100 +14,20 @@ import PhysLean.Mathematics.SchurTriangulation
 This file proves the formula `det (exp A) = exp (tr A)` for matrices, also known as Lie's trace
 formula.
 
+The proof proceeds by first showing the formula for upper-triangular matrices and then
+leveraging Schur triangulation to generalize to any matrix. An upper-triangular matrix `A`
+is defined in `mathlib` as `Matrix.BlockTriangular A id`.
+
 ## Main results
 
 - `Matrix.det_exp`: The determinant of the exponential of a matrix is the exponential of its trace.
 -/
 
-/-!
-We give a higher priority to the canonical `1` and `*` instances coming
-from `Mathlib` so that every occurrence of `1 : Matrix _ _ _` and
-`A * B` uses the very same definitions.
--/
-attribute [local instance 100] Matrix.instHMulOfFintypeOfMulOfAddCommMonoid
-attribute [local instance 100] Matrix.one
-
 namespace Matrix
-namespace IsUpperTriangular
-
-variable {α k n R 𝕂 m : Type*}
-variable [LinearOrder n][CommRing α]
-variable [SMulZeroClass R α]
-
-/-- Scalar multiplication preserves the property of being upper-triangular. -/
-lemma smul
-    {A : Matrix n n α} (hA : IsUpperTriangular A) (k : R) :
-    IsUpperTriangular (k • A) := by
-  intro i j hij
-  simp [smul_apply, hA hij]
-
-/-- The identity matrix is upper-triangular. -/
-lemma one  : IsUpperTriangular (1 : Matrix n n α) := by
-  intro i j hij
-  simp [one_apply, (ne_of_lt hij).symm];
-  intro a
-  subst a
-  simp_all only [id_eq, lt_self_iff_false]
-
-variable [Fintype n]
-variable [SMulZeroClass R α]
-
-/-- The product of two upper-triangular matrices is upper-triangular. -/
-lemma mul  {A B : Matrix n n α}
-    (hA : IsUpperTriangular A) (hB : IsUpperTriangular B) : IsUpperTriangular (A * B) := by
-  intro i j hij
-  rw [mul_apply]
-  apply Finset.sum_eq_zero
-  intro l _
-  by_cases h₁ : i ≤ l
-  · by_cases h₂ : l ≤ j
-    · exfalso; exact not_lt_of_ge (le_trans h₁ h₂) hij
-    · rw [not_le] at h₂; exact hB h₂ ▸ mul_zero (A i l)
-  · rw [not_le] at h₁; exact hA h₁ ▸ zero_mul (B l j)
-
-/-- Powers of an upper-triangular matrix are upper-triangular. -/
-lemma pow  {A : Matrix n n α}
-    (hA : IsUpperTriangular A) (k : ℕ) : IsUpperTriangular (A ^ k) := by
-  induction k with
-  | zero =>
-      rw [pow_zero]
-      exact one
-  | succ k ih =>
-      rw [pow_succ]
-      exact IsUpperTriangular.mul ih hA
-
-lemma diag_mul_of {A B : Matrix n n α}
-    (hA : IsUpperTriangular A) (hB : IsUpperTriangular B) : (A * B).diag = A.diag * B.diag := by
-  ext i
-  simp only [diag_apply, mul_apply, Pi.mul_apply]
-  have sum_eq : ∑ j ∈ Finset.univ, A i j * B j i = A i i * B i i := by
-    apply Finset.sum_eq_single i
-    · intro j _ j_ne_i
-      cases lt_or_gt_of_ne j_ne_i with
-      | inl h => -- j < i
-        rw [hA h, zero_mul]
-      | inr h => -- j > i
-        rw [hB h, mul_zero]
-    · intro hi_not_in
-      exact absurd (Finset.mem_univ i) hi_not_in
-  rw [sum_eq]
-
-lemma diag_pow_of {A : Matrix n n α}
-    (hA : IsUpperTriangular A) (k : ℕ) : (A ^ k).diag = A.diag ^ k := by
-  induction k with
-  | zero =>
-      rw [pow_zero, pow_zero]
-      ext i
-      simp [diag_one]
-  | succ k ih =>
-      rw [pow_succ, pow_succ]
-      have h_mul : (A ^ k * A).diag = (A ^ k).diag * A.diag :=
-        diag_mul_of (pow hA k) hA
-      rw [h_mul, ih]
-
-end IsUpperTriangular
 
 open scoped BigOperators Topology
+
+variable {𝕂 m n : Type*}
 
 instance [UniformSpace 𝕂] : UniformSpace (Matrix m n 𝕂) := by unfold Matrix; infer_instance
 
@@ -115,20 +36,33 @@ lemma tsum_eq_zero
     {β : Type*} [TopologicalSpace β] [AddCommMonoid β]
     {f : ℕ → β} (h : ∀ n, f n = 0) :
     (∑' n, f n) = 0 := by
-  rw [← h Nat.zero]
-  simp_all only [tsum_zero, Nat.zero_eq]
+  simp_all only [tsum_zero]
+
+namespace Finset
+
+variable [RCLike 𝕂] [LinearOrder m]
+
+private lemma prod_exp_eq_exp_sum (s : Finset m) (f : m → 𝕂) :
+    ∏ i ∈ s, NormedSpace.exp 𝕂 (f i) = NormedSpace.exp 𝕂 (∑ i ∈ s, f i) := by
+  letI : CompleteSpace 𝕂 := by infer_instance
+  induction' s using Finset.induction with a s ha ih
+  · simp [NormedSpace.exp_zero]
+  · rw [Finset.prod_insert ha, Finset.sum_insert ha, NormedSpace.exp_add, ih]
+
+end Finset
 
 /-!
  ### The determinant of the matrix exponential
  -/
 section DetExp
 
-open IsUpperTriangular
+variable [RCLike 𝕂]
 
-variable [RCLike 𝕂]--[IsAlgClosed 𝕂] [Fintype m] [DecidableEq m] [LinearOrder m]
-      --[LinearOrder 𝕂] [Fintype 𝕂]
+attribute [local instance] Matrix.linftyOpNormedAlgebra
+attribute [local instance] Matrix.linftyOpNormedRing
+attribute [local instance] Matrix.instCompleteSpace
 
-/-- Apply a matrix `tsum` to a given entry.                                        -/
+/-- Apply a matrix `tsum` to a given entry. -/
 lemma matrix_tsum_apply
     {f : ℕ → Matrix m m 𝕂} (hf : Summable f) (i j : m) :
     (∑' n, f n) i j = ∑' n, (f n) i j := by
@@ -141,136 +75,123 @@ lemma matrix_tsum_apply
     exact tsum_apply h_row_summable
   rw [h₁, h₂]
 
-namespace Finset
-
-private lemma prod_exp_eq_exp_sum [LinearOrder m] (s : Finset m) (f : m → 𝕂) :
-    ∏ i ∈ s, NormedSpace.exp 𝕂 (f i) = NormedSpace.exp 𝕂 (∑ i ∈ s, f i) := by
-  letI : CompleteSpace 𝕂 := by infer_instance
-  induction' s using Finset.induction with a s ha ih
-  · simp [NormedSpace.exp_zero]
-  · rw [Finset.prod_insert ha, Finset.sum_insert ha, NormedSpace.exp_add, ih]
-
-end Finset
-
-variable [Fintype m]
-
-lemma trace_of_isUpperTriangular {A : Matrix m m 𝕂} : A.trace = ∑ i, A i i := by
-  rfl
-
-variable [LinearOrder m]
-
-attribute [local instance] Matrix.linftyOpNormedAlgebra
-attribute [local instance] Matrix.linftyOpNormedRing
-attribute [local instance] Matrix.instCompleteSpace
+variable [Fintype m] [LinearOrder m]
 
 /-- Summability of the exponential series for matrices -/
-lemma summable_exp_series [CompleteSpace 𝕂] (A : Matrix m m 𝕂) :
-    Summable (fun n => ((n.factorial : 𝕂)⁻¹) • (A ^ n)) := by
-  letI : NormedAddCommGroup (Matrix m m 𝕂) := Matrix.linftyOpNormedAddCommGroup
-  letI : NormedSpace 𝕂 (Matrix m m 𝕂) := Matrix.linftyOpNormedSpace
-  exact NormedSpace.expSeries_summable' A
+lemma summable_exp_series (A : Matrix m m 𝕂) :
+    Summable (fun n => ((n.factorial : 𝕂)⁻¹) • (A ^ n)) :=
+  NormedSpace.expSeries_summable' A
 
-lemma isUpperTriangular_exp_of_isUpperTriangular
-    {A : Matrix m m 𝕂} (hA : A.IsUpperTriangular) :
-    (NormedSpace.exp 𝕂 A).IsUpperTriangular := by
+/-- For upper-triangular matrices, the diagonal of a product is the product of the diagonals.
+This is a specific case of a more general property for block-triangular matrices. -/
+lemma diag_mul_of_blockTriangular_id {A B : Matrix m m 𝕂}
+    (hA : BlockTriangular A id) (hB : BlockTriangular B id) : (A * B).diag = A.diag * B.diag := by
+  ext i
+  simp only [diag_apply, mul_apply, Pi.mul_apply]
+  apply Finset.sum_eq_single i
+  · intro j _ j_ne_i
+    cases lt_or_gt_of_ne j_ne_i with
+    | inl h => rw [hA h, zero_mul] -- j < i
+    | inr h => rw [hB h, mul_zero] -- i < j
+  · intro; simp_all only [Finset.mem_univ, not_true_eq_false]
+
+/-- Powers of block triangular matrices are block triangular. -/
+lemma blockTriangular_pow {A : Matrix m m 𝕂} (hA : BlockTriangular A id) (k : ℕ) :
+    BlockTriangular (A ^ k) id := by
+  induction k with
+  | zero => rw [pow_zero]; exact blockTriangular_one
+  | succ k ihk => rw [pow_succ]; exact ihk.mul hA
+
+/-- For an upper-triangular matrix, the diagonal of a power is the power of the diagonal. -/
+lemma diag_pow_of_blockTriangular_id {A : Matrix m m 𝕂}
+    (hA : BlockTriangular A id) (k : ℕ) : (A ^ k).diag = A.diag ^ k := by
+  induction k with
+  | zero => rw [pow_zero, pow_zero]; simp [diag_one]
+  | succ k ih =>
+    have h_pow_k : BlockTriangular (A ^ k) id := blockTriangular_pow hA k
+    rw [pow_succ, pow_succ, diag_mul_of_blockTriangular_id h_pow_k hA, ih]
+
+/-- The exponential of an upper-triangular matrix is upper-triangular. -/
+lemma blockTriangular_exp_of_blockTriangular_id
+    {A : Matrix m m 𝕂} (hA : BlockTriangular A id) :
+    (NormedSpace.exp 𝕂 A).BlockTriangular id := by
   intro i j hij
   rw [NormedSpace.exp_eq_tsum]
-  let exp_series := fun n ↦ ((n.factorial : 𝕂)⁻¹) • (A ^ n)
-  change (∑' (n : ℕ), exp_series n) i j = 0
+  let exp_series := fun n => ((n.factorial : 𝕂)⁻¹) • (A ^ n)
+  change (∑' n, exp_series n) i j = 0
   rw [matrix_tsum_apply (summable_exp_series A) i j]
   apply tsum_eq_zero
   intro n
-  have h_entry : (A ^ n) i j = 0 := by
-    convert (IsUpperTriangular.pow hA n) hij
-  simp [exp_series, smul_apply, h_entry]
+  have h_pow : BlockTriangular (A ^ n) id := by
+    induction n with
+    | zero => rw [pow_zero]; exact blockTriangular_one
+    | succ k ihk => rw [pow_succ]; exact ihk.mul hA
+  simp only [exp_series, smul_apply]
+  rw [h_pow hij, smul_zero]
 
 /--
 For an upper–triangular matrix `A`, the `(i,i)` entry of the power `A ^ n`
 is simply the `n`-th power of the original diagonal entry.
 -/
 lemma diag_pow_entry_eq_pow_diag_entry {A : Matrix m m 𝕂}
-    (hA : A.IsUpperTriangular) :
-    ∀ n : ℕ, ∀ i : m, (A ^ n) i i = (A i i) ^ n := by
-  intro n i
-  have h := diag_pow_of hA n
-  calc (A ^ n) i i = ((A ^ n).diag) i := by simp [diag_apply]
-    _ = (A.diag ^ n) i := by convert congrArg (fun d => d i) h
-    _ = (A i i) ^ n   := by simp [Pi.pow_apply]
+    (hA : BlockTriangular A id) (n : ℕ) (i : m) :
+    (A ^ n) i i = (A i i) ^ n := by
+  have h := diag_pow_of_blockTriangular_id hA n
+  simpa [diag_apply, Pi.pow_apply] using congr_arg (fun d => d i) h
 
 /-- Each term in the matrix exponential series equals the corresponding scalar term on the
 diagonal -/
-lemma exp_series_diag_term_eq {A : Matrix m m 𝕂} (hA : A.IsUpperTriangular)
+lemma exp_series_diag_term_eq {A : Matrix m m 𝕂} (hA : BlockTriangular A id)
     (n : ℕ) (i : m) :
     ((n.factorial : 𝕂)⁻¹ • (A ^ n)) i i = (n.factorial : 𝕂)⁻¹ • (A i i) ^ n := by
-  simp only [smul_apply]
-  rw [diag_pow_entry_eq_pow_diag_entry hA n i]
+  simp [smul_apply, diag_pow_entry_eq_pow_diag_entry hA]
 
 /-- The diagonal of the matrix exponential series equals the scalar exponential series -/
-lemma matrix_exp_series_diag_eq_scalar_series {A : Matrix m m 𝕂} (hA : A.IsUpperTriangular)
+lemma matrix_exp_series_diag_eq_scalar_series {A : Matrix m m 𝕂} (hA : BlockTriangular A id)
     (i : m) :
     (∑' n, ((n.factorial : 𝕂)⁻¹ • (A ^ n)) i i) = ∑' n, (n.factorial : 𝕂)⁻¹ • (A i i) ^ n := by
   exact tsum_congr (exp_series_diag_term_eq hA · i)
 
-theorem diag_exp_of_isUpperTriangular
-    {A : Matrix m m 𝕂} (hA : A.IsUpperTriangular) :
+/-- The diagonal of the exponential of an upper-triangular matrix `A` consists of the
+exponentials of the diagonal entries of `A`. -/
+theorem diag_exp_of_blockTriangular_id
+    {A : Matrix m m 𝕂} (hA : BlockTriangular A id) :
     (NormedSpace.exp 𝕂 A).diag = fun i => NormedSpace.exp 𝕂 (A i i) := by
   funext i
-  have exp_def : (NormedSpace.exp 𝕂 A) = ∑' (n : ℕ), (n.factorial : 𝕂)⁻¹ • (A ^ n) := by
-    rw [NormedSpace.exp_eq_tsum (𝕂 := 𝕂)]
-  rw [exp_def, diag_apply]
-  rw [matrix_tsum_apply (summable_exp_series A) i i]
+  rw [NormedSpace.exp_eq_tsum (𝕂 := 𝕂), diag_apply]
+  simp_rw [matrix_tsum_apply (summable_exp_series A) i i]
   rw [matrix_exp_series_diag_eq_scalar_series hA i]
   rw [NormedSpace.exp_eq_tsum (𝕂 := 𝕂)]
 
-lemma det_of_isUpperTriangular {A : Matrix m m 𝕂}
-    (hA : A.IsUpperTriangular) : A.det = ∏ i, A i i := by
-  exact Matrix.det_of_upperTriangular hA
+/-- Lie's trace formula for upper triangular matrices. -/
+lemma det_exp_of_blockTriangular_id {A : Matrix m m 𝕂} (hA : BlockTriangular A id) :
+    (NormedSpace.exp 𝕂 A).det = NormedSpace.exp 𝕂 A.trace := by
+  have h_exp_upper : BlockTriangular (NormedSpace.exp 𝕂 A) id :=
+    blockTriangular_exp_of_blockTriangular_id hA
+  rw [det_of_upperTriangular h_exp_upper]
+  have h_diag_exp : (NormedSpace.exp 𝕂 A).diag = fun i => NormedSpace.exp 𝕂 (A i i) :=
+    diag_exp_of_blockTriangular_id hA
+  simp_rw [← diag_apply]
+  simp_rw [h_diag_exp]
+  erw [← Finset.prod_exp_eq_exp_sum Finset.univ]
+  congr 1
 
 /-- The trace is invariant under unitary conjugation. -/
 lemma trace_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
     trace ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = trace A := by
-  have h :=
-    trace_mul_cycle
-      (A := (U : Matrix m m 𝕂))
-      (B := A)
-      (C := star (U : Matrix m m 𝕂))
-  simpa [Matrix.mul_assoc,
-        Matrix.one_mul] using h
+  have h_unitary : star (U : Matrix m m 𝕂) * (U : Matrix m m 𝕂) = 1 :=
+    UnitaryGroup.star_mul_self U
+  simpa [Matrix.mul_assoc, h_unitary, Matrix.one_mul] using
+    (Matrix.trace_mul_cycle (U : Matrix m m 𝕂) A (star (U : Matrix m m 𝕂)))
 
 /-- The determinant is invariant under unitary conjugation. -/
 lemma det_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
     det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
-  have h_det_U : star (det (U : Matrix m m 𝕂)) * det (U : Matrix m m 𝕂) = 1 := by
-    have h : star (U : Matrix m m 𝕂) * (U : Matrix m m 𝕂) = 1 :=
-      UnitaryGroup.star_mul_self U
-    have h_det := congrArg det h
-    rw [det_mul, det_one] at h_det
-    erw [det_conjTranspose] at h_det
-    exact h_det
-  calc
-    det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂))
-        = det ((U : Matrix m m 𝕂) * A) * det (star (U : Matrix m m 𝕂)) := by
-          exact det_mul ((U : Matrix m m 𝕂) * A) (star (U : Matrix m m 𝕂))
-    _ = det (U : Matrix m m 𝕂) * det A * det (star (U : Matrix m m 𝕂)) := by rw [det_mul]
-    _ = det (U : Matrix m m 𝕂) * det A * star (det (U : Matrix m m 𝕂)) := by
-          rw [← det_mul, ← det_conjTranspose]; rfl
-    _ = det A * (det (U : Matrix m m 𝕂) * star (det (U : Matrix m m 𝕂))) := by ring
-    _ = det A * (star (det (U : Matrix m m 𝕂)) * det (U : Matrix m m 𝕂)) := by
-          rw [mul_comm (det (U : Matrix m m 𝕂)) (star (det (U : Matrix m m 𝕂)))]
-    _ = det A * 1 := by rw [h_det_U]
-    _ = det A := by rw [mul_one]
-
-/-- Lie's trace formula for upper triangular matrices. -/
-lemma det_exp_of_isUpperTriangular {A : Matrix m m 𝕂} (hA : IsUpperTriangular A) :
-    (NormedSpace.exp 𝕂 A).det = NormedSpace.exp 𝕂 A.trace := by
-  have h_exp_upper : IsUpperTriangular (NormedSpace.exp 𝕂 A) :=
-    isUpperTriangular_exp_of_isUpperTriangular hA
-  letI : LinearOrder m := by infer_instance
-  rw [det_of_isUpperTriangular h_exp_upper];
-  have h_diag_exp : (NormedSpace.exp 𝕂 A).diag = fun i => NormedSpace.exp 𝕂 (A i i) :=
-    diag_exp_of_isUpperTriangular hA
-  erw [← Finset.prod_exp_eq_exp_sum Finset.univ]
-  exact congrArg Finset.univ.prod h_diag_exp
+  have h_det_U : det (U : Matrix m m 𝕂) * det (star (U : Matrix m m 𝕂)) = (1 : 𝕂) := by
+    have h := congr_arg det (UnitaryGroup.star_mul_self U)
+    rwa [det_mul, det_one, mul_comm] at h
+  rw [det_mul, det_mul]
+  rw [mul_assoc, mul_comm (det A), ← mul_assoc, h_det_U, one_mul]
 
 /-- The exponential of a matrix commutes with unitary conjugation. -/
 lemma exp_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
@@ -287,33 +208,24 @@ lemma exp_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
 lemma det_exp_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
     (NormedSpace.exp 𝕂 ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂))).det =
     (NormedSpace.exp 𝕂 A).det := by
-  have h_exp_conj := exp_unitary_conj A U
-  have h₁ : NormedSpace.exp 𝕂 ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) =
-      (U : Matrix m m 𝕂) * NormedSpace.exp 𝕂 A * star (U : Matrix m m 𝕂) := h_exp_conj
-  have h₂ : (NormedSpace.exp 𝕂 ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂))).det =
-      det ((U : Matrix m m 𝕂) * NormedSpace.exp 𝕂 A * star (U : Matrix m m 𝕂)) := by simp [h₁]
-  have h₃ : det ((U : Matrix m m 𝕂) * NormedSpace.exp 𝕂 A * star (U : Matrix m m 𝕂)) =
-        (NormedSpace.exp 𝕂 A).det :=
-    det_unitary_conj (NormedSpace.exp 𝕂 A) U
-  simpa [h₂] using h₃
+  rw [exp_unitary_conj, det_unitary_conj]
 
 /-- The determinant of the exponential of a matrix is the exponential of its trace.
 This is also known as **Lie's trace formula**. -/
 theorem det_exp {𝕂 m : Type*} [RCLike 𝕂] [IsAlgClosed 𝕂] [Fintype m] [LinearOrder m]
     (A : Matrix m m 𝕂) :
     (NormedSpace.exp 𝕂 A).det = NormedSpace.exp 𝕂 A.trace := by
-  let U := schurTriangulationUnitary A
-  let T := schurTriangulation A
-  have h_conj : A = U * T.val * star U := schur_triangulation A
+  let U := A.schurTriangulationUnitary
+  let T := A.schurTriangulation
+  have h_prop : T.val.IsUpperTriangular := T.property
+  have h_conj : A = U * T * star U := schur_triangulation A
   have h_trace_invariant : A.trace = T.val.trace := by
-    simpa [h_conj] using trace_unitary_conj (A := T.val) U
-  have h_det_invariant :
-      (NormedSpace.exp 𝕂 A).det = (NormedSpace.exp 𝕂 T.val).det := by
-    simpa [h_conj] using det_exp_unitary_conj T.val U
-  have h_triangular_case :
-      (NormedSpace.exp 𝕂 T.val).det = NormedSpace.exp 𝕂 T.val.trace :=
-    det_exp_of_isUpperTriangular T.property
-  simp [h_det_invariant, h_trace_invariant, h_triangular_case]
+    erw [h_conj, trace_unitary_conj]
+  have h_det_invariant : (NormedSpace.exp 𝕂 A).det = (NormedSpace.exp 𝕂 T.val).det := by
+    erw [h_conj, det_exp_unitary_conj]
+  have h_triangular_case : (NormedSpace.exp 𝕂 T.val).det = NormedSpace.exp 𝕂 T.val.trace :=
+    det_exp_of_blockTriangular_id h_prop
+  rw [h_det_invariant, h_triangular_case, h_trace_invariant]
 
 end DetExp
 
@@ -373,6 +285,7 @@ lemma exp_map_algebraMap {n : Type*} [Fintype n] [DecidableEq n]
     Complex.real_smul]
 
 end NormedSpace
+
 section DetExp
 namespace Matrix
 /--
@@ -399,3 +312,5 @@ theorem det_exp_real {n : Type*} [Fintype n] [LinearOrder n]
       Complex.ofReal_exp, A_ℂ]
   rw [h_exp_comm] at h_complex
   exact Complex.ofReal_injective h_complex
+
+end Matrix

--- a/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -169,11 +169,8 @@ lemma trace_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
 /-- The determinant is invariant under unitary conjugation. -/
 lemma det_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
     det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
-  have h_det_U : det (U : Matrix m m 𝕂) * det (star (U : Matrix m m 𝕂)) = (1 : 𝕂) := by
-    have h := congr_arg det (UnitaryGroup.star_mul_self U)
-    rwa [det_mul, det_one, mul_comm] at h
-  rw [det_mul, det_mul]
-  rw [mul_assoc, mul_comm (det A), ← mul_assoc, h_det_U, one_mul]
+  rw [det_mul_right_comm]
+  simp_all only [SetLike.coe_mem, unitary.mul_star_self_of_mem, one_mul]
 
 /-- The exponential of a matrix commutes with unitary conjugation. -/
 lemma exp_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :

--- a/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -38,19 +38,6 @@ lemma tsum_eq_zero
     (∑' n, f n) = 0 := by
   simp_all only [tsum_zero]
 
-namespace Finset
-
-variable [RCLike 𝕂] [LinearOrder m]
-
-private lemma prod_exp_eq_exp_sum (s : Finset m) (f : m → 𝕂) :
-    ∏ i ∈ s, NormedSpace.exp 𝕂 (f i) = NormedSpace.exp 𝕂 (∑ i ∈ s, f i) := by
-  letI : CompleteSpace 𝕂 := by infer_instance
-  induction' s using Finset.induction with a s ha ih
-  · simp [NormedSpace.exp_zero]
-  · rw [Finset.prod_insert ha, Finset.sum_insert ha, NormedSpace.exp_add, ih]
-
-end Finset
-
 /-!
  ### The determinant of the matrix exponential
  -/
@@ -96,7 +83,7 @@ lemma diag_mul_of_blockTriangular_id {A B : Matrix m m 𝕂}
   · intro; simp_all only [Finset.mem_univ, not_true_eq_false]
 
 /-- Powers of block triangular matrices are block triangular. -/
-lemma blockTriangular_pow {A : Matrix m m 𝕂} (hA : BlockTriangular A id) (k : ℕ) :
+lemma blockTriangular.pow {A : Matrix m m 𝕂} (hA : BlockTriangular A id) (k : ℕ) :
     BlockTriangular (A ^ k) id := by
   induction k with
   | zero => rw [pow_zero]; exact blockTriangular_one
@@ -108,7 +95,7 @@ lemma diag_pow_of_blockTriangular_id {A : Matrix m m 𝕂}
   induction k with
   | zero => rw [pow_zero, pow_zero]; simp [diag_one]
   | succ k ih =>
-    have h_pow_k : BlockTriangular (A ^ k) id := blockTriangular_pow hA k
+    have h_pow_k : BlockTriangular (A ^ k) id := blockTriangular.pow hA k
     rw [pow_succ, pow_succ, diag_mul_of_blockTriangular_id h_pow_k hA, ih]
 
 /-- The exponential of an upper-triangular matrix is upper-triangular. -/
@@ -173,7 +160,7 @@ lemma det_exp_of_blockTriangular_id {A : Matrix m m 𝕂} (hA : BlockTriangular 
     diag_exp_of_blockTriangular_id hA
   simp_rw [← diag_apply]
   simp_rw [h_diag_exp]
-  erw [← Finset.prod_exp_eq_exp_sum Finset.univ]
+  erw [← NormedSpace.exp_sum Finset.univ]
   congr 1
 
 /-- The trace is invariant under unitary conjugation. -/

--- a/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -168,7 +168,7 @@ lemma trace_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
 
 /-- The determinant is invariant under unitary conjugation. -/
 lemma det_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
-     det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
+    det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
   have h_det_U : det (U : Matrix m m 𝕂) * det (star (U : Matrix m m 𝕂)) = (1 : 𝕂) := by
     have h := congr_arg det (UnitaryGroup.star_mul_self U)
     rwa [det_mul, det_one, mul_comm] at h

--- a/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/PhysLean/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -64,11 +64,6 @@ lemma matrix_tsum_apply
 
 variable [Fintype m] [LinearOrder m]
 
-/-- Summability of the exponential series for matrices -/
-lemma summable_exp_series (A : Matrix m m 𝕂) :
-    Summable (fun n => ((n.factorial : 𝕂)⁻¹) • (A ^ n)) :=
-  NormedSpace.expSeries_summable' A
-
 /-- For upper-triangular matrices, the diagonal of a product is the product of the diagonals.
 This is a specific case of a more general property for block-triangular matrices. -/
 lemma diag_mul_of_blockTriangular_id {A B : Matrix m m 𝕂}
@@ -106,7 +101,7 @@ lemma blockTriangular_exp_of_blockTriangular_id
   rw [NormedSpace.exp_eq_tsum]
   let exp_series := fun n => ((n.factorial : 𝕂)⁻¹) • (A ^ n)
   change (∑' n, exp_series n) i j = 0
-  rw [matrix_tsum_apply (summable_exp_series A) i j]
+  rw [matrix_tsum_apply (NormedSpace.expSeries_summable' A) i j]
   apply tsum_eq_zero
   intro n
   have h_pow : BlockTriangular (A ^ n) id := by
@@ -146,7 +141,7 @@ theorem diag_exp_of_blockTriangular_id
     (NormedSpace.exp 𝕂 A).diag = fun i => NormedSpace.exp 𝕂 (A i i) := by
   funext i
   rw [NormedSpace.exp_eq_tsum (𝕂 := 𝕂), diag_apply]
-  simp_rw [matrix_tsum_apply (summable_exp_series A) i i]
+  simp_rw [matrix_tsum_apply (NormedSpace.expSeries_summable' A) i i]
   rw [matrix_exp_series_diag_eq_scalar_series hA i]
   rw [NormedSpace.exp_eq_tsum (𝕂 := 𝕂)]
 
@@ -173,7 +168,7 @@ lemma trace_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
 
 /-- The determinant is invariant under unitary conjugation. -/
 lemma det_unitary_conj (A : Matrix m m 𝕂) (U : unitaryGroup m 𝕂) :
-    det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
+     det ((U : Matrix m m 𝕂) * A * star (U : Matrix m m 𝕂)) = det A := by
   have h_det_U : det (U : Matrix m m 𝕂) * det (star (U : Matrix m m 𝕂)) = (1 : 𝕂) := by
     have h := congr_arg det (UnitaryGroup.star_mul_self U)
     rwa [det_mul, det_one, mul_comm] at h


### PR DESCRIPTION
removed upperTriangular API to leverage BlockTriangular (recommended by Eric Wieser)