### PR TITLE
feat: Electric field around a point particle

### DIFF
--- a/PhysLean.lean
+++ b/PhysLean.lean
@@ -16,6 +16,7 @@ import PhysLean.Electromagnetism.Charge.ChargeUnit
 import PhysLean.Electromagnetism.Electrostatics.Basic
 import PhysLean.Electromagnetism.Electrostatics.OneDimension.PointParticle
 import PhysLean.Electromagnetism.Electrostatics.OneDimension.Vacuum
+import PhysLean.Electromagnetism.Electrostatics.ThreeDimension.PointParticle
 import PhysLean.Electromagnetism.FieldStrength.Basic
 import PhysLean.Electromagnetism.FieldStrength.Derivative
 import PhysLean.Electromagnetism.Homogeneous

--- a/PhysLean/Electromagnetism/Electrostatics/OneDimension/PointParticle.lean
+++ b/PhysLean/Electromagnetism/Electrostatics/OneDimension/PointParticle.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.Electromagnetism.Electrostatics.Basic
-import PhysLean.Mathematics.Distribution.OfBounded
 import PhysLean.Mathematics.Distribution.PowMul
 /-!
 
@@ -37,7 +36,7 @@ def electricPotential (q ε : ℝ) : StaticElectricPotential 1 :=
 lemma electricPotential_eq_zero_of_ε_eq_zero (q : ℝ) :
     electricPotential q 0 = 0 := by
   ext x
-  simp [electricPotential, ofBounded_apply, div_zero]
+  simp [electricPotential, ofBounded_apply]
 
 /-- An electric field corresponding to a charge distribution of a point particle,
   defined as the negative of the gradient of `electricPotential q ε`.

--- a/PhysLean/Electromagnetism/Electrostatics/OneDimension/Vacuum.lean
+++ b/PhysLean/Electromagnetism/Electrostatics/OneDimension/Vacuum.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith
 -/
 import PhysLean.Electromagnetism.Electrostatics.Basic
-import PhysLean.Mathematics.Distribution.OfBounded
 import PhysLean.Mathematics.Distribution.PowMul
 /-!
 

--- a/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
+++ b/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
@@ -22,7 +22,6 @@ Any help proving this would be greatly appreciated.
 - https://math.stackexchange.com/questions/1335591/
 -/
 
-
 namespace Electromagnetism
 open Distribution SchwartzMap
 
@@ -34,7 +33,9 @@ noncomputable section
   Mathematically, this corresponds to a dirac delta distribution centered at the origin. -/
 def chargeDistribution (q : ℝ) : ChargeDistribution 3 := q • diracDelta ℝ 0
 
-
+/-- The electric field of a point particle of charge `q` in 3d space sitting at the origin.
+  Mathematically, this corresponds to the distribution associated to the distribution
+  `(q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r`. -/
 def electricField (q ε : ℝ) : StaticElectricField 3 :=
   Distribution.ofBounded (fun r => (q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r)
   ⟨|q / (4 * π * ε)|, 0, 0, by
@@ -53,13 +54,13 @@ def electricField (q ε : ℝ) : StaticElectricField 3 :=
     · subst hε
       simp
     field_simp
-    trans   |q| * ‖x‖ * (4 * |π| * |ε| * ‖x‖ ^ 2)
+    trans |q| * ‖x‖ * (4 * |π| * |ε| * ‖x‖ ^ 2)
     · rfl
     ring⟩ (by fun_prop)
 
 /-- Guass' law for a point particle in 3-dimensions, that is this theorem states that
-  the divergence of `(q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r` is equal to `q δ(r)`. -/
-lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribution q) := by
+  the divergence of `(q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r` is equal to `q • δ(r)`. -/
+lemma gaussLaw (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribution q) := by
   ext η
   let η' (n : ↑(Metric.sphere 0 1)) : 𝓢(ℝ, ℝ) := compCLM (g := fun a => a • n.1) ℝ (by
     apply And.intro
@@ -79,11 +80,11 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
         use 0, 0
         intro x
         simp
-        rw [iteratedFDeriv_succ_eq_comp_right ]
+        rw [iteratedFDeriv_succ_eq_comp_right]
         simp [fderiv_smul_const]
         rw [iteratedFDeriv_succ_const]
         simp
-        rfl) (by use 1, 1; simp [norm_smul] ) η
+        rfl) (by use 1, 1; simp [norm_smul]) η
   let s : Set (EuclideanSpace ℝ (Fin 3)) := {0}ᶜ
   haveI : MeasureSpace s := by
     exact Measure.Subtype.measureSpace
@@ -107,15 +108,15 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
     _ = - (q/(4 * π * ε)) * ∫ r, ‖r.2.1‖⁻¹ ^ 2 *
         (_root_.deriv (fun a => η (a • r.1)) ‖r.2.1‖)
         ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere.prod
