### PR TITLE
feat: Remove warnings for QuantumInfo

### DIFF
--- a/PhysLean/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/PhysLean/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -417,7 +417,7 @@ lemma trajectory_equationOfMotion (IC : InitialConditions) :
   have hωm : S.ω ^ 2 * S.m = S.k := by
     rw [ω_sq]
     field_simp [m_ne_zero S]
-  simp [trajectory_eq, smul_add, smul_smul, mul_comm, mul_left_comm]
+  simp [trajectory_eq, smul_add, smul_smul, mul_comm]
   rw [← hωm]
   field_simp [hω]
   ring

--- a/QuantumInfo/Finite/CPTPMap/Dual.lean
+++ b/QuantumInfo/Finite/CPTPMap/Dual.lean
@@ -48,13 +48,16 @@ theorem Dual.trace_eq (M : MatrixMap dIn dOut R) (A : Matrix dIn dIn R) (B : Mat
 theorem IsHermitianPreserving.dual (h : M.IsHermitianPreserving) : M.dual.IsHermitianPreserving := by
   sorry
 
+open MatrixOrder
 --TODO Cleanup, find home, abstract out to HermitianMats...?
 theorem _root_.Matrix.PosSemidef.trace_mul_nonneg {n : Type*} [Fintype n] [DecidableEq n]
     {A B : Matrix n n 𝕜} (hA : A.PosSemidef) (hB : B.PosSemidef) :
     0 ≤ (A * B).trace := by
   open scoped Matrix in
   obtain ⟨sqrtB, rfl⟩ : ∃ sqrtB : Matrix n n 𝕜, B = sqrtBᴴ * sqrtB := by
-    exact Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp hB;
+    classical
+    apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+    exact Matrix.nonneg_iff_posSemidef.mpr hB
   simp only [← Matrix.mul_assoc, ← Matrix.trace_mul_comm sqrtB]
   have h : (sqrtB * A * sqrtBᴴ).PosSemidef := by
     convert hA.conjTranspose_mul_mul_same sqrtBᴴ using 1

--- a/QuantumInfo/Finite/CPTPMap/Unbundled.lean
+++ b/QuantumInfo/Finite/CPTPMap/Unbundled.lean
@@ -346,16 +346,22 @@ end IsCompletelyPositive
 variable [Fintype A] [Fintype B] [Fintype C] [DecidableEq A]
 variable {d : Type*} [Fintype d]
 
+open MatrixOrder
+
 /-- The map that takes M and returns M ⊗ₖ C, where C is positive semidefinite, is a completely positive map. -/
 theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : _} : IsCompletelyPositive
     (⟨⟨fun M => M ⊗ₖ C, h₁⟩, h₂⟩ : MatrixMap A (A × d) R) := by
   intros n x hx
   have h_kronecker_pos : (x ⊗ₖ C).PosSemidef := by
     -- Since $x$ and $C$ are positive semidefinite, there exist matrices $U$ and $V$ such that $x = U^*U$ and $C = V^*V$.
-    obtain ⟨U, hU⟩ : ∃ U : Matrix (A × Fin n) (A × Fin n) R, x = star U * U :=
-      Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp hx
-    obtain ⟨V, hV⟩ : ∃ V : Matrix d d R, C = star V * V :=
-      Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp h
+    obtain ⟨U, hU⟩ : ∃ U : Matrix (A × Fin n) (A × Fin n) R, x = star U * U := by
+      classical
+      apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+      exact Matrix.nonneg_iff_posSemidef.mpr hx
+    obtain ⟨V, hV⟩ : ∃ V : Matrix d d R, C = star V * V := by
+      classical
+      apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+      exact Matrix.nonneg_iff_posSemidef.mpr h
     -- $W = (U \otimes V)^* (U \otimes V)$ is positive semidefinite.
     have hW_pos : (U ⊗ₖ V).conjTranspose * (U ⊗ₖ V) = x ⊗ₖ C := by
       rw [Matrix.kroneckerMap_conjTranspose, ← Matrix.mul_kronecker_mul]
@@ -596,7 +602,10 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
       simp +contextual [ eq_comm ];
     simp only [ h_inner ];
     simpa only [ mul_assoc, mul_comm, mul_left_comm ] using h_reindex
