### PR TITLE
feat(CanonicalEnsemble):add differentialEntropy and properties of partitionFunction and entropy

### DIFF
--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Matteo Cipollina, Joseph Tooby-Smith
+Authors: Joseph Tooby-Smith
 -/
 import PhysLean.Thermodynamics.Temperature.Basic
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
@@ -355,11 +355,6 @@ lemma paritionFunction_eq_zero_iff (T : Temperature) [IsFiniteMeasure (𝓒.μBo
 
 open NNReal Constants
 
-lemma partitionFunction_comp_ofβ_apply (β : ℝ≥0) :
-    𝓒.partitionFunction (ofβ β) =
-    (𝓒.μ.withDensity (fun i => ENNReal.ofReal (exp (- β * 𝓒.energy i)))).real Set.univ := by
-  simp only [partitionFunction, μBolt, β_ofβ, neg_mul]
-
 /-!
 
 ## The probability measure
@@ -603,7 +598,7 @@ lemma probability_pos
   have hZpos := partitionFunction_pos (𝓒:=𝓒) (T:=T)
   simp [probability, div_pos, Real.exp_pos, hZpos]
 
-/- A general normalisation statement (integral of the probability density = 1)
+/- TODO: A general normalisation statement (integral of the probability density = 1)
 is already encoded via `μProd` being a probability measure; the finite sum
 version lives in `Finite` : `sum_probability_eq_one`. -/
 

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -590,9 +590,6 @@ lemma meanEnergy_nsmul (n : ℕ) (T : Temperature)
 noncomputable def differentialEntropy (T : Temperature) : ℝ :=
   - kB * ∫ i, log (probability 𝓒 T i) ∂𝓒.μProd T
 
---@[deprecated differentialEntropy (since := "2025-08-22")]
---noncomputable def entropy (T : Temperature) : ℝ := differentialEntropy (𝓒:=𝓒) T
-
 /-- Probabilities are non-negative,
 assuming a positive partition function. -/
 lemma probability_nonneg
@@ -607,10 +604,6 @@ lemma probability_pos
     0 < 𝓒.probability T i := by
   have hZpos := partitionFunction_pos (𝓒:=𝓒) (T:=T)
   simp [probability, div_pos, Real.exp_pos, hZpos]
-
-/- TODO: A general normalisation statement (integral of the probability density = 1)
-is already encoded via `μProd` being a probability measure; the finite sum
-version lives in `Finite` : `sum_probability_eq_one`. -/
 
 /-- General entropy non-negativity under a pointwise upper bound `probability ≤ 1`.
 This assumption holds automatically in the finite/counting case (since sums bound each term),

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith
+Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 import PhysLean.Thermodynamics.Temperature.Basic
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -208,7 +208,7 @@ lemma entropy_nonneg [IsFinite 𝓒] [Nonempty ι] (T : Temperature) :
       Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T) := by
     classical
     simp [μProd_of_fintype, probability]
-  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt 
+  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt
     (probability_le_one (𝓒:=𝓒) (T:=T))
 
 end CanonicalEnsemble

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith, Matteo Cipollina
+Authors: Matteo Cipollina, Joseph Tooby-Smith
 -/
 import PhysLean.StatisticalMechanics.CanonicalEnsemble.Basic
 /-!

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -16,7 +16,7 @@ probability of being in a given microstate, the mean energy, the entropy and
 the Helmholtz free energy.
 
 We also define the addition of two canonical ensembles, and prove results related
-to the properties of additions of canonical ensembles and of entropy.
+to the properties of additions of canonical ensembles.
 
 ## References
 
@@ -97,6 +97,24 @@ instance [IsFinite 𝓒] : IsFiniteMeasure (𝓒.μ) := by
   rw [IsFinite.μ_eq_count]
   infer_instance
 
+/-- In the finite (counting) case a nonempty index type gives a nonzero measure. -/
+instance [IsFinite 𝓒] [Nonempty ι] : NeZero 𝓒.μ := by
+  classical
+  refine ⟨?_⟩
+  intro hμ
+  obtain ⟨i₀⟩ := (inferInstance : Nonempty ι)
+  have hzero : 𝓒.μ {i₀} = 0 := by simp [hμ]
+  have hone : 𝓒.μ {i₀} = 1 := by
+    simp [IsFinite.μ_eq_count (𝓒:=𝓒)]
+  simp_all only [Measure.coe_zero, Pi.zero_apply, zero_ne_one]
+
+noncomputable def entropy (T : Temperature) : ℝ :=
+  𝓒.differentialEntropy T
+
+omit [Fintype ι] [MeasurableSingletonClass ι] in
+@[simp] lemma entropy_eq_differentialEntropy (T : Temperature) :
+    𝓒.entropy T = 𝓒.differentialEntropy T := rfl
+
 lemma partitionFunction_of_fintype [IsFinite 𝓒] (T : Temperature) :
     𝓒.partitionFunction T = ∑ i, exp (- β T * 𝓒.energy i) := by
   rw [partitionFunction_eq_integral]
@@ -139,11 +157,10 @@ open Constants
 
 lemma entropy_of_fintype [IsFinite 𝓒] (T : Temperature) :
     𝓒.entropy T = - kB * ∑ i, 𝓒.probability T i * log (𝓒.probability T i) := by
-  simp [entropy]
+  simp [entropy, differentialEntropy]
   rw [MeasureTheory.integral_fintype]
   simp [mul_comm]
   exact Integrable.of_finite
-
 
 lemma probability_le_one [IsFinite 𝓒] [Nonempty ι] (T : Temperature) (i : ι) :
     𝓒.probability T i ≤ 1 := by
@@ -191,6 +208,6 @@ lemma entropy_nonneg [IsFinite 𝓒] [Nonempty ι] (T : Temperature) :
       Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T) := by
     classical
     simp [μProd_of_fintype, probability]