-        (Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))):= by
+        (Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))) := by
       rw [← MeasureTheory.MeasurePreserving.integral_comp (f := homeomorphUnitSphereProd _)
         (MeasureTheory.Measure.measurePreserving_homeomorphUnitSphereProd
-        (volume (α := EuclideanSpace ℝ (Fin 3)))) (
-          Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin 3))))]
+        (volume (α := EuclideanSpace ℝ (Fin 3))))
+          (Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin 3))))]
       congr 1
       simp
       let f (x : Space 3) : ℝ :=
-         (‖↑x‖ ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ‖↑x‖⁻¹ • ↑x)) ‖↑x‖
+        (‖↑x‖ ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ‖↑x‖⁻¹ • ↑x)) ‖↑x‖
       conv_rhs =>
         enter [2, x]
         change f x.1
@@ -130,10 +131,10 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
       · symm
         simp
     /- Splitting the integral over the sphere and radius-/
-    _ = - (q/(4 * π * ε)) * ∫ n,  (∫ r, ‖r.1‖⁻¹ ^ 2 *
+    _ = - (q/(4 * π * ε)) * ∫ n, (∫ r, ‖r.1‖⁻¹ ^ 2 *
         (_root_.deriv (fun a => η (a • n)) ‖r.1‖)
-         ∂((Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))))
-        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere):= by
+        ∂((Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))))
+        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere) := by
       congr 1
       rw [MeasureTheory.integral_prod]
       /- Integrable condition. -/
@@ -157,7 +158,7 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
       have hr := r.2.2
       simp [-Subtype.coe_prop] at hr
       have hr2 : r.2.1 ≠ 0 := by exact Ne.symm (ne_of_lt hr)
-      trans (r.2.1 ^ 2)⁻¹ * _root_.deriv (fun a => η (a •  ‖↑x‖⁻¹ • ↑x)) ‖x‖
+      trans (r.2.1 ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ‖↑x‖⁻¹ • ↑x)) ‖x‖
       · simp [x, norm_smul]
         left
         congr
@@ -173,9 +174,9 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
       ring
       exact SchwartzMap.differentiable η
     /- Simplifying the inner integral. -/
-    _ = - (q/(4 * π * ε)) * ∫ n,  (∫ (r : Set.Ioi (0 : ℝ)),
+    _ = - (q/(4 * π * ε)) * ∫ n, (∫ (r : Set.Ioi (0 : ℝ)),
         (_root_.deriv (fun a => η (a • n)) r.1) ∂(.comap Subtype.val volume))
-        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere):= by
+        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere) := by
       congr
       funext n
       simp [Measure.volumeIoiPow]
@@ -193,10 +194,10 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
       congr
       rw [abs_of_nonneg]
       have h1 := r.2
-      simp  [- Subtype.coe_prop] at h1
+      simp [- Subtype.coe_prop] at h1
       exact le_of_lt h1
       fun_prop
-    _ = - (q/(4 * π * ε)) * ∫ n,  (-η 0) ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere) := by
+    _ = - (q/(4 * π * ε)) * ∫ n, (-η 0) ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere) := by
       congr
       funext n
       rw [MeasureTheory.integral_subtype_comap (by simp)]