-  obtain ⟨m', rfl⟩ := Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp h
+  obtain ⟨m', rfl⟩ : ∃ B, m = B.conjTranspose * B := by
+    classical
+    apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+    exact Matrix.nonneg_iff_posSemidef.mpr h
   convert Matrix.posSemidef_conjTranspose_mul_self (m' * (M ⊗ₖ 1 : Matrix (B × Fin n) (A × Fin n) R).conjTranspose) using 1
   simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
   rw [Matrix.mul_assoc, Matrix.mul_assoc]

--- a/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
@@ -132,11 +132,13 @@ theorem log_smul {A : HermitianMat d 𝕜} {x : ℝ} (hx : x ≠ 0) [NonSingular
 /-
 The inverse function is operator antitone for positive definite matrices.
 -/
-open ComplexOrder in
+open ComplexOrder MatrixOrder in
 theorem inv_antitone (hA : A.mat.PosDef) (h : A ≤ B) : B⁻¹ ≤ A⁻¹ := by
   -- Since $B - A$ is positive semidefinite, we can write it as $C^*C$ for some matrix $C$.
-  obtain ⟨C, hC⟩ : ∃ C : Matrix d d 𝕜, B.mat - A.mat = C.conjTranspose * C :=
-    Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp h
+  obtain ⟨C, hC⟩ : ∃ C : Matrix d d 𝕜, B.mat - A.mat = C.conjTranspose * C := by
+    classical
+    apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+    simpa using h
   -- Using the fact that $B = A + C^*C$, we can write $B^{-1}$ as $(A + C^*C)^{-1}$.
   have h_inv_posDef : (1 + C * A.mat⁻¹ * C.conjTranspose).PosDef := by
     exact Matrix.PosDef.one.add_posSemidef (hA.inv.posSemidef.mul_mul_conjTranspose_same C)

--- a/QuantumInfo/ForMathlib/Matrix.lean
+++ b/QuantumInfo/ForMathlib/Matrix.lean
@@ -1328,7 +1328,7 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
             Unitary.conjStarAlgAut_apply]
           simp [ mul_comm, mul_left_comm, Algebra.smul_def ]
           congr! 1
-          simp [Algebra.algebraMap_eq_smul_one, mul_assoc]
+          simp [Algebra.algebraMap_eq_smul_one]
         -- Substitute the decomposition of $A$ into the expression $(star v ⬝ᵥ (A.mulVec v))$.
         have h_subst : (star v ⬝ᵥ (A.mulVec v)) = ∑ i, (hA.eigenvalues i) * (star v ⬝ᵥ (Matrix.mulVec (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k)))) v)) := by
           -- Substitute the decomposition of $A$ into the expression $(star v ⬝ᵥ (A.mulVec v))$ and use the linearity of matrix multiplication.
@@ -1541,8 +1541,7 @@ theorem trace_piProd [CommSemiring R] :
   symm
   simp [trace, piProd, Fintype.prod_sum]
 
-open ComplexOrder in
-set_option maxHeartbeats 400000 in
+open ComplexOrder MatrixOrder in
 theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
     (piProd A).PosSemidef := by
   -- Let B i be the square root of A i. Let BigB be the pi-product of B i. Show that BigB.conjTranspose * BigB equals the pi-product of A i using Fintype.prod_sum. Then use Matrix.PosSemidef.conjTranspose_mul_self to conclude the proof.
@@ -1551,7 +1550,9 @@ theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
     have h_decomp : ∀ i, ∃ B : Matrix (d i) (d i) R, A i = B * star B := by
       intro i
       obtain ⟨B, hB⟩ : ∃ B : Matrix (d i) (d i) R, A i = B.conjTranspose * B := by
-        exact Matrix.posSemidef_iff_eq_conjTranspose_mul_self.mp (hA i)
+        classical
+        apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
+        exact nonneg_iff_posSemidef.mpr (hA i)
       use B.conjTranspose;
       convert hB using 1;
       simp [ Matrix.star_eq_conjTranspose ];
@@ -1570,10 +1571,12 @@ theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
   · intro x
     set y := star (Matrix.of (fun j k : (∀ i, d i) => ∏ i, B i (j i) (k i))) *ᵥ x
     convert dotProduct_star_self_nonneg y using 1
-    simp [ Matrix.dotProduct_mulVec]
-    simp [ Matrix.dotProduct_mulVec, y ];
-    simp [ Matrix.vecMul, dotProduct, mul_comm ];
-    simp [ Matrix.mul_apply, Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _, mul_assoc, mul_comm, mul_left_comm ];
+    simp only [dotProduct_mulVec, y];
+    simp only [dotProduct, vecMul, Pi.star_apply, RCLike.star_def, mul_comm, star_apply, of_apply,
+      star_prod];
+    simp only [mul_apply, of_apply, star_apply, star_prod, RCLike.star_def, Finset.mul_sum _ _ _,
+      mul_left_comm, mulVec, dotProduct, mul_comm, map_sum, map_mul, map_prod,
+      RingHomCompTriple.comp_apply, RingHom.id_apply, mul_assoc];
     exact Finset.sum_congr rfl fun _ _ => Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring )
 
 end finprod

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -8,10 +8,16 @@ require "mathlib" from git "https://github.com/leanprover-community/mathlib4.git
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "v4.28.0"
 
 @[default_target]
-lean_lib PhysLean
+lean_lib PhysLean where
+  moreLeanArgs := #[
+    "-Dwarn.sorry=false"
+  ]
 
 @[default_target]
-lean_lib QuantumInfo
+lean_lib QuantumInfo where
+  moreLeanArgs := #[
+    "-Dwarn.sorry=false"
+  ]
 
 -- These were their own lean_lib in Lean-QuantumInfo, we should move them to appropriate directories.
 -- lean_lib ClassicalInfo


### PR DESCRIPTION
Removing the warnings on the `QuantumInfo` part of the library. Mainly getting rid of the deprecated `Matrix.posSemidef_iff_eq_conjTranspose_mul_self` using `MatrixOrder`. Also turned off the warning about `sorry` in both `QuantumInfo` and `PhysLean`. 