### PR TITLE
feat(QM): Add radius power operator

### DIFF
--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -189,14 +189,12 @@ lemma radiusPowOperator_apply_contDiffAt {d : ℕ} (s : ℝ) (n : ℕ∞) (ψ : 
   simp only [h]
   exact ContDiffAt.rpow_const_of_ne (by fun_prop) (inner_self_ne_zero.mpr hx)
 
-/-- `x ↦ ‖x‖ˢψ(x)` is a.e. strongly measurable. -/
+/-- `x ↦ ‖x‖ˢψ(x)` is strongly measurable. -/
 @[fun_prop]
-lemma radiusPowOperator_apply_AEStronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
-    AEStronglyMeasurable (𝐫[s] ψ) := by
-  change AEStronglyMeasurable ((fun x ↦ (‖x‖.rpow s : ℂ)) * ⇑ψ)
-  refine AEStronglyMeasurable.mul ?_ (by fun_prop)
-  refine Continuous.comp_aestronglyMeasurable (by fun_prop) ?_
-  exact StronglyMeasurable.aestronglyMeasurable (by measurability)
+lemma radiusPowOperator_apply_stronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
+    StronglyMeasurable (𝐫[s] ψ) := by
+  change StronglyMeasurable ((fun x ↦ (‖x‖.rpow s : ℂ)) * ⇑ψ)
+  exact StronglyMeasurable.mul (by measurability) ψ.continuous.stronglyMeasurable
 
 /-- `x ↦ ‖x‖ˢψ(x)` is square-integrable provided `s` is not too negative. -/
 lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2 * s)

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -158,6 +158,8 @@ lemma positionOperatorSqr_eq {d : ℕ} (ε : ℝˣ) :
 ### A.3. Radius powers
 -/
 
+open MeasureTheory
+
 /-- The radius operator to power `s` is the linear map from `𝓢(Space d, ℂ)` to `Space d → ℂ` that
   maps `ψ` to `x ↦ ‖x‖ˢψ(x)` (which is 'nearly' Schwartz for general `s`). -/
 def radiusPowOperator {d : ℕ} (s : ℝ) : 𝓢(Space d, ℂ) →ₗ[ℂ] Space d → ℂ where
