### PR TITLE
feat: Viable quanta

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -326,6 +326,7 @@ import PhysLean.StringTheory.FTheory.SU5.Fluxes.NoExotics.Completeness
 import PhysLean.StringTheory.FTheory.SU5.Fluxes.NoExotics.Elems
 import PhysLean.StringTheory.FTheory.SU5.Fluxes.NoExotics.ToList
 import PhysLean.StringTheory.FTheory.SU5U1.Basic
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.AnomalyFree
 import PhysLean.StringTheory.FTheory.SU5U1.Charges.OfRationalSection
 import PhysLean.StringTheory.FTheory.SU5U1.Charges.PhenoConstrained.Completeness
 import PhysLean.StringTheory.FTheory.SU5U1.Charges.PhenoConstrained.Elems.Basic
@@ -347,6 +348,7 @@ import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Basic
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Cases
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Completeness
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Elems
+import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Yukawa
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.TenQuanta
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.ToList
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.YukawaRegeneration

--- a/PhysLean/StringTheory/FTheory/SU5U1/Charges/AnomalyFree.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Charges/AnomalyFree.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.StringTheory.FTheory.SU5U1.Quanta.Basic
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.Viable
+/-!
+
+# Anomaly cancellation
+
+In this module we define the proposition `IsAnomalyFree` on charges, which states
+that the charges can be extended to quanta which are anomaly free.
+
+We give the viable charges which are anomaly free for each of the three codimension one
+configurations. This is in the lemma `viable_anomalyFree`.
+
+
+
+-/
+namespace FTheory
+
+namespace SU5U1
+
+namespace Charges
+open SuperSymmetry.SU5
+open SuperSymmetry.SU5.Charges
+open PotentialTerm
+open CodimensionOneConfig
+open Tree
+open PhysLean
+
+
+/-!
+
+## Anomaly coefficents of charges
+
+-/
+
+/-- The condition on a collection of charges `c` that it extends to an anomaly free `Quanta`.
+  That anomaly free `Quanta` is not tracked by this proposition. -/
+def IsAnomalyFree (c : Charges) : Prop :=
+  ∃ x ∈ Quanta.ofChargesExpand c, Quanta.AnomalyCancellation x.1 x.2.1 x.2.2.1 x.2.2.2
+
+instance {c} : Decidable (IsAnomalyFree c) := Multiset.decidableExistsMultiset
+
+
+set_option maxRecDepth 2000 in
+/-- The viable charges which are anomaly free. -/
+lemma viable_anomalyFree (I : CodimensionOneConfig) :
+   (viableCharges I).filter IsAnomalyFree =
+    (match I with
+    | .same => {(some 2, some (-2), {-1, 1}, {-1}), (some (-2), some 2, {-1, 1}, {1})}
+    | .nearestNeighbor => {(some 6, some (-14), {-9, 1}, {-7})}
+    | .nextToNearestNeighbor => ∅ ) := by
+  revert I
+  decide
+
+
+end Charges
+
+end SU5U1
+
+end FTheory

--- a/PhysLean/StringTheory/FTheory/SU5U1/Charges/AnomalyFree.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Charges/AnomalyFree.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.Basic
-import PhysLean.StringTheory.FTheory.SU5U1.Charges.Viable
 /-!
 
 # Anomaly cancellation
@@ -14,8 +13,6 @@ that the charges can be extended to quanta which are anomaly free.
 
 We give the viable charges which are anomaly free for each of the three codimension one
 configurations. This is in the lemma `viable_anomalyFree`.
-
-
 
 -/
 namespace FTheory
@@ -30,7 +27,6 @@ open CodimensionOneConfig
 open Tree
 open PhysLean
 
-
 /-!
 
 ## Anomaly coefficents of charges
@@ -44,18 +40,16 @@ def IsAnomalyFree (c : Charges) : Prop :=
 
 instance {c} : Decidable (IsAnomalyFree c) := Multiset.decidableExistsMultiset
 
-
 set_option maxRecDepth 2000 in
 /-- The viable charges which are anomaly free. -/
 lemma viable_anomalyFree (I : CodimensionOneConfig) :
-   (viableCharges I).filter IsAnomalyFree =
+    (viableCharges I).filter IsAnomalyFree =
     (match I with
     | .same => {(some 2, some (-2), {-1, 1}, {-1}), (some (-2), some 2, {-1, 1}, {1})}
     | .nearestNeighbor => {(some 6, some (-14), {-9, 1}, {-7})}
-    | .nextToNearestNeighbor => ∅ ) := by
+    | .nextToNearestNeighbor => ∅) := by
   revert I
   decide
-
 
 end Charges
 

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/AnomalyCancellation.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/AnomalyCancellation.lean
@@ -7,18 +7,9 @@ import PhysLean.StringTheory.FTheory.SU5U1.Quanta.FromParts
 import PhysLean.Particles.SuperSymmetry.SU5.Charges.MinimallyAllowsTerm.FinsetTerms
 /-!
 
-# Anomaly cancellation
+# Anomaly cancellation of trees
 
