### PR TITLE
feat: ElectromagneticPotential as a structure

### DIFF
--- a/PhysLean/Electromagnetism/Dynamics/Hamiltonian.lean
+++ b/PhysLean/Electromagnetism/Dynamics/Hamiltonian.lean
@@ -78,9 +78,9 @@ noncomputable def canonicalMomentum (𝓕 : FreeSpace) (A : ElectromagneticPoten
     (J : LorentzCurrentDensity d) :
     SpaceTime d → Lorentz.Vector d := fun x =>
   gradient (fun (v : Lorentz.Vector d) =>
-    lagrangian 𝓕 (fun x => A x + x (Sum.inl 0) • v) J x) 0
+    lagrangian 𝓕 ⟨fun x => A x + x (Sum.inl 0) • v⟩ J x) 0
   - x (Sum.inl 0) • gradient (fun (v : Lorentz.Vector d) =>
-    lagrangian 𝓕 (fun x => A x + v) J x) 0
+    lagrangian 𝓕 ⟨fun x => A x + v⟩ J x) 0
 
 /-!
 
@@ -92,7 +92,7 @@ lemma canonicalMomentum_eq_gradient_kineticTerm {d}
     (hA : ContDiff ℝ 2 A) (J : LorentzCurrentDensity d) :
     A.canonicalMomentum 𝓕 J = fun x =>
     gradient (fun (v : Lorentz.Vector d) =>
-    kineticTerm 𝓕 (fun x => A x + x (Sum.inl 0) • v) x) 0:= by
+    kineticTerm 𝓕 ⟨fun x => A x + x (Sum.inl 0) • v⟩ x) 0:= by
   funext x
   apply ext_inner_right (𝕜 := ℝ)
   intro v
@@ -103,7 +103,7 @@ lemma canonicalMomentum_eq_gradient_kineticTerm {d}
   conv_lhs =>
     enter [2]
     simp [lagrangian_add_const]
-  have hx : DifferentiableAt ℝ (fun v => kineticTerm 𝓕 (fun x => A x + x (Sum.inl 0) • v) x) 0 := by
+  have hx : DifferentiableAt ℝ (fun v => kineticTerm 𝓕 ⟨fun x => A x + x (Sum.inl 0) • v⟩ x) 0 := by
     apply Differentiable.differentiableAt _
     conv =>
       enter [2, v]

--- a/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/PhysLean/Electromagnetism/Dynamics/IsExtrema.lean
@@ -179,12 +179,12 @@ lemma isExtrema_lorentzGroup_apply_iff {𝓕 : FreeSpace}
     (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d) (hJ : ContDiff ℝ ∞ J)
     (Λ : LorentzGroup d) :
-    IsExtrema 𝓕 (fun x => Λ • A (Λ⁻¹ • x)) (fun x => Λ • J (Λ⁻¹ • x)) ↔
+    IsExtrema 𝓕 ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ (fun x => Λ • J (Λ⁻¹ • x)) ↔
     IsExtrema 𝓕 A J := by
   rw [isExtrema_iff_tensors]
   conv_lhs =>
     enter [x, 1, 1, 2, 2, 2]
-    change tensorDeriv (fun x => toFieldStrength (fun x => Λ • A (Λ⁻¹ • x)) x) x
+    change tensorDeriv (fun x => toFieldStrength ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ x) x
     enter [1,x]
     rw [toFieldStrength_equivariant _ _ (hA.differentiable (by simp))]
   conv_lhs =>

