### PR TITLE
feat: QuantumInfo `sorryful` results

### DIFF
--- a/Physlib/Meta/Basic.lean
+++ b/Physlib/Meta/Basic.lean
@@ -44,8 +44,8 @@ def Physlib.allImports : IO (Array Import) := do
   let mFile ← findOLean mods
   unless ← mFile.pathExists do
     throw <| IO.userError s!"object file '{mFile}' of module {mods} does not exist"
-  let (QIMods, _) ← readModuleData mFile
-  let QIImports := QIMods.imports.filter (fun c => c.module != `Init)
+  let (QIMod, _) ← readModuleData mFile
+  let QIImports := QIMod.imports.filter (fun c => c.module != `Init)
   return (PhysLibImports ++ QIImports)
 
 /-- Number of files within Physlib. -/

--- a/Physlib/Meta/Basic.lean
+++ b/Physlib/Meta/Basic.lean
@@ -30,7 +30,7 @@ open Lean
 
 -/
 
-/-- Gets all imports within Physlib. -/
+/-- Gets all imports within Physlib and QuantumInfo.. -/
 def Physlib.allImports : IO (Array Import) := do
   initSearchPath (← findSysroot)
   let mods := `Physlib
@@ -38,7 +38,15 @@ def Physlib.allImports : IO (Array Import) := do
   unless ← mFile.pathExists do
     throw <| IO.userError s!"object file '{mFile}' of module {mods} does not exist"
   let (physlibMod, _) ← readModuleData mFile
-  physlibMod.imports.filterM fun c => return c.module != `Init
+  let PhysLibImports := physlibMod.imports.filter (fun c => c.module != `Init)
+
+  let mods := `QuantumInfo
+  let mFile ← findOLean mods
+  unless ← mFile.pathExists do
+    throw <| IO.userError s!"object file '{mFile}' of module {mods} does not exist"
+  let (QIMods, _) ← readModuleData mFile
+  let QIImports := QIMods.imports.filter (fun c => c.module != `Init)
+  return (PhysLibImports ++ QIImports)
 
 /-- Number of files within Physlib. -/
 def Physlib.noImports : IO Nat := do

--- a/QuantumInfo/Finite/Capacity.lean
+++ b/QuantumInfo/Finite/Capacity.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.SpecialFunctions.Log.Base
 public import QuantumInfo.Finite.Entropy
 public import QuantumInfo.Finite.CPTPMap
 public import QuantumInfo.Finite.Distance
-
+public import Physlib.Meta.Sorry
 
 /-! # Quantum Capacity
 
@@ -123,6 +123,7 @@ end εApproximates
 section AchievesRate
 
 /-- Every quantum channel achieves a rate of zero. -/
+@[sorryful]
 theorem achievesRate_0 (Λ : CPTPMap d₁ d₂) : Λ.AchievesRate 0 := by
   intro ε hε
   use 1, zero_lt_one, 1, default
@@ -150,6 +151,7 @@ theorem id_achievesRate_log_dim : (id (dIn := d₁)).AchievesRate (Real.logb 2 (
   · exact εApproximates_monotone (εApproximates_self id) hε.le
 
 /-- A channel cannot achieve a rate greater than log2(D), where D is the input dimension. -/
+@[sorryful]
 theorem not_achievesRate_gt_log_dim_in (Λ : CPTPMap d₁ d₂) {R : ℝ} (hR : Real.logb 2 (Fintype.card d₁) < R) :
     ¬Λ.AchievesRate R := by
   sorry
@@ -159,6 +161,7 @@ noncomputable section AristotleLemmas
 end AristotleLemmas
 
 /-- A channel cannot achieve a rate greater than log2(D), where D is the output dimension. -/
+@[sorryful]
 theorem not_achievesRate_gt_log_dim_out (Λ : CPTPMap d₁ d₂) {R : ℝ} (hR : Real.logb 2 (Fintype.card d₂) < R): ¬Λ.AchievesRate R := by
   intro h;
   -- We show that the identity channel on the output space `d₂` emulates `Λ`. Since capacity is monotonic under emulation, `Q(Λ) ≤ Q(id_{d₂})`.
@@ -178,6 +181,7 @@ theorem not_achievesRate_gt_log_dim_out (Λ : CPTPMap d₁ d₂) {R : ℝ} (hR :
   exact not_lt_of_ge ( le_of_not_gt fun h' => not_achievesRate_gt_log_dim_in _ h' h_id_achieves ) h
 
 /-- The achievable rates are a bounded set. -/
+@[sorryful]
 theorem bddAbove_achievesRate (Λ : CPTPMap d₁ d₂) : BddAbove {R | Λ.AchievesRate R} := by
   use Real.logb 2 (Fintype.card d₁)
   intro R h
@@ -189,10 +193,12 @@ end AchievesRate
 section capacity
 
 /-- Quantum channel capacity is nonnegative. -/
+@[sorryful]
 theorem zero_le_quantumCapacity (Λ : CPTPMap d₁ d₂) : 0 ≤ Λ.quantumCapacity :=
   le_csSup (bddAbove_achievesRate Λ) (achievesRate_0 Λ)
 
 /-- Quantum channel capacity is at most log2(D), where D is the input dimension. -/
+@[sorryful]
 theorem quantumCapacity_ge_log_dim_in (Λ : CPTPMap d₁ d₂) : Λ.quantumCapacity ≤ Real.logb 2 (Fintype.card d₁) :=
   Real.sSup_le (by
     intro R h
@@ -207,10 +213,12 @@ theorem quantumCapacity_ge_log_dim_in (Λ : CPTPMap d₁ d₂) : Λ.quantumCapac
 information. The "coherent information" is used in literature to refer to both a function of state and
 a channel (`coherentInfo`), or a function of just a channel. In the latter case, the state is implicitly
 maximized over. Here we use the former definition and state that the lower bound is true for all states. -/
+@[sorryful]
 theorem coherentInfo_le_quantumCapacity (Λ : CPTPMap d₁ d₂) (ρ : MState d₁) : coherentInfo ρ Λ ≤ Λ.quantumCapacity := by
   sorry
 
 /-- The quantum capacity is the limit of the coherent information of n-copy uses of the channel. -/
+@[sorryful]
 theorem quantumCapacity_eq_piProd_coherentInfo (Λ : CPTPMap d₁ d₂) : Λ.quantumCapacity =
     sSup { r : ℝ | ∃ n ρ, r = coherentInfo ρ (CPTPMap.piProd (fun (_ : Fin n) ↦ Λ))} := by
   sorry

--- a/QuantumInfo/Finite/Capacity.lean
+++ b/QuantumInfo/Finite/Capacity.lean
@@ -187,6 +187,7 @@ end AchievesRate
 section capacity
 
 /-- Quantum channel capacity is nonnegative for channels out of a nonempty space. -/
+@[sorryful]
 theorem zero_le_quantumCapacity (Λ : CPTPMap d₁ d₂) [Nonempty d₁] :
     0 ≤ Λ.quantumCapacity :=
   le_csSup (bddAbove_achievesRate Λ) (achievesRate_0 Λ)

--- a/QuantumInfo/Finite/Ensemble.lean
+++ b/QuantumInfo/Finite/Ensemble.lean
@@ -211,7 +211,6 @@ theorem MState.exp_val_pure_eq_one_iff {d : Type*} [Fintype d] [DecidableEq d]
   · rintro rfl; simpa [MState.exp_val] using hpure_inner
 
 set_option backward.isDefEq.respectTransparency false in
-@[sorryful]
 theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
     mix e = pure ψ ↔ ∀ i : α, e.distr i ≠ 0 → e.states i = MState.pure ψ := by
   have h : (mix e).exp_val ↑(MState.pure ψ) = ∑ i, ↑(e.distr i) * (e.states i).exp_val ↑(MState.pure ψ) := by
@@ -224,7 +223,6 @@ theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
     apply (e.states i).exp_val_le_one (MState.le_one _)
 
 /-- The average of `f : MState d → T` on an ensemble that mixes to a pure state `ψ` is `f (pure ψ)` -/
-@[sorryful]
 theorem mix_mEnsemble_pure_average {e : MEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (hmix : mix e = pure ψ) :
   average f e = f (pure ψ) := by
   have hpure := mix_mEnsemble_pure_iff_pure.mp hmix

--- a/QuantumInfo/Finite/Ensemble.lean
+++ b/QuantumInfo/Finite/Ensemble.lean
@@ -6,6 +6,7 @@ Authors: Leonardo A Lessa
 module
 
 public import QuantumInfo.Finite.MState
+public import Physlib.Meta.Sorry
 
 @[expose] public section
 
@@ -188,6 +189,7 @@ theorem sum_prob_mul_eq_one_iff {ι : Type*} [Fintype ι] (p : ι → ℝ) (x : 
     · simp [a i hi]
 
 --CLEANUP. This proof used to work but it took forever to build. Also now it's broken.
+@[sorryful]
 theorem MState.exp_val_pure_eq_one_iff {d : Type*} [Fintype d] [DecidableEq d] (ρ : MState d) (ψ : Ket d) :
     ρ.exp_val (pure ψ) = 1 ↔ ρ = pure ψ := by
   stop
@@ -216,6 +218,7 @@ theorem MState.exp_val_pure_eq_one_iff {d : Type*} [Fintype d] [DecidableEq d] (
     rw [ MState.pure_mul_self ] ; aesop
 
 set_option backward.isDefEq.respectTransparency false in
+@[sorryful]
 theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
     mix e = pure ψ ↔ ∀ i : α, e.distr i ≠ 0 → e.states i = MState.pure ψ := by
   have h : (mix e).exp_val ↑(MState.pure ψ) = ∑ i, ↑(e.distr i) * (e.states i).exp_val ↑(MState.pure ψ) := by
@@ -228,6 +231,7 @@ theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
     apply (e.states i).exp_val_le_one (MState.le_one _)
 
 /-- The average of `f : MState d → T` on an ensemble that mixes to a pure state `ψ` is `f (pure ψ)` -/
+@[sorryful]
 theorem mix_mEnsemble_pure_average {e : MEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (hmix : mix e = pure ψ) :
   average f e = f (pure ψ) := by
   have hpure := mix_mEnsemble_pure_iff_pure.mp hmix

--- a/QuantumInfo/Finite/Entanglement.lean
+++ b/QuantumInfo/Finite/Entanglement.lean
@@ -195,7 +195,6 @@ theorem convex_roof_of_pure (ψ : Ket d) : convex_roof g (pure ψ) = g (KetUpToP
 
 omit [Nonempty d] in
 /-- The mixed convex roof extension of `f : MState d → ℝ≥0` applied to a pure state `ψ` is `f (pure ψ)`. -/
-@[sorryful]
 theorem mixed_convex_roof_of_pure (ψ : Ket d) : mixed_convex_roof f (pure ψ) = f (pure ψ) := by
   rw [le_antisymm_iff]
   constructor

--- a/QuantumInfo/Finite/Entanglement.lean
+++ b/QuantumInfo/Finite/Entanglement.lean
@@ -195,6 +195,7 @@ theorem convex_roof_of_pure (ψ : Ket d) : convex_roof g (pure ψ) = g (KetUpToP
 
 omit [Nonempty d] in
 /-- The mixed convex roof extension of `f : MState d → ℝ≥0` applied to a pure state `ψ` is `f (pure ψ)`. -/
+@[sorryful]
 theorem mixed_convex_roof_of_pure (ψ : Ket d) : mixed_convex_roof f (pure ψ) = f (pure ψ) := by
   rw [le_antisymm_iff]
   constructor

--- a/scripts/MetaPrograms/sorry_lint.lean
+++ b/scripts/MetaPrograms/sorry_lint.lean
@@ -21,7 +21,7 @@ open Lean
 unsafe def main (_ : List String) : IO Unit := do
   initSearchPath (← findSysroot)
   println! "Checking sorryful results."
-  let env ← importModules (loadExts := true) #[`Physlib] {} 0
+  let env ← importModules (loadExts := true) #[`Physlib, `QuantumInfo] {} 0
   let fileName := ""
   let options : Options := {}
   let ctx : Core.Context := {fileName, options, fileMap := default }


### PR DESCRIPTION
Turn on the `sorryful` result linter for the QuantumInfo directory. 