-There are two anomaly cancellation conditions in the SU(5)×U(1) model which involve the
-`U(1)` charges. These are
-
-- `∑ᵢ qᵢ Nᵢ + ∑ₐ qₐ Nₐ = 0` where the first sum is over all 5-bar represenations and the second
-  is over all 10d representations.
-- `∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0` where the first sum is over all 5-bar represenations and the
-  second is over all 10d representations.
-
-According to arXiv:1401.5084 it is unclear whether this second condition should necessarily be
-imposed.
+This module defines functions to impose the anomaly cancellation condition on a tree of charges.
 
 -/
 
@@ -30,60 +21,6 @@ variable {I : CodimensionOneConfig}
 
 /-!
 
-## Anomaly cancellation conditions
-
--/
-
-/-- The pair of anomaly cancellation coefficents associated with the `Hd` particle. -/
-def HdAnomalyCoefficent (qHd : Option ℤ) : ℤ × ℤ :=
-  match qHd with
-  | none => (0, 0)
-  | some qHd => (qHd, qHd ^ 2)
-
-/-- The pair of anomaly cancellation coefficents associated with the `Hu` particle. -/
-def HuAnomalyCoefficent (qHu : Option ℤ) : ℤ × ℤ :=
-  match qHu with
-  | none => (0, 0)
-  | some qHu => (-qHu, -qHu ^ 2)
-
-/-- The anomaly cancellation conditions on quanta making up the fields present in
-  the theory. This corresponds to the conditions that:
-
-- `∑ᵢ qᵢ Nᵢ + ∑ₐ qₐ Nₐ = 0` where the first sum is over all 5-bar represenations and the second
-  is over all 10d representations.
-- `∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0` where the first sum is over all 5-bar represenations and the
-  second is over all 10d representations.
--/
-def AnomalyCancellation (qHd qHu : Option ℤ) (F : FiveQuanta) (T : TenQuanta) : Prop :=
-  HdAnomalyCoefficent qHd + HuAnomalyCoefficent qHu + F.anomalyCoefficent +
-    T.anomalyCoefficent = (0, 0)
-
-instance : Decidable (AnomalyCancellation qHd qHu F T) :=
-  inferInstanceAs (Decidable ((HdAnomalyCoefficent qHd + HuAnomalyCoefficent qHu
-    + F.anomalyCoefficent + T.anomalyCoefficent) = (0, 0)))
-
-lemma anomalyCoefficent_snd_eq_zero_of_anomalyCancellation
-    {qHd qHu : Option ℤ} {F : FiveQuanta} {T : TenQuanta} (h : AnomalyCancellation qHd qHu F T) :
-    ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
-    + (F.anomalyCoefficent).2 + (T.anomalyCoefficent).2) = 0 := by
-  trans ((HdAnomalyCoefficent qHd)+ (HuAnomalyCoefficent qHu)
-    + (F.anomalyCoefficent) + (T.anomalyCoefficent)).2
-  · simp
-  rw [h]
-
-lemma five_anomalyCoefficent_mod_three_zero_of_anomalyCancellation
-    {qHd qHu : Option ℤ} {F : FiveQuanta} {T : TenQuanta} (h : AnomalyCancellation qHd qHu F T) :
-    ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
-    + (F.anomalyCoefficent).2) % 3 = 0 := by
-  trans ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
-    + (F.anomalyCoefficent).2 + (T.anomalyCoefficent).2) % 3
-  swap
-  · rw [anomalyCoefficent_snd_eq_zero_of_anomalyCancellation h]
-    simp
-  simp [TenQuanta.anomalyCoefficent]
-
-/-!
-
 ## Anomaly cancellation on charges tree
 
 -/
@@ -91,6 +28,7 @@ lemma five_anomalyCoefficent_mod_three_zero_of_anomalyCancellation
 namespace Charges
 namespace Tree
 open PhysLean FourTree
+open Quanta
 
 /-- Given charges `qHd` and `qHu` filters a twig of `Q5` and `Q10` charges
   by the anomaly cancellation condition. -/

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/Basic.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/Basic.lean
@@ -47,7 +47,7 @@ def toCharges (x : Quanta) : Charges :=
 -/
 
 /-- The reduce of `Quanta` is a new `Quanta` with all the fluxes corresponding to the same
-  charge (i.e. represenation) added together.-/
+  charge (i.e. represenation) added together. -/
 def reduce (x : Quanta) : Quanta :=
   (x.1, x.2.1, x.2.2.1.reduce, x.2.2.2.reduce)
 

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/Basic.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/Basic.lean
@@ -5,6 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.FiveQuanta
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.TenQuanta
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.Viable
 /-!
 
 # Quanta of representations
@@ -38,6 +39,102 @@ instance : DecidableEq Quanta := instDecidableEqProd
 /-- The underlying `Charges` of a `Quanta`. -/
 def toCharges (x : Quanta) : Charges :=
   (x.1, x.2.1, x.2.2.1.toCharges.toFinset, x.2.2.2.toCharges.toFinset)