--- a/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
@@ -964,7 +964,8 @@ lemma gradKineticTerm_smul {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential 
 -/
 
 lemma kineticTerm_hasVarGradientAt {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
-    (hA : ContDiff ℝ ∞ A) : HasVarGradientAt (fun A => kineticTerm 𝓕 ⟨A⟩) (A.gradKineticTerm 𝓕) A := by
+    (hA : ContDiff ℝ ∞ A) :
+    HasVarGradientAt (fun A => kineticTerm 𝓕 ⟨A⟩) (A.gradKineticTerm 𝓕) A := by
   rw [gradKineticTerm_eq_sum_fderiv A hA]
   change HasVarGradientAt (fun A' x => ElectromagneticPotential.kineticTerm 𝓕 ⟨A'⟩ x) _ A
   conv =>

--- a/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/PhysLean/Electromagnetism/Dynamics/KineticTerm.lean
@@ -104,7 +104,7 @@ We show that the kinetic energy is Lorentz invariant.
 lemma kineticTerm_equivariant {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (Λ : LorentzGroup d)
     (hf : Differentiable ℝ A) (x : SpaceTime d) :
-    kineticTerm 𝓕 (fun x => Λ • A (Λ⁻¹ • x)) x = kineticTerm 𝓕 A (Λ⁻¹ • x) := by
+    kineticTerm 𝓕 ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ x = kineticTerm 𝓕 A (Λ⁻¹ • x) := by
   rw [kineticTerm, kineticTerm]
   conv_lhs =>
     enter [2]
@@ -385,7 +385,7 @@ lemma kineticTerm_eq_electricMatrix_magneticFieldMatrix {𝓕 : FreeSpace}
 -/
 
 lemma kineticTerm_const {d} {𝓕 : FreeSpace} (A₀ : Lorentz.Vector d) :
-    kineticTerm 𝓕 (fun _ : SpaceTime d => A₀) = 0 := by
+    kineticTerm 𝓕 ⟨fun _ : SpaceTime d => A₀⟩ = 0 := by
   funext x
   rw [kineticTerm_eq_sum_potential]
   conv_lhs =>
@@ -396,7 +396,7 @@ lemma kineticTerm_const {d} {𝓕 : FreeSpace} (A₀ : Lorentz.Vector d) :
 
 lemma kineticTerm_add_const {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (A₀ : Lorentz.Vector d) :
-    kineticTerm 𝓕 (fun x => A x + A₀) = kineticTerm 𝓕 A := by
+    kineticTerm 𝓕 ⟨fun x => A x + A₀⟩ = kineticTerm 𝓕 A := by
   funext x
   rw [kineticTerm_eq_sum_potential, kineticTerm_eq_sum_potential]
   congr
@@ -448,7 +448,7 @@ This result is used in finding the canonical momentum.
 lemma kineticTerm_add_time_mul_const {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (ha : Differentiable ℝ A)
     (c : Lorentz.Vector d) (x : SpaceTime d) :
-    kineticTerm 𝓕 (fun x => A x + x (Sum.inl 0) • c) x = A.kineticTerm 𝓕 x +
+    kineticTerm 𝓕 ⟨fun x => A x + x (Sum.inl 0) • c⟩ x = A.kineticTerm 𝓕 x +
         (-1 / (2 * 𝓕.μ₀) * ∑ ν, ((2 * c ν * η ν ν * ∂_ (Sum.inl 0) A x ν + η ν ν * c ν ^ 2 -
         2 * c ν * (∂_ ν A x (Sum.inl 0)))) + 1/(2 * 𝓕.μ₀) * c (Sum.inl 0) ^2) := by
   have diff_a : ∂_ (Sum.inl 0) (fun x => A x + x (Sum.inl 0) • c) =
@@ -587,7 +587,7 @@ of Gauss's law and Ampère's law in vacuum.
 /-- The variational gradient of the kinetic term of an electromagnetic potential. -/
 noncomputable def gradKineticTerm {d} (𝓕 : FreeSpace) (A : ElectromagneticPotential d) :
     SpaceTime d → Lorentz.Vector d :=
-  (δ (q':=A), ∫ x, kineticTerm 𝓕 q' x)
+  (δ (q':=A), ∫ x, kineticTerm 𝓕 ⟨q'⟩ x)
 
 /-!
 
@@ -614,7 +614,7 @@ lemma gradKineticTerm_eq_sum_fderiv {d} {𝓕 : FreeSpace} (A : ElectromagneticP
           Lorentz.Vector.basis μν.1))
     A.gradKineticTerm 𝓕 = fun x => ∑ μν, F' μν (fun x' => -1/(2 * 𝓕.μ₀) * (fun _ => 1) x') x := by
   apply HasVarGradientAt.varGradient
-  change HasVarGradientAt (fun A' x => ElectromagneticPotential.kineticTerm 𝓕 A' x) _ A
+  change HasVarGradientAt (fun A' x => ElectromagneticPotential.kineticTerm 𝓕 ⟨A'⟩ x) _ A
   conv =>
     enter [1, A', x]
     rw [kineticTerm_eq_sum_potential]
@@ -964,9 +964,9 @@ lemma gradKineticTerm_smul {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential 
 -/
 
 lemma kineticTerm_hasVarGradientAt {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
-    (hA : ContDiff ℝ ∞ A) : HasVarGradientAt (kineticTerm 𝓕) (A.gradKineticTerm 𝓕) A := by
+    (hA : ContDiff ℝ ∞ A) : HasVarGradientAt (fun A => kineticTerm 𝓕 ⟨A⟩) (A.gradKineticTerm 𝓕) A := by
   rw [gradKineticTerm_eq_sum_fderiv A hA]
-  change HasVarGradientAt (fun A' x => ElectromagneticPotential.kineticTerm 𝓕 A' x) _ A
+  change HasVarGradientAt (fun A' x => ElectromagneticPotential.kineticTerm 𝓕 ⟨A'⟩ x) _ A
   conv =>
     enter [1, A', x]
     rw [kineticTerm_eq_sum_potential]

--- a/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
+++ b/PhysLean/Electromagnetism/Dynamics/Lagrangian.lean
@@ -104,7 +104,7 @@ noncomputable def freeCurrentPotential (A : ElectromagneticPotential d)
 
 lemma freeCurrentPotential_add_const (A : ElectromagneticPotential d)
     (J : LorentzCurrentDensity d) (c : Lorentz.Vector d) (x : SpaceTime d) :
-    freeCurrentPotential (fun x => A x + c) J x = freeCurrentPotential A J x + ⟪c, J x⟫ₘ := by
+    freeCurrentPotential ⟨fun x => A x + c⟩ J x = freeCurrentPotential A J x + ⟪c, J x⟫ₘ := by
   rw [freeCurrentPotential, freeCurrentPotential]
   simp
 
@@ -117,7 +117,7 @@ lemma freeCurrentPotential_add_const (A : ElectromagneticPotential d)
 lemma freeCurrentPotential_hasVarGradientAt (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d)
     (hJ : ContDiff ℝ ∞ J) :
-    HasVarGradientAt (fun A => freeCurrentPotential A J)
+    HasVarGradientAt (fun A => freeCurrentPotential ⟨A⟩ J)
     (((∑ μ, fun x => (η μ μ * J x μ) • Lorentz.Vector.basis μ))) A := by
   conv =>
     enter [1, q', x]
@@ -164,7 +164,7 @@ lemma freeCurrentPotential_eq_sum_scalarPotential_vectorPotential
 /-- The variational gradient of the free current potential. -/
 noncomputable def gradFreeCurrentPotential {d} (A : ElectromagneticPotential d)
     (J : LorentzCurrentDensity d) : SpaceTime d → Lorentz.Vector d :=
-  (δ (q':=A), ∫ x, freeCurrentPotential q' J x)
+  (δ (q':=A), ∫ x, freeCurrentPotential ⟨q'⟩ J x)
 
 lemma gradFreeCurrentPotential_eq_sum_basis {d} (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d)
@@ -225,7 +225,7 @@ noncomputable def lagrangian (𝓕 : FreeSpace) (A : ElectromagneticPotential d)
 
 lemma lagrangian_add_const {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (J : LorentzCurrentDensity d) (c : Lorentz.Vector d) (x : SpaceTime d) :
-    lagrangian 𝓕 (fun x => A x + c) J x = lagrangian 𝓕 A J x - ⟪c, J x⟫ₘ := by
+    lagrangian 𝓕 ⟨fun x => A x + c⟩ J x = lagrangian 𝓕 A J x - ⟪c, J x⟫ₘ := by
   rw [lagrangian, lagrangian, kineticTerm_add_const, freeCurrentPotential_add_const]
   ring
 
@@ -263,7 +263,7 @@ lemma lagrangian_eq_electric_magnetic {d} {𝓕 : FreeSpace}
 lemma lagrangian_hasVarGradientAt_eq_add_gradKineticTerm {𝓕 : FreeSpace}
     (A : ElectromagneticPotential d) (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d)
     (hJ : ContDiff ℝ ∞ J) :
-    HasVarGradientAt (fun A => lagrangian 𝓕 A J)
+    HasVarGradientAt (fun A => lagrangian 𝓕 ⟨A⟩ J)
     (A.gradKineticTerm 𝓕 - A.gradFreeCurrentPotential J) A := by
   conv =>
     enter [1, q', x]
@@ -283,7 +283,7 @@ lemma lagrangian_hasVarGradientAt_eq_add_gradKineticTerm {𝓕 : FreeSpace}
 /-- The variational gradient of the lagrangian of electromagnetic field. -/
 noncomputable def gradLagrangian {d} (𝓕 : FreeSpace) (A : ElectromagneticPotential d)
     (J : LorentzCurrentDensity d) : SpaceTime d → Lorentz.Vector d :=
-  (δ (q':=A), ∫ x, lagrangian 𝓕 q' J x)
+  (δ (q':=A), ∫ x, lagrangian 𝓕 ⟨q'⟩ J x)
 
 /-!
 
@@ -306,7 +306,7 @@ lemma gradLagrangian_eq_kineticTerm_sub {𝓕 : FreeSpace} (A : ElectromagneticP
 lemma lagrangian_hasVarGradientAt_gradLagrangian {𝓕 : FreeSpace}
     (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d) (hJ : ContDiff ℝ ∞ J) :
-    HasVarGradientAt (fun A => lagrangian 𝓕 A J) (A.gradLagrangian 𝓕 J) A := by
+    HasVarGradientAt (fun A => lagrangian 𝓕 ⟨A⟩ J) (A.gradLagrangian 𝓕 J) A := by
   rw [gradLagrangian_eq_kineticTerm_sub A hA J hJ]
   apply lagrangian_hasVarGradientAt_eq_add_gradKineticTerm A hA J hJ
 

--- a/PhysLean/Electromagnetism/Kinematics/Boosts.lean
+++ b/PhysLean/Electromagnetism/Kinematics/Boosts.lean
@@ -68,7 +68,7 @@ lemma electricField_apply_x_boost_zero {d : ℕ} {c : SpeedOfLight} (β : ℝ) (
     let x' : Space d.succ := ⟨fun
       | 0 => γ β * (x 0 + c * β * t.val)
       | ⟨Nat.succ n, ih⟩ => x ⟨Nat.succ n, ih⟩⟩
-    electricField c (fun x => Λ • A (Λ⁻¹ • x)) t x 0 =
+    electricField c ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ t x 0 =
     A.electricField c t' x' 0 := by
   dsimp
   rw [electricField_eq_fieldStrengthMatrix, fieldStrengthMatrix_equivariant]
@@ -94,7 +94,8 @@ lemma electricField_apply_x_boost_zero {d : ℕ} {c : SpeedOfLight} (β : ℝ) (
   rfl
   exact hA
   exact hA
-  · apply Differentiable.comp
+  · simp only
+    apply Differentiable.comp
     · change Differentiable ℝ (Lorentz.Vector.actionCLM (boost 0 β hβ))
       exact ContinuousLinearMap.differentiable (Lorentz.Vector.actionCLM (boost 0 β hβ))
     · apply Differentiable.comp
@@ -115,7 +116,7 @@ lemma electricField_apply_x_boost_succ {d : ℕ} {c : SpeedOfLight} (β : ℝ) (
     let x' : Space d.succ := ⟨fun
       | 0 => γ β * (x 0 + c * β * t.val)
       | ⟨Nat.succ n, ih⟩ => x ⟨Nat.succ n, ih⟩⟩
-    electricField c (fun x => Λ • A (Λ⁻¹ • x)) t x i.succ =
+    electricField c ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ t x i.succ =
     γ β * (A.electricField c t' x' i.succ + c * β * A.magneticFieldMatrix c t' x' (0, i.succ)) := by
   dsimp
   rw [electricField_eq_fieldStrengthMatrix,
@@ -133,7 +134,8 @@ lemma electricField_apply_x_boost_succ {d : ℕ} {c : SpeedOfLight} (β : ℝ) (
   field_simp
   rfl
   exact hA
-  · apply Differentiable.comp
+  · simp only
+    apply Differentiable.comp
     · change Differentiable ℝ (Lorentz.Vector.actionCLM (boost 0 β hβ))
       exact ContinuousLinearMap.differentiable (Lorentz.Vector.actionCLM (boost 0 β hβ))
     · apply Differentiable.comp
@@ -160,7 +162,7 @@ lemma magneticFieldMatrix_apply_x_boost_zero_succ {d : ℕ} {c : SpeedOfLight} (
     let x' : Space d.succ := ⟨fun
       | 0 => γ β * (x 0 + c * β * t.val)
       | ⟨Nat.succ n, ih⟩ => x ⟨Nat.succ n, ih⟩⟩
-    magneticFieldMatrix c (fun x => Λ • A (Λ⁻¹ • x)) t x (0, i.succ) =
+    magneticFieldMatrix c ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ t x (0, i.succ) =
     γ β * (A.magneticFieldMatrix c t' x' (0, i.succ) + β / c * A.electricField c t' x' i.succ) := by
   dsimp
   rw [magneticFieldMatrix_eq]
@@ -194,7 +196,7 @@ lemma magneticFieldMatrix_apply_x_boost_succ_succ {d : ℕ} {c : SpeedOfLight} (
     let x' : Space d.succ := ⟨fun
       | 0 => γ β * (x 0 + c * β * t.val)
       | ⟨Nat.succ n, ih⟩ => x ⟨Nat.succ n, ih⟩⟩
-    magneticFieldMatrix c (fun x => Λ • A (Λ⁻¹ • x)) t x (i.succ, j.succ) =
+    magneticFieldMatrix c ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ t x (i.succ, j.succ) =
     A.magneticFieldMatrix c t' x' (i.succ, j.succ) := by
   dsimp
   rw [magneticFieldMatrix_eq]

--- a/PhysLean/Electromagnetism/Kinematics/EMPotential.lean
+++ b/PhysLean/Electromagnetism/Kinematics/EMPotential.lean
@@ -30,10 +30,11 @@ spacetime to contravariant Lorentz vectors.
 ## iii. Table of contents
 
 - A. The electromagnetic potential
-  - A.1. The action on the space-time derivatives
-  - A.2. Differentiability
-  - A.3. Variational adjoint derivative of component
-  - A.4. Variational adjoint derivative of derivatives of the potential
+  - A.1. Basic instances on the type of electromagnetic potentials
+  - A.2. The action on the space-time derivatives
+  - A.3. Differentiability
+  - A.4. Variational adjoint derivative of component
+  - A.5. Variational adjoint derivative of derivatives of the potential
 - B. The derivative tensor of the electromagnetic potential
   - B.1. Equivariance of the derivative tensor
   - B.2. The elements of the derivative tensor in terms of the basis
@@ -113,7 +114,7 @@ lemma smul_apply {d} (r : ℝ) (A : ElectromagneticPotential d) (x : SpaceTime d
 
 /-!
 
-### A.1. The action on the space-time derivatives
+### A.2. The action on the space-time derivatives
 
 Given a ElectromagneticPotential `A^μ`, we can consider its derivative `∂_μ A^ν`.
 Under a Lorentz transformation `Λ`, this transforms as
@@ -184,7 +185,7 @@ lemma spaceTime_deriv_action_eq_sum {d} {μ ν : Fin 1 ⊕ Fin d} {x : SpaceTime
 
 /-!
 
-### A.2. Differentiability
+### A.3. Differentiability
 
 We show that the components of field strength tensor are differentiable if the potential is.
 -/
@@ -199,7 +200,7 @@ lemma differentiable_component {d : ℕ}
 
 /-!
 
-### A.3. Variational adjoint derivative of component
+### A.4. Variational adjoint derivative of component
 
 We find the variational adjoint derivative of the components of the potential.
 This will be used to find e.g. the variational derivative of the kinetic term,
@@ -231,7 +232,7 @@ lemma hasVarAdjDerivAt_component {d : ℕ} (μ : Fin 1 ⊕ Fin d) (A : SpaceTime
 
 /-!
 
-### A.4. Variational adjoint derivative of derivatives of the potential
+### A.5. Variational adjoint derivative of derivatives of the potential
 
 We find the variational adjoint derivative of the derivatives of the components of the potential.
 This will again be used to find the variational derivative of the kinetic term,

--- a/PhysLean/Electromagnetism/Kinematics/EMPotential.lean
+++ b/PhysLean/Electromagnetism/Kinematics/EMPotential.lean
@@ -66,8 +66,10 @@ contravariant Lorentz vectors, and prove some simple results about it.
 
 -/
 /-- The electromagnetic potential is a tensor `A^μ`. -/
-noncomputable abbrev ElectromagneticPotential (d : ℕ := 3) :=
-  SpaceTime d → Lorentz.Vector d
+structure ElectromagneticPotential (d : ℕ := 3) where
+  /-- The underlying map from `SpaceTime d` to `Lorentz.Vector d` associated
+    with an electromagnetic potential. -/
+  val : SpaceTime d → Lorentz.Vector d
 
 namespace ElectromagneticPotential
 
@@ -78,6 +80,37 @@ open TensorProduct
 open minkowskiMatrix
 attribute [-simp] Fintype.sum_sum_type
 attribute [-simp] Nat.succ_eq_add_one
+
+/-!
+
+## A.1. Basic instances on the type of electromagnetic potentials
+
+-/
+
+instance {d} : CoeFun (ElectromagneticPotential d)
+    (fun _ => SpaceTime d → Lorentz.Vector d) where
+  coe A := A.val
+
+instance {d} : Add (ElectromagneticPotential d) where
+  add A B := ⟨fun x => A x + B x⟩
+
+@[simp]
+lemma add_val {d} (A B : ElectromagneticPotential d) :
+    (A + B).val = A.val + B.val := rfl
+
+lemma add_apply {d} (A B : ElectromagneticPotential d) (x : SpaceTime d) :
+    (A + B) x = A x + B x := by simp
+
+noncomputable instance {d} : SMul ℝ (ElectromagneticPotential d) where
+  smul r A := ⟨fun x => r • A x⟩
+
+@[simp]
+lemma smul_val {d} (r : ℝ) (A : ElectromagneticPotential d) :
+    (r • A).val = r • A.val := rfl
+
+lemma smul_apply {d} (r : ℝ) (A : ElectromagneticPotential d) (x : SpaceTime d) :
+    (r • A) x = r • A x := by simp
+
 /-!
 
 ### A.1. The action on the space-time derivatives
@@ -156,6 +189,7 @@ lemma spaceTime_deriv_action_eq_sum {d} {μ ν : Fin 1 ⊕ Fin d} {x : SpaceTime
 We show that the components of field strength tensor are differentiable if the potential is.
 -/
 
+@[fun_prop]
 lemma differentiable_component {d : ℕ}
     (A : ElectromagneticPotential d) (hA : Differentiable ℝ A) (μ : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => A x μ) := by
@@ -246,7 +280,7 @@ as taking the derivative and then applying the Lorentz transformation to the res
 -/
 lemma deriv_equivariant {d} {x : SpaceTime d} (A : ElectromagneticPotential d)
     (Λ : LorentzGroup d)
-    (hf : Differentiable ℝ A) : deriv (fun x => Λ • A (Λ⁻¹ • x)) x = Λ • (deriv A (Λ⁻¹ • x)) := by
+    (hf : Differentiable ℝ A) : deriv ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ x = Λ • (deriv A (Λ⁻¹ • x)) := by
     calc _
       _ = ∑ μ, ∑ ν, ∑ κ, ∑ ρ, (Λ.1 ν κ * (Λ⁻¹.1 ρ μ • ∂_ ρ A (Λ⁻¹ • x) κ)) •
           (Lorentz.CoVector.basis μ) ⊗ₜ[ℝ]

--- a/PhysLean/Electromagnetism/Kinematics/FieldStrength.lean
+++ b/PhysLean/Electromagnetism/Kinematics/FieldStrength.lean
@@ -369,7 +369,7 @@ as taking the field strength and then transforming the resulting tensor.
 
 lemma toFieldStrength_equivariant {d} (A : ElectromagneticPotential d) (Λ : LorentzGroup d)
     (hf : Differentiable ℝ A) (x : SpaceTime d) :
-    toFieldStrength (fun x => Λ • A (Λ⁻¹ • x)) x =
+    toFieldStrength ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ x =
       Λ • toFieldStrength A (Λ⁻¹ • x) := by
   rw [toFieldStrength, deriv_equivariant A Λ hf, ← actionT_contrMetric Λ, toFieldStrength]
   simp only [Tensorial.toTensor_smul, prodT_equivariant, contrT_equivariant, map_neg,
@@ -378,7 +378,7 @@ lemma toFieldStrength_equivariant {d} (A : ElectromagneticPotential d) (Λ : Lor
 lemma fieldStrengthMatrix_equivariant {d} (A : ElectromagneticPotential d)
     (Λ : LorentzGroup d) (hf : Differentiable ℝ A) (x : SpaceTime d)
     (μ : (Fin 1 ⊕ Fin d)) (ν : Fin 1 ⊕ Fin d) :
-    fieldStrengthMatrix (fun x => Λ • A (Λ⁻¹ • x)) x (μ, ν) =
+    fieldStrengthMatrix ⟨fun x => Λ • A (Λ⁻¹ • x)⟩ x (μ, ν) =
     ∑ κ, ∑ ρ, (Λ.1 μ κ * Λ.1 ν ρ) * A.fieldStrengthMatrix (Λ⁻¹ • x) (κ, ρ) := by
   rw [fieldStrengthMatrix, toFieldStrength_equivariant A Λ hf x]
   conv_rhs =>
@@ -429,6 +429,7 @@ lemma toFieldStrength_add {d} (A1 A2 : ElectromagneticPotential d)
   rw [← Finset.sum_add_distrib]
   apply Finset.sum_congr rfl (fun κ _ => ?_)
   repeat rw [SpaceTime.deriv_eq]
+  simp only [add_val]
   rw [fderiv_add]
   simp only [ContinuousLinearMap.add_apply, Lorentz.Vector.apply_add]
   ring
@@ -453,6 +454,7 @@ lemma toFieldStrength_smul {d} (c : ℝ) (A : ElectromagneticPotential d)
   rw [Finset.mul_sum]
   apply Finset.sum_congr rfl (fun κ _ => ?_)
   repeat rw [SpaceTime.deriv_eq]
+  simp only [smul_val]
   rw [fderiv_const_smul]
   simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, Lorentz.Vector.apply_smul]
   ring

--- a/PhysLean/Electromagnetism/Kinematics/ScalarPotential.lean
+++ b/PhysLean/Electromagnetism/Kinematics/ScalarPotential.lean
@@ -86,6 +86,7 @@ lemma scalarPotential_contDiff {n} {d} (c : SpeedOfLight) (A : ElectromagneticPo
   · fun_prop
   exact h1 (Sum.inl 0)
 
+@[fun_prop]
 lemma scalarPotential_contDiff_space {n} {d} (c : SpeedOfLight)
     (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ n A) (t : Time) : ContDiff ℝ n (A.scalarPotential c t) := by
@@ -93,6 +94,15 @@ lemma scalarPotential_contDiff_space {n} {d} (c : SpeedOfLight)
   refine ContDiff.comp ?_ ?_
   · exact scalarPotential_contDiff c A hA
   · fun_prop
+
+open ContDiff
+
+@[fun_prop]
+lemma scalarPotential_contDiff_space_of_smooth {n : ℕ} {d} (c : SpeedOfLight)
+    (A : ElectromagneticPotential d)
+    (hA : ContDiff ℝ ∞ A) (t : Time) : ContDiff ℝ n (A.scalarPotential c t) := by
+  apply scalarPotential_contDiff_space
+  exact hA.of_le (ENat.LEInfty.out)
 
 lemma scalarPotential_contDiff_time {n} {d} (c : SpeedOfLight) (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ n A) (x : Space d) : ContDiff ℝ n (A.scalarPotential c · x) := by

--- a/PhysLean/Electromagnetism/Kinematics/VectorPotential.lean
+++ b/PhysLean/Electromagnetism/Kinematics/VectorPotential.lean
@@ -77,6 +77,7 @@ the smoothness of the electromagnetic potential.
 
 -/
 
+@[fun_prop]
 lemma vectorPotential_contDiff {n} {d} {c : SpeedOfLight} (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ n A) : ContDiff ℝ n ↿(A.vectorPotential c) := by
   simp [vectorPotential]
@@ -86,6 +87,13 @@ lemma vectorPotential_contDiff {n} {d} {c : SpeedOfLight} (A : ElectromagneticPo
     rw [SpaceTime.contDiff_vector]
     exact hA
   exact fun i => h1 (Sum.inr i)
+
+open ContDiff
+@[fun_prop]
+lemma vectorPotential_contDiff_of_smooth {n : ℕ} {d} {c : SpeedOfLight} (A : ElectromagneticPotential d)
+    (hA : ContDiff ℝ ∞ A) : ContDiff ℝ n ↿(A.vectorPotential c) := by
+  apply vectorPotential_contDiff
+  exact hA.of_le (ENat.LEInfty.out)
 
 lemma vectorPotential_apply_contDiff {n} {d} {c : SpeedOfLight} (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ n A) (i : Fin d) : ContDiff ℝ n ↿(fun t x => A.vectorPotential c t x i) := by

--- a/PhysLean/Electromagnetism/Kinematics/VectorPotential.lean
+++ b/PhysLean/Electromagnetism/Kinematics/VectorPotential.lean
@@ -90,8 +90,9 @@ lemma vectorPotential_contDiff {n} {d} {c : SpeedOfLight} (A : ElectromagneticPo
 
 open ContDiff
 @[fun_prop]
-lemma vectorPotential_contDiff_of_smooth {n : ℕ} {d} {c : SpeedOfLight} (A : ElectromagneticPotential d)
-    (hA : ContDiff ℝ ∞ A) : ContDiff ℝ n ↿(A.vectorPotential c) := by
+lemma vectorPotential_contDiff_of_smooth {n : ℕ} {d} {c : SpeedOfLight}
+    (A : ElectromagneticPotential d) (hA : ContDiff ℝ ∞ A) :
+    ContDiff ℝ n ↿(A.vectorPotential c) := by
   apply vectorPotential_contDiff
   exact hA.of_le (ENat.LEInfty.out)
 

--- a/PhysLean/Electromagnetism/ThreeDimension/MaxwellEquations.lean
+++ b/PhysLean/Electromagnetism/ThreeDimension/MaxwellEquations.lean
@@ -43,10 +43,8 @@ theorem gaussLawElectric (t : Time) (x : Space)
 /-- Gauss's law for the magnetic field. -/
 theorem gaussLawMagnetic (t : Time) (x : Space) (hV : ContDiff ℝ ∞ V) :
     (∇ ⬝ B t) x = 0 := by
-  rw [magneticField_eq_3D, div_of_curl_eq_zero]
+  rw [magneticField_eq_3D, div_of_curl_eq_zero _ (by fun_prop)]
   simp only [Pi.zero_apply]
-  · apply vectorPotential_contDiff_space
-    exact hV.of_le ENat.LEInfty.out
 
 /-- Ampère's law. -/
 theorem ampereLaw (t : Time) (x : Space)
@@ -66,24 +64,7 @@ theorem faradayLaw (t : Time) (x : Space) (hV : ContDiff ℝ ∞ V) :
       (fun t x => ∂ₜ (fun t => vectorPotential 𝓕.c V t x) t) t)) x = _
   rw [curl_sub, curl_neg, curl_of_grad_eq_zero, time_deriv_curl_commute]
   simp only [neg_zero, Pi.sub_apply, Pi.zero_apply, zero_sub]
-  · apply vectorPotential_contDiff
-    exact hV.of_le ENat.LEInfty.out
-  · apply scalarPotential_contDiff_space
-    exact hV.of_le ENat.LEInfty.out
-  · refine ContDiff.differentiable ?_ (show ((⊤ : ℕ∞) : WithTop ℕ∞) ≠ 0 by simp)
-    apply contDiff_grad
-    apply scalarPotential_contDiff_space
-    exact hV.of_le (le_of_eq ENat.coe_top_add_one)
-  · refine ContDiff.differentiable ?_ (show ((⊤ : ℕ∞) : WithTop ℕ∞) ≠ 0 by simp)
-    apply ContDiff.neg
-    apply contDiff_grad
-    apply scalarPotential_contDiff_space
-    exact hV.of_le (le_of_eq ENat.coe_top_add_one)
-  · refine ContDiff.differentiable ?_ (show ((⊤ : ℕ∞) : WithTop ℕ∞) ≠ 0 by simp)
-    change ContDiff ℝ ∞ fun x => (∂ₜ (fun t => vectorPotential 𝓕.c V t x) t)
-    apply deriv_contDiff_of_space
-    apply vectorPotential_contDiff
-    exact hV.of_le (le_of_eq ENat.coe_top_add_one)
+  all_goals fun_prop
 
 end ThreeDimension
 end Electromagnetism

--- a/PhysLean/Electromagnetism/Vacuum/Constant.lean
+++ b/PhysLean/Electromagnetism/Vacuum/Constant.lean
@@ -69,8 +69,8 @@ set_option linter.unusedVariables false
 @[nolint unusedArguments]
 noncomputable def constantEB {d : ℕ} (c : SpeedOfLight)
     (E₀ : EuclideanSpace ℝ (Fin d)) (B₀ : Fin d × Fin d → ℝ)
-    (B₀_antisymm : ∀ i j, B₀ (i, j) = - B₀ (j, i)) : ElectromagneticPotential d :=
-  fun x μ =>
+    (B₀_antisymm : ∀ i j, B₀ (i, j) = - B₀ (j, i)) : ElectromagneticPotential d where
+  val := fun x μ =>
   match μ with
   | Sum.inl _ => - (1/c) * ⟪E₀, Space.basis.repr x.space⟫_ℝ
   | Sum.inr i => (1/2) * ∑ j, B₀ (i, j) * x.space j

--- a/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
+++ b/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
@@ -74,12 +74,26 @@ open InnerProductSpace
 /-- The electromagnetic potential for a Harmonic wave travelling in the `x`-direction
   with wave number `k`. -/
 noncomputable def harmonicWaveX (𝓕 : FreeSpace) (k : ℝ) (E₀ : Fin d → ℝ)
-  (φ : Fin d → ℝ) : ElectromagneticPotential d.succ := fun x μ =>
+  (φ : Fin d → ℝ) : ElectromagneticPotential d.succ where
+  val := fun x μ =>
   match μ with
   | Sum.inl 0 => 0
   | Sum.inr 0 => 0
   | Sum.inr ⟨Nat.succ i, h⟩ => -E₀ ⟨i, Nat.succ_lt_succ_iff.mp h⟩ * 1 / (𝓕.c * k) *
       Real.sin (k * (𝓕.c * x.time 𝓕.c - x.space 0) + φ ⟨i, Nat.succ_lt_succ_iff.mp h⟩)
+
+@[simp]
+lemma harmonicWaveX_inl_zero {d} (𝓕 : FreeSpace) (k : ℝ) (E₀ : Fin d → ℝ) (φ : Fin d → ℝ)
+    (x : SpaceTime d.succ) :
+    harmonicWaveX 𝓕 k E₀ φ x (Sum.inl 0) = 0 := by
+  simp [harmonicWaveX]
+
+@[simp]
+lemma harmonicWaveX_inr_zero {d} (𝓕 : FreeSpace) (k : ℝ) (E₀ : Fin d → ℝ) (φ : Fin d → ℝ)
+    (x : SpaceTime d.succ) :
+    harmonicWaveX 𝓕 k E₀ φ x (Sum.inr 0) = 0 := by
+  simp [harmonicWaveX]
+  rfl
 
 /-!
 
@@ -93,8 +107,8 @@ lemma harmonicWaveX_differentiable {d} (𝓕 : FreeSpace) (k : ℝ)
   rw [← Lorentz.Vector.differentiable_apply]
   intro μ
   match μ with
-  | Sum.inl 0 => simp [harmonicWaveX]
-  | Sum.inr ⟨0, h⟩ => simp [harmonicWaveX]
+  | Sum.inl 0 => simp
+  | Sum.inr ⟨0, h⟩ => simp
   | Sum.inr ⟨Nat.succ i, h⟩ =>
     simp [harmonicWaveX]
     apply Differentiable.const_mul

--- a/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
+++ b/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
@@ -97,7 +97,7 @@ lemma harmonicWaveX_inr_zero {d} (𝓕 : FreeSpace) (k : ℝ) (E₀ : Fin d → 
 
 /-!
 
-### A.1. Differentiability of the electromagnetic potential
+### A.2. Differentiability of the electromagnetic potential
 
 -/
 
@@ -116,7 +116,7 @@ lemma harmonicWaveX_differentiable {d} (𝓕 : FreeSpace) (k : ℝ)
 
 /-!
 
-### A.2. Smoothness of the electromagnetic potential
+### A.3. Smoothness of the electromagnetic potential
 
 -/
 

--- a/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
+++ b/PhysLean/Electromagnetism/Vacuum/HarmonicWave.lean
@@ -97,7 +97,7 @@ lemma harmonicWaveX_inr_zero {d} (𝓕 : FreeSpace) (k : ℝ) (E₀ : Fin d → 
 
 /-!
 
-### A.2. Differentiability of the electromagnetic potential
+### A.1. Differentiability of the electromagnetic potential
 
 -/
 
@@ -116,7 +116,7 @@ lemma harmonicWaveX_differentiable {d} (𝓕 : FreeSpace) (k : ℝ)
 
 /-!
 
-### A.3. Smoothness of the electromagnetic potential
+### A.2. Smoothness of the electromagnetic potential
 
 -/
 


### PR DESCRIPTION
Changes `ElectromagneticPotential` to a `structure`, and added around that the minimal instances needed to get things to build. 

The reason for making this change is to enable the use of `@[fun_prop]` which should hopefully simplify a lot of the differentiability lemmas involved in EM. 