@@ -176,6 +178,31 @@ lemma radiusPowOperator_apply {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) (x :
     𝐫[s] ψ x = ‖x‖ ^ s • ψ x := by
   rw [radiusPowOperator_apply_fun]
 
+/-- `x ↦ ‖x‖ˢψ(x)` is smooth away from `x = 0`. -/
+@[fun_prop]
+lemma radiusPowOperator_apply_contDiffAt {d : ℕ} (s : ℝ) (n : ℕ∞) (ψ : 𝓢(Space d, ℂ)) {x : Space d}
+    (hx : x ≠ 0) : ContDiffAt ℝ n (𝐫[s] ψ) x := by
+  refine ContDiffAt.smul ?_ (ψ.contDiffAt n)
+  have h (x : Space d) : ‖x‖ ^ s = (inner ℝ x x) ^ (s / 2) := by
+    simp [← Real.rpow_natCast_mul, mul_div_cancel₀]
+  simp only [h]
+  exact ContDiffAt.rpow_const_of_ne (by fun_prop) (inner_self_ne_zero.mpr hx)
+
+/-- `x ↦ ‖x‖ˢψ(x)` is smooth away from `x = 0`. -/
+@[fun_prop]
+lemma radiusPowOperator_apply_contDiffOn {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) (n : ℕ∞) :
+    ContDiffOn ℝ n (𝐫[s] ψ) (⊤ \ {0}) :=
+  fun _ hx ↦ contDiffWithinAt_diff_singleton.mpr <| radiusPowOperator_apply_contDiffAt s n ψ hx.2
+
+/-- `x ↦ ‖x‖ˢψ(x)` is a.e. strongly measurable. -/
+@[fun_prop]
+lemma radiusPowOperator_apply_AEStronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
+    AEStronglyMeasurable (𝐫[s] ψ) := by
+  change AEStronglyMeasurable ((fun x ↦ (‖x‖.rpow s : ℂ)) * ⇑ψ)
+  refine AEStronglyMeasurable.mul ?_ (by measurability)
+  refine Continuous.comp_aestronglyMeasurable (by fun_prop) ?_
+  refine StronglyMeasurable.aestronglyMeasurable ?_
+  measurability
 
 end
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -158,6 +158,24 @@ lemma positionOperatorSqr_eq {d : ℕ} (ε : ℝˣ) :
 ### A.3. Radius powers
 -/
 
+/-- The radius operator to power `s` is the linear map from `𝓢(Space d, ℂ)` to `Space d → ℂ` that
+  maps `ψ` to `x ↦ ‖x‖ˢψ(x)` (which is 'nearly' Schwartz for general `s`). -/
+def radiusPowOperator {d : ℕ} (s : ℝ) : 𝓢(Space d, ℂ) →ₗ[ℂ] Space d → ℂ where
+  toFun ψ := (fun x : Space d ↦ ‖x‖ ^ s) • ψ
+  map_add' _ _ := by rw [← smul_add]; rfl
+  map_smul' _ _ := by rw [smul_comm]; rfl
+
+@[inherit_doc radiusPowOperator]
+notation "𝐫[" s "]" => radiusPowOperator s
+
+lemma radiusPowOperator_apply_fun {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
+    𝐫[s] ψ = fun x ↦ ‖x‖ ^ s • ψ x := rfl
+
+@[simp]
+lemma radiusPowOperator_apply {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
+    𝐫[s] ψ x = ‖x‖ ^ s • ψ x := by
+  rw [radiusPowOperator_apply_fun]
+
 
 end
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -254,7 +254,7 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : 0 < d + 2 * s)
             Nat.cast_eq_zero.mpr <| Int.toNat_of_nonpos <| Int.ceil_le.mpr (by rwa [Int.cast_zero])
           exact hs' ▸ hs
       calc
-        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d: ℝ)‖ₑ :=
+        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
           setLIntegral_mono' (by measurability) hbound
         _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
           lintegral_const_mul _ (by fun_prop)

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -7,7 +7,6 @@ module
 
 public import PhysLean.QuantumMechanics.DDimensions.Operators.Unbounded
 public import PhysLean.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
-public import PhysLean.SpaceAndTime.Space.Derivatives.Basic
 public import PhysLean.SpaceAndTime.Space.Integrals.NormPow
 /-!
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -200,10 +200,9 @@ lemma radiusPowOperator_apply_contDiffOn {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d,
 lemma radiusPowOperator_apply_AEStronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
     AEStronglyMeasurable (𝐫[s] ψ) := by
   change AEStronglyMeasurable ((fun x ↦ (‖x‖.rpow s : ℂ)) * ⇑ψ)
-  refine AEStronglyMeasurable.mul ?_ (by measurability)
+  refine AEStronglyMeasurable.mul ?_ (by fun_prop)
   refine Continuous.comp_aestronglyMeasurable (by fun_prop) ?_
-  refine StronglyMeasurable.aestronglyMeasurable ?_
-  measurability
+  exact StronglyMeasurable.aestronglyMeasurable (by measurability)
 
 /-- `x ↦ ‖x‖ˢψ(x)` is square-integrable provided `s` is not too negative. -/
 lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2 * s)
@@ -218,12 +217,12 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
     rw [← lintegral_add_compl _ (measurableSet_ball (x := 0) (ε := 1)), ENNReal.add_lt_top]
     constructor
     · -- `‖x‖ < 1`: bound `‖ψ x‖` by a constant
-      obtain ⟨C, hC, hCbound⟩ := ψ.decay 0 0
-      simp only [pow_zero, norm_iteratedFDeriv_zero, one_mul] at hCbound
+      obtain ⟨C, hC_pos, hC⟩ := ψ.decay 0 0
+      simp only [pow_zero, norm_iteratedFDeriv_zero, one_mul] at hC
       have hbound (x : Space d) : ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ := by
         simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs]
         refine mul_le_mul_of_nonneg_right ?_ (abs_nonneg _)
-        exact (sq_le_sq₀ (norm_nonneg _) hC.le).mpr (hCbound x)
+        exact (sq_le_sq₀ (norm_nonneg _) hC_pos.le).mpr (hC x)
       calc
         _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ :=
           setLIntegral_mono' measurableSet_ball (fun x _ ↦ hbound x)