+
+/-!
+
+## Reduce
+
+-/
+
+/-- The reduce of `Quanta` is a new `Quanta` with all the fluxes corresponding to the same
+  charge (i.e. represenation) added together.-/
+def reduce (x : Quanta) : Quanta :=
+  (x.1, x.2.1, x.2.2.1.reduce, x.2.2.2.reduce)
+
+/-!
+
+## Anomaly cancellation conditions
+
+There are two anomaly cancellation conditions in the SU(5)×U(1) model which involve the
+`U(1)` charges. These are
+
+- `∑ᵢ qᵢ Nᵢ + ∑ₐ qₐ Nₐ = 0` where the first sum is over all 5-bar represenations and the second
+  is over all 10d representations.
+- `∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0` where the first sum is over all 5-bar represenations and the
+  second is over all 10d representations.
+
+According to arXiv:1401.5084 it is unclear whether this second condition should necessarily be
+imposed.
+
+-/
+
+/-- The pair of anomaly cancellation coefficents associated with the `Hd` particle. -/
+def HdAnomalyCoefficent (qHd : Option ℤ) : ℤ × ℤ :=
+  match qHd with
+  | none => (0, 0)
+  | some qHd => (qHd, qHd ^ 2)
+
+/-- The pair of anomaly cancellation coefficents associated with the `Hu` particle. -/
+def HuAnomalyCoefficent (qHu : Option ℤ) : ℤ × ℤ :=
+  match qHu with
+  | none => (0, 0)
+  | some qHu => (-qHu, -qHu ^ 2)
+
+/-- The anomaly cancellation conditions on quanta making up the fields present in
+  the theory. This corresponds to the conditions that:
+
+- `∑ᵢ qᵢ Nᵢ + ∑ₐ qₐ Nₐ = 0` where the first sum is over all 5-bar represenations and the second
+  is over all 10d representations.
+- `∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0` where the first sum is over all 5-bar represenations and the
+  second is over all 10d representations.
+-/
+def AnomalyCancellation (qHd qHu : Option ℤ) (F : FiveQuanta) (T : TenQuanta) : Prop :=
+  HdAnomalyCoefficent qHd + HuAnomalyCoefficent qHu + F.anomalyCoefficent +
+    T.anomalyCoefficent = (0, 0)
+
+instance : Decidable (AnomalyCancellation qHd qHu F T) :=
+  inferInstanceAs (Decidable ((HdAnomalyCoefficent qHd + HuAnomalyCoefficent qHu
+    + F.anomalyCoefficent + T.anomalyCoefficent) = (0, 0)))
+
+lemma anomalyCoefficent_snd_eq_zero_of_anomalyCancellation
+    {qHd qHu : Option ℤ} {F : FiveQuanta} {T : TenQuanta} (h : AnomalyCancellation qHd qHu F T) :
+    ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
+    + (F.anomalyCoefficent).2 + (T.anomalyCoefficent).2) = 0 := by
+  trans ((HdAnomalyCoefficent qHd)+ (HuAnomalyCoefficent qHu)
+    + (F.anomalyCoefficent) + (T.anomalyCoefficent)).2
+  · simp
+  rw [h]
+
+lemma five_anomalyCoefficent_mod_three_zero_of_anomalyCancellation
+    {qHd qHu : Option ℤ} {F : FiveQuanta} {T : TenQuanta} (h : AnomalyCancellation qHd qHu F T) :
+    ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
+    + (F.anomalyCoefficent).2) % 3 = 0 := by
+  trans ((HdAnomalyCoefficent qHd).2 + (HuAnomalyCoefficent qHu).2
+    + (F.anomalyCoefficent).2 + (T.anomalyCoefficent).2) % 3
+  swap
+  · rw [anomalyCoefficent_snd_eq_zero_of_anomalyCancellation h]
+    simp
+  simp [TenQuanta.anomalyCoefficent]
+
+/-!
+
+## ofChargesExpand
+
+-/
+
+/-- Given a finite set of charges `c` the `Quanta`
+  with fluxes `{(1, -1), (1, -1), (1, -1), (0, 1), (0, 1), (0, 1)}`
+  for the 5-bar matter content and fluxes
+  `{(1, 0), (1, 0), (1, 0)}` or `{(1, 1), (1, -1), (1, 0)}` for the
+  10d matter content, and finite set of charges equal to `c`.
+
+  These quanta reduce to all viable quanta. -/
+def ofChargesExpand (c : Charges) : Multiset Quanta :=
+  let Q5s := FiveQuanta.ofChargesExpand c.2.2.1
+  let Q10s := TenQuanta.ofChargesExpand c.2.2.2
+  Q5s.bind <| fun Q5 =>
+  Q10s.map <| fun Q10 =>
+    (c.1, c.2.1, Q5, Q10)
 
 end Quanta
 

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/FiveQuanta.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/FiveQuanta.lean
@@ -202,14 +202,14 @@ lemma reduce_eq_self_of_ofCharges_nodup (x : FiveQuanta) (h : x.toCharges.Nodup)
   conv_rhs => rw [← Multiset.map_id x]
   apply Multiset.map_congr rfl
   intro p hp
-  simp
+  simp only [id_eq]
   have x_noDup : x.Nodup := Multiset.Nodup.of_map Prod.fst h
   suffices (Multiset.filter (fun f => f.1 = p.1) x) = {p} by simp [this]
   refine (Multiset.Nodup.ext ?_ ?_).mpr ?_
   · exact Multiset.Nodup.filter (fun f => f.1 = p.1) x_noDup
   · exact Multiset.nodup_singleton p
   intro p'
-  simp
+  simp only [Multiset.mem_filter, Multiset.mem_singleton]
   constructor
   · rintro ⟨h1, h2⟩
     simp [toCharges] at h