@@ -214,7 +215,8 @@ lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribut
         exact integrable ((derivCLM ℝ) (η' n))
       · change Filter.Tendsto (η' n) Filter.atTop (nhds 0)
         exact Filter.Tendsto.mono_left (η' n).toZeroAtInfty.zero_at_infty' atTop_le_cocompact
-    _ = (q/(4 * π * ε)) * η 0 * (3 * (volume (α := EuclideanSpace ℝ (Fin 3))).real (Metric.ball 0 1)):= by
+    _ = (q/(4 * π * ε)) * η 0 * (3 * (volume (α := EuclideanSpace ℝ (Fin 3))).real
+        (Metric.ball 0 1)) := by
       simp
       ring
     _ = (q/(4 * π * ε)) * η 0 * (3 * (π * 4/3)) := by

--- a/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
+++ b/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
@@ -39,12 +39,14 @@ def chargeDistribution (q : ℝ) : ChargeDistribution 3 := q • diracDelta ℝ 
 def electricField (q ε : ℝ) : StaticElectricField 3 :=
   Distribution.ofBounded (fun r => (q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r)
   ⟨|q / (4 * π * ε)|, 0, 0, by
-    simp
+    simp only [abs_nonneg, le_refl, Nat.succ_eq_add_one, Nat.reduceAdd, inv_pow, Nat.cast_ofNat,
+      rpow_neg_ofNat, Int.reduceNeg, zpow_neg, pow_zero, mul_one, add_zero, true_and]
     intro x
     simp [norm_smul]
     by_cases h : x = 0
     · subst h
-      simp
+      simp only [norm_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, inv_zero,
+        mul_zero]
       apply le_of_eq
       ring
     have h' : ‖x‖ ≠ 0 := by exact norm_ne_zero_iff.mpr h
@@ -79,7 +81,7 @@ lemma gaussLaw (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistributi
       | n' + 1 + 1 =>
         use 0, 0
         intro x
-        simp
+        simp only [norm_eq_abs, pow_zero, mul_one, norm_le_zero_iff]
         rw [iteratedFDeriv_succ_eq_comp_right]
         simp [fderiv_smul_const]
         rw [iteratedFDeriv_succ_const]
@@ -114,7 +116,8 @@ lemma gaussLaw (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistributi
         (volume (α := EuclideanSpace ℝ (Fin 3))))
           (Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin 3))))]
       congr 1
-      simp
+      simp only [inv_pow, homeomorphUnitSphereProd_apply_snd_coe, norm_norm,
+        homeomorphUnitSphereProd_apply_fst_coe]
       let f (x : Space 3) : ℝ :=
         (‖↑x‖ ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ‖↑x‖⁻¹ • ↑x)) ‖↑x‖
       conv_rhs =>
@@ -153,7 +156,8 @@ lemma gaussLaw (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistributi
         conv_rhs => rw [pow_succ, mul_comm]
         rfl) (by fun_prop) η
       rename_i r
-      simp
+      simp only [norm_eq_abs, inv_pow, sq_abs, Nat.succ_eq_add_one, Nat.reduceAdd,
+        Function.comp_apply, homeomorphUnitSphereProd_symm_apply_coe]
       let x : Space 3 := r.2.1 • r.1.1
       have hr := r.2.2
       simp [-Subtype.coe_prop] at hr
@@ -217,7 +221,8 @@ lemma gaussLaw (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistributi
         exact Filter.Tendsto.mono_left (η' n).toZeroAtInfty.zero_at_infty' atTop_le_cocompact
     _ = (q/(4 * π * ε)) * η 0 * (3 * (volume (α := EuclideanSpace ℝ (Fin 3))).real
         (Metric.ball 0 1)) := by
-      simp
+      simp only [integral_const, Measure.toSphere_real_apply_univ, finrank_euclideanSpace,
+        Fintype.card_fin, Nat.cast_ofNat, smul_eq_mul, mul_neg, neg_mul, neg_neg]
       ring
     _ = (q/(4 * π * ε)) * η 0 * (3 * (π * 4/3)) := by
       congr

--- a/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
+++ b/PhysLean/Electromagnetism/Electrostatics/ThreeDimension/PointParticle.lean
@@ -1,0 +1,231 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+import PhysLean.Electromagnetism.Electrostatics.Basic
+import PhysLean.Mathematics.Distribution.OfBounded
+import PhysLean.Mathematics.Distribution.PowMul
+import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
+/-!
+
+# A electrostatics of a point particle in 3d.
+
+This file is currently a stub.
+
+It will eventually contain the proof of Gauss's law for a point particle in 3d.
+Any help proving this would be greatly appreciated.
+
+## Some references
+
+- https://math.stackexchange.com/questions/2409008/
+- https://math.stackexchange.com/questions/1335591/
+-/
+
+
+namespace Electromagnetism
+open Distribution SchwartzMap
+
+namespace ThreeDimPointParticle
+open Space StaticElectricField MeasureTheory Real InnerProductSpace
+noncomputable section
+
+/-- The charge distribution of a point particle of charge `q` in 1d space sitting at the origin.
+  Mathematically, this corresponds to a dirac delta distribution centered at the origin. -/
+def chargeDistribution (q : ℝ) : ChargeDistribution 3 := q • diracDelta ℝ 0
+
+
+def electricField (q ε : ℝ) : StaticElectricField 3 :=
+  Distribution.ofBounded (fun r => (q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r)
+  ⟨|q / (4 * π * ε)|, 0, 0, by
+    simp
+    intro x
+    simp [norm_smul]
+    by_cases h : x = 0
+    · subst h
+      simp
+      apply le_of_eq
+      ring
+    have h' : ‖x‖ ≠ 0 := by exact norm_ne_zero_iff.mpr h
+    apply le_of_eq
+    field_simp [abs_mul, abs_div]
+    by_cases hε : ε = 0
+    · subst hε
+      simp
+    field_simp
+    trans   |q| * ‖x‖ * (4 * |π| * |ε| * ‖x‖ ^ 2)
+    · rfl
+    ring⟩ (by fun_prop)
+
+/-- Guass' law for a point particle in 3-dimensions, that is this theorem states that
+  the divergence of `(q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r` is equal to `q δ(r)`. -/
+lemma gaussLaw  (q ε : ℝ) : (electricField q ε).GaussLaw ε (chargeDistribution q) := by
+  ext η
+  let η' (n : ↑(Metric.sphere 0 1)) : 𝓢(ℝ, ℝ) := compCLM (g := fun a => a • n.1) ℝ (by
+    apply And.intro
+    · fun_prop
+    · intro n'
+      match n' with
+      | 0 =>
+        simp [norm_smul]
+        use 1, 1
+        simp
+      | 1 =>
+        use 0, 1
+        intro x
+        rw [iteratedFDeriv_succ_eq_comp_right]
+        simp [fderiv_smul_const]
+      | n' + 1 + 1 =>
+        use 0, 0
+        intro x
+        simp
+        rw [iteratedFDeriv_succ_eq_comp_right ]
+        simp [fderiv_smul_const]
+        rw [iteratedFDeriv_succ_const]
+        simp
+        rfl) (by use 1, 1; simp [norm_smul] ) η
+  let s : Set (EuclideanSpace ℝ (Fin 3)) := {0}ᶜ
+  haveI : MeasureSpace s := by
+    exact Measure.Subtype.measureSpace
+  calc _
+    _ = (divD (electricField q ε)) η := by rfl
+    _ = - ∫ r : Space 3, ⟪((q/(4 * π * ε)) • ‖r‖⁻¹ ^ 3 • r), Space.grad η r⟫_ℝ := by
+      rw [electricField, Space.divD_ofBounded]
+    _ = - (q/(4 * π * ε)) * ∫ r : Space 3, ‖r‖⁻¹ ^ 2 * ⟪‖r‖⁻¹ • r, Space.grad η r⟫_ℝ := by
+      simp [inner_smul_left, integral_const_mul]
+      left
+      congr
+      funext r
+      ring
+    _ = - (q/(4 * π * ε)) * ∫ r : Space 3, ‖r‖⁻¹ ^ 2 *
+        (_root_.deriv (fun a => η (a • ‖r‖⁻¹ • r)) ‖r‖) := by
+      congr
+      funext r
+      congr
+      rw [real_inner_comm, ← grad_inner_space_unit_vector _ _ (SchwartzMap.differentiable η)]
+    /- Moving to spherical coordinates. -/
+    _ = - (q/(4 * π * ε)) * ∫ r, ‖r.2.1‖⁻¹ ^ 2 *
+        (_root_.deriv (fun a => η (a • r.1)) ‖r.2.1‖)
+        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere.prod
+        (Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))):= by
+      rw [← MeasureTheory.MeasurePreserving.integral_comp (f := homeomorphUnitSphereProd _)
+        (MeasureTheory.Measure.measurePreserving_homeomorphUnitSphereProd
+        (volume (α := EuclideanSpace ℝ (Fin 3)))) (
+          Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin 3))))]
+      congr 1
+      simp
+      let f (x : Space 3) : ℝ :=
+         (‖↑x‖ ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ‖↑x‖⁻¹ • ↑x)) ‖↑x‖
+      conv_rhs =>
+        enter [2, x]
+        change f x.1
+      rw [MeasureTheory.integral_subtype_comap (by simp), ← setIntegral_univ]
+      change ∫ x in Set.univ, f x = ∫ (x : Space) in _, f x
+      refine (setIntegral_congr_set ?_)
+      rw [← MeasureTheory.ae_eq_set_compl]
+      trans (∅ : Set (EuclideanSpace ℝ (Fin 3)))
+      · apply Filter.EventuallyEq.of_eq
+        rw [← Set.compl_empty]
+        exact compl_compl _
+      · symm
+        simp
+    /- Splitting the integral over the sphere and radius-/
+    _ = - (q/(4 * π * ε)) * ∫ n,  (∫ r, ‖r.1‖⁻¹ ^ 2 *
+        (_root_.deriv (fun a => η (a • n)) ‖r.1‖)
+         ∂((Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin 3)) - 1))))
+        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere):= by
+      congr 1
+      rw [MeasureTheory.integral_prod]
+      /- Integrable condition. -/
+      convert integrable_ofBounded_inner_grad_schwartzMap_spherical (f := fun r => ‖r‖⁻¹ ^ 3 • r)
+        (by
+        use 1, 0, 0
+        simp [norm_smul]
+        intro x
+        by_cases hx : x = 0
+        · subst hx
+          simp [@zpow_two]
+        apply le_of_eq
+        have hx' : ‖x‖ ≠ 0 := by exact norm_ne_zero_iff.mpr hx
+        field_simp
+        change ‖x‖ * ‖x‖ ^ 2 = ‖x‖ ^ 3
+        conv_rhs => rw [pow_succ, mul_comm]
+        rfl) (by fun_prop) η
+      rename_i r
+      simp
+      let x : Space 3 := r.2.1 • r.1.1
+      have hr := r.2.2
+      simp [-Subtype.coe_prop] at hr
+      have hr2 : r.2.1 ≠ 0 := by exact Ne.symm (ne_of_lt hr)
+      trans (r.2.1 ^ 2)⁻¹ * _root_.deriv (fun a => η (a •  ‖↑x‖⁻¹ • ↑x)) ‖x‖
+      · simp [x, norm_smul]
+        left
+        congr
+        funext a
+        congr
+        simp [smul_smul]
+        rw [abs_of_nonneg (le_of_lt hr)]
+        field_simp
+      rw [← grad_inner_space_unit_vector]
+      rw [real_inner_comm]
+      simp [inner_smul_left, x, norm_smul, abs_of_nonneg (le_of_lt hr)]
+      field_simp
+      ring
+      exact SchwartzMap.differentiable η
+    /- Simplifying the inner integral. -/
+    _ = - (q/(4 * π * ε)) * ∫ n,  (∫ (r : Set.Ioi (0 : ℝ)),
+        (_root_.deriv (fun a => η (a • n)) r.1) ∂(.comap Subtype.val volume))
+        ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere):= by
+      congr
+      funext n
+      simp [Measure.volumeIoiPow]
+      erw [integral_withDensity_eq_integral_smul]
+      congr
+      funext r
+      trans ((r.1 ^ 2).toNNReal : ℝ) • ((r.1 ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ↑n)) |r.1|)
+      · rfl
+      trans ((r.1 ^ 2) : ℝ) • ((r.1 ^ 2)⁻¹ * _root_.deriv (fun a => η (a • ↑n)) |r.1|)
+      · congr
+        refine coe_toNNReal (↑r ^ 2) ?_
+        apply pow_two_nonneg
+      have h1 : r.1 ≠ 0 := by exact ne_of_gt r.2
+      field_simp
+      congr
+      rw [abs_of_nonneg]
+      have h1 := r.2
+      simp  [- Subtype.coe_prop] at h1
+      exact le_of_lt h1
+      fun_prop
+    _ = - (q/(4 * π * ε)) * ∫ n,  (-η 0) ∂(volume (α := EuclideanSpace ℝ (Fin 3)).toSphere) := by
+      congr
+      funext n
+      rw [MeasureTheory.integral_subtype_comap (by simp)]
+      rw [MeasureTheory.integral_Ioi_of_hasDerivAt_of_tendsto
+        (f := fun a => η (a • n)) (m := 0)]
+      · simp
+      · refine ContinuousAt.continuousWithinAt ?_
+        fun_prop
+      · intro x hx
+        refine DifferentiableAt.hasDerivAt ?_
+        have h1 : Differentiable ℝ η := by exact SchwartzMap.differentiable η
+        fun_prop
+      · change IntegrableOn (SchwartzMap.derivCLM ℝ (η' n)) (Set.Ioi 0) volume
+        refine Integrable.integrableOn ?_
+        exact integrable ((derivCLM ℝ) (η' n))
+      · change Filter.Tendsto (η' n) Filter.atTop (nhds 0)
+        exact Filter.Tendsto.mono_left (η' n).toZeroAtInfty.zero_at_infty' atTop_le_cocompact
+    _ = (q/(4 * π * ε)) * η 0 * (3 * (volume (α := EuclideanSpace ℝ (Fin 3))).real (Metric.ball 0 1)):= by
+      simp
+      ring
+    _ = (q/(4 * π * ε)) * η 0 * (3 * (π * 4/3)) := by
+      congr
+      simp [Measure.real]
+      positivity
+    _ = (q/ε) * η 0 := by
+      by_cases hε : ε = 0
+      · subst hε
+        simp
+      field_simp
+      ring
+  simp [chargeDistribution]
+  ring

--- a/PhysLean/SpaceAndTime/Space/Distributions.lean
+++ b/PhysLean/SpaceAndTime/Space/Distributions.lean
@@ -3,11 +3,13 @@ Copyright (c) 2025 Zhi Kai Pong. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhi Kai Pong
 -/
-import PhysLean.SpaceAndTime.Space.Basic
+import PhysLean.SpaceAndTime.Space.VectorIdentities
 import PhysLean.Mathematics.Distribution.Basic
+import PhysLean.Mathematics.Distribution.OfBounded
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.Calculus.FDeriv.Symmetric
 import Mathlib.Analysis.Calculus.Gradient.Basic
+import Mathlib.MeasureTheory.SpecificCodomains.WithLp
 /-!
 
 # Distributions on space
@@ -214,6 +216,125 @@ lemma divD_constD {d} (m : EuclideanSpace ℝ (Fin d)) :
     divD (constD d m) = 0 := by
   ext η
   simp [divD, constD]
+
+open MeasureTheory
+open SchwartzMap
+
+/-- The divergence of a distribution from a bounded function. -/
+lemma divD_ofBounded {dm1 : ℕ} {f : Space dm1.succ → EuclideanSpace ℝ (Fin dm1.succ)}
+    {hf : ∃ c1 c2 n, 0 ≤ c1 ∧ 0 ≤ c2 ∧ ∀ x, ‖f x‖ ≤ c1 * ‖x‖ ^ (-dm1 : ℝ) + c2 * ‖x‖ ^ n}
+    {hae: AEStronglyMeasurable (fun x => f x) volume} (η : 𝓢(EuclideanSpace ℝ (Fin dm1.succ), ℝ)) :
+    divD (Distribution.ofBounded f hf hae) η =
+    - ∫ x : Space dm1.succ, ⟪f x, Space.grad η x⟫_ℝ := by
+  rw [divD_apply_eq_sum_fderivD]
+  conv_rhs =>
+    enter [1, 2, x]
+    rw [grad_eq_sum, inner_sum]
+  conv_lhs =>
+    enter [2, i]
+    rw [fderivD_apply, ofBounded_apply]
+  /- The following lemma could probably be moved out of this result. -/
+  have integrable_lemma (i j : Fin (dm1 + 1)) :
+      Integrable (fun x => (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j) volume := by
+    simp only [PiLp.smul_apply]
+    apply bounded_integrable
+    · obtain ⟨c1, c2, n, hc1, hc2, h⟩ := hf
+      use c1, c2, n
+      simp_all
+      intro x
+      trans ‖f x‖
+      · rw [@PiLp.norm_eq_of_L2]
+        refine Real.abs_le_sqrt ?_
+        trans ∑ i ∈ {j}, ‖(f x) i‖ ^ 2
+        · simp
+        apply Finset.sum_le_univ_sum_of_nonneg
+        intro y
+        exact sq_nonneg ‖f x y‖
+      exact h x
+    · fun_prop
+  rw [MeasureTheory.integral_finset_sum]
+  · simp
+    congr
+    funext i
+    rw [MeasureTheory.eval_integral_piLp]
+    · congr
+      funext x
+      simp [inner_smul_right]
+      left
+      rw [deriv_eq_fderiv_basis]
+      rfl
+    · intro j
+      exact integrable_lemma i j
+  · intro i hi
+    simp only [Nat.succ_eq_add_one, inner_smul_right, inner_basis]
+    convert integrable_lemma i i
+    rename_i x
+    simp
+    left
+    rw [deriv_eq_fderiv_basis]
+    rfl
+
+/- The quantity `⟪f x, Space.grad η x⟫_ℝ` is integrable for `f` bounded
+  and `η` a Schwartz map. -/
+lemma integrable_ofBounded_inner_grad_schwartzMap {dm1 : ℕ}
+    {f : Space dm1.succ → EuclideanSpace ℝ (Fin dm1.succ)}
+    (hf : ∃ c1 c2 n, 0 ≤ c1 ∧ 0 ≤ c2 ∧ ∀ x, ‖f x‖ ≤ c1 * ‖x‖ ^ (-dm1 : ℝ) + c2 * ‖x‖ ^ n)
+    (hae: AEStronglyMeasurable (fun x => f x) volume) (η : 𝓢(EuclideanSpace ℝ (Fin dm1.succ), ℝ)) :
+    Integrable (fun x => ⟪f x, Space.grad η x⟫_ℝ) volume := by
+  conv =>
+    enter [1, x]
+    rw [grad_eq_sum, inner_sum]
+  apply MeasureTheory.integrable_finset_sum
+  intro i _
+  simp [inner_smul_right]
+  have integrable_lemma (i j : Fin (dm1 + 1)) :
+      Integrable (fun x => (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j) volume := by
+    simp only [PiLp.smul_apply]
+    apply bounded_integrable
+    · obtain ⟨c1, c2, n, hc1, hc2, h⟩ := hf
+      use c1, c2, n
+      simp_all
+      intro x
+      trans ‖f x‖
+      · rw [@PiLp.norm_eq_of_L2]
+        refine Real.abs_le_sqrt ?_
+        trans ∑ i ∈ {j}, ‖(f x) i‖ ^ 2
+        · simp
+        apply Finset.sum_le_univ_sum_of_nonneg
+        intro y
+        exact sq_nonneg ‖f x y‖
+      exact h x
+    · fun_prop
+  convert integrable_lemma i i
+  rename_i x
+  simp
+  left
+  rw [deriv_eq_fderiv_basis]
+  rfl
+
+lemma integrable_ofBounded_inner_grad_schwartzMap_spherical{dm1 : ℕ}
+    {f : Space dm1.succ → EuclideanSpace ℝ (Fin dm1.succ)}
+    (hf : ∃ c1 c2 n, 0 ≤ c1 ∧ 0 ≤ c2 ∧ ∀ x, ‖f x‖ ≤ c1 * ‖x‖ ^ (-dm1 : ℝ) + c2 * ‖x‖ ^ n)
+    (hae: AEStronglyMeasurable (fun x => f x) volume) (η : 𝓢(EuclideanSpace ℝ (Fin dm1.succ), ℝ)) :
+    Integrable ((fun x => ⟪f x.1, Space.grad η x.1⟫_ℝ)
+      ∘ (homeomorphUnitSphereProd (Space dm1.succ)).symm)
+      ((volume (α := Space dm1.succ)).toSphere.prod
+      (Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin dm1.succ)) - 1))) := by
+  have h1 : Integrable ((fun x => ⟪f x.1, Space.grad η x.1⟫_ℝ))
+      (.comap (Subtype.val (p := fun x => x ∈ ({0}ᶜ : Set _))) volume) := by
+    change  Integrable ((fun x => ⟪f x, Space.grad η x⟫_ℝ) ∘ Subtype.val)
+      (.comap (Subtype.val (p := fun x => x ∈ ({0}ᶜ : Set _))) volume)
+    rw [← MeasureTheory.integrableOn_iff_comap_subtypeVal]
+    apply Integrable.integrableOn
+    exact integrable_ofBounded_inner_grad_schwartzMap hf hae η
+    simp
+  have he := (MeasureTheory.Measure.measurePreserving_homeomorphUnitSphereProd
+    (volume (α := EuclideanSpace ℝ (Fin dm1.succ))))
+  rw [← he.integrable_comp_emb]
+  convert h1
+  simp
+  exact Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin dm1.succ)))
+
 
 /-!
 

--- a/PhysLean/SpaceAndTime/Space/Distributions.lean
+++ b/PhysLean/SpaceAndTime/Space/Distributions.lean
@@ -4,11 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhi Kai Pong
 -/
 import PhysLean.SpaceAndTime.Space.VectorIdentities
-import PhysLean.Mathematics.Distribution.Basic
 import PhysLean.Mathematics.Distribution.OfBounded
-import Mathlib.Analysis.InnerProductSpace.Calculus
-import Mathlib.Analysis.Calculus.FDeriv.Symmetric
-import Mathlib.Analysis.Calculus.Gradient.Basic
 import Mathlib.MeasureTheory.SpecificCodomains.WithLp
 /-!
 
@@ -235,7 +231,8 @@ lemma divD_ofBounded {dm1 : ℕ} {f : Space dm1.succ → EuclideanSpace ℝ (Fin
     rw [fderivD_apply, ofBounded_apply]
   /- The following lemma could probably be moved out of this result. -/
   have integrable_lemma (i j : Fin (dm1 + 1)) :
-      Integrable (fun x => (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j) volume := by
+      Integrable (fun x =>
+        (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j) volume := by
     simp only [PiLp.smul_apply]
     apply bounded_integrable
     · obtain ⟨c1, c2, n, hc1, hc2, h⟩ := hf
@@ -288,7 +285,8 @@ lemma integrable_ofBounded_inner_grad_schwartzMap {dm1 : ℕ}
   intro i _
   simp [inner_smul_right]
   have integrable_lemma (i j : Fin (dm1 + 1)) :
-      Integrable (fun x => (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j) volume := by
+      Integrable (fun x => (((SchwartzMap.evalCLM (𝕜 := ℝ) (basis i)) ((fderivCLM ℝ) η)) x • f x) j)
+        volume := by
     simp only [PiLp.smul_apply]
     apply bounded_integrable
     · obtain ⟨c1, c2, n, hc1, hc2, h⟩ := hf
@@ -322,7 +320,7 @@ lemma integrable_ofBounded_inner_grad_schwartzMap_spherical{dm1 : ℕ}
       (Measure.volumeIoiPow (Module.finrank ℝ (EuclideanSpace ℝ (Fin dm1.succ)) - 1))) := by
   have h1 : Integrable ((fun x => ⟪f x.1, Space.grad η x.1⟫_ℝ))
       (.comap (Subtype.val (p := fun x => x ∈ ({0}ᶜ : Set _))) volume) := by
-    change  Integrable ((fun x => ⟪f x, Space.grad η x⟫_ℝ) ∘ Subtype.val)
+    change Integrable ((fun x => ⟪f x, Space.grad η x⟫_ℝ) ∘ Subtype.val)
       (.comap (Subtype.val (p := fun x => x ∈ ({0}ᶜ : Set _))) volume)
     rw [← MeasureTheory.integrableOn_iff_comap_subtypeVal]
     apply Integrable.integrableOn
@@ -334,7 +332,6 @@ lemma integrable_ofBounded_inner_grad_schwartzMap_spherical{dm1 : ℕ}
   convert h1
   simp
   exact Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin dm1.succ)))
-
 
 /-!
 

--- a/PhysLean/SpaceAndTime/Space/Distributions.lean
+++ b/PhysLean/SpaceAndTime/Space/Distributions.lean
@@ -266,7 +266,7 @@ lemma divD_ofBounded {dm1 : ℕ} {f : Space dm1.succ → EuclideanSpace ℝ (Fin
     simp only [Nat.succ_eq_add_one, inner_smul_right, inner_basis]
     convert integrable_lemma i i
     rename_i x
-    simp
+    simp only [Nat.succ_eq_add_one, PiLp.smul_apply, smul_eq_mul, mul_eq_mul_right_iff]
     left
     rw [deriv_eq_fderiv_basis]
     rfl
@@ -305,7 +305,7 @@ lemma integrable_ofBounded_inner_grad_schwartzMap {dm1 : ℕ}
     · fun_prop
   convert integrable_lemma i i
   rename_i x
-  simp
+  simp only [Nat.succ_eq_add_one, PiLp.smul_apply, smul_eq_mul, mul_eq_mul_right_iff]
   left
   rw [deriv_eq_fderiv_basis]
   rfl
@@ -330,7 +330,7 @@ lemma integrable_ofBounded_inner_grad_schwartzMap_spherical{dm1 : ℕ}
     (volume (α := EuclideanSpace ℝ (Fin dm1.succ))))
   rw [← he.integrable_comp_emb]
   convert h1
-  simp
+  simp only [Nat.succ_eq_add_one, Function.comp_apply, Homeomorph.symm_apply_apply]
   exact Homeomorph.measurableEmbedding (homeomorphUnitSphereProd (EuclideanSpace ℝ (Fin dm1.succ)))
 
 /-!

--- a/PhysLean/SpaceAndTime/Space/VectorIdentities.lean
+++ b/PhysLean/SpaceAndTime/Space/VectorIdentities.lean
@@ -252,7 +252,7 @@ lemma grad_inner_space_unit_vector {d} (x : Space d) (f : Space d → ℝ) (hd :
   symm
   calc _
     _ = fderiv ℝ (f ∘ (fun r => r • ‖x‖⁻¹ • x)) ‖x‖ 1 := by rfl
-    _ =  (fderiv ℝ f (‖x‖ • ‖x‖⁻¹ • x)) (_root_.deriv (fun r => r • ‖x‖⁻¹ • x) ‖x‖) := by
+    _ = (fderiv ℝ f (‖x‖ • ‖x‖⁻¹ • x)) (_root_.deriv (fun r => r • ‖x‖⁻¹ • x) ‖x‖) := by
       rw [fderiv_comp _ (by fun_prop) (by fun_prop)]
       simp
     _ = (fderiv ℝ f x) (_root_.deriv (fun r => r • ‖x‖⁻¹ • x) ‖x‖) := by

--- a/PhysLean/SpaceAndTime/Space/VectorIdentities.lean
+++ b/PhysLean/SpaceAndTime/Space/VectorIdentities.lean
@@ -243,6 +243,35 @@ lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
   rw [inner_self_eq_zero, sub_eq_zero] at h2
   rw [h2]
 
+/-- The gradient in the direction of the space position. -/
+lemma grad_inner_space_unit_vector {d} (x : Space d) (f : Space d → ℝ) (hd : Differentiable ℝ f) :
+    ⟪∇ f x, ‖x‖⁻¹ • x⟫_ℝ = _root_.deriv (fun r => f (r • ‖x‖⁻¹ • x)) ‖x‖ := by
+  by_cases hx : x = 0
+  · subst hx
+    simp
+  symm
+  calc _
+    _ = fderiv ℝ (f ∘ (fun r => r • ‖x‖⁻¹ • x)) ‖x‖ 1 := by rfl
+    _ =  (fderiv ℝ f (‖x‖ • ‖x‖⁻¹ • x)) (_root_.deriv (fun r => r • ‖x‖⁻¹ • x) ‖x‖) := by
+      rw [fderiv_comp _ (by fun_prop) (by fun_prop)]
+      simp
+    _ = (fderiv ℝ f x) (_root_.deriv (fun r => r • ‖x‖⁻¹ • x) ‖x‖) := by
+      have hx : ‖x‖ ≠ 0 := norm_ne_zero_iff.mpr hx
+      field_simp [smul_smul]
+  rw [grad_inner_eq f x (‖x‖⁻¹ • x)]
+  congr
+  rw [deriv_smul_const (by fun_prop)]
+  simp
+
+lemma grad_inner_space {d} (x : Space d) (f : Space d → ℝ) (hd : Differentiable ℝ f) :
+    ⟪∇ f x, x⟫_ℝ = ‖x‖ * _root_.deriv (fun r => f (r • ‖x‖⁻¹ • x)) ‖x‖ := by
+  rw [← grad_inner_space_unit_vector _ _ hd, inner_smul_right]
+  by_cases hx : x = 0
+  · subst hx
+    simp
+  have hx : ‖x‖ ≠ 0 := norm_ne_zero_iff.mpr hx
+  field_simp
+
 /-!
 
 ## Vector calculus identities


### PR DESCRIPTION
Proofs Gauss' law for the electric field around a point particle in 3d. 

There are still some possible generalizations, in particular, this currently assumes that the point particle is at the origin, which need not be the case.