-  refine entropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt (probability_le_one (𝓒:=𝓒) (T:=T))
+  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt (probability_le_one (𝓒:=𝓒) (T:=T))
 
 end CanonicalEnsemble

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -103,11 +103,12 @@ instance [IsFinite 𝓒] [Nonempty ι] : NeZero 𝓒.μ := by
   refine ⟨?_⟩
   intro hμ
   obtain ⟨i₀⟩ := (inferInstance : Nonempty ι)
-  have hzero : 𝓒.μ {i₀} = 0 := by simp [hμ]
   have hone : 𝓒.μ {i₀} = 1 := by
     simp [IsFinite.μ_eq_count (𝓒:=𝓒)]
   simp_all only [Measure.coe_zero, Pi.zero_apply, zero_ne_one]
 
+/--
+Entropy of the finite canonical ensemble (Shannon entropy). -/
 noncomputable def entropy (T : Temperature) : ℝ :=
   𝓒.differentialEntropy T
 
@@ -208,7 +209,6 @@ lemma entropy_nonneg [IsFinite 𝓒] [Nonempty ι] (T : Temperature) :
       Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T) := by
     classical
     simp [μProd_of_fintype, probability]
-  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt
-    (probability_le_one (𝓒:=𝓒) (T:=T))
+  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt (probability_le_one (𝓒:=𝓒) (T:=T))
 
 end CanonicalEnsemble

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -209,6 +209,7 @@ lemma entropy_nonneg [IsFinite 𝓒] [Nonempty ι] (T : Temperature) :
       Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T) := by
     classical
     simp [μProd_of_fintype, probability]
-  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt (probability_le_one (𝓒:=𝓒) (T:=T))
+  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt
+    (probability_le_one (𝓒:=𝓒) (T:=T))
 
 end CanonicalEnsemble

--- a/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
+++ b/PhysLean/StatisticalMechanics/CanonicalEnsemble/Finite.lean
@@ -208,6 +208,7 @@ lemma entropy_nonneg [IsFinite 𝓒] [Nonempty ι] (T : Temperature) :
       Integrable (fun i => Real.log (𝓒.probability T i)) (𝓒.μProd T) := by
     classical
     simp [μProd_of_fintype, probability]
-  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt (probability_le_one (𝓒:=𝓒) (T:=T))
+  refine differentialEntropy_nonneg_of_prob_le_one (𝓒:=𝓒) (T:=T) hInt 
+    (probability_le_one (𝓒:=𝓒) (T:=T))
 
 end CanonicalEnsemble


### PR DESCRIPTION
Proves positivity/normalisation properties: partitionFunction_pos, probability_nonneg, sum_probability_eq_one, and entropy_nonneg. Nonempty ι is required where sums must be nonzero.
Add differentialEntropy 