@@ -220,7 +220,6 @@ lemma reduce_eq_self_of_ofCharges_nodup (x : FiveQuanta) (h : x.toCharges.Nodup)
     · exact h2
   · rintro ⟨rfl⟩
     simp_all
-
 
 /-!
 

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/FiveQuanta.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/FiveQuanta.lean
@@ -30,7 +30,7 @@ properties thereof.
 ## Key theorems
 
 - `mem_ofChargesExpand_map_reduce_iff` states that a `FiveQuanta` is in the
-  image of  `ofChargesExpand c` under `reduce` if and only if it is a `FiveQuanta` with
+  image of `ofChargesExpand c` under `reduce` if and only if it is a `FiveQuanta` with
   charges equal to `c` and fluxes which have no exotics or zero.
 -/
 namespace FTheory
@@ -194,6 +194,34 @@ lemma reduce_sum_eq_sum_toCharges {M} [AddCommMonoid M] (x : FiveQuanta) (f : �
           · simp_all
           · simp_all
 
+lemma reduce_eq_self_of_ofCharges_nodup (x : FiveQuanta) (h : x.toCharges.Nodup) :
+    x.reduce = x := by
+  rw [reduce]
+  rw [Multiset.Nodup.dedup h]
+  simp [toCharges]
+  conv_rhs => rw [← Multiset.map_id x]
+  apply Multiset.map_congr rfl
+  intro p hp
+  simp
+  have x_noDup : x.Nodup := Multiset.Nodup.of_map Prod.fst h
+  suffices (Multiset.filter (fun f => f.1 = p.1) x) = {p} by simp [this]
+  refine (Multiset.Nodup.ext ?_ ?_).mpr ?_
+  · exact Multiset.Nodup.filter (fun f => f.1 = p.1) x_noDup
+  · exact Multiset.nodup_singleton p
+  intro p'
+  simp
+  constructor
+  · rintro ⟨h1, h2⟩
+    simp [toCharges] at h
+    rw [propext (Multiset.nodup_map_iff_inj_on x_noDup)] at h
+    apply h
+    · exact h1
+    · exact hp
+    · exact h2
+  · rintro ⟨rfl⟩
+    simp_all
+
+
 /-!
 
 ## Anomaly cancellation
@@ -242,7 +270,7 @@ open SuperSymmetry.SU5.Charges
 
 /-- Given a finite set of charges `c` the `FiveQuanta`
   with fluxes `{(1, -1), (1, -1), (1, -1), (0, 1), (0, 1), (0, 1)}`
-  and finite set of charges equal to `c`.  -/
+  and finite set of charges equal to `c`. -/
 def ofChargesExpand (c : Finset ℤ) : Multiset FiveQuanta :=
   /- The multisets of cardinality 3 containing 3 elements of `c`. -/
   let S53 : Multiset (Multiset ℤ) := toMultisetsThree c
@@ -929,4 +957,3 @@ end FiveQuanta
 end SU5U1
 
 end FTheory
-#lint

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/IsViable/Yukawa.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/IsViable/Yukawa.lean
@@ -1,0 +1,322 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.StringTheory.FTheory.SU5U1.Quanta.AnomalyCancellation
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.PhenoConstrained.Completeness
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.Viable
+import PhysLean.StringTheory.FTheory.SU5U1.Charges.AnomalyFree
+/-!
+
+# Viable Quanta with Yukawa
+
+We say a term of a type `Quanta` is viable for a given `I : CodimensionOneConfig`,
+  if it satisfies the following properties:
+- It has a `Hd`, `Hu` and at leat one matter particle in the 5 and 10 representation.
+- It has no exotic chiral particles.
+- It leads to a top Yukawa coupling.
+- It does not lead to a pheno constraining terms.
+- It satisfies anomaly cancellation.
+- The charges are allowed by the `I` configuration.
+
+This somes with one caveat, the `IsViable` constraint enforces the anomaly cancellation condition:
+`∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0`
+to hold, which is not always necessary, see arXiv:1401.5084.
+
+-/
+namespace FTheory
+
+namespace SU5U1
+
+variable {I : CodimensionOneConfig}
+
+namespace Quanta
+open SuperSymmetry.SU5
+open PotentialTerm Charges
+
+/-- For a given `I : CodimensionOneConfig` the condition on a `Quanta` for it to be
+  phenomenologically viable. -/
+def IsViableYukawa (I : CodimensionOneConfig) (x : Quanta) : Prop :=
+  x.toCharges.IsComplete ∧
+  ¬ x.toCharges.IsPhenoConstrained ∧
+  ¬ x.toCharges.YukawaGeneratesDangerousAtLevel 1 ∧
+  AllowsTerm x.toCharges topYukawa ∧
+  x.2.2.1.toFluxesFive.NoExotics ∧
+  x.2.2.1.toFluxesFive.HasNoZero ∧
+  x.2.2.2.toFluxesTen.NoExotics ∧
+  x.2.2.2.toFluxesTen.HasNoZero ∧
+  AnomalyCancellation x.1 x.2.1 x.2.2.1 x.2.2.2 ∧
+  x.toCharges ∈ ofFinset I.allowedBarFiveCharges I.allowedTenCharges ∧
+  x.2.2.1.toCharges.Nodup ∧
+  x.2.2.2.toCharges.Nodup
+
+lemma isViableYukawa_iff_expand_ofFinset (I : CodimensionOneConfig) (x : Quanta) :
+    IsViableYukawa I x ↔
+      x.toCharges.IsComplete ∧
+  ¬ x.toCharges.IsPhenoConstrained ∧
+  ¬ x.toCharges.YukawaGeneratesDangerousAtLevel 1 ∧
+  AllowsTerm x.toCharges topYukawa ∧
+  x.2.2.1.toFluxesFive.NoExotics ∧
+  x.2.2.1.toFluxesFive.HasNoZero ∧
+  x.2.2.2.toFluxesTen.NoExotics ∧
+  x.2.2.2.toFluxesTen.HasNoZero ∧
+  AnomalyCancellation x.1 x.2.1 x.2.2.1 x.2.2.2 ∧
+  (x.1.toFinset ⊆ I.allowedBarFiveCharges ∧ x.2.1.toFinset ⊆ I.allowedBarFiveCharges ∧
+      x.toCharges.2.2.1 ⊆ I.allowedBarFiveCharges ∧ x.toCharges.2.2.2 ⊆ I.allowedTenCharges)
+      ∧
+    x.2.2.1.toCharges.Nodup ∧
+    x.2.2.2.toCharges.Nodup := by
+  rw [IsViableYukawa, Charges.mem_ofFinset_iff]
+  simp [toCharges]
+
+instance (I : CodimensionOneConfig) (x : Quanta) : Decidable (IsViableYukawa I x) :=
+  decidable_of_iff _ (isViableYukawa_iff_expand_ofFinset I x).symm
+
+/-!
+
+## Basic properties of charges satisfying `IsViableYukawa`
+
+-/
+
+lemma toCharges_five_nodup_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.1.toCharges.Nodup := h.2.2.2.2.2.2.2.2.2.2.1
+
+lemma toCharges_ten_nodup_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.2.toCharges.Nodup := h.2.2.2.2.2.2.2.2.2.2.2
+
+lemma toCharges_mem_ofFinset_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.toCharges ∈ ofFinset I.allowedBarFiveCharges I.allowedTenCharges :=
+  h.2.2.2.2.2.2.2.2.2.1
+
+lemma toFluxesFive_noExotics_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.1.toFluxesFive.NoExotics := h.2.2.2.2.1
+
+lemma toFluxesTen_noExotics_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.2.toFluxesTen.NoExotics := h.2.2.2.2.2.2.1
+
+lemma toFluxesFive_hasNoZero_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.1.toFluxesFive.HasNoZero := h.2.2.2.2.2.1
+
+lemma toFluxesTen_hasNoZero_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.2.toFluxesTen.HasNoZero := h.2.2.2.2.2.2.2.1
+
+lemma Q10_charges_mem_allowedBarTenCharges_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    ∀ s ∈ x.2.2.2.toCharges, s ∈ I.allowedTenCharges := by
+  have h1 := toCharges_mem_ofFinset_of_isViableYukawa I x h
+  rw [Charges.mem_ofFinset_iff] at h1
+  have h2 := h1.2.2.2
+  intro y hy
+  apply h2
+  simp [toCharges]
+  exact hy
+
+lemma Q5_charges_mem_allowedBarFiveCharges_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    ∀ s ∈ x.2.2.1.toCharges, s ∈ I.allowedBarFiveCharges := by
+  have h1 := toCharges_mem_ofFinset_of_isViableYukawa I x h
+  rw [Charges.mem_ofFinset_iff] at h1
+  have h2 := h1.2.2.1
+  intro y hy
+  apply h2
+  simp [toCharges]
+  exact hy
+
+lemma fiveQuanta_mem_ofCharges_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.1 ∈ FiveQuanta.ofCharges I x.2.2.1.toCharges := by
+  rw [FiveQuanta.mem_ofCharges_iff]
+  · simp
+    constructor
+    · exact toFluxesFive_noExotics_of_isViableYukawa I x h
+    · exact toFluxesFive_hasNoZero_of_isViableYukawa I x h
+  · exact fun s a => Q5_charges_mem_allowedBarFiveCharges_of_isViableYukawa I x h s a
+
+lemma tenQuanta_mem_ofCharges_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.2 ∈ TenQuanta.ofCharges I x.2.2.2.toCharges := by
+  rw [TenQuanta.mem_ofCharges_iff]
+  · simp
+    constructor
+    · exact toFluxesTen_noExotics_of_isViableYukawa I x h
+    · exact toFluxesTen_hasNoZero_of_isViableYukawa I x h
+  · exact fun s a => Q10_charges_mem_allowedBarTenCharges_of_isViableYukawa I x h s a
+
+lemma topYukawa_allowsTerm_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    AllowsTerm x.toCharges topYukawa := by
+  exact h.2.2.2.1
+
+lemma not_isPhenoConstrained_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    ¬ x.toCharges.IsPhenoConstrained := by
+  exact h.2.1
+
+lemma toCharges_isComplete_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.toCharges.IsComplete := by
+  exact h.1
+
+lemma anomalyCancellation_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    AnomalyCancellation x.1 x.2.1 x.2.2.1 x.2.2.2 := by
+  exact h.2.2.2.2.2.2.2.2.1
+
+lemma reduce_five_eq_self_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.1.reduce = x.2.2.1 := by
+  match x with
+  | (qHd, qHu, F, T) =>
+    simp [reduce]
+    refine FiveQuanta.reduce_eq_self_of_ofCharges_nodup F ?_
+    simp [IsViableYukawa] at h
+    simp_all
+
+lemma reduce_ten_eq_self_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.2.2.2.reduce = x.2.2.2 := by
+  match x with
+  | (qHd, qHu, F, T) =>
+    simp [reduce]
+    refine TenQuanta.reduce_eq_self_of_ofCharges_nodup T ?_
+    simp [IsViableYukawa] at h
+    simp_all
+
+lemma reduce_eq_self_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.reduce = x := by
+  match x with
+  | (qHd, qHu, F, T) =>
+    simp [reduce]
+    constructor
+    · exact reduce_five_eq_self_of_isViableYukawa I _ h
+    · exact reduce_ten_eq_self_of_isViableYukawa I _ h
+
+lemma mem_ofChargesExpand_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x ∈ (ofChargesExpand x.toCharges).map reduce := by
+  simp [ofChargesExpand]
+  have h_five : x.2.2.1 ∈ (FiveQuanta.ofChargesExpand x.2.2.1.toCharges.toFinset).map
+      FiveQuanta.reduce := by
+    refine (FiveQuanta.mem_ofChargesExpand_map_reduce_iff x.2.2.1.toCharges.toFinset x.2.2.1).mpr ?_
+    · refine ⟨?_, rfl, ?_⟩
+      · rw [← SU5.FluxesFive.noExotics_iff_mem_elemsNoExotics]
+        refine ⟨?_, ?_⟩
+        · exact toFluxesFive_noExotics_of_isViableYukawa I x h
+        · exact toFluxesFive_hasNoZero_of_isViableYukawa I x h
+      · exact reduce_five_eq_self_of_isViableYukawa I x h
+  have h_ten : x.2.2.2 ∈ (TenQuanta.ofChargesExpand x.2.2.2.toCharges.toFinset).map
+      TenQuanta.reduce := by
+    refine (TenQuanta.mem_ofChargesExpand_map_reduce_iff x.2.2.2.toCharges.toFinset x.2.2.2).mpr ?_
+    · refine ⟨?_, rfl, ?_⟩
+      · rw [← SU5.FluxesTen.noExotics_iff_mem_elemsNoExotics]
+        refine ⟨?_, ?_⟩
+        · exact toFluxesTen_noExotics_of_isViableYukawa I x h
+        · exact toFluxesTen_hasNoZero_of_isViableYukawa I x h
+      · exact reduce_ten_eq_self_of_isViableYukawa I x h
+  rw [Multiset.mem_map] at h_five h_ten
+  obtain ⟨F, F_mem, hF⟩ := h_five
+  obtain ⟨T, T_mem, hT⟩ := h_ten
+  refine ⟨F, ⟨F_mem, ⟨T, ⟨T_mem, ?_⟩⟩⟩⟩
+  simp_all [reduce, toCharges]
+
+lemma toCharges_isAnomalyFree_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    IsAnomalyFree x.toCharges := by
+  simp only [IsAnomalyFree]
+  have h1 := mem_ofChargesExpand_of_isViableYukawa I x h
+  rw [Multiset.mem_map] at h1
+  obtain ⟨y, y_mem, rfl⟩ := h1
+  use y
+  refine ⟨?_, ?_⟩
+  · exact y_mem
+  · have acc := anomalyCancellation_of_isViableYukawa I _ h
+    simp only [AnomalyCancellation, reduce] at acc
+    rw [FiveQuanta.anomalyCoefficent_of_reduce, TenQuanta.anomalyCoefficent_of_reduce] at acc
+    simp [AnomalyCancellation]
+    rw [← acc]
+
+lemma toCharges_mem_viableCharges_filter_isAnomalyFree_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x.toCharges ∈ (viableCharges I).filter IsAnomalyFree := by
+  simp
+  apply And.intro
+  · refine (mem_viableCharges_iff ?_).mpr ⟨?_, ?_, ?_, ?_⟩
+    · exact toCharges_mem_ofFinset_of_isViableYukawa I x h
+    · exact topYukawa_allowsTerm_of_isViableYukawa I x h
+    · exact not_isPhenoConstrained_of_isViableYukawa I x h
+    · exact h.2.2.1
+    · exact toCharges_isComplete_of_isViableYukawa I x h
+  · exact toCharges_isAnomalyFree_of_isViableYukawa I x h
+
+/-!
+
+## viableYukawaElems
+-/
+
+def viableYukawaElems : CodimensionOneConfig → Multiset Quanta
+  | .same => {(some 2, some (-2), {(-1, 1, 2), (1, 2, -2)}, {(-1, 3, 0)}),
+      (some 2, some (-2), {(-1, 0, 2), (1, 3, -2)}, {(-1, 3, 0)}),
+      (some (-2), some 2, {(-1, 2, -2), (1, 1, 2)}, {(1, 3, 0)}),
+      (some (-2), some 2, {(-1, 3, -2), (1, 0, 2)}, {(1, 3, 0)})}
+  | .nearestNeighbor => {(some 6, some (-14), {(-9, 1, 2), (1, 2, -2)}, {(-7, 3, 0)}),
+    (some 6, some (-14), {(-9, 0, 2), (1, 3, -2)}, {(-7, 3, 0)})}
+  | .nextToNearestNeighbor => {}
+
+lemma isViableYukawa_of_mem_viableYukawaElems
+    (I : CodimensionOneConfig) (x : Quanta) (h : x ∈ viableYukawaElems I) :
+    IsViableYukawa I x := by
+ revert x I
+ decide
+
+
+lemma viableYukawaElems_card_eq (I : CodimensionOneConfig) :
+    (viableYukawaElems I).card = match I with
+    | .same => 4
+    | .nearestNeighbor => 2
+    | .nextToNearestNeighbor => 0 := by
+  cases I <;> rfl
+
+lemma mem_viableYukawaElems_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    x ∈ viableYukawaElems I  := by
+  have hx := mem_ofChargesExpand_of_isViableYukawa I x h
+  have hc := toCharges_mem_viableCharges_filter_isAnomalyFree_of_isViableYukawa I x h
+  rw [viable_anomalyFree] at hc
+  generalize x.toCharges = c at hc hx
+  fin_cases I
+  all_goals
+  · dsimp at hc
+    fin_cases hc
+    all_goals
+    · revert h
+      revert x
+      decide
+
+lemma isViableYukawa_iff_mem_viableYukawaElems
+    (I : CodimensionOneConfig) (x : Quanta) :
+    IsViableYukawa I x ↔ x ∈ viableYukawaElems I := by
+  constructor
+  · exact mem_viableYukawaElems_of_isViableYukawa I x
+  · exact isViableYukawa_of_mem_viableYukawaElems I x
+
+lemma yukawaSingletsRegenerateDangerousInsertion_two_of_isViableYukawa
+    (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
+    (toCharges x).YukawaGeneratesDangerousAtLevel 2 := by
+  rw [isViableYukawa_iff_mem_viableYukawaElems] at h
+  revert I x
+  decide
+
+end Quanta
+
+end SU5U1
+
+end FTheory

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/IsViable/Yukawa.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/IsViable/Yukawa.lean
@@ -5,7 +5,6 @@ Authors: Joseph Tooby-Smith
 -/
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.AnomalyCancellation
 import PhysLean.StringTheory.FTheory.SU5U1.Charges.PhenoConstrained.Completeness
-import PhysLean.StringTheory.FTheory.SU5U1.Charges.Viable
 import PhysLean.StringTheory.FTheory.SU5U1.Charges.AnomalyFree
 /-!
 
@@ -17,10 +16,12 @@ We say a term of a type `Quanta` is viable for a given `I : CodimensionOneConfig
 - It has no exotic chiral particles.
 - It leads to a top Yukawa coupling.
 - It does not lead to a pheno constraining terms.
+- It does not lead to a dangerous Yukawa coupling at one insertion of the Yukawa singlets.
 - It satisfies anomaly cancellation.
 - The charges are allowed by the `I` configuration.
 
-This somes with one caveat, the `IsViable` constraint enforces the anomaly cancellation condition:
+This somes with one caveat, the `IsViableYukawa` constraint enforces the anomaly
+  cancellation condition:
 `∑ᵢ qᵢ² Nᵢ + 3 * ∑ₐ qₐ² Nₐ = 0`
 to hold, which is not always necessary, see arXiv:1401.5084.
 
@@ -247,7 +248,7 @@ lemma toCharges_isAnomalyFree_of_isViableYukawa
 lemma toCharges_mem_viableCharges_filter_isAnomalyFree_of_isViableYukawa
     (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
     x.toCharges ∈ (viableCharges I).filter IsAnomalyFree := by
-  simp
+  simp only [Multiset.mem_filter]
   apply And.intro
   · refine (mem_viableCharges_iff ?_).mpr ⟨?_, ?_, ?_, ?_⟩
     · exact toCharges_mem_ofFinset_of_isViableYukawa I x h
@@ -262,6 +263,7 @@ lemma toCharges_mem_viableCharges_filter_isAnomalyFree_of_isViableYukawa
 ## viableYukawaElems
 -/
 
+/-- Given a `CodimensionOneConfig` the `Quanta` which statisfy the condition `IsViableYukawa`. -/
 def viableYukawaElems : CodimensionOneConfig → Multiset Quanta
   | .same => {(some 2, some (-2), {(-1, 1, 2), (1, 2, -2)}, {(-1, 3, 0)}),
       (some 2, some (-2), {(-1, 0, 2), (1, 3, -2)}, {(-1, 3, 0)}),
@@ -274,9 +276,8 @@ def viableYukawaElems : CodimensionOneConfig → Multiset Quanta
 lemma isViableYukawa_of_mem_viableYukawaElems
     (I : CodimensionOneConfig) (x : Quanta) (h : x ∈ viableYukawaElems I) :
     IsViableYukawa I x := by
- revert x I
- decide
-
+  revert x I
+  decide
 
 lemma viableYukawaElems_card_eq (I : CodimensionOneConfig) :
     (viableYukawaElems I).card = match I with
@@ -287,7 +288,7 @@ lemma viableYukawaElems_card_eq (I : CodimensionOneConfig) :
 
 lemma mem_viableYukawaElems_of_isViableYukawa
     (I : CodimensionOneConfig) (x : Quanta) (h : IsViableYukawa I x) :
-    x ∈ viableYukawaElems I  := by
+    x ∈ viableYukawaElems I := by
   have hx := mem_ofChargesExpand_of_isViableYukawa I x h
   have hc := toCharges_mem_viableCharges_filter_isAnomalyFree_of_isViableYukawa I x h
   rw [viable_anomalyFree] at hc

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/TenQuanta.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/TenQuanta.lean
@@ -30,7 +30,7 @@ properties thereof.
 ## Key theorems
 
 - `mem_ofChargesExpand_map_reduce_iff` states that a `TenQuanta` is in the
-  image of  `ofChargesExpand c` under `reduce` if and only if it is a `TenQuanta` with
+  image of `ofChargesExpand c` under `reduce` if and only if it is a `TenQuanta` with
   charges equal to `c` and fluxes which have no exotics or zero.
 -/
 namespace FTheory
@@ -194,6 +194,34 @@ lemma reduce_sum_eq_sum_toCharges {M} [AddCommMonoid M] (x : TenQuanta) (f : ℤ
           · simp_all
           · simp_all
 
+
+lemma reduce_eq_self_of_ofCharges_nodup (x : TenQuanta) (h : x.toCharges.Nodup) :
+    x.reduce = x := by
+  rw [reduce]
+  rw [Multiset.Nodup.dedup h]
+  simp [toCharges]
+  conv_rhs => rw [← Multiset.map_id x]
+  apply Multiset.map_congr rfl
+  intro p hp
+  simp
+  have x_noDup : x.Nodup := Multiset.Nodup.of_map Prod.fst h
+  suffices (Multiset.filter (fun f => f.1 = p.1) x) = {p} by simp [this]
+  refine (Multiset.Nodup.ext ?_ ?_).mpr ?_
+  · exact Multiset.Nodup.filter (fun f => f.1 = p.1) x_noDup
+  · exact Multiset.nodup_singleton p
+  intro p'
+  simp
+  constructor
+  · rintro ⟨h1, h2⟩
+    simp [toCharges] at h
+    rw [propext (Multiset.nodup_map_iff_inj_on x_noDup)] at h
+    apply h
+    · exact h1
+    · exact hp
+    · exact h2
+  · rintro ⟨rfl⟩
+    simp_all
+
 /-!
 ## Anomaly cancellation
 
@@ -240,7 +268,7 @@ open SuperSymmetry.SU5.Charges
 
 /-- Given a finite set of charges `c` the `TenQuanta`
   with fluxes `{(1, 0), (1, 0), (1, 0)}` and `{(1, 1), (1, -1), (1, 0)}`
-  and finite set of charges equal to `c`.  -/
+  and finite set of charges equal to `c`. -/
 def ofChargesExpand (c : Finset ℤ) : Multiset TenQuanta :=
   /- The {(1, 0), (1, 0), (1, 0)} case. -/
   /- The multisets of cardinality 3 containing 3 elements of `c`. -/

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/TenQuanta.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/TenQuanta.lean
@@ -194,7 +194,6 @@ lemma reduce_sum_eq_sum_toCharges {M} [AddCommMonoid M] (x : TenQuanta) (f : ℤ
           · simp_all
           · simp_all
 
-
 lemma reduce_eq_self_of_ofCharges_nodup (x : TenQuanta) (h : x.toCharges.Nodup) :
     x.reduce = x := by
   rw [reduce]
@@ -203,14 +202,14 @@ lemma reduce_eq_self_of_ofCharges_nodup (x : TenQuanta) (h : x.toCharges.Nodup) 
   conv_rhs => rw [← Multiset.map_id x]
   apply Multiset.map_congr rfl
   intro p hp
-  simp
+  simp only [id_eq]
   have x_noDup : x.Nodup := Multiset.Nodup.of_map Prod.fst h
   suffices (Multiset.filter (fun f => f.1 = p.1) x) = {p} by simp [this]
   refine (Multiset.Nodup.ext ?_ ?_).mpr ?_
   · exact Multiset.Nodup.filter (fun f => f.1 = p.1) x_noDup
   · exact Multiset.nodup_singleton p
   intro p'
-  simp
+  simp only [Multiset.mem_filter, Multiset.mem_singleton]
   constructor
   · rintro ⟨h1, h2⟩
     simp [toCharges] at h
@@ -223,6 +222,7 @@ lemma reduce_eq_self_of_ofCharges_nodup (x : TenQuanta) (h : x.toCharges.Nodup) 
     simp_all
 
 /-!
+
 ## Anomaly cancellation
 
 -/

--- a/PhysLean/StringTheory/FTheory/SU5U1/Quanta/YukawaRegeneration.lean
+++ b/PhysLean/StringTheory/FTheory/SU5U1/Quanta/YukawaRegeneration.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.StringTheory.FTheory.SU5U1.Quanta.IsViable.Elems
-import PhysLean.Particles.SuperSymmetry.SU5.Charges.Yukawa
 /-!
 
 # Generation of Yukawa couplings


### PR DESCRIPTION
Adding viable quanta in an SU(5)+U(1) theory which do not regenerate dangerous couplings with Yukawa terms. This PR is part of collection based on refactoring and speeding up this part of PhysLean.