@@ -233,8 +232,8 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
       have := (integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr (h.resolve_left hd.ne')
       exact this.hasFiniteIntegral
     · -- `1 ≤ ‖x‖`: bound `‖ψ x‖` by a suitable power of `‖x‖`
-      obtain ⟨C, hC, hCbound⟩ := ψ.decay (⌈s⌉.toNat + d) 0
-      simp only [norm_iteratedFDeriv_zero, ← Real.rpow_natCast, Nat.cast_add] at hCbound
+      obtain ⟨C, hC_pos, hC⟩ := ψ.decay (⌈s⌉.toNat + d) 0
+      simp only [norm_iteratedFDeriv_zero, ← Real.rpow_natCast, Nat.cast_add] at hC
       have hbound (x : Space d) (hx : x ∈ (Metric.ball 0 1)ᶜ) :
           ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ := by
         simp only [Set.mem_compl_iff, Metric.mem_ball, dist_zero_right, not_lt] at hx
@@ -243,7 +242,7 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
         have hx' : 0 < ‖x‖ := by linarith
         have hψ : ‖ψ x‖ ≤ C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ) := by
           rw [Real.rpow_neg hx'.le]
-          exact (le_mul_inv_iff₀' <| Real.rpow_pos_of_pos hx' _).mpr (hCbound x)
+          exact (le_mul_inv_iff₀' <| Real.rpow_pos_of_pos hx' _).mpr (hC x)
         calc
           _ ≤ (C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ)) ^ 2 * ‖x‖ ^ (2 * s) := by
             refine mul_le_mul_of_nonneg_right ?_ (Real.rpow_nonneg hx'.le _)
@@ -253,7 +252,7 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
             ring_nf
         suffices s ≤ ⌈s⌉.toNat by
           have h' : 0 < C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) :=
-            mul_pos (sq_pos_of_pos hC) (Real.rpow_pos_of_pos hx' _)
+            mul_pos (sq_pos_of_pos hC_pos) (Real.rpow_pos_of_pos hx' _)
           apply (mul_le_iff_le_one_right h').mpr
           exact Real.rpow_le_one_of_one_le_of_nonpos hx (by linarith)
         rcases lt_or_ge 0 s with (hs | hs)

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -36,10 +36,13 @@ Notation:
 
 ## iii. Table of contents
 
-- A. Position vector operator
-- B. Regularized radius operator
-- C. Unbounded position vector operator
-- D. Unbounded regularized radius operator
+- A. Schwartz operators
+  - A.1. Position vector
+  - A.2. Radius powers (regularized)
+  - A.3. Radius powers
+- B. Unbounded operators
+  - B.1. Position vector
+  - B.2. Radius powers (regularized)
 
 ## iv. References
 
@@ -48,16 +51,19 @@ Notation:
 @[expose] public section
 
 namespace QuantumMechanics
-noncomputable section
-open Space
-open Function SchwartzMap ContDiff
 
 variable {d : ℕ} (i : Fin d)
 
 /-!
+## A. Schwartz operators
+-/
 
-## A. Position vector operator
+noncomputable section
+open Space Function
+open SchwartzMap
 
+/-!
+### A.1. Position vector
 -/
 
 /-- Component `i` of the position operator is the continuous linear map
@@ -78,9 +84,7 @@ lemma positionOperator_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐱[i] �
   simp [positionOperator_apply_fun]
 
 /-!
-
-## B. Regularized radius operator
-
+### A.2. Radius powers (regularized)
 -/
 TODO "ZGCNP" "Incorporate normRegularizedPow into Space.Norm"
 
@@ -151,12 +155,23 @@ lemma positionOperatorSqr_eq {d : ℕ} (ε : ℝˣ) :
   simp [Space.norm_sq_eq, add_mul, ← mul_assoc, ← pow_two, Finset.sum_mul]
 
 /-!
-
-## C. Unbounded position vector operator
-
+### A.3. Radius powers
 -/
 
+
+end
+
+/-!
+## B. Unbounded operators
+-/
+
+noncomputable section
+
 open SpaceDHilbertSpace
+
+/-!
+### B.1. Position vector
+-/
 
 /-- The position operators defined on the Schwartz submodule. -/
 def positionOperatorSchwartz : schwartzSubmodule d →ₗ[ℂ] schwartzSubmodule d :=
@@ -167,7 +182,7 @@ lemma positionOperatorSchwartz_isSymmetric : (positionOperatorSchwartz i).IsSymm
   obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ
   obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ'
   unfold positionOperatorSchwartz
-  simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply, schwartzEquiv_inner]
+  simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply, schwartzEquiv_inner]
   congr with x
   simp only [LinearEquiv.symm_apply_apply, ContinuousLinearMap.coe_coe,
     positionOperator_apply, map_mul, Complex.conj_ofReal]
@@ -179,9 +194,7 @@ def positionUnboundedOperator : UnboundedOperator (SpaceDHilbertSpace d) (SpaceD
   UnboundedOperator.ofSymmetric (schwartzSubmodule_dense d) (positionOperatorSchwartz_isSymmetric i)
 
 /-!
-
-## D. Unbounded regularized radius operator
-
+### B.2. Radius powers (regularized)
 -/
 
 /-- The (regularized) radius operators defined on the Schwartz submodule. -/
@@ -194,8 +207,8 @@ lemma radiusRegPowOperatorSchwartz_isSymmetric {d : ℕ} (ε : ℝˣ) (s : ℝ) 
   intro ψ ψ'
   obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ
   obtain ⟨_, rfl⟩ := schwartzEquiv.surjective ψ'
-  simp only [radiusRegPowOperatorSchwartz, LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply,
-    schwartzEquiv_inner]
+  simp only [radiusRegPowOperatorSchwartz, LinearMap.coe_comp, LinearEquiv.coe_coe,
+    Function.comp_apply, schwartzEquiv_inner]
   congr with x -- match integrands
   simp only [LinearEquiv.symm_apply_apply, ContinuousLinearMap.coe_coe, radiusRegPowOperator_apply,
     Complex.real_smul, map_mul, Complex.conj_ofReal]

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -189,12 +189,6 @@ lemma radiusPowOperator_apply_contDiffAt {d : ℕ} (s : ℝ) (n : ℕ∞) (ψ : 
   simp only [h]
   exact ContDiffAt.rpow_const_of_ne (by fun_prop) (inner_self_ne_zero.mpr hx)
 
-/-- `x ↦ ‖x‖ˢψ(x)` is smooth away from `x = 0`. -/
-@[fun_prop]
-lemma radiusPowOperator_apply_contDiffOn {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) (n : ℕ∞) :
-    ContDiffOn ℝ n (𝐫[s] ψ) (⊤ \ {0}) :=
-  fun _ hx ↦ contDiffWithinAt_diff_singleton.mpr <| radiusPowOperator_apply_contDiffAt s n ψ hx.2
-
 /-- `x ↦ ‖x‖ˢψ(x)` is a.e. strongly measurable. -/
 @[fun_prop]
 lemma radiusPowOperator_apply_AEStronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -8,6 +8,7 @@ module
 public import PhysLean.QuantumMechanics.DDimensions.Operators.Unbounded
 public import PhysLean.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 public import PhysLean.SpaceAndTime.Space.Derivatives.Basic
+public import PhysLean.SpaceAndTime.Space.Integrals.NormPow
 /-!
 
 # Position operators
@@ -159,6 +160,7 @@ lemma positionOperatorSqr_eq {d : ℕ} (ε : ℝˣ) :
 -/
 
 open MeasureTheory
+open SpaceDHilbertSpace
 
 /-- The radius operator to power `s` is the linear map from `𝓢(Space d, ℂ)` to `Space d → ℂ` that
   maps `ψ` to `x ↦ ‖x‖ˢψ(x)` (which is 'nearly' Schwartz for general `s`). -/
@@ -203,6 +205,74 @@ lemma radiusPowOperator_apply_AEStronglyMeasurable {d : ℕ} (s : ℝ) (ψ : �
   refine Continuous.comp_aestronglyMeasurable (by fun_prop) ?_
   refine StronglyMeasurable.aestronglyMeasurable ?_
   measurability
+
+/-- `x ↦ ‖x‖ˢψ(x)` is square-integrable provided `s` is not too negative. -/
+lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2 * s)
+    (ψ : 𝓢(Space d, ℂ)) : MemHS (𝐫[s] ψ) := by
+  rcases Nat.eq_zero_or_pos d with (rfl | hd)
+  · simp only [MemHS, MemLp.of_discrete]
+  · refine (MeasureTheory.memLp_two_iff_integrable_sq_norm (by fun_prop)).mpr ⟨by fun_prop, ?_⟩
+    suffices ∫⁻ (a : Space d), ‖‖ψ a‖ ^ 2 * ‖a‖ ^ (2 * s)‖ₑ < ⊤ by
+      have hInt (x : Space d) : ‖𝐫[s] ψ x‖ ^ 2 = ‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s) := by
+        simp [radiusPowOperator, mul_pow, mul_comm, Real.rpow_mul]
+      simpa only [HasFiniteIntegral, hInt]
+    rw [← lintegral_add_compl _ (measurableSet_ball (x := 0) (ε := 1)), ENNReal.add_lt_top]
+    constructor
+    · -- `‖x‖ < 1`: bound `‖ψ x‖` by a constant
+      obtain ⟨C, hC, hCbound⟩ := ψ.decay 0 0
+      simp only [pow_zero, norm_iteratedFDeriv_zero, one_mul] at hCbound
+      have hbound (x : Space d) : ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ := by
+        simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs]
+        refine mul_le_mul_of_nonneg_right ?_ (abs_nonneg _)
+        exact (sq_le_sq₀ (norm_nonneg _) hC.le).mpr (hCbound x)
+      calc
+        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ :=
+          setLIntegral_mono' measurableSet_ball (fun x _ ↦ hbound x)
+        _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖‖x‖ ^ (2 * s)‖ₑ :=
+          lintegral_const_mul _ (by fun_prop)
+      apply ENNReal.mul_lt_top enorm_lt_top
+      have := (integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr (h.resolve_left hd.ne')
+      exact this.hasFiniteIntegral
+    · -- `1 ≤ ‖x‖`: bound `‖ψ x‖` by a suitable power of `‖x‖`
+      obtain ⟨C, hC, hCbound⟩ := ψ.decay (⌈s⌉.toNat + d) 0
+      simp only [norm_iteratedFDeriv_zero, ← Real.rpow_natCast, Nat.cast_add] at hCbound
+      have hbound (x : Space d) (hx : x ∈ (Metric.ball 0 1)ᶜ) :
+          ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ := by
+        simp only [Set.mem_compl_iff, Metric.mem_ball, dist_zero_right, not_lt] at hx
+        simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs,
+          Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
+        have hx' : 0 < ‖x‖ := by linarith
+        have hψ : ‖ψ x‖ ≤ C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ) := by
+          rw [Real.rpow_neg hx'.le]
+          exact (le_mul_inv_iff₀' <| Real.rpow_pos_of_pos hx' _).mpr (hCbound x)
+        calc
+          _ ≤ (C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ)) ^ 2 * ‖x‖ ^ (2 * s) := by
+            refine mul_le_mul_of_nonneg_right ?_ (Real.rpow_nonneg hx'.le _)
+            exact pow_le_pow_left₀ (norm_nonneg _) hψ 2
+          _ = C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) * ‖x‖ ^ (2 * (s - ⌈s⌉.toNat) : ℝ) := by
+            simp_rw [mul_pow, ← Real.rpow_mul_natCast hx'.le, mul_assoc, ← Real.rpow_add hx']
+            ring_nf
+        suffices s ≤ ⌈s⌉.toNat by
+          have h' : 0 < C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) :=
+            mul_pos (sq_pos_of_pos hC) (Real.rpow_pos_of_pos hx' _)
+          apply (mul_le_iff_le_one_right h').mpr
+          exact Real.rpow_le_one_of_one_le_of_nonpos hx (by linarith)
+        rcases lt_or_ge 0 s with (hs | hs)
+        · have hs' : ⌈s⌉.toNat = (⌈s⌉ : ℝ) :=
+            Int.cast_inj.mpr <| Int.toNat_of_nonneg <| Int.ceil_nonneg hs.le
+          exact hs' ▸ Int.le_ceil s
+        · have hs' : ⌈s⌉.toNat = (0 : ℝ) :=
+            Nat.cast_eq_zero.mpr <| Int.toNat_of_nonpos <| Int.ceil_le.mpr (by rwa [Int.cast_zero])
+          exact hs' ▸ hs
+      calc
+        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d: ℝ)‖ₑ :=
+          setLIntegral_mono' (by measurability) hbound
+        _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
+          lintegral_const_mul _ (by fun_prop)
+      apply ENNReal.mul_lt_top enorm_lt_top
+      have hd' : (d + -2 * d : ℝ) < 0 := by aesop
+      have := (integrableOn_norm_rpow_ball_compl_iff hd Real.zero_lt_one _).mpr hd'
+      exact this.hasFiniteIntegral
 
 end
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -193,12 +193,12 @@ lemma radiusPowOperator_apply_contDiffAt {d : ℕ} (s : ℝ) (n : ℕ∞) (ψ : 
 @[fun_prop]
 lemma radiusPowOperator_apply_stronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(Space d, ℂ)) :
     StronglyMeasurable (𝐫[s] ψ) := by
-  change StronglyMeasurable ((fun x ↦ (‖x‖.rpow s : ℂ)) * ⇑ψ)
-  exact StronglyMeasurable.mul (by measurability) ψ.continuous.stronglyMeasurable
+  rw [radiusPowOperator_apply_fun]
+  exact StronglyMeasurable.smul (by measurability) ψ.continuous.stronglyMeasurable
 
 /-- `x ↦ ‖x‖ˢψ(x)` is square-integrable provided `s` is not too negative. -/
-lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : 0 < d + 2 * s)
-    (ψ : 𝓢(Space d, ℂ)) : MemHS (𝐫[s] ψ) := by
+lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : 0 < d + 2 * s) (ψ : 𝓢(Space d, ℂ)) :
+    MemHS (𝐫[s] ψ) := by
   rcases Nat.eq_zero_or_pos d with (rfl | hd)
   · simp only [MemHS, MemLp.of_discrete]
   · refine (MeasureTheory.memLp_two_iff_integrable_sq_norm (by fun_prop)).mpr ⟨by fun_prop, ?_⟩
@@ -211,56 +211,58 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : 0 < d + 2 * s)
     · -- `‖x‖ < 1`: bound `‖ψ x‖` by a constant
       obtain ⟨C, hC_pos, hC⟩ := ψ.decay 0 0
       simp only [pow_zero, norm_iteratedFDeriv_zero, one_mul] at hC
-      have hbound (x : Space d) : ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ := by
-        simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs]
-        refine mul_le_mul_of_nonneg_right ?_ (abs_nonneg _)
-        exact (sq_le_sq₀ (norm_nonneg _) hC_pos.le).mpr (hC x)
-      calc
-        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ :=
-          setLIntegral_mono' measurableSet_ball (fun x _ ↦ hbound x)
-        _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖‖x‖ ^ (2 * s)‖ₑ :=
-          lintegral_const_mul _ (by fun_prop)
-      apply ENNReal.mul_lt_top enorm_lt_top
-      exact ((integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr h).hasFiniteIntegral
+      suffices hBound : ∀ x, ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ by
+        calc
+          _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖C ^ 2‖ₑ * ‖‖x‖ ^ (2 * s)‖ₑ :=
+            setLIntegral_mono' measurableSet_ball (fun x _ ↦ hBound x)
+          _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖‖x‖ ^ (2 * s)‖ₑ :=
+            lintegral_const_mul _ (by fun_prop)
+        apply ENNReal.mul_lt_top enorm_lt_top
+        exact ((integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr h).hasFiniteIntegral
+      intro x
+      simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs]
+      refine mul_le_mul_of_nonneg_right ?_ (abs_nonneg _)
+      exact (sq_le_sq₀ (norm_nonneg _) hC_pos.le).mpr (hC x)
     · -- `1 ≤ ‖x‖`: bound `‖ψ x‖` by a suitable power of `‖x‖`
       obtain ⟨C, hC_pos, hC⟩ := ψ.decay (⌈s⌉.toNat + d) 0
       simp only [norm_iteratedFDeriv_zero, ← Real.rpow_natCast, Nat.cast_add] at hC
-      have hbound (x : Space d) (hx : x ∈ (Metric.ball 0 1)ᶜ) :
-          ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ := by
-        simp only [Set.mem_compl_iff, Metric.mem_ball, dist_zero_right, not_lt] at hx
-        simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs,
-          Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
-        have hx' : 0 < ‖x‖ := by linarith
-        have hψ : ‖ψ x‖ ≤ C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ) := by
-          rw [Real.rpow_neg hx'.le]
-          exact (le_mul_inv_iff₀' <| Real.rpow_pos_of_pos hx' _).mpr (hC x)
+      suffices hBound : ∀ x ∈ (Metric.ball 0 1)ᶜ,
+          ‖‖ψ x‖ ^ 2 * ‖x‖ ^ (2 * s)‖ₑ ≤ ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ by
         calc
-          _ ≤ (C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ)) ^ 2 * ‖x‖ ^ (2 * s) := by
-            refine mul_le_mul_of_nonneg_right ?_ (Real.rpow_nonneg hx'.le _)
-            exact pow_le_pow_left₀ (norm_nonneg _) hψ 2
-          _ = C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) * ‖x‖ ^ (2 * (s - ⌈s⌉.toNat) : ℝ) := by
-            simp_rw [mul_pow, ← Real.rpow_mul_natCast hx'.le, mul_assoc, ← Real.rpow_add hx']
-            ring_nf
-        suffices s ≤ ⌈s⌉.toNat by
-          have h' : 0 < C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) :=
-            mul_pos (sq_pos_of_pos hC_pos) (Real.rpow_pos_of_pos hx' _)
-          apply (mul_le_iff_le_one_right h').mpr
-          exact Real.rpow_le_one_of_one_le_of_nonpos hx (by linarith)
-        rcases lt_or_ge 0 s with (hs | hs)
-        · have hs' : ⌈s⌉.toNat = (⌈s⌉ : ℝ) :=
-            Int.cast_inj.mpr <| Int.toNat_of_nonneg <| Int.ceil_nonneg hs.le
-          exact hs' ▸ Int.le_ceil s
-        · have hs' : ⌈s⌉.toNat = (0 : ℝ) :=
-            Nat.cast_eq_zero.mpr <| Int.toNat_of_nonpos <| Int.ceil_le.mpr (by rwa [Int.cast_zero])
-          exact hs' ▸ hs
+          _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
+            setLIntegral_mono' (by measurability) hBound
+          _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
+            lintegral_const_mul _ (by fun_prop)
+        apply ENNReal.mul_lt_top enorm_lt_top
+        have hd' : (d + -2 * d : ℝ) < 0 := by simp [hd]
+        exact ((integrableOn_norm_rpow_ball_compl_iff hd zero_lt_one _).mpr hd').hasFiniteIntegral
+      intro x hx
+      simp only [Set.mem_compl_iff, Metric.mem_ball, dist_zero_right, not_lt] at hx
+      simp_rw [← enorm_mul, enorm_le_iff_norm_le, norm_mul, norm_pow, Real.norm_eq_abs, sq_abs,
+        Real.abs_rpow_of_nonneg (norm_nonneg _), abs_norm]
+      have hx' : 0 < ‖x‖ := by linarith
+      have hψ : ‖ψ x‖ ≤ C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ) := by
+        rw [Real.rpow_neg hx'.le]
+        exact (le_mul_inv_iff₀' <| Real.rpow_pos_of_pos hx' _).mpr (hC x)
       calc
-        _ ≤ ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖C ^ 2‖ₑ * ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
-          setLIntegral_mono' (by measurability) hbound
-        _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1)ᶜ, ‖‖x‖ ^ (-2 * d : ℝ)‖ₑ :=
-          lintegral_const_mul _ (by fun_prop)
-      apply ENNReal.mul_lt_top enorm_lt_top
-      have hd' : (d + -2 * d : ℝ) < 0 := by aesop
-      exact ((integrableOn_norm_rpow_ball_compl_iff hd zero_lt_one _).mpr hd').hasFiniteIntegral
+        _ ≤ (C * ‖x‖ ^ (-(⌈s⌉.toNat + d) : ℝ)) ^ 2 * ‖x‖ ^ (2 * s) := by
+          refine mul_le_mul_of_nonneg_right ?_ (Real.rpow_nonneg hx'.le _)
+          exact pow_le_pow_left₀ (norm_nonneg _) hψ 2
+        _ = C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) * ‖x‖ ^ (2 * (s - ⌈s⌉.toNat) : ℝ) := by
+          simp_rw [mul_pow, ← Real.rpow_mul_natCast hx'.le, mul_assoc, ← Real.rpow_add hx']
+          ring_nf
+      suffices s ≤ ⌈s⌉.toNat by
+        have h' : 0 < C ^ 2 * ‖x‖ ^ (-2 * d : ℝ) :=
+          mul_pos (sq_pos_of_pos hC_pos) (Real.rpow_pos_of_pos hx' _)
+        apply (mul_le_iff_le_one_right h').mpr
+        exact Real.rpow_le_one_of_one_le_of_nonpos hx (by linarith)
+      rcases lt_or_ge 0 s with (hs | hs)
+      · have hs' : ⌈s⌉.toNat = (⌈s⌉ : ℝ) :=
+          Int.cast_inj.mpr <| Int.toNat_of_nonneg <| Int.ceil_nonneg hs.le
+        exact hs' ▸ Int.le_ceil s
+      · have hs' : ⌈s⌉.toNat = (0 : ℝ) :=
+          Nat.cast_eq_zero.mpr <| Int.toNat_of_nonpos <| Int.ceil_le.mpr (by rwa [Int.cast_zero])
+        exact hs' ▸ hs
 
 end
 

--- a/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/PhysLean/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -197,7 +197,7 @@ lemma radiusPowOperator_apply_stronglyMeasurable {d : ℕ} (s : ℝ) (ψ : 𝓢(
   exact StronglyMeasurable.mul (by measurability) ψ.continuous.stronglyMeasurable
 
 /-- `x ↦ ‖x‖ˢψ(x)` is square-integrable provided `s` is not too negative. -/
-lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2 * s)
+lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : 0 < d + 2 * s)
     (ψ : 𝓢(Space d, ℂ)) : MemHS (𝐫[s] ψ) := by
   rcases Nat.eq_zero_or_pos d with (rfl | hd)
   · simp only [MemHS, MemLp.of_discrete]
@@ -221,8 +221,7 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
         _ = ‖C ^ 2‖ₑ * ∫⁻ (x : Space d) in (Metric.ball 0 1), ‖‖x‖ ^ (2 * s)‖ₑ :=
           lintegral_const_mul _ (by fun_prop)
       apply ENNReal.mul_lt_top enorm_lt_top
-      have := (integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr (h.resolve_left hd.ne')
-      exact this.hasFiniteIntegral
+      exact ((integrableOn_norm_rpow_ball_iff hd Real.zero_lt_one _).mpr h).hasFiniteIntegral
     · -- `1 ≤ ‖x‖`: bound `‖ψ x‖` by a suitable power of `‖x‖`
       obtain ⟨C, hC_pos, hC⟩ := ψ.decay (⌈s⌉.toNat + d) 0
       simp only [norm_iteratedFDeriv_zero, ← Real.rpow_natCast, Nat.cast_add] at hC
@@ -261,8 +260,7 @@ lemma radiusPowOperator_apply_memHS {d : ℕ} (s : ℝ) (h : d = 0 ∨ 0 < d + 2
           lintegral_const_mul _ (by fun_prop)
       apply ENNReal.mul_lt_top enorm_lt_top
       have hd' : (d + -2 * d : ℝ) < 0 := by aesop
-      have := (integrableOn_norm_rpow_ball_compl_iff hd Real.zero_lt_one _).mpr hd'
-      exact this.hasFiniteIntegral
+      exact ((integrableOn_norm_rpow_ball_compl_iff hd zero_lt_one _).mpr hd').hasFiniteIntegral
 
 end
 


### PR DESCRIPTION
Defines a linear operator which maps a Schwartz function `ψ` to `x ↦ ‖x‖ ^ s * ψ x`.

The resulting function is smooth away from `x = 0` and strongly measurable, and is also square-integrable as long as `s` is not too negative.