### PR TITLE
fix: autocomplete results blends in with the background in light theme

### DIFF
--- a/scripts/Template.lean
+++ b/scripts/Template.lean
@@ -64,7 +64,7 @@ def baseHtmlGenerator (title : String) (site : Array Html) : BaseHtmlM Html := d
           PhysLean Documentation</a>
           </span></h1>
           <h2  style="color: #fff; font-family: serif">[breakWithin title]</h2>
-          <form action="https://google.com/search" method="get" id="search_form">
+          <form action="https://google.com/search" method="get" id="search_form" style="color: var(--text-color);">
             <input type="hidden" name="sitesearch" value="https://leanprover-community.github.io/mathlib4_docs"/>
             <input type="text" name="q" autocomplete="off"/>{.raw "&#32;"}
             <button id="search_button" onclick={s!"javascript: form.action='{← getRoot}search.html';"}>Search</button>


### PR DESCRIPTION
<img width="1854" height="1048" alt="Screenshot from 2025-09-21 02-53-20" src="https://github.com/user-attachments/assets/c40c7be1-daf2-4e2f-af01-a00be78be7f1" />

This bug harms user experiences, so this PR fixes this.
