### PR TITLE
refactor: Rename dropPairEmb to Fin.succSuccAbove

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -321,6 +321,7 @@ public import Physlib.Relativity.Tensors.Contraction.Basic
 public import Physlib.Relativity.Tensors.Contraction.Basis
 public import Physlib.Relativity.Tensors.Contraction.Products
 public import Physlib.Relativity.Tensors.Contraction.Pure
+public import Physlib.Relativity.Tensors.Contraction.SuccSuccAbove
 public import Physlib.Relativity.Tensors.Dual
 public import Physlib.Relativity.Tensors.Elab
 public import Physlib.Relativity.Tensors.Evaluation

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -716,7 +716,8 @@ lemma PermCond.append_right_succSuccAbove {n n1 : ℕ} {c : Fin (n + 1 + 1) → 
         (finSumFinEquiv (m := n1) (Sum.inr j))))
       (Fin.append c1 (c ∘ (i.succSuccAbove j))) id := by
   apply And.intro (Function.bijective_id)
-  simp [Fin.forall_fin_add]
+  simp only [Nat.add_eq, finSumFinEquiv_apply_right, id_eq, Function.comp_apply, forall_fin_add,
+    append_left, append_right]
   apply And.intro
   · intro m
     rw [succSuccAbove_natAdd_apply_castAdd i j hij.1]

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.Tensors.TensorSpecies.Basic
+public import Physlib.Relativity.Tensors.Contraction.SuccSuccAbove
 public import Mathlib.Topology.Algebra.Module.ModuleTopology
 public import Mathlib.Analysis.RCLike.Basic
 public import Mathlib.Tactic.Cases
@@ -677,6 +678,52 @@ lemma PermCond.comp {n n1 n2 : ℕ} {c : Fin n → C} {c1 : Fin n1 → C}
   · intro x
     simp only [Function.comp_apply]
     rw [h.2, h2.2]
+
+open Fin in
+lemma PermCond.succSuccAbove {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
+    {c1 : Fin (n1 + 1 + 1) → C}
+    (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
+    {σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)} (hσ : PermCond c c1 σ) :
+    PermCond (c ∘ succSuccAbove (σ i) (σ j))
+      (c1 ∘ succSuccAbove i j) (funPredPredAbove i j hij σ hσ.1) := by
+  apply And.intro
+  · exact funPredPredAbove_bijective i j hij σ hσ.left
+  · intro m
+    simp [funPredPredAbove, hσ.2]
+
+open Fin in
+lemma PermCond.succSuccAbove_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
+    (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
+    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) :
+    let i2' := (i1.succSuccAbove j1 i2);
+    let j2' := (i1.succSuccAbove j1 j2);
+    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    PermCond ((c ∘ i2'.succSuccAbove j2') ∘ i1'.succSuccAbove j1')
+      ((c ∘ i1.succSuccAbove j1) ∘ i2.succSuccAbove  j2) id := by
+  apply And.intro (Function.bijective_id)
+  simp only [id_eq, Function.comp_apply]
+  intro i
+  rw [succSuccAbove_comm_apply]
+  · simp [hij1]
+  · simp [hij2]
+
+open Fin in
+lemma PermCond.append_right_succSuccAbove {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
+    {c1 : Fin n1 → C} (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) :
+    PermCond (Fin.append c1 c ∘ (Fin.succSuccAbove (finSumFinEquiv (m := n1) (Sum.inr i))
+        (finSumFinEquiv (m := n1) (Sum.inr j))))
+      (Fin.append c1 (c ∘ (i.succSuccAbove j))) id := by
+  apply And.intro (Function.bijective_id)
+  simp [Fin.forall_fin_add]
+  apply And.intro
+  · intro m
+    rw [succSuccAbove_natAdd_apply_castAdd i j hij.1]
+    simp
+  · intro m
+    rw [succSuccAbove_comm_natAdd i j hij.1]
+    simp
 
 TODO "Prove that if `σ` satisfies `PermCond c c1 σ` then `PermCond.inv σ h`
   satisfies `PermCond c1 c (PermCond.inv σ h)`."

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -711,20 +711,12 @@ lemma PermCond.succSuccAbove_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
 
 open Fin in
 lemma PermCond.append_right_succSuccAbove {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
-    {c1 : Fin n1 → C} (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) :
+    {c1 : Fin n1 → C} (i j : Fin (n + 1 + 1)) :
     PermCond (Fin.append c1 c ∘ (Fin.succSuccAbove (finSumFinEquiv (m := n1) (Sum.inr i))
         (finSumFinEquiv (m := n1) (Sum.inr j))))
       (Fin.append c1 (c ∘ (i.succSuccAbove j))) id := by
   apply And.intro (Function.bijective_id)
-  simp only [Nat.add_eq, finSumFinEquiv_apply_right, id_eq, Function.comp_apply, forall_fin_add,
-    append_left, append_right]
-  apply And.intro
-  · intro m
-    rw [succSuccAbove_natAdd_apply_castAdd i j hij.1]
-    simp
-  · intro m
-    rw [succSuccAbove_comm_natAdd i j hij.1]
-    simp
+  simp [forall_fin_add, succSuccAbove_comm_natAdd i j, succSuccAbove_natAdd_apply_castAdd i j]
 
 TODO "Prove that if `σ` satisfies `PermCond c c1 σ` then `PermCond.inv σ h`
   satisfies `PermCond c1 c (PermCond.inv σ h)`."
@@ -735,6 +727,7 @@ lemma fin_cast_permCond (n n1 : ℕ) {c : Fin n → C} (h : n1 = n) :
   · exact Equiv.bijective (finCongr h)
   · intro i
     rfl
+
 /-!
 
 ## Permutations

--- a/Physlib/Relativity/Tensors/Constructors.lean
+++ b/Physlib/Relativity/Tensors/Constructors.lean
@@ -319,11 +319,12 @@ lemma fromSingleT_contr_fromPairT_tmul {c c2 : C}
       rw [permT_permT, permT_permT, permT_permT]
     rw [fromPairT_tmul]
     symm
-    have h1 : Pure.dropPairOfMap 1 2 (by simp) (prodSwapMap (Nat.succ 0) (0 + 1 + 1)) (by decide) ∘
-      id ∘ prodSwapMap 0 (Nat.succ 0) ∘ id = id := by
+    have h1 : Fin.funPredPredAbove 1 2 (by simp)
+        (prodSwapMap (Nat.succ 0) (0 + 1 + 1)) (by decide) ∘
+        id ∘ prodSwapMap 0 (Nat.succ 0) ∘ id = id := by
       ext i
       fin_cases i
-      dsimp [Pure.dropPairOfMap]
+      dsimp [Fin.funPredPredAbove]
       rfl
     conv_lhs =>
       enter [1, 1]
@@ -469,7 +470,7 @@ lemma fromPairT_contr_fromPairT_eq_fromPairTContr_tmul (c c1 c2 : C)
     · rfl
     · rfl
   simp only [Fin.isValue, Function.comp_id,
-    Pure.dropPairOfMap_id, Function.comp_apply, id_eq]
+    Fin.funPredPredAbove_id, Function.comp_apply, id_eq]
   rw [h1, contrT_fromSingleT_fromSingleT]
   simp only [map_smul, prodT_default_right, LinearMap.smul_apply]
   rw [prodT_permT_left, permT_permT]

--- a/Physlib/Relativity/Tensors/Contraction/Basic.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Basic.lean
@@ -29,7 +29,7 @@ TODO "docs: The files on contractions of tensors are currently lacking documenta
   These should be added, mirroring good examples within Physlib."
 
 namespace Tensor
-
+open Fin
 /-!
 
 ## contrT
@@ -49,7 +49,7 @@ lemma contrT_decide {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)
   with the `j`th index. -/
 noncomputable def contrT (n : ℕ) {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
       (hij : i ≠ j ∧ S.τ (c i) = c j) :
-    Tensor S c →ₗ[k] Tensor S (c ∘ dropPairEmb i j) :=
+    Tensor S c →ₗ[k] Tensor S (c ∘ succSuccAbove i j) :=
   PiTensorProduct.lift (Pure.contrPMultilinear i j hij)
 
 lemma contrT_congr {n : ℕ} {c : Fin (n + 1 + 1) → C}
@@ -95,12 +95,10 @@ lemma contrT_permT {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j ∧ S.τ (c1 i) = (c1 j))
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1))
     (hσ : PermCond c c1 σ) (t : Tensor S c) :
-    contrT n1 i j hij (permT σ hσ t) = permT (dropPairOfMap i j hij.1 σ hσ.1)
-      (permCond_dropPairOfMap i j hij.1 σ hσ)
+    contrT n1 i j hij (permT σ hσ t) = permT _ (hσ.succSuccAbove i j hij.1 )
       (contrT n (σ i) (σ j) (by simp [hσ.2, hij, hσ.1.injective.eq_iff]) t) := by
   let P (t : Tensor S c) : Prop := contrT n1 i j hij (permT σ hσ t) =
-      permT (dropPairOfMap i j hij.1 σ hσ.1)
-        (permCond_dropPairOfMap i j hij.1 σ hσ)
+      permT _ (hσ.succSuccAbove i j hij.1 )
         (contrT n (σ i) (σ j) (by simp [hσ.2, hij, hσ.1.injective.eq_iff]) t)
   change P t
   apply induction_on_pure
@@ -134,25 +132,25 @@ lemma contrT_symm {n : ℕ} {c : Fin (n + 1 + 1) → C}
 lemma contrT_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
     (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1 ∧ S.τ (c i1) = (c j1))
-    (hij2 : i2 ≠ j2 ∧ S.τ (c (dropPairEmb i1 j1 i2)) = (c (dropPairEmb i1 j1 j2)))
+    (hij2 : i2 ≠ j2 ∧ S.τ (c (succSuccAbove i1 j1 i2)) = (c (succSuccAbove i1 j1 j2)))
     (t : Tensor S c) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
+    let i2' := (succSuccAbove i1 j1 i2);
+    let j2' := (succSuccAbove i1 j1 j2);
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
     contrT n i2 j2 hij2 (contrT (n + 1 + 1) i1 j1 hij1 t) =
-    permT id (permCond_dropPairEmb_comm i1 j1 i2 j2 hij1.left hij2.left)
+    permT id (PermCond.succSuccAbove_comm i1 j1 i2 j2 hij1.left hij2.left)
       (contrT n i1' j1' (by simp [i1', j1', i2', j2', hij1])
       (contrT (n + 1 + 1) i2' j2' (by simp [i2', j2', hij2]) t)) := by
-  let i2' := (dropPairEmb i1 j1 i2);
-  let j2' := (dropPairEmb i1 j1 j2);
-  let i1' := (dropPairEmbPre i2' j2' (by simp [i2', j2', hij2]) i1
+  let i2' := (succSuccAbove i1 j1 i2);
+  let j2' := (succSuccAbove i1 j1 j2);
+  let i1' := (predPredAbove i2' j2' (by simp [i2', j2', hij2]) i1
     (by simp [i2', j2']));
-  let j1' := (dropPairEmbPre i2' j2' (by simp [i2', j2', hij2]) j1
+  let j1' := (predPredAbove i2' j2' (by simp [i2', j2', hij2]) j1
     (by simp [i2', j2']));
   let P (t : Tensor S c) : Prop := contrT n i2 j2 hij2 (contrT (n + 1 + 1) i1 j1 hij1 t) =
-      permT id (permCond_dropPairEmb_comm i1 j1 i2 j2 hij1.left hij2.left)
+      permT id (PermCond.succSuccAbove_comm i1 j1 i2 j2 hij1.left hij2.left)
         (contrT n i1' j1' (by simp [i1', j1', i2', j2', hij1])
         (contrT (n + 1 + 1) i2' j2' (by simp [i2', j2', hij2]) t))
   change P t

--- a/Physlib/Relativity/Tensors/Contraction/Basis.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Basis.lean
@@ -33,26 +33,26 @@ namespace ComponentIdx
 /-- The `ComponentIdx` obtained by dropping two components. -/
 def dropPair {n : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (b : ComponentIdx (S := S) c) :
-    ComponentIdx (S := S) (c ∘ Pure.dropPairEmb i j) :=
-  fun m => b (Pure.dropPairEmb i j m)
+    ComponentIdx (S := S) (c ∘ Fin.succSuccAbove i j) :=
+  fun m => b (Fin.succSuccAbove i j m)
 
 /-- Given a coordinate parameter
   `b : Π k, Fin (S.repDim ((c ∘ i.succAbove ∘ j.succAbove) k)))`, the
   coordinate parameter `Π k, Fin (S.repDim (c k))` which map down to `b`. -/
 def DropPairSection {n : ℕ} {c : Fin (n + 1 + 1) → C}
     {i : Fin (n + 1 + 1)} {j : Fin (n + 1 + 1)}
-    (b : ComponentIdx (S := S) (c ∘ Pure.dropPairEmb i j)) :
+    (b : ComponentIdx (S := S) (c ∘ Fin.succSuccAbove i j)) :
     Finset (ComponentIdx (S := S) c) :=
   {b' : ComponentIdx c | dropPair i j b' = b}
 
 namespace DropPairSection
 
-lemma mem_iff_apply_dropPairEmb_eq {n : ℕ} {c : Fin (n + 1 + 1) → C}
+lemma mem_iff_apply_succSuccAbove_eq {n : ℕ} {c : Fin (n + 1 + 1) → C}
     {i j : Fin (n + 1 + 1)}
-    (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+    (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (b' : ComponentIdx c) :
     b' ∈ DropPairSection (S := S) b ↔
-      ∀ m, b' (Pure.dropPairEmb i j m) = b m := by
+      ∀ m, b' (Fin.succSuccAbove i j m) = b m := by
   simp only [DropPairSection, Finset.mem_filter, Finset.mem_univ, true_and]
   rw [funext_iff]
   simp [dropPair]
@@ -64,42 +64,42 @@ lemma mem_self_of_dropPair {n : ℕ} {c : Fin (n + 1 + 1) → C}
     b ∈ DropPairSection (S := S) (b.dropPair i j) := by
   simp [DropPairSection]
 
-/-- Given a `b` in `ComponentIdx (c ∘ Pure.dropPairEmb i j))` and
+/-- Given a `b` in `ComponentIdx (c ∘ Fin.succSuccAbove i j))` and
   an `x` in `Fin (S.repDim (c i)) × Fin (S.repDim (c j))`, the corresponding
   coordinate parameter in `ComponentIdx c`. -/
 def ofFin {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (S := S) (c ∘ Pure.dropPairEmb i j))
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (S := S) (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     ComponentIdx (S := S) c := fun m =>
   if hi : m = i then basisIdxCongr (by subst hi; rfl) x.1
   else if hj : m = j then basisIdxCongr (by subst hj; rfl) x.2
   else
     basisIdxCongr (by simp)
-    (b (Pure.dropPairEmbPre i j hij m (by omega)))
+    (b (Fin.predPredAbove i j hij m (by omega)))
 
 @[simp]
 lemma ofFin_apply_fst {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     ofFin (S := S) hij b x i = x.1 := by
   simp [ofFin]
 
 @[simp]
 lemma ofFin_apply_snd {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     ofFin (S := S) hij b x j = x.2 := by
   simp [ofFin]
   intro h
   omega
 
-lemma ofFin_mem_dropPairEmbSection {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+lemma ofFin_mem_succSuccAboveSection {n : ℕ} {c : Fin (n + 1 + 1) → C}
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     ofFin (S := S) hij b x ∈ DropPairSection b := by
   simp only [DropPairSection, Finset.mem_filter, Finset.mem_univ, true_and]
   ext m
-  simp only [ofFin, dropPair, Pure.dropPairEmb_ne_fst, ↓reduceDIte, Pure.dropPairEmb_ne_snd,
+  simp only [ofFin, dropPair, Fin.succSuccAbove_ne_fst, ↓reduceDIte, Fin.succSuccAbove_ne_snd,
     Function.comp_apply]
   symm
   apply ComponentIdx.congr_right
@@ -109,19 +109,19 @@ lemma ofFin_mem_dropPairEmbSection {n : ℕ} {c : Fin (n + 1 + 1) → C}
   `basisIdx (c i) × basisIdx (c j)`. -/
 def ofFinEquiv {n : ℕ} {c : Fin n.succ.succ → C}
     {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
-    (b : ComponentIdx (c ∘ Pure.dropPairEmb i j)) :
+    (b : ComponentIdx (c ∘ Fin.succSuccAbove i j)) :
     basisIdx (c i) × basisIdx (c j) ≃ DropPairSection (S := S) b where
   invFun b' := ⟨b'.1 i, b'.1 j⟩
-  toFun x := ⟨ofFin hij b x, ofFin_mem_dropPairEmbSection hij b x⟩
+  toFun x := ⟨ofFin hij b x, ofFin_mem_succSuccAboveSection hij b x⟩
   right_inv b' := by
     ext m
     simp
-    rcases Pure.eq_or_exists_dropPairEmb i j hij m with rfl | rfl | ⟨m, rfl⟩
+    rcases Fin.eq_or_exists_succSuccAbove i j hij m with rfl | rfl | ⟨m, rfl⟩
     · simp
     · simp
     · simp [ofFin]
       obtain ⟨b', hb'⟩ := b'
-      simp only [mem_iff_apply_dropPairEmb_eq] at hb'
+      simp only [mem_iff_apply_succSuccAbove_eq] at hb'
       simp [hb']
       symm
       apply ComponentIdx.congr_right
@@ -131,14 +131,14 @@ def ofFinEquiv {n : ℕ} {c : Fin n.succ.succ → C}
 
 @[simp]
 lemma ofFinEquiv_apply_fst {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     (ofFinEquiv (S := S) hij b x).1 i = x.1 := by
   simp [ofFinEquiv]
 
 @[simp]
 lemma ofFinEquiv_apply_snd {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j))
+    {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j))
     (x : basisIdx (c i) × basisIdx (c j)) :
     (ofFinEquiv (S := S) hij b x).1 j = x.2 := by
   simp [ofFinEquiv]
@@ -152,15 +152,15 @@ set_option backward.isDefEq.respectTransparency false in
 lemma Pure.dropPair_basisVector {n : ℕ} {c : Fin (n + 1 + 1) → C}
     {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (b : ComponentIdx c) :
     Pure.dropPair i j hij (basisVector c b) =
-    basisVector (S := S) (c ∘ Pure.dropPairEmb i j) fun m => b (dropPairEmb i j m) := by
+    basisVector (S := S) (c ∘ Fin.succSuccAbove i j) fun m => b (Fin.succSuccAbove i j m) := by
   funext l
   simp [dropPair, basisVector]
 
 set_option backward.isDefEq.respectTransparency false in
 lemma contrT_basis_repr_apply {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
     (h : i ≠ j ∧ S.τ (c i) = c j) (t : Tensor S c)
-    (b : ComponentIdx (c ∘ Pure.dropPairEmb i j)) :
-    (basis (c ∘ Pure.dropPairEmb i j)).repr (contrT n i j h t) b =
+    (b : ComponentIdx (c ∘ Fin.succSuccAbove i j)) :
+    (basis (c ∘ Fin.succSuccAbove i j)).repr (contrT n i j h t) b =
     ∑ (b' : DropPairSection b), (basis c).repr t b'.1 *
     S.castToField ((S.contr.app (Discrete.mk (c i))).hom
     (S.basis (c i) (b'.1 i) ⊗ₜ[k] S.basis (S.τ (c i)) (basisIdxCongr (by rw [h.2]) (b'.1 j)))) := by
@@ -216,8 +216,8 @@ lemma contrT_basis_repr_apply {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (
 set_option backward.isDefEq.respectTransparency false in
 lemma contrT_basis_repr_apply_eq_sum_fin {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
     (h : i ≠ j ∧ S.τ (c i) = c j) (t : Tensor S c)
-    (b : ComponentIdx (c ∘ Pure.dropPairEmb i j)) :
-    (basis (c ∘ Pure.dropPairEmb i j)).repr (contrT n i j h t) b =
+    (b : ComponentIdx (c ∘ Fin.succSuccAbove i j)) :
+    (basis (c ∘ Fin.succSuccAbove i j)).repr (contrT n i j h t) b =
     ∑ (x1 : basisIdx (c i)), ∑ (x2 : basisIdx (c j)),
     (basis c).repr t (DropPairSection.ofFinEquiv h.1 b (x1, x2)).1 *
     S.castToField ((S.contr.app (Discrete.mk (c i))).hom
@@ -231,7 +231,7 @@ lemma contrT_basis {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
     (h : i ≠ j ∧ S.τ (c i) = c j) (b : ComponentIdx (S := S) c):
     contrT n i j h (basis c b) =
     Pure.contrPCoeff i j h (Pure.basisVector c b) •
-      basis (c ∘ Pure.dropPairEmb i j) (b.dropPair i j) := by
+      basis (c ∘ Fin.succSuccAbove i j) (b.dropPair i j) := by
   simp only [basis_apply, contrT_pure, Pure.contrP, Pure.dropPair_basisVector]
   rfl
 

--- a/Physlib/Relativity/Tensors/Contraction/Products.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Products.lean
@@ -34,150 +34,6 @@ namespace Tensor
 
 -/
 
-lemma Pure.dropPairEmb_apply_lt_lt {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) (hi : m.val < i.val) (hj : m.val < j.val) :
-    dropPairEmb i j m = m.castSucc.castSucc := by
-  rcases Fin.eq_self_or_eq_succAbove i j with hj' | hj'
-  · subst hj'
-    simp at hij
-  obtain ⟨j, rfl⟩ := hj'
-  rw [dropPairEmb_succAbove]
-  simp only [Function.comp_apply]
-  have hj'' : m.val < j.val := by
-    simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq]
-    by_cases hj : j.val < i.val
-    · simp_all
-    · simp_all only [ite_false, Fin.val_succ, not_lt]
-      omega
-  rw [Fin.succAbove_of_succ_le, Fin.succAbove_of_succ_le]
-  · simp only [Fin.le_def, Fin.val_succ]
-    omega
-  · simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq, ite_true, Fin.le_def,
-    Fin.val_succ]
-    omega
-
-set_option backward.isDefEq.respectTransparency false in
-lemma Pure.dropPairEmb_natAdd_apply_castAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n1) :
-    (dropPairEmb (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    (Fin.castAdd n m)
-    = Fin.castAdd (n + 1 + 1) (m) := by
-  rw [dropPairEmb_apply_lt_lt]
-  · simp [Fin.ext_iff]
-  · simp_all [Fin.ne_iff_vne]
-  · simp only [Fin.val_castAdd, Fin.val_natAdd]
-    omega
-  · simp only [Fin.val_castAdd, Fin.val_natAdd]
-    omega
-
-lemma Pure.dropPairEmb_natAdd_image_range_castAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
-    (dropPairEmb (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j)) ''
-    (Set.range (Fin.castAdd (m := n) (n := n1))) = {i | i.1 < n1} := by
-  ext a
-  simp only [Set.mem_image, Set.mem_range, exists_exists_eq_and, Set.mem_setOf_eq]
-  conv_lhs =>
-    enter [1, b]
-    rw [dropPairEmb_natAdd_apply_castAdd i j hij]
-  apply Iff.intro
-  · intro h
-    obtain ⟨b, rfl⟩ := h
-    simp
-  · intro h
-    use ⟨a, by omega⟩
-    simp
-
-set_option backward.isDefEq.respectTransparency false in
-lemma Pure.dropPairEmb_comm_natAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) :
-    (dropPairEmb (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    (Fin.natAdd n1 m)
-    = Fin.natAdd (n1) (dropPairEmb i j m) := by
-  let f : Fin n ↪o Fin (n1 + n + 1 + 1) :=
-    ⟨⟨(dropPairEmb (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    ∘ Fin.natAdd n1, by
-      intro i j
-      simp only [Function.comp_apply, dropPairEmb_eq_iff_eq]
-      simp [Fin.ext_iff]⟩, by
-      intro a b
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply, dropPairEmb_leq_iff_leq]
-      rw [Fin.le_def, Fin.le_def]
-      simp⟩
-  let g : Fin n ↪o Fin (n1 + n + 1 + 1) :=
-      ⟨⟨(Fin.natAdd (n1) ∘ dropPairEmb i j), by
-      intro a b
-      simp only [Function.comp_apply, Fin.ext_iff, Fin.val_natAdd, add_right_inj]
-      simp [← Fin.ext_iff]⟩, by
-      intro a b
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply]
-      rw [Fin.le_def, Fin.le_def]
-      simp⟩
-  have hcastRange : Set.range (Fin.castAdd (m := n) (n := n1)) = {i | i.1 < n1} := by
-    rw [@Set.range_eq_iff]
-    apply And.intro
-    · intro a
-      simp
-    · intro b hb
-      simp only [Set.mem_setOf_eq] at hb
-      use ⟨b, by omega⟩
-      simp
-  have hnatRange : Set.range (Fin.natAdd (m := n) n1) =
-    (Set.range (Fin.castAdd (m := n) (n := n1)))ᶜ := by
-    rw [hcastRange]
-    rw [@Set.range_eq_iff]
-    apply And.intro
-    · intro a
-      simp
-    · intro b hb
-      simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hb
-      use ⟨b - n1, by omega⟩
-      simp only [Fin.natAdd_mk, Fin.ext_iff]
-      omega
-  have hfg : f = g := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, f, g]
-    rw [Set.range_comp, Set.range_comp]
-    simp only [dropPairEmb_range hij]
-    rw [hnatRange]
-    rw [dropPairEmb_image_compl]
-    simp only [Set.compl_union]
-    rw [dropPairEmb_natAdd_image_range_castAdd i j hij]
-    ext a
-    simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
-      not_or, Set.mem_setOf_eq, not_lt, Set.mem_image]
-    apply Iff.intro
-    · intro h
-      use ⟨a - n1, by omega⟩
-      simp only [Fin.ext_iff, Fin.val_natAdd, Fin.natAdd_mk] at h ⊢
-      omega
-    · intro h
-      obtain ⟨x, h1, rfl⟩ := h
-      simp_all [Fin.ext_iff]
-    · simp_all [Fin.ext_iff]
-  simpa using congrFun (congrArg (fun x => x.toFun) hfg) m
-
-lemma Pure.dropPairEmb_permCond_prod {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
-    {c1 : Fin n1 → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) :
-    PermCond
-      (Fin.append c1 c ∘
-        (dropPairEmb (finSumFinEquiv (m := n1) (Sum.inr i))
-        (finSumFinEquiv (m := n1) (Sum.inr j))))
-      (Fin.append c1 (c ∘ (dropPairEmb i j)))
-      id := by
-  apply And.intro (Function.bijective_id)
-  simp [Fin.forall_fin_add]
-  apply And.intro
-  · intro m
-    rw [dropPairEmb_natAdd_apply_castAdd i j hij.1]
-    simp
-  · intro m
-    rw [dropPairEmb_comm_natAdd i j hij.1]
-    simp
-
 set_option backward.isDefEq.respectTransparency false in
 lemma Pure.contrPCoeff_natAdd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     {c1 : Fin n1 → C}
@@ -223,7 +79,7 @@ lemma Pure.prodP_dropPair {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     {c1 : Fin n1 → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (p : Pure S c) (p1 : Pure S c1) :
-    p1.prodP (dropPair i j hij.1 p) = permP id (Pure.dropPairEmb_permCond_prod i j hij)
+    p1.prodP (dropPair i j hij.1 p) = permP id (PermCond.append_right_succSuccAbove i j hij)
     (dropPair (Fin.natAdd n1 i) (Fin.natAdd n1 j)
     (by simp_all [Fin.ext_iff]) (p1.prodP p)) := by
   ext x
@@ -235,12 +91,12 @@ lemma Pure.prodP_dropPair {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
   | Sum.inl x =>
     simp only [finSumFinEquiv_apply_left]
     rw [← congr_right (p1.prodP p) _ (Fin.castAdd (n + 1 + 1) x)
-      (by rw [dropPairEmb_natAdd_apply_castAdd i j hij.1])]
+      (by rw [Fin.succSuccAbove_natAdd_apply_castAdd i j hij.1])]
     simp [map_map_apply]
   | Sum.inr m =>
     simp only [finSumFinEquiv_apply_right]
-    rw [← congr_right (p1.prodP p) _ (Fin.natAdd n1 (dropPairEmb i j m))
-      (by rw [dropPairEmb_comm_natAdd i j hij.1])]
+    rw [← congr_right (p1.prodP p) _ (Fin.natAdd n1 (i.succSuccAbove j m))
+      (by rw [Fin.succSuccAbove_comm_natAdd i j hij.1])]
     simp [map_map_apply]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -249,7 +105,7 @@ lemma Pure.prodP_contrP_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (p : Pure S c) (p1 : Pure S c1) :
     prodT p1.toTensor (contrP i j hij p) =
-    ((permT id (Pure.dropPairEmb_permCond_prod i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
     contrP
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j))
@@ -268,7 +124,7 @@ lemma prodT_contrT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (t : Tensor S c) (t1 : Tensor S c1) :
     prodT t1 (contrT n i j hij t) =
-    ((permT id (Pure.dropPairEmb_permCond_prod i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
     contrT _
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j))
@@ -277,7 +133,7 @@ lemma prodT_contrT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
   generalize_proofs ha hb hc hd
   let P (t : Tensor S c) (t1 : Tensor S c1) : Prop :=
     prodT t1 (contrT _ i j hij t) =
-    ((permT id (Pure.dropPairEmb_permCond_prod i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
     contrT _
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j)) hc <|
@@ -316,7 +172,7 @@ lemma contrT_prodT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
       (finSumFinEquiv (m := n1) (Sum.inr j))
       (by simpa using hij) <|
     prodT t1 t) =
-    ((permT id (PermCond.on_id_symm (Pure.dropPairEmb_permCond_prod i j hij))) <|
+    ((permT id (PermCond.on_id_symm (PermCond.append_right_succSuccAbove i j hij))) <|
       (prodT t1 (contrT n i j hij t))) := by
   rw [prodT_contrT_snd]
   simp

--- a/Physlib/Relativity/Tensors/Contraction/Products.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Products.lean
@@ -79,7 +79,7 @@ lemma Pure.prodP_dropPair {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     {c1 : Fin n1 → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (p : Pure S c) (p1 : Pure S c1) :
-    p1.prodP (dropPair i j hij.1 p) = permP id (PermCond.append_right_succSuccAbove i j hij)
+    p1.prodP (dropPair i j hij.1 p) = permP id (PermCond.append_right_succSuccAbove i j)
     (dropPair (Fin.natAdd n1 i) (Fin.natAdd n1 j)
     (by simp_all [Fin.ext_iff]) (p1.prodP p)) := by
   ext x
@@ -91,12 +91,12 @@ lemma Pure.prodP_dropPair {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
   | Sum.inl x =>
     simp only [finSumFinEquiv_apply_left]
     rw [← congr_right (p1.prodP p) _ (Fin.castAdd (n + 1 + 1) x)
-      (by rw [Fin.succSuccAbove_natAdd_apply_castAdd i j hij.1])]
+      (by rw [Fin.succSuccAbove_natAdd_apply_castAdd i j])]
     simp [map_map_apply]
   | Sum.inr m =>
     simp only [finSumFinEquiv_apply_right]
     rw [← congr_right (p1.prodP p) _ (Fin.natAdd n1 (i.succSuccAbove j m))
-      (by rw [Fin.succSuccAbove_comm_natAdd i j hij.1])]
+      (by rw [Fin.succSuccAbove_comm_natAdd i j])]
     simp [map_map_apply]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -105,7 +105,7 @@ lemma Pure.prodP_contrP_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (p : Pure S c) (p1 : Pure S c1) :
     prodT p1.toTensor (contrP i j hij p) =
-    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j)) <|
     contrP
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j))
@@ -124,7 +124,7 @@ lemma prodT_contrT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (t : Tensor S c) (t1 : Tensor S c1) :
     prodT t1 (contrT n i j hij t) =
-    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j)) <|
     contrT _
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j))
@@ -133,7 +133,7 @@ lemma prodT_contrT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
   generalize_proofs ha hb hc hd
   let P (t : Tensor S c) (t1 : Tensor S c1) : Prop :=
     prodT t1 (contrT _ i j hij t) =
-    ((permT id (PermCond.append_right_succSuccAbove i j hij)) <|
+    ((permT id (PermCond.append_right_succSuccAbove i j)) <|
     contrT _
       (finSumFinEquiv (m := n1) (Sum.inr i))
       (finSumFinEquiv (m := n1) (Sum.inr j)) hc <|
@@ -167,12 +167,9 @@ lemma contrT_prodT_snd {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     {c1 : Fin n1 → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
     (t : Tensor S c) (t1 : Tensor S c1) :
-    (contrT _
-      (finSumFinEquiv (m := n1) (Sum.inr i))
-      (finSumFinEquiv (m := n1) (Sum.inr j))
-      (by simpa using hij) <|
-    prodT t1 t) =
-    ((permT id (PermCond.on_id_symm (PermCond.append_right_succSuccAbove i j hij))) <|
+    (contrT _ (finSumFinEquiv (m := n1) (Sum.inr i)) (finSumFinEquiv (m := n1) (Sum.inr j))
+      (by simpa using hij) <| prodT t1 t) =
+    ((permT id (PermCond.on_id_symm (PermCond.append_right_succSuccAbove i j))) <|
       (prodT t1 (contrT n i j hij t))) := by
   rw [prodT_contrT_snd]
   simp

--- a/Physlib/Relativity/Tensors/Contraction/Pure.lean
+++ b/Physlib/Relativity/Tensors/Contraction/Pure.lean
@@ -37,509 +37,18 @@ namespace Pure
 
 /-!
 
-## Defining succSuccAbove
-
-In Mathlib there is the `Fin.succAbove` function which gives an embedding of `Fin n` into
-`Fin (n + 1)` by leaving a hole at a specified index. We will need a version of this which
-gives an embedding of `Fin n` into `Fin (n + 1 + 1)` by leaving holes at
-two specified indices. We call this `succSuccAbove`.
-
-We will also need an explicit inverse of this map from
-`Fin (n + 1 + 1)` to `Fin n` which is defined on the complement of the two specified indices.
-This is similar to `Fin.predAbove` (although not exactly the same),
-for this reason we call it `predPredAbove`.
-
--/
-
-variable {n : ℕ} {c : Fin (n + 1 + 1) → C}
-
-/-- The embedding of `Fin n` into `Fin (n + 1 + 1)` which leaves a hole
-  at `i` and `j`. -/
-def dropPairEmb (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
-  if m.1 < i.1 ∧ m.1 < j.1 then
-    ⟨m, by omega⟩
-  else if m.1 + 1 < i.1 ∧ j.1 ≤ m.1 then
-    ⟨m + 1, by omega⟩
-  else if i.1 ≤ m.1 ∧ m.1 + 1 < j.1 then
-    ⟨m + 1, by omega⟩
-  else
-    ⟨m + 2, by omega⟩
-
-lemma dropPairEmb_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
-    dropPairEmb i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
-  simp [dropPairEmb]
-  by_cases hm : m.1 < i.1
-  · simp_all
-  · have hn : i.1 ≤ m.1 := by omega
-    have hn2 : ¬ m.1 + 1 < i.1 := by omega
-    simp [hm, hn, hn2]
-
-lemma dropPairEmb_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
-    dropPairEmb i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
-  ext m
-  by_cases h : m.1 < i.1
-  · simp [dropPairEmb, h, Fin.succAbove, Fin.lt_def]
-    split_ifs
-    all_goals
-      simp_all
-      try omega
-  · simp [dropPairEmb, Fin.succAbove, Fin.lt_def]
-    split_ifs
-    all_goals
-      simp_all
-      try omega
-
-lemma dropPairEmb_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    dropPairEmb i j = fun x => (i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x)) := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · contradiction
-  · ext x
-    rw [dropPairEmb_eq_succAbove_succAbove, Function.comp_apply]
-    congr
-    rcases eq_or_ne i 0 with rfl | hi
-    · rfl
-    · rw [Fin.predAbove_zero_of_ne_zero hi]
-      rcases lt_or_ge (i.pred hi).castSucc (i.succAbove j) with h | h
-      · rw [Fin.predAbove_of_castSucc_lt _ _ h, Fin.pred_succAbove]
-        rw [← Fin.lt_succAbove_iff_le_castSucc]
-        exact lt_of_le_of_ne ((Fin.castSucc_pred_lt_iff hi).mp h) hij
-      · rw [Fin.predAbove_of_le_castSucc _ _ h, Fin.castPred_succAbove]
-        rw [Fin.castSucc_lt_iff_succ_le, ← Fin.succAbove_lt_iff_succ_le]
-        exact (Fin.le_castSucc_pred_iff hi).mp h
-
-lemma dropPairEmb_injective {n : ℕ}
-    (i j : Fin (n + 1 + 1)) : Function.Injective (dropPairEmb i j) := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · intro a b
-    simp [dropPairEmb_self_apply]
-    intro h
-    split_ifs at h
-    · simp_all [Fin.ext_iff]
-    · simp_all [Fin.ext_iff]
-      omega
-    · simp_all [Fin.ext_iff]
-      omega
-    · simp_all [Fin.ext_iff]
-  · rw [dropPairEmb_eq_succAbove_succAbove]
-    apply Function.Injective.comp
-    · exact Fin.succAbove_right_injective
-    · exact Fin.succAbove_right_injective
-
-@[simp]
-lemma dropPairEmb_eq_iff_eq {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 = dropPairEmb i j m2 ↔ m1 = m2 := by
-  rw [(dropPairEmb_injective i j).eq_iff]
-
-@[simp]
-lemma dropPairEmb_leq_iff_leq {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 ≤ dropPairEmb i j m2 ↔ m1 ≤ m2 := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [dropPairEmb_self_apply]
-    split_ifs
-    · simp_all
-    · simp_all
-      omega
-    · simp_all
-      omega
-    · simp_all
-  · rw [dropPairEmb_eq_succAbove_succAbove]
-    simp only [Function.comp_apply]
-    rw [Fin.succAbove_le_succAbove_iff]
-    rw [Fin.succAbove_le_succAbove_iff]
-
-@[simp]
-lemma dropPairEmb_lt_iff_lt {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 < dropPairEmb i j m2 ↔ m1 < m2 := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [dropPairEmb_self_apply]
-    split_ifs
-    · simp_all
-    · simp_all
-      omega
-    · simp_all
-      omega
-    · simp_all
-  · rw [dropPairEmb_eq_succAbove_succAbove]
-    simp only [Function.comp_apply]
-    rw [Fin.succAbove_lt_succAbove_iff]
-    rw [Fin.succAbove_lt_succAbove_iff]
-
-@[simp]
-lemma dropPairEmb_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
-    Monotone (dropPairEmb i j) := by
-  intro a b
-  simp
-
-lemma dropPairEmb_eq_orderEmbOfFin {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
-    dropPairEmb i j = (Finset.orderEmbOfFin {i, j}ᶜ
-    (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) := by
-  let dropPairEmb : Fin n ↪o Fin (n + 1 + 1) :=
-  (Finset.orderEmbOfFin {i, j}ᶜ
-  (by rw [Finset.card_compl]; simp [Finset.card_pair hij]))
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp at hij
-  rw [dropPairEmb_eq_succAbove_succAbove]
-  symm
-  let f : Fin n ↪o Fin (n + 1 + 1) :=
-    ⟨⟨i.succAboveOrderEmb ∘ j.succAboveOrderEmb, by
-      refine Function.Injective.comp ?_ ?_
-      exact Fin.succAbove_right_injective
-      exact Fin.succAbove_right_injective⟩, by
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply, OrderEmbedding.le_iff_le,
-        implies_true]⟩
-  have hf : dropPairEmb = f := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [Finset.range_orderEmbOfFin, Finset.coe_compl,
-      RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, dropPairEmb, f]
-    change _ = Set.range (i.succAbove ∘ j.succAbove)
-    rw [Set.range_comp]
-    simp only [Fin.range_succAbove]
-    ext a
-    simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_image]
-    apply Iff.intro
-    · intro h
-      have ha := Fin.eq_self_or_eq_succAbove i a
-      simp_all [false_or]
-      obtain ⟨a, rfl⟩ := ha
-      use a
-      simp_all only [and_true]
-      rw [Fin.succAbove_right_injective.eq_iff] at h
-      exact h.2
-    · intro h
-      obtain ⟨a, h1, rfl⟩ := h
-      simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff, Set.mem_singleton_iff,
-        not_or]
-      rw [Fin.succAbove_right_injective.eq_iff]
-      simp_all only [not_false_eq_true, and_true]
-      exact Fin.succAbove_ne i a
-  ext a
-  have hf' := congrFun (congrArg (fun x => x.toFun) hf) a
-  simp only [Function.Embedding.toFun_eq_coe, RelEmbedding.coe_toEmbedding, Function.comp_apply,
-    Fin.succAboveOrderEmb_apply, f] at hf'
-  rw [hf']
-  rfl
-
-lemma dropPairEmb_symm (i j : Fin (n + 1 + 1)) :
-    dropPairEmb i j = dropPairEmb j i := by
-  by_cases hij : i = j
-  · subst hij
-    rfl
-  rw [dropPairEmb_eq_orderEmbOfFin i j hij,
-    dropPairEmb_eq_orderEmbOfFin j i (Ne.symm hij)]
-  simp [Finset.pair_comm]
-
-@[simp, nolint simpVarHead]
-lemma permCond_dropPairEmb_symm {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
-    (k : Fin n) : c (dropPairEmb i j k) = c (dropPairEmb j i k) := by
-  rw [dropPairEmb_symm]
-
-lemma dropPairEmb_apply_eq_orderIsoOfFin {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (m : Fin n) :
-    (dropPairEmb i j) m = (Finset.orderIsoOfFin {i, j}ᶜ
-      (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) m := by
-  simp [dropPairEmb_eq_orderEmbOfFin i j hij]
-
-@[simp]
-lemma dropPairEmb_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    Set.range (dropPairEmb i j) = {i, j}ᶜ := by
-  rw [dropPairEmb_eq_orderEmbOfFin i j hij, Finset.range_orderEmbOfFin]
-  simp only [Finset.compl_insert, Finset.coe_erase, Finset.coe_compl, Finset.coe_singleton]
-  ext x : 1
-  simp only [Set.mem_diff, Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_insert_iff, not_or]
-  apply Iff.intro
-  · intro a
-    simp_all only [not_false_eq_true, and_self]
-  · intro a
-    simp_all only [not_false_eq_true, and_self]
-
-lemma dropPairEmb_image_compl {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
-    (X : Set (Fin n)) :
-    (dropPairEmb i j) '' Xᶜ = ({i, j} ∪ dropPairEmb i j '' X)ᶜ := by
-  rw [← compl_inj_iff, Function.Injective.compl_image_eq (dropPairEmb_injective i j)]
-  simp only [compl_compl, dropPairEmb_range hij]
-  exact Set.union_comm ((dropPairEmb i j) '' X) {i, j}
-
-@[simp]
-lemma fst_ne_dropPairEmb_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ i = dropPairEmb i j m := by
-  by_cases hij : i = j
-  · subst hij
-    simp [dropPairEmb_self_apply]
-    by_cases hm : m.1 < i.1
-    · simp [hm, Fin.ext_iff]
-      omega
-    · simp [hm, Fin.ext_iff]
-      omega
-  · by_contra hn
-    have hi : i ∉ Set.range (dropPairEmb i j) := by
-      simp [dropPairEmb_eq_orderEmbOfFin i j hij]
-    nth_rewrite 2 [hn] at hi
-    simp [- dropPairEmb_range] at hi
-
-@[simp]
-lemma dropPairEmb_ne_fst (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ dropPairEmb i j m = i := by
-  apply Ne.symm
-  simp
-
-@[simp]
-lemma snd_ne_dropPairEmb_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ j = (dropPairEmb i j) m := by
-  rw [dropPairEmb_symm]
-  exact fst_ne_dropPairEmb_pre j i m
-
-@[simp]
-lemma dropPairEmb_ne_snd (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ dropPairEmb i j m = j := by
-  apply Ne.symm
-  simp
-
-lemma dropPairEmb_succAbove {n : ℕ}
-    (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
-    dropPairEmb i (i.succAbove j) =
-    i.succAbove ∘ j.succAbove := by
-  exact dropPairEmb_eq_succAbove_succAbove i j
-
-lemma eq_or_exists_dropPairEmb
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1)) :
-    m = i ∨ m = j ∨ ∃ m', m = dropPairEmb i j m' := by
-  by_cases h : m = i
-  · subst h
-    simp
-  · by_cases h' : m = j
-    · subst h'
-      simp
-    · simp_all only [false_or]
-      have h'' : m ∈ Set.range (dropPairEmb i j) := by
-        simp_all [dropPairEmb_eq_orderEmbOfFin]
-      rw [@Set.mem_range] at h''
-      obtain ⟨m', rfl⟩ := h''
-      exact ⟨m', rfl⟩
-
-/-!
-
-## dropPairEmbPre
-
--/
-
-/-- The preimage of `m` under `dropPairEmb i j hij` given that `m` is not equal
-  to `i` or `j`. -/
-def dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
-    (hm : m ≠ i ∧ m ≠ j) : Fin n :=
-  if h1 : m.1 < i.1 ∧ m.1 < j.1 then
-        ⟨m, by fin_omega⟩
-      else if h2 : m.1 - 1 < i.1 ∧ j.1 ≤ m.1 then
-        ⟨m - 1, by fin_omega⟩
-      else if h3 : i.1 - 1 ≤ m.1 ∧ m.1 < j.1 then
-        ⟨m - 1, by fin_omega⟩
-      else
-        ⟨m - 2, by fin_omega⟩
-
-@[simp]
-lemma dropPairEmb_dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
-    (hm : m ≠ i ∧ m ≠ j) :
-    dropPairEmb i j (dropPairEmbPre i j hij m hm) = m := by
-  dsimp [dropPairEmb, dropPairEmbPre]
-  split_ifs
-  · rfl
-  all_goals
-    simp_all [Fin.ext_iff]
-    try omega
-
-set_option backward.isDefEq.respectTransparency false in
-lemma dropPairEmbPre_eq_orderIsoOfFin (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
-    (hm : m ≠ i ∧ m ≠ j) :
-    dropPairEmbPre i j hij m hm =
-    (Finset.orderIsoOfFin {i, j}ᶜ (by rw [Finset.card_compl]; simp [Finset.card_pair hij])).symm
-    ⟨m, by simp [hm]⟩ := by
-  apply dropPairEmb_injective i j
-  conv_rhs => rw [dropPairEmb_apply_eq_orderIsoOfFin hij]
-  simp
-
-@[simp]
-lemma dropPairEmbPre_injective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m1 m2 : Fin (n + 1 + 1)) (hm1 : m1 ≠ i ∧ m1 ≠ j) (hm2 : m2 ≠ i ∧ m2 ≠ j) :
-    dropPairEmbPre i j hij m1 hm1 = dropPairEmbPre i j hij m2 hm2 ↔ m1 = m2 := by
-  rw [← Function.Injective.eq_iff (dropPairEmb_injective i j)]
-  simp
-
-lemma dropPairEmbPre_surjective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) :
-    ∃ m' : Fin (n + 1 + 1), ∃ (h : m' ≠ i ∧ m' ≠ j),
-    dropPairEmbPre i j hij m' h = m := by
-  use (dropPairEmb i j) m
-  have h : (dropPairEmb i j) m ≠ i ∧ (dropPairEmb i j) m ≠ j := by
-    simp [Ne.symm]
-  use h
-  apply (dropPairEmb_injective i j)
-  simp
-
-@[simp]
-lemma dropPairEmbPre_dropPairEmb (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) :
-    dropPairEmbPre i j hij (dropPairEmb i j m) (by simp) = m := by
-  apply dropPairEmb_injective i j
-  simp
-
-/-!
-
-## Commutativity of dropPairEmb
-
--/
-lemma dropPairEmb_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    dropPairEmb i1 j1 ∘ dropPairEmb i2 j2 =
-    dropPairEmb i2' j2' ∘
-    dropPairEmb i1' j1':= by
-  intro i2' j2' hi2j2'
-  let fl : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨dropPairEmb i1 j1 ∘ dropPairEmb i2 j2, by
-      apply Function.Injective.comp
-      exact dropPairEmb_injective i1 j1
-      exact dropPairEmb_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, dropPairEmb_leq_iff_leq, implies_true]⟩
-  let fr : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨dropPairEmb i2' j2' ∘ dropPairEmb
-      (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']))
-      (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2'])),
-      by
-      apply Function.Injective.comp
-      exact dropPairEmb_injective _ _
-      exact dropPairEmb_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, dropPairEmb_leq_iff_leq, implies_true]⟩
-  have h : fl = fr := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, Set.range_comp,
-      dropPairEmb_range hij2, fl, fr, j2', i2']
-    rw [dropPairEmb_range (by simp [hij1])]
-    rw [dropPairEmb_image_compl, dropPairEmb_image_compl]
-    congr 1
-    rw [Set.image_pair, Set.image_pair]
-    simp only [dropPairEmb_dropPairEmbPre, i2', j2']
-    exact Set.union_comm {i1, j1} {(dropPairEmb i1 j1) i2, (dropPairEmb i1 j1) j2}
-    simp [hij2]
-    simp [hij1]
-  ext1 a
-  have h' := congrFun (congrArg (fun x => x.toFun) h) a
-  dsimp [fl, fr] at h'
-  exact h'
-
-lemma dropPairEmb_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) (m : Fin n) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    dropPairEmb i2' j2'
-    (dropPairEmb i1' j1' m) =
-    dropPairEmb i1 j1 (dropPairEmb i2 j2 m) := by
-  intro i2' j2' hi2j2' i1' j1'
-  change _ = (dropPairEmb i1 j1 ∘ dropPairEmb i2 j2) m
-  rw [dropPairEmb_comm i1 j1 i2 j2 hij1 hij2]
-  rfl
-
-lemma permCond_dropPairEmb_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
-    (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    PermCond
-      ((c ∘ dropPairEmb i2' j2') ∘ dropPairEmb i1' j1')
-      ((c ∘ dropPairEmb i1 j1) ∘ dropPairEmb i2 j2)
-      id := by
-  apply And.intro (Function.bijective_id)
-  simp only [id_eq, Function.comp_apply]
-  intro i
-  rw [dropPairEmb_comm_apply]
-  · simp [hij1]
-  · simp [hij2]
-
-/-!
-
-## dropPairOfMap
-
--/
-
-/-- Given a bijection `Fin (n1 + 1 + 1) → Fin (n + 1 + 1))` and a pair `i j : Fin (n1 + 1 + 1)`,
-  then `dropPairOfMap i j _ σ _ : Fin n1 → Fin n` corresponds to the induced bijection
-  formed by dropping `i` and `j` in the source and their image in the target. -/
-def dropPairOfMap {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ)
-    (m : Fin n1) : Fin n :=
-  dropPairEmbPre (σ i) (σ j)
-    (by simp [hσ.injective.eq_iff, hij])
-    (σ (dropPairEmb i j m)) (by simp [hσ.injective.eq_iff, Ne.symm])
-
-lemma dropPairOfMap_injective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Injective (dropPairOfMap i j hij σ hσ) := by
-  intro m1 m2 h
-  simpa [dropPairOfMap, hσ.injective.eq_iff] using h
-
-lemma dropPairOfMap_surjective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Surjective (dropPairOfMap i j hij σ hσ) := by
-  intro m
-  simp only [dropPairOfMap]
-  obtain ⟨m, hm, rfl⟩ := dropPairEmbPre_surjective (σ i) (σ j)
-    (by simp [hσ.injective.eq_iff, hij]) m
-  simp only [dropPairEmbPre_injective]
-  obtain ⟨m', rfl⟩ := hσ.surjective m
-  simp only [ne_eq, hσ.injective.eq_iff] at hm ⊢
-  rcases eq_or_exists_dropPairEmb i j hij m' with rfl | rfl | ⟨m'', rfl⟩
-  · simp_all
-  · simp_all
-  · exact ⟨m'', rfl⟩
-
-lemma dropPairOfMap_bijective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Bijective (dropPairOfMap i j hij σ hσ) := by
-  apply And.intro
-  · apply dropPairOfMap_injective
-  · apply dropPairOfMap_surjective
-
-lemma permCond_dropPairOfMap {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
-    {c1 : Fin (n1 + 1 + 1) → C}
-    (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : PermCond c c1 σ) :
-    PermCond (c ∘ dropPairEmb (σ i) (σ j))
-      (c1 ∘ dropPairEmb i j) (dropPairOfMap i j hij σ hσ.1) := by
-  apply And.intro
-  · exact dropPairOfMap_bijective i j hij σ hσ.left
-  · intro m
-    simp [dropPairOfMap, hσ.2]
-
-@[simp]
-lemma dropPairOfMap_id { n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j) :
-    dropPairOfMap i j hij id (Function.bijective_id) = id := by
-  ext1 m
-  simp [dropPairOfMap]
-
-/-!
-
 ## dropPair
 
 -/
+open Fin
 
 set_option linter.unusedVariables false in
 /-- Given `i j : Fin (n + 1 + 1)`, `c : Fin (n + 1 + 1) → C` and a pure tensor `p : Pure S c`,
   `dropPair i j _ p` is the tensor formed by dropping the `i`th and `j`th parts of `p`. -/
 @[nolint unusedArguments]
 def dropPair (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c) :
-    Pure S (c ∘ dropPairEmb i j) :=
-    fun m => p (dropPairEmb i j m)
+    Pure S (c ∘ succSuccAbove i j) :=
+    fun m => p (succSuccAbove i j m)
 
 @[simp]
 lemma dropPair_equivariant {n : ℕ} {c : Fin (n + 1 + 1) → C}
@@ -555,23 +64,23 @@ lemma dropPair_symm (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
   ext m
   simp only [Function.comp_apply, dropPair, permP, id_eq]
   refine (congr_right _ _ _ ?_).symm
-  rw [dropPairEmb_symm]
+  rw [succSuccAbove_symm]
 
 lemma dropPair_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
     (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) (p : Pure S c) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
+    let i2' := (succSuccAbove i1 j1 i2);
+    let j2' := (succSuccAbove i1 j1 j2);
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
     dropPair i2 j2 hij2 (dropPair i1 j1 hij1 p) =
-    permP id (permCond_dropPairEmb_comm i1 j1 i2 j2 hij1 hij2)
+    permP id (PermCond.succSuccAbove_comm i1 j1 i2 j2 hij1 hij2)
     ((dropPair i1' j1' (by simp [i1', j1', hij1]) (dropPair i2' j2' hi2j2' p))) := by
   ext m
   simp only [Function.comp_apply, dropPair, permP, id_eq]
   apply (congr_right _ _ _ ?_).symm
-  rw [dropPairEmb_comm_apply]
+  rw [succSuccAbove_comm_apply]
   · simp [hij1]
   · simp [hij2]
 
@@ -583,7 +92,7 @@ lemma dropPair_update_fst {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : F
   ext m
   simp only [Function.comp_apply, dropPair, update]
   rw [Function.update_of_ne]
-  exact Ne.symm (fst_ne_dropPairEmb_pre i j m)
+  exact Ne.symm (fst_ne_succSuccAbove_pre i j m)
 
 @[simp]
 lemma dropPair_update_snd {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin (n + 1 + 1) → C}
@@ -595,12 +104,12 @@ lemma dropPair_update_snd {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : F
   conv_rhs => rw [dropPair_symm]
 
 @[simp]
-lemma dropPair_update_dropPairEmb {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
+lemma dropPair_update_succSuccAbove {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
     {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c)
     (m : Fin n)
-    (x : S.FD.obj (Discrete.mk (c (dropPairEmb i j m)))) :
-    dropPair i j hij (p.update (dropPairEmb i j m) x) =
+    (x : S.FD.obj (Discrete.mk (c (succSuccAbove i j m)))) :
+    dropPair i j hij (p.update (succSuccAbove i j m) x) =
     (dropPair i j hij p).update m x := by
   ext m'
   simp only [Function.comp_apply, dropPair, update]
@@ -618,11 +127,10 @@ TODO "Prove lemmas relating to the commutation rules of `dropPair` and `prodP`."
 lemma dropPair_permP {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
     {c1 : Fin (n1 + 1 + 1) → C} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : PermCond c c1 σ) (p : Pure S c) :
-    dropPair i j hij (permP σ hσ p) =
-    permP (dropPairOfMap i j hij σ hσ.1) (permCond_dropPairOfMap i j hij σ hσ)
+    dropPair i j hij (permP σ hσ p) = permP _ (hσ.succSuccAbove i j hij)
     (dropPair (σ i) (σ j) (by simp [hσ.1.injective.eq_iff, hij]) p) := by
   ext m
-  simp only [Function.comp_apply, dropPair, permP, dropPairOfMap]
+  simp only [Function.comp_apply, dropPair, permP, funPredPredAbove]
   apply congr_mid
   · simp
   · simp [hσ.2]
@@ -660,11 +168,11 @@ lemma contrPCoeff_permP {n n1 : ℕ} {c : Fin n → C}
   simp
 
 @[simp]
-lemma contrPCoeff_update_dropPairEmb {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
+lemma contrPCoeff_update_succSuccAbove {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
     {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) (m : Fin n)
-    (p : Pure S c) (x : S.FD.obj (Discrete.mk (c (dropPairEmb i j m)))) :
-    contrPCoeff i j hij (p.update (dropPairEmb i j m) x) =
+    (p : Pure S c) (x : S.FD.obj (Discrete.mk (c (succSuccAbove i j m)))) :
+    contrPCoeff i j hij (p.update (succSuccAbove i j m) x) =
     contrPCoeff i j hij p := by
   simp only [contrPCoeff]
   congr
@@ -739,9 +247,9 @@ lemma contrPCoeff_update_snd_smul {n : ℕ} [inst : DecidableEq (Fin n)] {c : Fi
 
 lemma contrPCoeff_dropPair {n : ℕ} {c : Fin (n + 1 + 1) → C}
     (a b : Fin (n + 1 + 1)) (hab : a ≠ b)
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c (dropPairEmb a b i)) = (c (dropPairEmb a b j)))
+    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c (succSuccAbove a b i)) = (c (succSuccAbove a b j)))
     (p : Pure S c) : (p.dropPair a b hab).contrPCoeff i j hij =
-    p.contrPCoeff (dropPairEmb a b i) (dropPairEmb a b j)
+    p.contrPCoeff (succSuccAbove a b i) (succSuccAbove a b j)
       (by simpa using hij) := by rfl
 
 lemma contrPCoeff_symm {n : ℕ} {c : Fin n → C} {i j : Fin n} {hij : i ≠ j ∧ S.τ (c i) = c j}
@@ -766,18 +274,18 @@ lemma contrPCoeff_symm {n : ℕ} {c : Fin n → C} {i j : Fin n} {hij : i ≠ j 
 lemma contrPCoeff_mul_dropPair {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
     (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1 ∧ S.τ (c i1) = (c j1))
-    (hij2 : i2 ≠ j2 ∧ S.τ (c (dropPairEmb i1 j1 i2)) = (c (dropPairEmb i1 j1 j2)))
+    (hij2 : i2 ≠ j2 ∧ S.τ (c (succSuccAbove i1 j1 i2)) = (c (succSuccAbove i1 j1 j2)))
     (p : Pure S c) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
+    let i2' := (succSuccAbove i1 j1 i2);
+    let j2' := (succSuccAbove i1 j1 j2);
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
     (p.contrPCoeff i1 j1 hij1) * (dropPair i1 j1 hij1.1 p).contrPCoeff i2 j2 hij2 =
     (p.contrPCoeff i2' j2' (by simp [i2', j2', hij2])) *
     (dropPair i2' j2' (by simp [i2', j2', hij2]) p).contrPCoeff i1' j1'
       (by simp [i1', j1', hij1]) := by
-  simp only [contrPCoeff_dropPair, dropPairEmb_dropPairEmbPre]
+  simp only [contrPCoeff_dropPair, succSuccAbove_predPredAbove]
   rw [mul_comm]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -812,7 +320,7 @@ lemma contrPCoeff_invariant {n : ℕ} {c : Fin n → C} {i j : Fin n}
   with the `j`th index. -/
 noncomputable def contrP {n : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) (p : Pure S c) :
-    S.Tensor (c ∘ dropPairEmb i j) :=
+    S.Tensor (c ∘ succSuccAbove i j) :=
   (p.contrPCoeff i j hij) • (p.dropPair i j hij.1).toTensor
 
 set_option backward.isDefEq.respectTransparency false in
@@ -822,7 +330,7 @@ lemma contrP_update_add {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin
     (p : Pure S c) (x y : S.FD.obj (Discrete.mk (c m))) :
     contrP i j hij (p.update m (x + y)) =
     contrP i j hij (p.update m x) + contrP i j hij (p.update m y) := by
-  rcases eq_or_exists_dropPairEmb i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
+  rcases eq_or_exists_succSuccAbove i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
   · simp [contrP, add_smul]
   · simp [contrP, add_smul]
   · simp [contrP]
@@ -834,7 +342,7 @@ lemma contrP_update_smul {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fi
     (p : Pure S c) (r : k) (x : S.FD.obj (Discrete.mk (c m))) :
     contrP i j hij (p.update m (r • x)) =
     r • contrP i j hij (p.update m x) := by
-  rcases eq_or_exists_dropPairEmb i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
+  rcases eq_or_exists_succSuccAbove i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
   · simp [contrP, smul_smul]
   · simp [contrP, smul_smul]
   · simp [contrP, smul_smul, mul_comm]
@@ -863,7 +371,7 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable def contrPMultilinear {n : ℕ} {c : Fin (n + 1 + 1) → C}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) :
     MultilinearMap k (fun i => S.FD.obj (Discrete.mk (c i)))
-      (S.Tensor (c ∘ dropPairEmb i j))where
+      (S.Tensor (c ∘ succSuccAbove i j))where
   toFun p := contrP i j hij p
   map_update_add' p m x y := by
     change (update p m (x + y)).contrP i j hij = _

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -60,13 +60,13 @@ def succSuccAbove (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
 
 lemma succSuccAbove_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
     succSuccAbove i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
-  simp [succSuccAbove]
+  simp only [succSuccAbove, and_self]
   grind
 
 lemma succSuccAbove_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
     succSuccAbove i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
   ext m
-  simp [succSuccAbove, Fin.succAbove, Fin.lt_def]
+  simp only [succSuccAbove, succAbove, lt_def, val_castSucc, Function.comp_apply]
   grind
 
 lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
@@ -91,7 +91,7 @@ lemma succSuccAbove_injective {n : ℕ}
     (i j : Fin (n + 1 + 1)) : Function.Injective (succSuccAbove i j) := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
   · intro a b
-    simp [succSuccAbove_self_apply]
+    simp only [succSuccAbove_self_apply]
     grind
   · rw [succSuccAbove_eq_succAbove_succAbove]
     exact Function.Injective.comp Fin.succAbove_right_injective Fin.succAbove_right_injective
@@ -107,19 +107,17 @@ lemma succSuccAbove_leq_iff_leq {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
     succSuccAbove i j m1 ≤ succSuccAbove i j m2 ↔ m1 ≤ m2 := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [succSuccAbove_self_apply]
+  · simp only [succSuccAbove_self_apply]
     grind
   · rw [succSuccAbove_eq_succAbove_succAbove]
-    simp only [Function.comp_apply]
-    rw [Fin.succAbove_le_succAbove_iff]
-    rw [Fin.succAbove_le_succAbove_iff]
+    simp only [Function.comp_apply, Fin.succAbove_le_succAbove_iff]
 
 @[simp]
 lemma succSuccAbove_lt_iff_lt {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
     succSuccAbove i j m1 < succSuccAbove i j m2 ↔ m1 < m2 := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [succSuccAbove_self_apply]
+  · simp only [succSuccAbove_self_apply]
     grind
   · rw [succSuccAbove_eq_succAbove_succAbove]
     simp only [Function.comp_apply]
@@ -134,8 +132,8 @@ lemma succSuccAbove_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
 
 lemma succSuccAbove_eq_orderEmbOfFin {n : ℕ}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
-    succSuccAbove i j = (Finset.orderEmbOfFin {i, j}ᶜ
-    (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) := by
+    succSuccAbove i j = Finset.orderEmbOfFin {i, j}ᶜ
+    (by rw [Finset.card_compl]; simp [Finset.card_pair hij]) := by
   let succSuccAbove : Fin n ↪o Fin (n + 1 + 1) :=
   (Finset.orderEmbOfFin {i, j}ᶜ
   (by rw [Finset.card_compl]; simp [Finset.card_pair hij]))
@@ -144,10 +142,8 @@ lemma succSuccAbove_eq_orderEmbOfFin {n : ℕ}
   rw [succSuccAbove_eq_succAbove_succAbove]
   symm
   let f : Fin n ↪o Fin (n + 1 + 1) :=
-    ⟨⟨i.succAboveOrderEmb ∘ j.succAboveOrderEmb, by
-      refine Function.Injective.comp ?_ ?_
-      exact Fin.succAbove_right_injective
-      exact Fin.succAbove_right_injective⟩, by
+    ⟨⟨i.succAboveOrderEmb ∘ j.succAboveOrderEmb,
+        Fin.succAbove_right_injective.comp Fin.succAbove_right_injective⟩, by
       simp only [Function.Embedding.coeFn_mk, Function.comp_apply, OrderEmbedding.le_iff_le,
         implies_true]⟩
   have hf : succSuccAbove = f := by
@@ -226,7 +222,7 @@ lemma fst_ne_succSuccAbove_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
     ¬ i = succSuccAbove i j m := by
   by_cases hij : i = j
   · subst hij
-    simp [succSuccAbove_self_apply]
+    simp only [succSuccAbove_self_apply]
     grind
   · by_contra hn
     have hi : i ∉ Set.range (succSuccAbove i j) := by
@@ -271,7 +267,6 @@ lemma eq_or_exists_succSuccAbove(i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin
       rw [@Set.mem_range] at h''
       obtain ⟨m', rfl⟩ := h''
       exact ⟨m', rfl⟩
-
 
 lemma succSuccAbove_apply_lt_lt {n : ℕ}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j)

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -325,76 +325,12 @@ lemma succSuccAbove_natAdd_image_range_castAdd {n n1 : ℕ}
     use ⟨a, by omega⟩
     simp
 
-set_option backward.isDefEq.respectTransparency false in
 lemma succSuccAbove_comm_natAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) :
-    (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    (Fin.natAdd n1 m)
+    (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j) (Fin.natAdd n1 m)
     = Fin.natAdd (n1) (succSuccAbove i j m) := by
-  let f : Fin n ↪o Fin (n1 + n + 1 + 1) :=
-    ⟨⟨(succSuccAbove (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    ∘ Fin.natAdd n1, by
-      intro i j
-      simp only [Function.comp_apply, succSuccAbove_eq_iff_eq]
-      simp [Fin.ext_iff]⟩, by
-      intro a b
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply, succSuccAbove_leq_iff_leq]
-      rw [Fin.le_def, Fin.le_def]
-      simp⟩
-  let g : Fin n ↪o Fin (n1 + n + 1 + 1) :=
-      ⟨⟨(Fin.natAdd (n1) ∘ succSuccAbove i j), by
-      intro a b
-      simp only [Function.comp_apply, Fin.ext_iff, Fin.val_natAdd, add_right_inj]
-      simp [← Fin.ext_iff]⟩, by
-      intro a b
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply]
-      rw [Fin.le_def, Fin.le_def]
-      simp⟩
-  have hcastRange : Set.range (Fin.castAdd (m := n) (n := n1)) = {i | i.1 < n1} := by
-    rw [@Set.range_eq_iff]
-    apply And.intro
-    · intro a
-      simp
-    · intro b hb
-      simp only [Set.mem_setOf_eq] at hb
-      use ⟨b, by omega⟩
-      simp
-  have hnatRange : Set.range (Fin.natAdd (m := n) n1) =
-    (Set.range (Fin.castAdd (m := n) (n := n1)))ᶜ := by
-    rw [hcastRange]
-    rw [@Set.range_eq_iff]
-    apply And.intro
-    · intro a
-      simp
-    · intro b hb
-      simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hb
-      use ⟨b - n1, by omega⟩
-      simp only [Fin.natAdd_mk, Fin.ext_iff]
-      omega
-  have hfg : f = g := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, f, g]
-    rw [Set.range_comp, Set.range_comp]
-    simp only [succSuccAbove_range hij]
-    rw [hnatRange]
-    rw [succSuccAbove_image_compl]
-    simp only [Set.compl_union]
-    rw [succSuccAbove_natAdd_image_range_castAdd i j hij]
-    ext a
-    simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
-      not_or, Set.mem_setOf_eq, not_lt, Set.mem_image]
-    apply Iff.intro
-    · intro h
-      use ⟨a - n1, by omega⟩
-      simp only [Fin.ext_iff, Fin.val_natAdd, Fin.natAdd_mk] at h ⊢
-      omega
-    · intro h
-      obtain ⟨x, h1, rfl⟩ := h
-      simp_all [Fin.ext_iff]
-    · simp_all [Fin.ext_iff]
-  simpa using congrFun (congrArg (fun x => x.toFun) hfg) m
-
+  simp only [succSuccAbove, val_natAdd, add_lt_add_iff_left, add_le_add_iff_left, Fin.ext_iff]
+  grind
 
 /-!
 

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -58,6 +58,14 @@ def succSuccAbove (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
   else
     ⟨m + 2, by omega⟩
 
+lemma succSuccAbove_val (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    (succSuccAbove i j m).val = if m.1 < i.1 ∧ m.1 < j.1 then m.1
+    else if m.1 + 1 < i.1 ∧ j.1 ≤ m.1 then m.1 + 1
+    else if i.1 ≤ m.1 ∧ m.1 + 1 < j.1 then m.1 + 1
+    else m.1 + 2 := by
+  simp only [succSuccAbove]
+  grind
+
 lemma succSuccAbove_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
     succSuccAbove i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
   simp only [succSuccAbove, and_self]
@@ -269,49 +277,33 @@ lemma eq_or_exists_succSuccAbove(i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin
       exact ⟨m', rfl⟩
 
 lemma succSuccAbove_apply_lt_lt {n : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) (hi : m.val < i.val) (hj : m.val < j.val) :
+    (i j : Fin (n + 1 + 1)) (m : Fin n) (hi : m.val < i.val) (hj : m.val < j.val) :
     succSuccAbove i j m = m.castSucc.castSucc := by
-  rcases Fin.eq_self_or_eq_succAbove i j with hj' | hj'
-  · subst hj'
-    simp at hij
-  obtain ⟨j, rfl⟩ := hj'
-  rw [succSuccAbove_succAbove]
-  simp only [Function.comp_apply]
-  have hj'' : m.val < j.val := by
-    simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq]
-    grind
-  rw [Fin.succAbove_of_succ_le, Fin.succAbove_of_succ_le]
-  · simp only [Fin.le_def, Fin.val_succ]
-    omega
-  · simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq, ite_true, Fin.le_def,
-    Fin.val_succ]
-    omega
+  ext
+  simp [succSuccAbove, hi, hj]
 
 set_option backward.isDefEq.respectTransparency false in
 lemma succSuccAbove_natAdd_apply_castAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n1) :
+    (i j : Fin (n + 1 + 1)) (m : Fin n1) :
     (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
     (Fin.castAdd n m)
     = Fin.castAdd (n + 1 + 1) (m) := by
   rw [succSuccAbove_apply_lt_lt]
   · simp [Fin.ext_iff]
-  · simp_all [Fin.ne_iff_vne]
   · simp only [Fin.val_castAdd, Fin.val_natAdd]
     omega
   · simp only [Fin.val_castAdd, Fin.val_natAdd]
     omega
 
 lemma succSuccAbove_natAdd_image_range_castAdd {n n1 : ℕ}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
+    (i j : Fin (n + 1 + 1)) :
     (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j)) ''
     (Set.range (Fin.castAdd (m := n) (n := n1))) = {i | i.1 < n1} := by
   ext a
   simp only [Set.mem_image, Set.mem_range, exists_exists_eq_and, Set.mem_setOf_eq]
   conv_lhs =>
     enter [1, b]
-    rw [succSuccAbove_natAdd_apply_castAdd i j hij]
+    rw [succSuccAbove_natAdd_apply_castAdd i j]
   apply Iff.intro
   · intro h
     obtain ⟨b, rfl⟩ := h
@@ -345,6 +337,15 @@ def predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
         ⟨m - 1, by fin_omega⟩
       else
         ⟨m - 2, by fin_omega⟩
+
+lemma predPredAbove_val (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
+    (hm : m ≠ i ∧ m ≠ j) :
+    (predPredAbove i j hij m hm).val = if m.1 < i.1 ∧ m.1 < j.1 then m.1
+    else if m.1 - 1 < i.1 ∧ j.1 ≤ m.1 then m.1 - 1
+    else if i.1 - 1 ≤ m.1 ∧ m.1 < j.1 then m.1 - 1
+    else m.1 - 2 := by
+  simp only [predPredAbove]
+  grind
 
 @[simp]
 lemma succSuccAbove_predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
@@ -401,40 +402,11 @@ lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 +
     let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
     let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
     succSuccAbove i1 j1 ∘ succSuccAbove i2 j2 =
-    succSuccAbove i2' j2' ∘
-    succSuccAbove i1' j1':= by
-  intro i2' j2' hi2j2'
-  let fl : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨succSuccAbove i1 j1 ∘ succSuccAbove i2 j2, by
-      apply Function.Injective.comp
-      · exact succSuccAbove_injective i1 j1
-      · exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
-  let fr : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨succSuccAbove i2' j2' ∘ succSuccAbove
-      (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']))
-      (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2'])),
-      by
-      apply Function.Injective.comp
-      · exact succSuccAbove_injective _ _
-      · exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
-  have h : fl = fr := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, Set.range_comp,
-      succSuccAbove_range hij2, fl, fr, j2', i2']
-    rw [succSuccAbove_range (by simp [hij1])]
-    rw [succSuccAbove_image_compl, succSuccAbove_image_compl]
-    · congr 1
-      rw [Set.image_pair, Set.image_pair]
-      simp only [succSuccAbove_predPredAbove, i2', j2']
-      exact Set.union_comm {i1, j1} {(succSuccAbove i1 j1) i2, (succSuccAbove i1 j1) j2}
-    · simp [hij2]
-    · simp [hij1]
-  ext1 a
-  have h' := congrFun (congrArg (fun x => x.toFun) h) a
-  dsimp [fl, fr] at h'
-  exact h'
+    succSuccAbove i2' j2' ∘ succSuccAbove i1' j1':= by
+  ext m
+  simp only [Function.comp_apply]
+  simp only [predPredAbove_val, succSuccAbove_val]
+  grind (splits := 20)
 
 lemma succSuccAbove_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) (m : Fin n) :

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -5,7 +5,8 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.Relativity.Tensors.Basic
+public import Mathlib.Data.Finset.Sort
+public import Mathlib.Data.Nat.SuccPred
 /-!
 
 # Defining succSuccAbove
@@ -39,6 +40,7 @@ variable {n : ℕ} {c : Fin (n + 1 + 1) → C}
 ## Defining succSuccAbove
 
 -/
+
 /-- The embedding of `Fin n` into `Fin (n + 1 + 1)` which leaves a hole
   at `i` and `j`. -/
 def succSuccAbove (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
@@ -54,26 +56,13 @@ def succSuccAbove (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
 lemma succSuccAbove_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
     succSuccAbove i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
   simp [succSuccAbove]
-  by_cases hm : m.1 < i.1
-  · simp_all
-  · have hn : i.1 ≤ m.1 := by omega
-    have hn2 : ¬ m.1 + 1 < i.1 := by omega
-    simp [hm, hn, hn2]
+  grind
 
 lemma succSuccAbove_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
     succSuccAbove i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
   ext m
-  by_cases h : m.1 < i.1
-  · simp [succSuccAbove, h, Fin.succAbove, Fin.lt_def]
-    split_ifs
-    all_goals
-      simp_all
-      try omega
-  · simp [succSuccAbove, Fin.succAbove, Fin.lt_def]
-    split_ifs
-    all_goals
-      simp_all
-      try omega
+  simp [succSuccAbove, Fin.succAbove, Fin.lt_def]
+  grind
 
 lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
     succSuccAbove i j = fun x => (i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x)) := by
@@ -93,82 +82,61 @@ lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
         rw [Fin.castSucc_lt_iff_succ_le, ← Fin.succAbove_lt_iff_succ_le]
         exact (Fin.le_castSucc_pred_iff hi).mp h
 
-lemma dropPairEmb_injective {n : ℕ}
-    (i j : Fin (n + 1 + 1)) : Function.Injective (dropPairEmb i j) := by
+lemma succSuccAbove_injective {n : ℕ}
+    (i j : Fin (n + 1 + 1)) : Function.Injective (succSuccAbove i j) := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
   · intro a b
-    simp [dropPairEmb_self_apply]
-    intro h
-    split_ifs at h
-    · simp_all [Fin.ext_iff]
-    · simp_all [Fin.ext_iff]
-      omega
-    · simp_all [Fin.ext_iff]
-      omega
-    · simp_all [Fin.ext_iff]
-  · rw [dropPairEmb_eq_succAbove_succAbove]
-    apply Function.Injective.comp
-    · exact Fin.succAbove_right_injective
-    · exact Fin.succAbove_right_injective
+    simp [succSuccAbove_self_apply]
+    grind
+  · rw [succSuccAbove_eq_succAbove_succAbove]
+    exact Function.Injective.comp Fin.succAbove_right_injective Fin.succAbove_right_injective
 
 @[simp]
-lemma dropPairEmb_eq_iff_eq {n : ℕ}
+lemma succSuccAbove_eq_iff_eq {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 = dropPairEmb i j m2 ↔ m1 = m2 := by
-  rw [(dropPairEmb_injective i j).eq_iff]
+    succSuccAbove i j m1 = succSuccAbove i j m2 ↔ m1 = m2 := by
+  rw [(succSuccAbove_injective i j).eq_iff]
 
 @[simp]
-lemma dropPairEmb_leq_iff_leq {n : ℕ}
+lemma succSuccAbove_leq_iff_leq {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 ≤ dropPairEmb i j m2 ↔ m1 ≤ m2 := by
+    succSuccAbove i j m1 ≤ succSuccAbove i j m2 ↔ m1 ≤ m2 := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [dropPairEmb_self_apply]
-    split_ifs
-    · simp_all
-    · simp_all
-      omega
-    · simp_all
-      omega
-    · simp_all
-  · rw [dropPairEmb_eq_succAbove_succAbove]
+  · simp [succSuccAbove_self_apply]
+    grind
+  · rw [succSuccAbove_eq_succAbove_succAbove]
     simp only [Function.comp_apply]
     rw [Fin.succAbove_le_succAbove_iff]
     rw [Fin.succAbove_le_succAbove_iff]
 
 @[simp]
-lemma dropPairEmb_lt_iff_lt {n : ℕ}
+lemma succSuccAbove_lt_iff_lt {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
-    dropPairEmb i j m1 < dropPairEmb i j m2 ↔ m1 < m2 := by
+    succSuccAbove i j m1 < succSuccAbove i j m2 ↔ m1 < m2 := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp [dropPairEmb_self_apply]
-    split_ifs
-    · simp_all
-    · simp_all
-      omega
-    · simp_all
-      omega
-    · simp_all
-  · rw [dropPairEmb_eq_succAbove_succAbove]
+  · simp [succSuccAbove_self_apply]
+    grind
+  · rw [succSuccAbove_eq_succAbove_succAbove]
     simp only [Function.comp_apply]
     rw [Fin.succAbove_lt_succAbove_iff]
     rw [Fin.succAbove_lt_succAbove_iff]
 
 @[simp]
-lemma dropPairEmb_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
-    Monotone (dropPairEmb i j) := by
+lemma succSuccAbove_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
+    Monotone (succSuccAbove i j) := by
   intro a b
   simp
 
-lemma dropPairEmb_eq_orderEmbOfFin {n : ℕ}
+lemma succSuccAbove_eq_orderEmbOfFin {n : ℕ}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
-    dropPairEmb i j = (Finset.orderEmbOfFin {i, j}ᶜ
+    succSuccAbove i j = (Finset.orderEmbOfFin {i, j}ᶜ
     (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) := by
-  let dropPairEmb : Fin n ↪o Fin (n + 1 + 1) :=
+  let succSuccAbove : Fin n ↪o Fin (n + 1 + 1) :=
   (Finset.orderEmbOfFin {i, j}ᶜ
   (by rw [Finset.card_compl]; simp [Finset.card_pair hij]))
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
   · simp at hij
-  rw [dropPairEmb_eq_succAbove_succAbove]
+  rw [succSuccAbove_eq_succAbove_succAbove]
   symm
   let f : Fin n ↪o Fin (n + 1 + 1) :=
     ⟨⟨i.succAboveOrderEmb ∘ j.succAboveOrderEmb, by
@@ -177,10 +145,10 @@ lemma dropPairEmb_eq_orderEmbOfFin {n : ℕ}
       exact Fin.succAbove_right_injective⟩, by
       simp only [Function.Embedding.coeFn_mk, Function.comp_apply, OrderEmbedding.le_iff_le,
         implies_true]⟩
-  have hf : dropPairEmb = f := by
+  have hf : succSuccAbove = f := by
     rw [← OrderEmbedding.range_inj]
     simp only [Finset.range_orderEmbOfFin, Finset.coe_compl,
-      RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, dropPairEmb, f]
+      RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, succSuccAbove, f]
     change _ = Set.range (i.succAbove ∘ j.succAbove)
     rw [Set.range_comp]
     simp only [Fin.range_succAbove]
@@ -209,29 +177,29 @@ lemma dropPairEmb_eq_orderEmbOfFin {n : ℕ}
   rw [hf']
   rfl
 
-lemma dropPairEmb_symm (i j : Fin (n + 1 + 1)) :
-    dropPairEmb i j = dropPairEmb j i := by
+lemma succSuccAbove_symm (i j : Fin (n + 1 + 1)) :
+    succSuccAbove i j = succSuccAbove j i := by
   by_cases hij : i = j
   · subst hij
     rfl
-  rw [dropPairEmb_eq_orderEmbOfFin i j hij,
-    dropPairEmb_eq_orderEmbOfFin j i (Ne.symm hij)]
+  rw [succSuccAbove_eq_orderEmbOfFin i j hij,
+    succSuccAbove_eq_orderEmbOfFin j i (Ne.symm hij)]
   simp [Finset.pair_comm]
 
 @[simp, nolint simpVarHead]
-lemma permCond_dropPairEmb_symm {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
-    (k : Fin n) : c (dropPairEmb i j k) = c (dropPairEmb j i k) := by
-  rw [dropPairEmb_symm]
+lemma permCond_succSuccAbove_symm {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
+    (k : Fin n) : c (succSuccAbove i j k) = c (succSuccAbove j i k) := by
+  rw [succSuccAbove_symm]
 
-lemma dropPairEmb_apply_eq_orderIsoOfFin {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (m : Fin n) :
-    (dropPairEmb i j) m = (Finset.orderIsoOfFin {i, j}ᶜ
+lemma succSuccAbove_apply_eq_orderIsoOfFin {i j : Fin (n + 1 + 1)} (hij : i ≠ j) (m : Fin n) :
+    (succSuccAbove i j) m = (Finset.orderIsoOfFin {i, j}ᶜ
       (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) m := by
-  simp [dropPairEmb_eq_orderEmbOfFin i j hij]
+  simp [succSuccAbove_eq_orderEmbOfFin i j hij]
 
 @[simp]
-lemma dropPairEmb_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    Set.range (dropPairEmb i j) = {i, j}ᶜ := by
-  rw [dropPairEmb_eq_orderEmbOfFin i j hij, Finset.range_orderEmbOfFin]
+lemma succSuccAbove_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
+    Set.range (succSuccAbove i j) = {i, j}ᶜ := by
+  rw [succSuccAbove_eq_orderEmbOfFin i j hij, Finset.range_orderEmbOfFin]
   simp only [Finset.compl_insert, Finset.coe_erase, Finset.coe_compl, Finset.coe_singleton]
   ext x : 1
   simp only [Set.mem_diff, Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_insert_iff, not_or]
@@ -241,57 +209,51 @@ lemma dropPairEmb_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
   · intro a
     simp_all only [not_false_eq_true, and_self]
 
-lemma dropPairEmb_image_compl {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
+lemma succSuccAbove_image_compl {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
     (X : Set (Fin n)) :
-    (dropPairEmb i j) '' Xᶜ = ({i, j} ∪ dropPairEmb i j '' X)ᶜ := by
-  rw [← compl_inj_iff, Function.Injective.compl_image_eq (dropPairEmb_injective i j)]
-  simp only [compl_compl, dropPairEmb_range hij]
-  exact Set.union_comm ((dropPairEmb i j) '' X) {i, j}
+    (succSuccAbove i j) '' Xᶜ = ({i, j} ∪ succSuccAbove i j '' X)ᶜ := by
+  rw [← compl_inj_iff, Function.Injective.compl_image_eq (succSuccAbove_injective i j)]
+  simp only [compl_compl, succSuccAbove_range hij]
+  exact Set.union_comm ((succSuccAbove i j) '' X) {i, j}
 
 @[simp]
-lemma fst_ne_dropPairEmb_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ i = dropPairEmb i j m := by
+lemma fst_ne_succSuccAbove_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    ¬ i = succSuccAbove i j m := by
   by_cases hij : i = j
   · subst hij
-    simp [dropPairEmb_self_apply]
-    by_cases hm : m.1 < i.1
-    · simp [hm, Fin.ext_iff]
-      omega
-    · simp [hm, Fin.ext_iff]
-      omega
+    simp [succSuccAbove_self_apply]
+    grind
   · by_contra hn
-    have hi : i ∉ Set.range (dropPairEmb i j) := by
-      simp [dropPairEmb_eq_orderEmbOfFin i j hij]
+    have hi : i ∉ Set.range (succSuccAbove i j) := by
+      simp [succSuccAbove_eq_orderEmbOfFin i j hij]
     nth_rewrite 2 [hn] at hi
-    simp [- dropPairEmb_range] at hi
+    simp [- succSuccAbove_range] at hi
 
 @[simp]
-lemma dropPairEmb_ne_fst (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ dropPairEmb i j m = i := by
+lemma succSuccAbove_ne_fst (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    ¬ succSuccAbove i j m = i := by
   apply Ne.symm
   simp
 
 @[simp]
-lemma snd_ne_dropPairEmb_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ j = (dropPairEmb i j) m := by
-  rw [dropPairEmb_symm]
-  exact fst_ne_dropPairEmb_pre j i m
+lemma snd_ne_succSuccAbove_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    ¬ j = (succSuccAbove i j) m := by
+  rw [succSuccAbove_symm]
+  exact fst_ne_succSuccAbove_pre j i m
 
 @[simp]
-lemma dropPairEmb_ne_snd (i j : Fin (n + 1 + 1)) (m : Fin n) :
-    ¬ dropPairEmb i j m = j := by
+lemma succSuccAbove_ne_snd (i j : Fin (n + 1 + 1)) (m : Fin n) :
+    ¬ succSuccAbove i j m = j := by
   apply Ne.symm
   simp
 
-lemma dropPairEmb_succAbove {n : ℕ}
+lemma succSuccAbove_succAbove {n : ℕ}
     (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
-    dropPairEmb i (i.succAbove j) =
-    i.succAbove ∘ j.succAbove := by
-  exact dropPairEmb_eq_succAbove_succAbove i j
+    succSuccAbove i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
+  exact succSuccAbove_eq_succAbove_succAbove i j
 
-lemma eq_or_exists_dropPairEmb
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1)) :
-    m = i ∨ m = j ∨ ∃ m', m = dropPairEmb i j m' := by
+lemma eq_or_exists_succSuccAbove(i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1)) :
+    m = i ∨ m = j ∨ ∃ m', m = succSuccAbove i j m' := by
   by_cases h : m = i
   · subst h
     simp
@@ -299,21 +261,145 @@ lemma eq_or_exists_dropPairEmb
     · subst h'
       simp
     · simp_all only [false_or]
-      have h'' : m ∈ Set.range (dropPairEmb i j) := by
-        simp_all [dropPairEmb_eq_orderEmbOfFin]
+      have h'' : m ∈ Set.range (succSuccAbove i j) := by
+        simp_all [succSuccAbove_eq_orderEmbOfFin]
       rw [@Set.mem_range] at h''
       obtain ⟨m', rfl⟩ := h''
       exact ⟨m', rfl⟩
 
+
+lemma succSuccAbove_apply_lt_lt {n : ℕ}
+    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+    (m : Fin n) (hi : m.val < i.val) (hj : m.val < j.val) :
+    succSuccAbove i j m = m.castSucc.castSucc := by
+  rcases Fin.eq_self_or_eq_succAbove i j with hj' | hj'
+  · subst hj'
+    simp at hij
+  obtain ⟨j, rfl⟩ := hj'
+  rw [succSuccAbove_succAbove]
+  simp only [Function.comp_apply]
+  have hj'' : m.val < j.val := by
+    simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq]
+    grind
+  rw [Fin.succAbove_of_succ_le, Fin.succAbove_of_succ_le]
+  · simp only [Fin.le_def, Fin.val_succ]
+    omega
+  · simp_all only [Fin.succAbove, Fin.lt_def, Fin.val_castSucc, ne_eq, ite_true, Fin.le_def,
+    Fin.val_succ]
+    omega
+
+set_option backward.isDefEq.respectTransparency false in
+lemma succSuccAbove_natAdd_apply_castAdd {n n1 : ℕ}
+    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+    (m : Fin n1) :
+    (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
+    (Fin.castAdd n m)
+    = Fin.castAdd (n + 1 + 1) (m) := by
+  rw [succSuccAbove_apply_lt_lt]
+  · simp [Fin.ext_iff]
+  · simp_all [Fin.ne_iff_vne]
+  · simp only [Fin.val_castAdd, Fin.val_natAdd]
+    omega
+  · simp only [Fin.val_castAdd, Fin.val_natAdd]
+    omega
+
+lemma succSuccAbove_natAdd_image_range_castAdd {n n1 : ℕ}
+    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
+    (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j)) ''
+    (Set.range (Fin.castAdd (m := n) (n := n1))) = {i | i.1 < n1} := by
+  ext a
+  simp only [Set.mem_image, Set.mem_range, exists_exists_eq_and, Set.mem_setOf_eq]
+  conv_lhs =>
+    enter [1, b]
+    rw [succSuccAbove_natAdd_apply_castAdd i j hij]
+  apply Iff.intro
+  · intro h
+    obtain ⟨b, rfl⟩ := h
+    simp
+  · intro h
+    use ⟨a, by omega⟩
+    simp
+
+set_option backward.isDefEq.respectTransparency false in
+lemma succSuccAbove_comm_natAdd {n n1 : ℕ}
+    (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+    (m : Fin n) :
+    (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
+    (Fin.natAdd n1 m)
+    = Fin.natAdd (n1) (succSuccAbove i j m) := by
+  let f : Fin n ↪o Fin (n1 + n + 1 + 1) :=
+    ⟨⟨(succSuccAbove (Fin.natAdd n1 i) (Fin.natAdd n1 j))
+    ∘ Fin.natAdd n1, by
+      intro i j
+      simp only [Function.comp_apply, succSuccAbove_eq_iff_eq]
+      simp [Fin.ext_iff]⟩, by
+      intro a b
+      simp only [Function.Embedding.coeFn_mk, Function.comp_apply, succSuccAbove_leq_iff_leq]
+      rw [Fin.le_def, Fin.le_def]
+      simp⟩
+  let g : Fin n ↪o Fin (n1 + n + 1 + 1) :=
+      ⟨⟨(Fin.natAdd (n1) ∘ succSuccAbove i j), by
+      intro a b
+      simp only [Function.comp_apply, Fin.ext_iff, Fin.val_natAdd, add_right_inj]
+      simp [← Fin.ext_iff]⟩, by
+      intro a b
+      simp only [Function.Embedding.coeFn_mk, Function.comp_apply]
+      rw [Fin.le_def, Fin.le_def]
+      simp⟩
+  have hcastRange : Set.range (Fin.castAdd (m := n) (n := n1)) = {i | i.1 < n1} := by
+    rw [@Set.range_eq_iff]
+    apply And.intro
+    · intro a
+      simp
+    · intro b hb
+      simp only [Set.mem_setOf_eq] at hb
+      use ⟨b, by omega⟩
+      simp
+  have hnatRange : Set.range (Fin.natAdd (m := n) n1) =
+    (Set.range (Fin.castAdd (m := n) (n := n1)))ᶜ := by
+    rw [hcastRange]
+    rw [@Set.range_eq_iff]
+    apply And.intro
+    · intro a
+      simp
+    · intro b hb
+      simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hb
+      use ⟨b - n1, by omega⟩
+      simp only [Fin.natAdd_mk, Fin.ext_iff]
+      omega
+  have hfg : f = g := by
+    rw [← OrderEmbedding.range_inj]
+    simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, f, g]
+    rw [Set.range_comp, Set.range_comp]
+    simp only [succSuccAbove_range hij]
+    rw [hnatRange]
+    rw [succSuccAbove_image_compl]
+    simp only [Set.compl_union]
+    rw [succSuccAbove_natAdd_image_range_castAdd i j hij]
+    ext a
+    simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
+      not_or, Set.mem_setOf_eq, not_lt, Set.mem_image]
+    apply Iff.intro
+    · intro h
+      use ⟨a - n1, by omega⟩
+      simp only [Fin.ext_iff, Fin.val_natAdd, Fin.natAdd_mk] at h ⊢
+      omega
+    · intro h
+      obtain ⟨x, h1, rfl⟩ := h
+      simp_all [Fin.ext_iff]
+    · simp_all [Fin.ext_iff]
+  simpa using congrFun (congrArg (fun x => x.toFun) hfg) m
+
+
 /-!
 
-## dropPairEmbPre
+## predPredAbove
 
 -/
 
-/-- The preimage of `m` under `dropPairEmb i j hij` given that `m` is not equal
+/-- The preimage of `m` under `succSuccAbove i j hij` given that `m` is not equal
   to `i` or `j`. -/
-def dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
+def predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) : Fin n :=
   if h1 : m.1 < i.1 ∧ m.1 < j.1 then
         ⟨m, by fin_omega⟩
@@ -325,10 +411,10 @@ def dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
         ⟨m - 2, by fin_omega⟩
 
 @[simp]
-lemma dropPairEmb_dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
+lemma succSuccAbove_predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) :
-    dropPairEmb i j (dropPairEmbPre i j hij m hm) = m := by
-  dsimp [dropPairEmb, dropPairEmbPre]
+    succSuccAbove i j (predPredAbove i j hij m hm) = m := by
+  dsimp [succSuccAbove, predPredAbove]
   split_ifs
   · rfl
   all_goals
@@ -336,81 +422,81 @@ lemma dropPairEmb_dropPairEmbPre (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fi
     try omega
 
 set_option backward.isDefEq.respectTransparency false in
-lemma dropPairEmbPre_eq_orderIsoOfFin (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
+lemma predPredAbove_eq_orderIsoOfFin (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) :
-    dropPairEmbPre i j hij m hm =
+    predPredAbove i j hij m hm =
     (Finset.orderIsoOfFin {i, j}ᶜ (by rw [Finset.card_compl]; simp [Finset.card_pair hij])).symm
     ⟨m, by simp [hm]⟩ := by
-  apply dropPairEmb_injective i j
-  conv_rhs => rw [dropPairEmb_apply_eq_orderIsoOfFin hij]
+  apply succSuccAbove_injective i j
+  conv_rhs => rw [succSuccAbove_apply_eq_orderIsoOfFin hij]
   simp
 
 @[simp]
-lemma dropPairEmbPre_injective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+lemma predPredAbove_injective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
     (m1 m2 : Fin (n + 1 + 1)) (hm1 : m1 ≠ i ∧ m1 ≠ j) (hm2 : m2 ≠ i ∧ m2 ≠ j) :
-    dropPairEmbPre i j hij m1 hm1 = dropPairEmbPre i j hij m2 hm2 ↔ m1 = m2 := by
-  rw [← Function.Injective.eq_iff (dropPairEmb_injective i j)]
+    predPredAbove i j hij m1 hm1 = predPredAbove i j hij m2 hm2 ↔ m1 = m2 := by
+  rw [← Function.Injective.eq_iff (succSuccAbove_injective i j)]
   simp
 
-lemma dropPairEmbPre_surjective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+lemma predPredAbove_surjective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
     (m : Fin n) :
     ∃ m' : Fin (n + 1 + 1), ∃ (h : m' ≠ i ∧ m' ≠ j),
-    dropPairEmbPre i j hij m' h = m := by
-  use (dropPairEmb i j) m
-  have h : (dropPairEmb i j) m ≠ i ∧ (dropPairEmb i j) m ≠ j := by
+    predPredAbove i j hij m' h = m := by
+  use (succSuccAbove i j) m
+  have h : (succSuccAbove i j) m ≠ i ∧ (succSuccAbove i j) m ≠ j := by
     simp [Ne.symm]
   use h
-  apply (dropPairEmb_injective i j)
+  apply (succSuccAbove_injective i j)
   simp
 
 @[simp]
-lemma dropPairEmbPre_dropPairEmb (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
+lemma predPredAbove_succSuccAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
     (m : Fin n) :
-    dropPairEmbPre i j hij (dropPairEmb i j m) (by simp) = m := by
-  apply dropPairEmb_injective i j
+    predPredAbove i j hij (succSuccAbove i j m) (by simp) = m := by
+  apply succSuccAbove_injective i j
   simp
 
 /-!
 
-## Commutativity of dropPairEmb
+## Commutativity of succSuccAbove
 
 -/
-lemma dropPairEmb_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
+lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
+    let i2' := (succSuccAbove i1 j1 i2);
+    let j2' := (succSuccAbove i1 j1 j2);
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    dropPairEmb i1 j1 ∘ dropPairEmb i2 j2 =
-    dropPairEmb i2' j2' ∘
-    dropPairEmb i1' j1':= by
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    succSuccAbove i1 j1 ∘ succSuccAbove i2 j2 =
+    succSuccAbove i2' j2' ∘
+    succSuccAbove i1' j1':= by
   intro i2' j2' hi2j2'
   let fl : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨dropPairEmb i1 j1 ∘ dropPairEmb i2 j2, by
+    ⟨⟨succSuccAbove i1 j1 ∘ succSuccAbove i2 j2, by
       apply Function.Injective.comp
-      exact dropPairEmb_injective i1 j1
-      exact dropPairEmb_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, dropPairEmb_leq_iff_leq, implies_true]⟩
+      exact succSuccAbove_injective i1 j1
+      exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
+        Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
   let fr : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
-    ⟨⟨dropPairEmb i2' j2' ∘ dropPairEmb
-      (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']))
-      (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2'])),
+    ⟨⟨succSuccAbove i2' j2' ∘ succSuccAbove
+      (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']))
+      (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2'])),
       by
       apply Function.Injective.comp
-      exact dropPairEmb_injective _ _
-      exact dropPairEmb_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
-        Function.comp_apply, dropPairEmb_leq_iff_leq, implies_true]⟩
+      exact succSuccAbove_injective _ _
+      exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
+        Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
   have h : fl = fr := by
     rw [← OrderEmbedding.range_inj]
     simp only [RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, Set.range_comp,
-      dropPairEmb_range hij2, fl, fr, j2', i2']
-    rw [dropPairEmb_range (by simp [hij1])]
-    rw [dropPairEmb_image_compl, dropPairEmb_image_compl]
+      succSuccAbove_range hij2, fl, fr, j2', i2']
+    rw [succSuccAbove_range (by simp [hij1])]
+    rw [succSuccAbove_image_compl, succSuccAbove_image_compl]
     congr 1
     rw [Set.image_pair, Set.image_pair]
-    simp only [dropPairEmb_dropPairEmbPre, i2', j2']
-    exact Set.union_comm {i1, j1} {(dropPairEmb i1 j1) i2, (dropPairEmb i1 j1) j2}
+    simp only [succSuccAbove_predPredAbove, i2', j2']
+    exact Set.union_comm {i1, j1} {(succSuccAbove i1 j1) i2, (succSuccAbove i1 j1) j2}
     simp [hij2]
     simp [hij1]
   ext1 a
@@ -418,444 +504,69 @@ lemma dropPairEmb_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1
   dsimp [fl, fr] at h'
   exact h'
 
-lemma dropPairEmb_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
+lemma succSuccAbove_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
     (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) (m : Fin n) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
+    let i2' := (succSuccAbove i1 j1 i2);
+    let j2' := (succSuccAbove i1 j1 j2);
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    dropPairEmb i2' j2'
-    (dropPairEmb i1' j1' m) =
-    dropPairEmb i1 j1 (dropPairEmb i2 j2 m) := by
+    let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
+    let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
+    succSuccAbove i2' j2'
+    (succSuccAbove i1' j1' m) =
+    succSuccAbove i1 j1 (succSuccAbove i2 j2 m) := by
   intro i2' j2' hi2j2' i1' j1'
-  change _ = (dropPairEmb i1 j1 ∘ dropPairEmb i2 j2) m
-  rw [dropPairEmb_comm i1 j1 i2 j2 hij1 hij2]
+  change _ = (succSuccAbove i1 j1 ∘ succSuccAbove i2 j2) m
+  rw [succSuccAbove_comm i1 j1 i2 j2 hij1 hij2]
   rfl
-
-lemma permCond_dropPairEmb_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
-    (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    PermCond
-      ((c ∘ dropPairEmb i2' j2') ∘ dropPairEmb i1' j1')
-      ((c ∘ dropPairEmb i1 j1) ∘ dropPairEmb i2 j2)
-      id := by
-  apply And.intro (Function.bijective_id)
-  simp only [id_eq, Function.comp_apply]
-  intro i
-  rw [dropPairEmb_comm_apply]
-  · simp [hij1]
-  · simp [hij2]
 
 /-!
 
-## dropPairOfMap
+## funPredPredAbove
 
 -/
 
 /-- Given a bijection `Fin (n1 + 1 + 1) → Fin (n + 1 + 1))` and a pair `i j : Fin (n1 + 1 + 1)`,
-  then `dropPairOfMap i j _ σ _ : Fin n1 → Fin n` corresponds to the induced bijection
+  then `funPredPredAbove i j _ σ _ : Fin n1 → Fin n` corresponds to the induced bijection
   formed by dropping `i` and `j` in the source and their image in the target. -/
-def dropPairOfMap {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
+def funPredPredAbove {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ)
     (m : Fin n1) : Fin n :=
-  dropPairEmbPre (σ i) (σ j)
+  predPredAbove (σ i) (σ j)
     (by simp [hσ.injective.eq_iff, hij])
-    (σ (dropPairEmb i j m)) (by simp [hσ.injective.eq_iff, Ne.symm])
+    (σ (succSuccAbove i j m)) (by simp [hσ.injective.eq_iff, Ne.symm])
 
-lemma dropPairOfMap_injective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
+lemma funPredPredAbove_injective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Injective (dropPairOfMap i j hij σ hσ) := by
+    Function.Injective (funPredPredAbove i j hij σ hσ) := by
   intro m1 m2 h
-  simpa [dropPairOfMap, hσ.injective.eq_iff] using h
+  simpa [funPredPredAbove, hσ.injective.eq_iff] using h
 
-lemma dropPairOfMap_surjective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
+lemma funPredPredAbove_surjective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Surjective (dropPairOfMap i j hij σ hσ) := by
+    Function.Surjective (funPredPredAbove i j hij σ hσ) := by
   intro m
-  simp only [dropPairOfMap]
-  obtain ⟨m, hm, rfl⟩ := dropPairEmbPre_surjective (σ i) (σ j)
+  simp only [funPredPredAbove]
+  obtain ⟨m, hm, rfl⟩ := predPredAbove_surjective (σ i) (σ j)
     (by simp [hσ.injective.eq_iff, hij]) m
-  simp only [dropPairEmbPre_injective]
+  simp only [predPredAbove_injective]
   obtain ⟨m', rfl⟩ := hσ.surjective m
   simp only [ne_eq, hσ.injective.eq_iff] at hm ⊢
-  rcases eq_or_exists_dropPairEmb i j hij m' with rfl | rfl | ⟨m'', rfl⟩
+  rcases eq_or_exists_succSuccAbove i j hij m' with rfl | rfl | ⟨m'', rfl⟩
   · simp_all
   · simp_all
   · exact ⟨m'', rfl⟩
 
-lemma dropPairOfMap_bijective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
+lemma funPredPredAbove_bijective {n n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
     (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : Function.Bijective σ) :
-    Function.Bijective (dropPairOfMap i j hij σ hσ) := by
+    Function.Bijective (funPredPredAbove i j hij σ hσ) := by
   apply And.intro
-  · apply dropPairOfMap_injective
-  · apply dropPairOfMap_surjective
-
-lemma permCond_dropPairOfMap {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
-    {c1 : Fin (n1 + 1 + 1) → C}
-    (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : PermCond c c1 σ) :
-    PermCond (c ∘ dropPairEmb (σ i) (σ j))
-      (c1 ∘ dropPairEmb i j) (dropPairOfMap i j hij σ hσ.1) := by
-  apply And.intro
-  · exact dropPairOfMap_bijective i j hij σ hσ.left
-  · intro m
-    simp [dropPairOfMap, hσ.2]
+  · apply funPredPredAbove_injective
+  · apply funPredPredAbove_surjective
 
 @[simp]
-lemma dropPairOfMap_id { n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j) :
-    dropPairOfMap i j hij id (Function.bijective_id) = id := by
+lemma funPredPredAbove_id { n1 : ℕ} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j) :
+    funPredPredAbove i j hij id (Function.bijective_id) = id := by
   ext1 m
-  simp [dropPairOfMap]
+  simp [funPredPredAbove]
 
-/-!
-
-## dropPair
-
--/
-
-set_option linter.unusedVariables false in
-/-- Given `i j : Fin (n + 1 + 1)`, `c : Fin (n + 1 + 1) → C` and a pure tensor `p : Pure S c`,
-  `dropPair i j _ p` is the tensor formed by dropping the `i`th and `j`th parts of `p`. -/
-@[nolint unusedArguments]
-def dropPair (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c) :
-    Pure S (c ∘ dropPairEmb i j) :=
-    fun m => p (dropPairEmb i j m)
-
-@[simp]
-lemma dropPair_equivariant {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c) (g : G) :
-    dropPair i j hij (g • p) = g • dropPair i j hij p := by
-  ext m
-  simp only [dropPair, actionP_eq]
-  rfl
-
-lemma dropPair_symm (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (p : Pure S c) : dropPair i j hij p =
-    permP id (by simp) (dropPair j i hij.symm p) := by
-  ext m
-  simp only [Function.comp_apply, dropPair, permP, id_eq]
-  refine (congr_right _ _ _ ?_).symm
-  rw [dropPairEmb_symm]
-
-lemma dropPair_comm {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
-    (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1) (hij2 : i2 ≠ j2) (p : Pure S c) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    dropPair i2 j2 hij2 (dropPair i1 j1 hij1 p) =
-    permP id (permCond_dropPairEmb_comm i1 j1 i2 j2 hij1 hij2)
-    ((dropPair i1' j1' (by simp [i1', j1', hij1]) (dropPair i2' j2' hi2j2' p))) := by
-  ext m
-  simp only [Function.comp_apply, dropPair, permP, id_eq]
-  apply (congr_right _ _ _ ?_).symm
-  rw [dropPairEmb_comm_apply]
-  · simp [hij1]
-  · simp [hij2]
-
-@[simp]
-lemma dropPair_update_fst {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c)
-    (x : S.FD.obj (Discrete.mk (c i))) :
-    dropPair i j hij (p.update i x) = dropPair i j hij p := by
-  ext m
-  simp only [Function.comp_apply, dropPair, update]
-  rw [Function.update_of_ne]
-  exact Ne.symm (fst_ne_dropPairEmb_pre i j m)
-
-@[simp]
-lemma dropPair_update_snd {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c)
-    (x : S.FD.obj (Discrete.mk (c j))) :
-    dropPair i j hij (p.update j x) = dropPair i j hij p := by
-  rw [dropPair_symm]
-  simp only [dropPair_update_fst]
-  conv_rhs => rw [dropPair_symm]
-
-@[simp]
-lemma dropPair_update_dropPairEmb {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
-    {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (p : Pure S c)
-    (m : Fin n)
-    (x : S.FD.obj (Discrete.mk (c (dropPairEmb i j m)))) :
-    dropPair i j hij (p.update (dropPairEmb i j m) x) =
-    (dropPair i j hij p).update m x := by
-  ext m'
-  simp only [Function.comp_apply, dropPair, update]
-  by_cases h : m' = m
-  · subst h
-    simp
-  · rw [Function.update_of_ne, Function.update_of_ne]
-    · rfl
-    · simp [h]
-    · simp [h]
-
-TODO "Prove lemmas relating to the commutation rules of `dropPair` and `prodP`."
-
-@[simp]
-lemma dropPair_permP {n n1 : ℕ} {c : Fin (n + 1 + 1) → C}
-    {c1 : Fin (n1 + 1 + 1) → C} (i j : Fin (n1 + 1 + 1)) (hij : i ≠ j)
-    (σ : Fin (n1 + 1 + 1) → Fin (n + 1 + 1)) (hσ : PermCond c c1 σ) (p : Pure S c) :
-    dropPair i j hij (permP σ hσ p) =
-    permP (dropPairOfMap i j hij σ hσ.1) (permCond_dropPairOfMap i j hij σ hσ)
-    (dropPair (σ i) (σ j) (by simp [hσ.1.injective.eq_iff, hij]) p) := by
-  ext m
-  simp only [Function.comp_apply, dropPair, permP, dropPairOfMap]
-  apply congr_mid
-  · simp
-  · simp [hσ.2]
-  · simp [hσ.2]
-
-/-!
-
-## Contraction coefficient
-
--/
-
-/-- Given a pure tensor `p : Pure S c` and a `i j : Fin n`
-  corresponding to dual colors in `c`, `contrPCoeff i j _ p` is the
-  element of the underlying ring `k` formed by contracting `p i` and `p j`. -/
-noncomputable def contrPCoeff {n : ℕ} {c : Fin n → C}
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c i) = c j) (p : Pure S c) : k :=
-    (S.contr.app (Discrete.mk (c i))) (p i ⊗ₜ ((S.FD.map (eqToHom (by simp [hij]))) (p j)))
-
-@[simp]
-lemma contrPCoeff_permP {n n1 : ℕ} {c : Fin n → C}
-    {c1 : Fin n1 → C} (i j : Fin n1) (hij : i ≠ j ∧ S.τ (c1 i) = c1 j)
-    (σ : Fin n1 → Fin n) (hσ : PermCond c c1 σ) (p : Pure S c) :
-    contrPCoeff i j hij (permP σ hσ p) =
-    contrPCoeff (σ i) (σ j) (by simp [hσ.1.injective.eq_iff, hij, hσ.2]) p := by
-  simp only [contrPCoeff, Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply, permP]
-  conv_rhs => erw [S.contr_congr (c (σ i)) ((c1 i)) (by simp [hσ.2])]
-  simp only [Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply]
-  apply congrArg
-  congr 1
-  change ((S.FD.map (eqToHom _) ≫ S.FD.map (eqToHom _)).hom) _ =
-    ((S.FD.map (eqToHom _) ≫ S.FD.map (eqToHom _)).hom) _
-  rw [← Functor.map_comp, ← Functor.map_comp]
-  simp
-
-@[simp]
-lemma contrPCoeff_update_dropPairEmb {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))]
-    {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) (m : Fin n)
-    (p : Pure S c) (x : S.FD.obj (Discrete.mk (c (dropPairEmb i j m)))) :
-    contrPCoeff i j hij (p.update (dropPairEmb i j m) x) =
-    contrPCoeff i j hij p := by
-  simp only [contrPCoeff]
-  congr
-  · simp [update]
-  · simp [update]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrPCoeff_update_fst_add {n : ℕ} [inst : DecidableEq (Fin n)] {c : Fin n → C}
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (x y : S.FD.obj (Discrete.mk (c i))) :
-    contrPCoeff i j hij (p.update i (x + y)) =
-    contrPCoeff i j hij (p.update i x) + contrPCoeff i j hij (p.update i y) := by
-  change ((S.contr.app { as := c i })).hom.toLinearMap _ =
-    ((S.contr.app { as := c i })).hom.toLinearMap _
-    + ((S.contr.app { as := c i })).hom.toLinearMap _
-  simp [Function.update_of_ne (Ne.symm hij.1), update, TensorProduct.add_tmul, LinearMap.map_add]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrPCoeff_update_snd_add {n : ℕ} [inst : DecidableEq (Fin n)] {c : Fin n → C}
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (x y : S.FD.obj (Discrete.mk (c j))) :
-    contrPCoeff i j hij (p.update j (x + y)) =
-    contrPCoeff i j hij (p.update j x) + contrPCoeff i j hij (p.update j y) := by
-  simp only [contrPCoeff, Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply, update, Function.update_self]
-  change ((S.contr.app { as := c i })).hom.toLinearMap _ =
-    ((S.contr.app { as := c i })).hom.toLinearMap _
-    + ((S.contr.app { as := c i })).hom.toLinearMap _
-  rw [Function.update_of_ne hij.1, Function.update_of_ne hij.1,
-    Function.update_of_ne hij.1]
-  conv_lhs =>
-    enter [2, 3]
-    change ((S.FD.map (eqToHom _))).hom.toLinearMap (x + y)
-  simp only [Monoidal.tensorUnit_obj, TensorProduct.tmul_add, LinearMap.map_add]
-  rfl
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrPCoeff_update_fst_smul {n : ℕ} [inst : DecidableEq (Fin n)] {c : Fin n → C}
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (r : k) (x : S.FD.obj (Discrete.mk (c i))) :
-    contrPCoeff i j hij (p.update i (r • x)) =
-    r * contrPCoeff i j hij (p.update i x) := by
-  simp only [contrPCoeff, Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply, update, Function.update_self,
-    TensorProduct.smul_tmul, TensorProduct.tmul_smul]
-  change ((S.contr.app { as := c i })).hom.toLinearMap _ = r * _
-  simp only [Monoidal.tensorUnit_obj, LinearMap.map_smul, smul_eq_mul]
-  congr 1
-  change ((S.contr.app { as := c i })).hom.toLinearMap _ =
-    ((S.contr.app { as := c i })).hom.toLinearMap _
-  rw [Function.update_of_ne (Ne.symm hij.1), Function.update_of_ne (Ne.symm hij.1)]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrPCoeff_update_snd_smul {n : ℕ} [inst : DecidableEq (Fin n)] {c : Fin n → C}
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (r : k) (x : S.FD.obj (Discrete.mk (c j))) :
-    contrPCoeff i j hij (p.update j (r • x)) =
-    r * contrPCoeff i j hij (p.update j x) := by
-  simp only [contrPCoeff, Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply, update, Function.update_self]
-  change ((S.contr.app { as := c i })).hom.toLinearMap _ = r * _
-  rw [Function.update_of_ne hij.1, Function.update_of_ne hij.1]
-  conv_lhs =>
-    enter [2, 3]
-    change ((S.FD.map (eqToHom _))).hom.toLinearMap (r • _)
-  simp only [Monoidal.tensorUnit_obj, LinearMap.map_smul, TensorProduct.tmul_smul, smul_eq_mul]
-  rfl
-
-lemma contrPCoeff_dropPair {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    (a b : Fin (n + 1 + 1)) (hab : a ≠ b)
-    (i j : Fin n) (hij : i ≠ j ∧ S.τ (c (dropPairEmb a b i)) = (c (dropPairEmb a b j)))
-    (p : Pure S c) : (p.dropPair a b hab).contrPCoeff i j hij =
-    p.contrPCoeff (dropPairEmb a b i) (dropPairEmb a b j)
-      (by simpa using hij) := by rfl
-
-lemma contrPCoeff_symm {n : ℕ} {c : Fin n → C} {i j : Fin n} {hij : i ≠ j ∧ S.τ (c i) = c j}
-    {p : Pure S c} :
-    p.contrPCoeff i j hij = p.contrPCoeff j i ⟨hij.1.symm, by simp [← hij.2]⟩ := by
-  rw [contrPCoeff, contrPCoeff]
-  erw [S.contr_tmul_symm]
-  rw [S.contr_congr (S.τ (c i)) (c j)]
-  simp only [Monoidal.tensorUnit_obj,
-    Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply]
-  change _ = (S.contr.app { as := c j }).hom _
-  congr 2
-  · change ((S.FD.map (eqToHom _) ≫ S.FD.map (eqToHom _)).hom) _ = _
-    rw [← S.FD.map_comp]
-    simp
-  · change ((S.FD.map (eqToHom _) ≫ S.FD.map (eqToHom _)).hom) _ = _
-    rw [← S.FD.map_comp]
-    simp only [eqToHom_trans]
-    rfl
-  · simp [hij.2]
-
-lemma contrPCoeff_mul_dropPair {n : ℕ} {c : Fin (n + 1 + 1 + 1 + 1) → C}
-    (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))
-    (hij1 : i1 ≠ j1 ∧ S.τ (c i1) = (c j1))
-    (hij2 : i2 ≠ j2 ∧ S.τ (c (dropPairEmb i1 j1 i2)) = (c (dropPairEmb i1 j1 j2)))
-    (p : Pure S c) :
-    let i2' := (dropPairEmb i1 j1 i2);
-    let j2' := (dropPairEmb i1 j1 j2);
-    have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
-    let i1' := (dropPairEmbPre i2' j2' hi2j2' i1 (by simp [i2', j2']));
-    let j1' := (dropPairEmbPre i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    (p.contrPCoeff i1 j1 hij1) * (dropPair i1 j1 hij1.1 p).contrPCoeff i2 j2 hij2 =
-    (p.contrPCoeff i2' j2' (by simp [i2', j2', hij2])) *
-    (dropPair i2' j2' (by simp [i2', j2', hij2]) p).contrPCoeff i1' j1'
-      (by simp [i1', j1', hij1]) := by
-  simp only [contrPCoeff_dropPair, dropPairEmb_dropPairEmbPre]
-  rw [mul_comm]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrPCoeff_invariant {n : ℕ} {c : Fin n → C} {i j : Fin n}
-    {hij : i ≠ j ∧ S.τ (c i) = c j} {p : Pure S c}
-    (g : G) : (g • p).contrPCoeff i j hij = p.contrPCoeff i j hij := by
-  calc (g • p).contrPCoeff i j hij
-    _ = (S.contr.app (Discrete.mk (c i)))
-          ((S.FD.obj _).ρ g (p i) ⊗ₜ ((S.FD.map (eqToHom (by simp [hij])))
-          ((S.FD.obj _).ρ g (p j)))) := rfl
-    _ = (S.contr.app (Discrete.mk (c i)))
-          ((S.FD.obj _).ρ g (p i) ⊗ₜ (S.FD.obj _).ρ g ((S.FD.map (eqToHom (by simp [hij])))
-          (p j))) := by
-        congr 2
-        simp only [Functor.comp_obj, Discrete.functor_obj_eq_as, Function.comp_apply]
-        have h1 := (S.FD.map (eqToHom (by simp [hij] : { as := c j } =
-          (Discrete.functor (Discrete.mk ∘ S.τ)).obj { as := c i }))).hom.isIntertwining' g
-        exact LinearMap.congr_fun h1 (p j)
-  have h1 := (S.contr.app (Discrete.mk (c i))).hom.isIntertwining' g
-  exact LinearMap.congr_fun h1 ((p i) ⊗ₜ ((S.FD.map (eqToHom (by simp [hij]))) (p j)))
-
-/-!
-
-## Contractions
-
--/
-
-/-- For `c : Fin (n + 1 + 1) → C`, `i j : Fin (n + 1 + 1)` with dual color, and a pure tensor
-  `p : Pure S c`, `contrP i j _ p` is the tensor (not pure due to the `n = 0` case)
-  formed by contracting the `i`th index of `p`
-  with the `j`th index. -/
-noncomputable def contrP {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) (p : Pure S c) :
-    S.Tensor (c ∘ dropPairEmb i j) :=
-  (p.contrPCoeff i j hij) • (p.dropPair i j hij.1).toTensor
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrP_update_add {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin (n + 1 + 1) → C}
-    (i j m : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (x y : S.FD.obj (Discrete.mk (c m))) :
-    contrP i j hij (p.update m (x + y)) =
-    contrP i j hij (p.update m x) + contrP i j hij (p.update m y) := by
-  rcases eq_or_exists_dropPairEmb i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
-  · simp [contrP, add_smul]
-  · simp [contrP, add_smul]
-  · simp [contrP]
-
-set_option backward.isDefEq.respectTransparency false in
-@[simp]
-lemma contrP_update_smul {n : ℕ} [inst : DecidableEq (Fin (n + 1 +1))] {c : Fin (n + 1 + 1) → C}
-    (i j m : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j)
-    (p : Pure S c) (r : k) (x : S.FD.obj (Discrete.mk (c m))) :
-    contrP i j hij (p.update m (r • x)) =
-    r • contrP i j hij (p.update m x) := by
-  rcases eq_or_exists_dropPairEmb i j hij.1 m with rfl | rfl | ⟨m', rfl⟩
-  · simp [contrP, smul_smul]
-  · simp [contrP, smul_smul]
-  · simp [contrP, smul_smul, mul_comm]
-
-@[simp]
-lemma contrP_equivariant {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) (p : Pure S c) (g : G) :
-    contrP i j hij (g • p) = g • contrP i j hij p := by
-  simp [contrP, contrPCoeff_invariant, dropPair_equivariant, actionT_pure]
-
-lemma contrP_symm {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    {i j : Fin (n + 1 + 1)} {hij : i ≠ j ∧ S.τ (c i) = c j} {p : Pure S c} :
-    contrP i j hij p = permT id (by simp)
-    (contrP j i ⟨hij.1.symm, by simp [← hij.2]⟩ p) := by
-  rw [contrP, contrPCoeff_symm, dropPair_symm]
-  simp [contrP, permT_pure]
-
-/-!
-
-## contrP as a multilinear map
-
--/
-
-set_option backward.isDefEq.respectTransparency false in
-/-- The multi-linear map formed by contracting a pair of indices of pure tensors. -/
-noncomputable def contrPMultilinear {n : ℕ} {c : Fin (n + 1 + 1) → C}
-    (i j : Fin (n + 1 + 1)) (hij : i ≠ j ∧ S.τ (c i) = c j) :
-    MultilinearMap k (fun i => S.FD.obj (Discrete.mk (c i)))
-      (S.Tensor (c ∘ dropPairEmb i j))where
-  toFun p := contrP i j hij p
-  map_update_add' p m x y := by
-    change (update p m (x + y)).contrP i j hij = _
-    simp only [contrP_update_add]
-    rfl
-  map_update_smul' p k r y := by
-    change (update p k (r • y)).contrP i j hij = _
-    rw [Pure.contrP_update_smul]
-    rfl
+end Fin

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -78,7 +78,7 @@ lemma succSuccAbove_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1
   grind
 
 lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    succSuccAbove i j = fun x => (i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x)) := by
+    succSuccAbove i j = fun x => i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x) := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
   · contradiction
   · ext x
@@ -97,12 +97,9 @@ lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
 
 lemma succSuccAbove_injective {n : ℕ}
     (i j : Fin (n + 1 + 1)) : Function.Injective (succSuccAbove i j) := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · intro a b
-    simp only [succSuccAbove_self_apply]
-    grind
-  · rw [succSuccAbove_eq_succAbove_succAbove]
-    exact Function.Injective.comp Fin.succAbove_right_injective Fin.succAbove_right_injective
+  intro a b
+  simp only [Fin.ext_iff, succSuccAbove_val]
+  grind (splits := 20)
 
 @[simp]
 lemma succSuccAbove_eq_iff_eq {n : ℕ}
@@ -114,23 +111,15 @@ lemma succSuccAbove_eq_iff_eq {n : ℕ}
 lemma succSuccAbove_leq_iff_leq {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
     succSuccAbove i j m1 ≤ succSuccAbove i j m2 ↔ m1 ≤ m2 := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp only [succSuccAbove_self_apply]
-    grind
-  · rw [succSuccAbove_eq_succAbove_succAbove]
-    simp only [Function.comp_apply, Fin.succAbove_le_succAbove_iff]
+  simp only [Fin.le_def, Fin.succSuccAbove_val]
+  grind (splits := 20)
 
 @[simp]
 lemma succSuccAbove_lt_iff_lt {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m1 m2 : Fin n) :
     succSuccAbove i j m1 < succSuccAbove i j m2 ↔ m1 < m2 := by
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp only [succSuccAbove_self_apply]
-    grind
-  · rw [succSuccAbove_eq_succAbove_succAbove]
-    simp only [Function.comp_apply]
-    rw [Fin.succAbove_lt_succAbove_iff]
-    rw [Fin.succAbove_lt_succAbove_iff]
+  simp only [Fin.lt_def, Fin.succSuccAbove_val]
+  grind (splits := 20)
 
 @[simp]
 lemma succSuccAbove_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
@@ -139,11 +128,8 @@ lemma succSuccAbove_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
   simp
 
 lemma succSuccAbove_strictMono {n : ℕ} (i j : Fin (n + 1 + 1)) :
-    StrictMono (succSuccAbove i j) := by
-  refine Monotone.strictMono_of_injective ?_ ?_
-  · exact succSuccAbove_monotone i j
-  · exact succSuccAbove_injective i j
-
+    StrictMono (succSuccAbove i j) :=
+  (succSuccAbove_monotone i j).strictMono_of_injective (succSuccAbove_injective i j)
 
 @[simp]
 lemma succSuccAbove_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
@@ -168,20 +154,15 @@ lemma succSuccAbove_eq_orderEmbOfFin {n : ℕ}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
     succSuccAbove i j = Finset.orderEmbOfFin {i, j}ᶜ
     (by rw [Finset.card_compl]; simp [Finset.card_pair hij]) := by
-  apply (StrictMono.range_inj _ _).mp
-  · simp only [succSuccAbove_range hij, Finset.range_orderEmbOfFin, Finset.coe_compl,
+  apply ((succSuccAbove_strictMono i j).range_inj  (OrderEmbedding.strictMono _)).mp
+  simp only [succSuccAbove_range hij, Finset.range_orderEmbOfFin, Finset.coe_compl,
       Finset.coe_insert, Finset.coe_singleton]
-  · exact succSuccAbove_strictMono i j
-  · exact OrderEmbedding.strictMono _
 
 lemma succSuccAbove_symm (i j : Fin (n + 1 + 1)) :
     succSuccAbove i j = succSuccAbove j i := by
-  by_cases hij : i = j
-  · subst hij
-    rfl
-  rw [succSuccAbove_eq_orderEmbOfFin i j hij,
-    succSuccAbove_eq_orderEmbOfFin j i (Ne.symm hij)]
-  simp [Finset.pair_comm]
+  ext m
+  simp only [succSuccAbove_val]
+  grind (splits := 5)
 
 @[simp, nolint simpVarHead]
 lemma permCond_succSuccAbove_symm {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
@@ -203,21 +184,14 @@ lemma succSuccAbove_image_compl {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
 @[simp]
 lemma fst_ne_succSuccAbove_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
     ¬ i = succSuccAbove i j m := by
-  by_cases hij : i = j
-  · subst hij
-    simp only [succSuccAbove_self_apply]
-    grind
-  · by_contra hn
-    have hi : i ∉ Set.range (succSuccAbove i j) := by
-      simp [succSuccAbove_eq_orderEmbOfFin i j hij]
-    nth_rewrite 2 [hn] at hi
-    simp [- succSuccAbove_range] at hi
+  simp only [Fin.ext_iff, succSuccAbove_val]
+  grind (splits := 5)
 
 @[simp]
 lemma succSuccAbove_ne_fst (i j : Fin (n + 1 + 1)) (m : Fin n) :
     ¬ succSuccAbove i j m = i := by
-  apply Ne.symm
-  simp
+  simp only [Fin.ext_iff, succSuccAbove_val]
+  grind (splits := 5)
 
 @[simp]
 lemma snd_ne_succSuccAbove_pre (i j : Fin (n + 1 + 1)) (m : Fin n) :
@@ -231,25 +205,15 @@ lemma succSuccAbove_ne_snd (i j : Fin (n + 1 + 1)) (m : Fin n) :
   apply Ne.symm
   simp
 
-lemma succSuccAbove_succAbove {n : ℕ}
-    (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
-    succSuccAbove i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
-  exact succSuccAbove_eq_succAbove_succAbove i j
-
 lemma eq_or_exists_succSuccAbove(i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1)) :
     m = i ∨ m = j ∨ ∃ m', m = succSuccAbove i j m' := by
   by_cases h : m = i
-  · subst h
-    simp
+  · simp [h]
   · by_cases h' : m = j
-    · subst h'
+    · simp [h']
+    · obtain ⟨m', rfl⟩ : ∃ y, succSuccAbove i j y = m := by
+        simp_all [← Set.mem_range, succSuccAbove_eq_orderEmbOfFin]
       simp
-    · simp_all only [false_or]
-      have h'' : m ∈ Set.range (succSuccAbove i j) := by
-        simp_all [succSuccAbove_eq_orderEmbOfFin]
-      rw [@Set.mem_range] at h''
-      obtain ⟨m', rfl⟩ := h''
-      exact ⟨m', rfl⟩
 
 lemma succSuccAbove_apply_lt_lt {n : ℕ}
     (i j : Fin (n + 1 + 1)) (m : Fin n) (hi : m.val < i.val) (hj : m.val < j.val) :
@@ -257,18 +221,12 @@ lemma succSuccAbove_apply_lt_lt {n : ℕ}
   ext
   simp [succSuccAbove, hi, hj]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma succSuccAbove_natAdd_apply_castAdd {n n1 : ℕ}
     (i j : Fin (n + 1 + 1)) (m : Fin n1) :
     (succSuccAbove (n := n1 + n) (Fin.natAdd n1 i) (Fin.natAdd n1 j))
-    (Fin.castAdd n m)
-    = Fin.castAdd (n + 1 + 1) (m) := by
-  rw [succSuccAbove_apply_lt_lt]
-  · simp [Fin.ext_iff]
-  · simp only [Fin.val_castAdd, Fin.val_natAdd]
-    omega
-  · simp only [Fin.val_castAdd, Fin.val_natAdd]
-    omega
+    (Fin.castAdd n m) = Fin.castAdd (n + 1 + 1) (m) := by
+  simp only [Fin.ext_iff, succSuccAbove_val, natAdd, castAdd]
+  grind (splits := 20)
 
 lemma succSuccAbove_natAdd_image_range_castAdd {n n1 : ℕ}
     (i j : Fin (n + 1 + 1)) :
@@ -280,12 +238,9 @@ lemma succSuccAbove_natAdd_image_range_castAdd {n n1 : ℕ}
     enter [1, b]
     rw [succSuccAbove_natAdd_apply_castAdd i j]
   apply Iff.intro
-  · intro h
-    obtain ⟨b, rfl⟩ := h
+  · rintro ⟨b, rfl⟩
     simp
-  · intro h
-    use ⟨a, by omega⟩
-    simp
+  · exact fun h ↦ ⟨⟨a, by omega⟩, by simp⟩
 
 lemma succSuccAbove_comm_natAdd {n n1 : ℕ}
     (i j : Fin (n + 1 + 1)) (m : Fin n) :
@@ -305,13 +260,13 @@ lemma succSuccAbove_comm_natAdd {n n1 : ℕ}
 def predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) : Fin n :=
   if h1 : m.1 < i.1 ∧ m.1 < j.1 then
-        ⟨m, by grind⟩
-      else if h2 : m.1 - 1 < i.1 ∧ j.1 ≤ m.1 then
-        ⟨m - 1, by grind⟩
-      else if h3 : i.1 - 1 ≤ m.1 ∧ m.1 < j.1 then
-        ⟨m - 1, by grind⟩
-      else
-        ⟨m - 2, by grind⟩
+      ⟨m, by grind⟩
+    else if h2 : m.1 - 1 < i.1 ∧ j.1 ≤ m.1 then
+      ⟨m - 1, by grind⟩
+    else if h3 : i.1 - 1 ≤ m.1 ∧ m.1 < j.1 then
+      ⟨m - 1, by grind⟩
+    else
+      ⟨m - 2, by grind⟩
 
 lemma predPredAbove_val (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) :
@@ -374,8 +329,7 @@ lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 +
     succSuccAbove i1 j1 ∘ succSuccAbove i2 j2 =
     succSuccAbove i2' j2' ∘ succSuccAbove i1' j1':= by
   ext m
-  simp only [Function.comp_apply]
-  simp only [predPredAbove_val, succSuccAbove_val]
+  simp only [Function.comp_apply, predPredAbove_val, succSuccAbove_val]
   grind (splits := 20)
 
 lemma succSuccAbove_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 + 1))

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -138,53 +138,41 @@ lemma succSuccAbove_monotone {n : ℕ} (i j : Fin (n + 1 + 1)) :
   intro a b
   simp
 
+lemma succSuccAbove_strictMono {n : ℕ} (i j : Fin (n + 1 + 1)) :
+    StrictMono (succSuccAbove i j) := by
+  refine Monotone.strictMono_of_injective ?_ ?_
+  · exact succSuccAbove_monotone i j
+  · exact succSuccAbove_injective i j
+
+
+@[simp]
+lemma succSuccAbove_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
+    Set.range (succSuccAbove i j) = {i, j}ᶜ := by
+  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
+  · simp_all
+  rw [succSuccAbove_eq_succAbove_succAbove, Set.range_comp, Fin.range_succAbove]
+  ext a
+  simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_image]
+  apply Iff.intro
+  · intro h
+    obtain ⟨b, h1, rfl⟩ := h
+    simpa using h1
+  · intro h
+    simp at h
+    rcases  Fin.eq_self_or_eq_succAbove i a with rfl | ⟨a, rfl⟩
+    · simp_all
+    use a
+    simp_all
+
 lemma succSuccAbove_eq_orderEmbOfFin {n : ℕ}
     (i j : Fin (n + 1 + 1)) (hij : i ≠ j) :
     succSuccAbove i j = Finset.orderEmbOfFin {i, j}ᶜ
     (by rw [Finset.card_compl]; simp [Finset.card_pair hij]) := by
-  let succSuccAbove : Fin n ↪o Fin (n + 1 + 1) :=
-  (Finset.orderEmbOfFin {i, j}ᶜ
-  (by rw [Finset.card_compl]; simp [Finset.card_pair hij]))
-  rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
-  · simp at hij
-  rw [succSuccAbove_eq_succAbove_succAbove]
-  symm
-  let f : Fin n ↪o Fin (n + 1 + 1) :=
-    ⟨⟨i.succAboveOrderEmb ∘ j.succAboveOrderEmb,
-        Fin.succAbove_right_injective.comp Fin.succAbove_right_injective⟩, by
-      simp only [Function.Embedding.coeFn_mk, Function.comp_apply, OrderEmbedding.le_iff_le,
-        implies_true]⟩
-  have hf : succSuccAbove = f := by
-    rw [← OrderEmbedding.range_inj]
-    simp only [Finset.range_orderEmbOfFin, Finset.coe_compl,
-      RelEmbedding.coe_mk, Function.Embedding.coeFn_mk, succSuccAbove, f]
-    change _ = Set.range (i.succAbove ∘ j.succAbove)
-    rw [Set.range_comp]
-    simp only [Fin.range_succAbove]
-    ext a
-    simp only [Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_image]
-    apply Iff.intro
-    · intro h
-      have ha := Fin.eq_self_or_eq_succAbove i a
-      simp_all [false_or]
-      obtain ⟨a, rfl⟩ := ha
-      use a
-      simp_all only [and_true]
-      rw [Fin.succAbove_right_injective.eq_iff] at h
-      exact h.2
-    · intro h
-      obtain ⟨a, h1, rfl⟩ := h
-      simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff, Set.mem_singleton_iff,
-        not_or]
-      rw [Fin.succAbove_right_injective.eq_iff]
-      simp_all only [not_false_eq_true, and_true]
-      exact Fin.succAbove_ne i a
-  ext a
-  have hf' := congrFun (congrArg (fun x => x.toFun) hf) a
-  simp only [Function.Embedding.toFun_eq_coe, RelEmbedding.coe_toEmbedding, Function.comp_apply,
-    Fin.succAboveOrderEmb_apply, f] at hf'
-  rw [hf']
-  rfl
+  apply (StrictMono.range_inj _ _).mp
+  · simp only [succSuccAbove_range hij, Finset.range_orderEmbOfFin, Finset.coe_compl,
+      Finset.coe_insert, Finset.coe_singleton]
+  · exact succSuccAbove_strictMono i j
+  · exact OrderEmbedding.strictMono _
 
 lemma succSuccAbove_symm (i j : Fin (n + 1 + 1)) :
     succSuccAbove i j = succSuccAbove j i := by
@@ -204,19 +192,6 @@ lemma succSuccAbove_apply_eq_orderIsoOfFin {i j : Fin (n + 1 + 1)} (hij : i ≠ 
     (succSuccAbove i j) m = (Finset.orderIsoOfFin {i, j}ᶜ
       (by rw [Finset.card_compl]; simp [Finset.card_pair hij])) m := by
   simp [succSuccAbove_eq_orderEmbOfFin i j hij]
-
-@[simp]
-lemma succSuccAbove_range {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    Set.range (succSuccAbove i j) = {i, j}ᶜ := by
-  rw [succSuccAbove_eq_orderEmbOfFin i j hij, Finset.range_orderEmbOfFin]
-  simp only [Finset.compl_insert, Finset.coe_erase, Finset.coe_compl, Finset.coe_singleton]
-  ext x : 1
-  simp only [Set.mem_diff, Set.mem_compl_iff, Set.mem_singleton_iff, Set.mem_insert_iff, not_or]
-  apply Iff.intro
-  · intro a
-    simp_all only [not_false_eq_true, and_self]
-  · intro a
-    simp_all only [not_false_eq_true, and_self]
 
 lemma succSuccAbove_image_compl {i j : Fin (n + 1 + 1)} (hij : i ≠ j)
     (X : Set (Fin n)) :

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -330,13 +330,13 @@ lemma succSuccAbove_comm_natAdd {n n1 : ℕ}
 def predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) : Fin n :=
   if h1 : m.1 < i.1 ∧ m.1 < j.1 then
-        ⟨m, by fin_omega⟩
+        ⟨m, by grind⟩
       else if h2 : m.1 - 1 < i.1 ∧ j.1 ≤ m.1 then
-        ⟨m - 1, by fin_omega⟩
+        ⟨m - 1, by grind⟩
       else if h3 : i.1 - 1 ≤ m.1 ∧ m.1 < j.1 then
-        ⟨m - 1, by fin_omega⟩
+        ⟨m - 1, by grind⟩
       else
-        ⟨m - 2, by fin_omega⟩
+        ⟨m - 2, by grind⟩
 
 lemma predPredAbove_val (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
     (hm : m ≠ i ∧ m ≠ j) :
@@ -372,14 +372,9 @@ lemma predPredAbove_injective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
   simp
 
 lemma predPredAbove_surjective (i j : Fin (n + 1 + 1)) (hij : i ≠ j)
-    (m : Fin n) :
-    ∃ m' : Fin (n + 1 + 1), ∃ (h : m' ≠ i ∧ m' ≠ j),
+    (m : Fin n) : ∃ m' : Fin (n + 1 + 1), ∃ (h : m' ≠ i ∧ m' ≠ j),
     predPredAbove i j hij m' h = m := by
-  use (succSuccAbove i j) m
-  have h : (succSuccAbove i j) m ≠ i ∧ (succSuccAbove i j) m ≠ j := by
-    simp [Ne.symm]
-  use h
-  apply (succSuccAbove_injective i j)
+  refine ⟨succSuccAbove i j m, by simp [Ne.symm], succSuccAbove_injective i j ?_⟩
   simp
 
 @[simp]

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Data.Finset.Sort
 public import Mathlib.Data.Nat.SuccPred
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Defining succSuccAbove
@@ -40,6 +41,10 @@ variable {n : ℕ} {c : Fin (n + 1 + 1) → C}
 ## Defining succSuccAbove
 
 -/
+
+TODO "Determine a way to simplify the definition of `succSuccAbove` using
+  predefined functions from Mathlib, but ensuring tactics such as `decide` still
+  work."
 
 /-- The embedding of `Fin n` into `Fin (n + 1 + 1)` which leaves a hole
   at `i` and `j`. -/
@@ -471,8 +476,8 @@ lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 +
   let fl : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
     ⟨⟨succSuccAbove i1 j1 ∘ succSuccAbove i2 j2, by
       apply Function.Injective.comp
-      exact succSuccAbove_injective i1 j1
-      exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
+      · exact succSuccAbove_injective i1 j1
+      · exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
         Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
   let fr : Fin n ↪o Fin (n + 1 + 1 + 1 + 1) :=
     ⟨⟨succSuccAbove i2' j2' ∘ succSuccAbove
@@ -480,8 +485,8 @@ lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 +
       (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2'])),
       by
       apply Function.Injective.comp
-      exact succSuccAbove_injective _ _
-      exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
+      · exact succSuccAbove_injective _ _
+      · exact succSuccAbove_injective _ _⟩, by simp only [Function.Embedding.coeFn_mk,
         Function.comp_apply, succSuccAbove_leq_iff_leq, implies_true]⟩
   have h : fl = fr := by
     rw [← OrderEmbedding.range_inj]
@@ -489,12 +494,12 @@ lemma succSuccAbove_comm (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n + 1 +
       succSuccAbove_range hij2, fl, fr, j2', i2']
     rw [succSuccAbove_range (by simp [hij1])]
     rw [succSuccAbove_image_compl, succSuccAbove_image_compl]
-    congr 1
-    rw [Set.image_pair, Set.image_pair]
-    simp only [succSuccAbove_predPredAbove, i2', j2']
-    exact Set.union_comm {i1, j1} {(succSuccAbove i1 j1) i2, (succSuccAbove i1 j1) j2}
-    simp [hij2]
-    simp [hij1]
+    · congr 1
+      rw [Set.image_pair, Set.image_pair]
+      simp only [succSuccAbove_predPredAbove, i2', j2']
+      exact Set.union_comm {i1, j1} {(succSuccAbove i1 j1) i2, (succSuccAbove i1 j1) j2}
+    · simp [hij2]
+    · simp [hij1]
   ext1 a
   have h' := congrFun (congrArg (fun x => x.toFun) h) a
   dsimp [fl, fr] at h'

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -8,36 +8,7 @@ module
 public import Physlib.Relativity.Tensors.Basic
 /-!
 
-# Contractions on pure tensors
-
--/
-
-@[expose] public section
-
-open IndexNotation
-open CategoryTheory
-open MonoidalCategory
-
-namespace TensorSpecies
-open OverColor
-
-variable {k : Type} [CommRing k] {C G : Type} [Group G]
-  {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
-  {S : TensorSpecies k C G basisIdx}
-
-namespace Tensor
-
-/-!
-
-## Pure.contrPCoeff
-
--/
-
-namespace Pure
-
-/-!
-
-## Defining succSuccAbove
+# Defining succSuccAbove
 
 In Mathlib there is the `Fin.succAbove` function which gives an embedding of `Fin n` into
 `Fin (n + 1)` by leaving a hole at a specified index. We will need a version of this which
@@ -49,13 +20,28 @@ We will also need an explicit inverse of this map from
 This is similar to `Fin.predAbove` (although not exactly the same),
 for this reason we call it `predPredAbove`.
 
+## Implementation
+
+In previous versions of Physlib the function which is now called `succSuccAbove`
+was previously called `dropPairEmb` and the function which is now called `predPredAbove` was
+previously called `dropPairEmbPre`.
+
 -/
+
+@[expose] public section
+
+namespace Fin
 
 variable {n : ℕ} {c : Fin (n + 1 + 1) → C}
 
+/-!
+
+## Defining succSuccAbove
+
+-/
 /-- The embedding of `Fin n` into `Fin (n + 1 + 1)` which leaves a hole
   at `i` and `j`. -/
-def dropPairEmb (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
+def succSuccAbove (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
   if m.1 < i.1 ∧ m.1 < j.1 then
     ⟨m, by omega⟩
   else if m.1 + 1 < i.1 ∧ j.1 ≤ m.1 then
@@ -65,36 +51,36 @@ def dropPairEmb (i j : Fin (n + 1 + 1)) (m : Fin n) : Fin (n + 1 + 1) :=
   else
     ⟨m + 2, by omega⟩
 
-lemma dropPairEmb_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
-    dropPairEmb i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
-  simp [dropPairEmb]
+lemma succSuccAbove_self_apply (i : Fin (n + 1 + 1)) (m : Fin n) :
+    succSuccAbove i i m = if m.1 < i.1 then ⟨m.1, by omega⟩ else ⟨m.1 + 2, by omega⟩ := by
+  simp [succSuccAbove]
   by_cases hm : m.1 < i.1
   · simp_all
   · have hn : i.1 ≤ m.1 := by omega
     have hn2 : ¬ m.1 + 1 < i.1 := by omega
     simp [hm, hn, hn2]
 
-lemma dropPairEmb_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
-    dropPairEmb i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
+lemma succSuccAbove_eq_succAbove_succAbove (i : Fin (n + 1 + 1)) (j : Fin (n + 1)) :
+    succSuccAbove i (i.succAbove j) = i.succAbove ∘ j.succAbove := by
   ext m
   by_cases h : m.1 < i.1
-  · simp [dropPairEmb, h, Fin.succAbove, Fin.lt_def]
+  · simp [succSuccAbove, h, Fin.succAbove, Fin.lt_def]
     split_ifs
     all_goals
       simp_all
       try omega
-  · simp [dropPairEmb, Fin.succAbove, Fin.lt_def]
+  · simp [succSuccAbove, Fin.succAbove, Fin.lt_def]
     split_ifs
     all_goals
       simp_all
       try omega
 
-lemma dropPairEmb_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
-    dropPairEmb i j = fun x => (i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x)) := by
+lemma succSuccAbove_eq_predAbove {i j : Fin (n + 1 + 1)} (hij : i ≠ j) :
+    succSuccAbove i j = fun x => (i.succAbove (((Fin.predAbove 0 i).predAbove j).succAbove x)) := by
   rcases Fin.eq_self_or_eq_succAbove i j with rfl | ⟨j, rfl⟩
   · contradiction
   · ext x
-    rw [dropPairEmb_eq_succAbove_succAbove, Function.comp_apply]
+    rw [succSuccAbove_eq_succAbove_succAbove, Function.comp_apply]
     congr
     rcases eq_or_ne i 0 with rfl | hi
     · rfl
@@ -873,9 +859,3 @@ noncomputable def contrPMultilinear {n : ℕ} {c : Fin (n + 1 + 1) → C}
     change (update p k (r • y)).contrP i j hij = _
     rw [Pure.contrP_update_smul]
     rfl
-
-end Pure
-
-end Tensor
-
-end TensorSpecies

--- a/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
+++ b/Physlib/Relativity/Tensors/Contraction/SuccSuccAbove.lean
@@ -415,11 +415,7 @@ lemma succSuccAbove_predPredAbove (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : F
     (hm : m ≠ i ∧ m ≠ j) :
     succSuccAbove i j (predPredAbove i j hij m hm) = m := by
   dsimp [succSuccAbove, predPredAbove]
-  split_ifs
-  · rfl
-  all_goals
-    simp_all [Fin.ext_iff]
-    try omega
+  grind
 
 set_option backward.isDefEq.respectTransparency false in
 lemma predPredAbove_eq_orderIsoOfFin (i j : Fin (n + 1 + 1)) (hij : i ≠ j) (m : Fin (n + 1 + 1))
@@ -511,8 +507,7 @@ lemma succSuccAbove_comm_apply (i1 j1 : Fin (n + 1 + 1 + 1 + 1)) (i2 j2 : Fin (n
     have hi2j2' : i2' ≠ j2' := by simp [i2', j2', hij2];
     let i1' := (predPredAbove i2' j2' hi2j2' i1 (by simp [i2', j2']));
     let j1' := (predPredAbove i2' j2' hi2j2' j1 (by simp [i2', j2']));
-    succSuccAbove i2' j2'
-    (succSuccAbove i1' j1' m) =
+    succSuccAbove i2' j2' (succSuccAbove i1' j1' m) =
     succSuccAbove i1 j1 (succSuccAbove i2 j2 m) := by
   intro i2' j2' hi2j2' i1' j1'
   change _ = (succSuccAbove i1 j1 ∘ succSuccAbove i2 j2) m

--- a/Physlib/Relativity/Tensors/RealTensor/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Basic.lean
@@ -202,8 +202,8 @@ open Tensor
 lemma contrT_basis_repr_apply_eq_dropPairSection {n d: ℕ}
     {c : Fin (n + 1 + 1) → realLorentzTensor.Color}
     {i j : Fin (n + 1 + 1)} (h : i ≠ j ∧ (realLorentzTensor d).τ (c i) = c j)
-    (t : ℝT(d, c)) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j)) :
-    (basis (c ∘ Pure.dropPairEmb i j)).repr (contrT n i j h t) b =
+    (t : ℝT(d, c)) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j)) :
+    (basis (c ∘ Fin.succSuccAbove i j)).repr (contrT n i j h t) b =
     ∑ (x : b.DropPairSection),
     ((basis c).repr t x.1) *
     if (x.1 i) = (x.1 j) then 1 else 0 := by
@@ -218,8 +218,8 @@ open ComponentIdx in
 lemma contrT_basis_repr_apply_eq_fin {n d: ℕ} {c : Fin (n + 1 + 1) → realLorentzTensor.Color}
     {i j : Fin (n + 1 + 1)}
     {h : i ≠ j ∧ (realLorentzTensor d).τ (c i) = c j}
-    (t : ℝT(d,c)) (b : ComponentIdx (c ∘ Pure.dropPairEmb i j)) :
-    (basis (c ∘ Pure.dropPairEmb i j)).repr (contrT n i j h t) b =
+    (t : ℝT(d,c)) (b : ComponentIdx (c ∘ Fin.succSuccAbove i j)) :
+    (basis (c ∘ Fin.succSuccAbove i j)).repr (contrT n i j h t) b =
     ∑ (x : Fin 1 ⊕ Fin d),
     ((basis c).repr t
     (DropPairSection.ofFinEquiv h.1 b ⟨x, x⟩)) := by
@@ -266,7 +266,7 @@ lemma contrPCoeff_basis {d n : ℕ} {c : Fin n → realLorentzTensor.Color} (i j
 lemma contrT_eq_sum_evalT {n} {d} (c : Fin (n + 1 + 1) → Color) (i j : Fin (n + 1 + 1))
     (h : i ≠ j ∧ (realLorentzTensor d).τ (c i) = c j) (t : ℝT(d, c)) :
     contrT n i j h t =  ∑ (μ : Fin 1 ⊕ Fin d), permT id (by
-      simp [Pure.dropPairEmb_eq_predAbove h.1])
+      simp [Fin.succSuccAbove_eq_predAbove h.1])
      (evalT ((Fin.predAbove 0 i).predAbove j) μ (evalT i μ t)) := by
   induction' t using Tensor.induction_on_basis with b r t h t1 t2 h1 h2
   · rw [contrT_basis]
@@ -287,7 +287,7 @@ lemma contrT_eq_sum_evalT {n} {d} (c : Fin (n + 1 + 1) → Color) (i j : Fin (n 
       ext x
       simp only [Function.comp_apply, ComponentIdx.dropPair, id_eq, basisIdxCongr_eq_refl,
         Equiv.refl_apply]
-      rw [Pure.dropPairEmb_eq_predAbove h.1]
+      rw [Fin.succSuccAbove_eq_predAbove h.1]
     · symm at h₁; contradiction
     · symm at h₂; contradiction
     · rfl

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -707,17 +707,17 @@ lemma tau_colorToComplex (x : realLorentzTensor.Color) :
     (complexLorentzTensor).τ (colorToComplex x) = colorToComplex ((realLorentzTensor).τ x) := by
   cases x <;> rfl
 
-/-- `complexify` commutes with precomposition by `dropPairEmb`.
-  We use `fun k => b (Pure.dropPairEmb i j k)` and direct application
-  `(ComponentIdx.complexify b) (Pure.dropPairEmb i j m)` rather than composition so that
+/-- `complexify` commutes with precomposition by `succSuccAbove`.
+  We use `fun k => b (Fin.succSuccAbove i j k)` and direct application
+  `(ComponentIdx.complexify b) (Fin.succSuccAbove i j m)` rather than composition so that
   dependent `ComponentIdx` types unify correctly (avoiding `Function.comp` type mismatch). -/
 @[simp]
-lemma ComponentIdx.complexify_comp_dropPairEmb
+lemma ComponentIdx.complexify_comp_succSuccAbove
     {n : ℕ} {c : Fin (n + 1 + 1) → realLorentzTensor.Color}
     {i j : Fin (n + 1 + 1)} (b : ComponentIdx (S := realLorentzTensor) c) (m : Fin n) :
-    (ComponentIdx.complexify (c := c ∘ Pure.dropPairEmb i j)
-      (fun k => b (Pure.dropPairEmb i j k))) m =
-    (ComponentIdx.complexify (c := c) b) (Pure.dropPairEmb i j m) := by
+    (ComponentIdx.complexify (c := c ∘ Fin.succSuccAbove i j)
+      (fun k => b (Fin.succSuccAbove i j k))) m =
+    (ComponentIdx.complexify (c := c) b) (Fin.succSuccAbove i j m) := by
   simp only [ComponentIdx.complexify_apply, Function.comp_apply]
 
 /-- For a real basis vector, `toComplex(contrP(basisVector c b))` equals
@@ -725,7 +725,7 @@ lemma ComponentIdx.complexify_comp_dropPairEmb
 lemma toComplex_contrP_basisVector {n : ℕ} {c : Fin (n + 1 + 1) → realLorentzTensor.Color}
     {i j : Fin (n + 1 + 1)} (h : i ≠ j ∧ (realLorentzTensor).τ (c i) = c j)
     (b : ComponentIdx (S := realLorentzTensor) c) :
-    toComplex (c := c ∘ Pure.dropPairEmb i j)
+    toComplex (c := c ∘ Fin.succSuccAbove i j)
       (Pure.contrP (S := realLorentzTensor) i j h (Pure.basisVector c b))
       =
     Pure.contrP (S := complexLorentzTensor) i j
@@ -733,13 +733,13 @@ lemma toComplex_contrP_basisVector {n : ℕ} {c : Fin (n + 1 + 1) → realLorent
         simpa [Function.comp_apply] using And.intro h.1
           (by simpa [tau_colorToComplex] using congrArg colorToComplex h.2))
       (Pure.basisVector (colorToComplex ∘ c) (ComponentIdx.complexify b)) := by
-  let c' := c ∘ Pure.dropPairEmb i j
+  let c' := c ∘ Fin.succSuccAbove i j
   simp only [Pure.contrP]
   rw [toComplex_map_smul c' (Pure.contrPCoeff i j h (Pure.basisVector c b))
     ((Pure.dropPair i j h.1 (Pure.basisVector c b)).toTensor),
     Pure.dropPair_basisVector (c := c),
-    ← Tensor.basis_apply (S := realLorentzTensor) c' (fun k => b (Pure.dropPairEmb i j k)),
-    toComplex_basis (c := c') (i := fun k => b (Pure.dropPairEmb i j k))]
+    ← Tensor.basis_apply (S := realLorentzTensor) c' (fun k => b (Fin.succSuccAbove i j k)),
+    toComplex_basis (c := c') (i := fun k => b (Fin.succSuccAbove i j k))]
   congr 1
   · -- contrPCoeff: real and complex both equal 0 or 1 with same condition
     have h_real := realLorentzTensor.contr_basis (c := c i) (b i) (b j)
@@ -778,20 +778,20 @@ lemma toComplex_contrP_basisVector {n : ℕ} {c : Fin (n + 1 + 1) → realLorent
       ext
       exact h2
     · rfl
-  · -- complexify(fun k => b (dropPairEmb k)) = (complexify b) ∘ dropPairEmb
+  · -- complexify(fun k => b (succSuccAbove k)) = (complexify b) ∘ succSuccAbove
     conv_rhs => enter [1]; rw [Pure.dropPair_basisVector (S := complexLorentzTensor)
       (c := colorToComplex ∘ c) h.1 (b := ComponentIdx.complexify b)]
     conv_rhs => rw [← Tensor.basis_apply (S := complexLorentzTensor)
-      (c := (colorToComplex ∘ c) ∘ Pure.dropPairEmb i j)
-      (b := fun m => (ComponentIdx.complexify b) (Pure.dropPairEmb i j m))]
-    refine congr_arg _ (funext fun m => ComponentIdx.complexify_comp_dropPairEmb b m)
+      (c := (colorToComplex ∘ c) ∘ Fin.succSuccAbove i j)
+      (b := fun m => (ComponentIdx.complexify b) (Fin.succSuccAbove i j m))]
+    refine congr_arg _ (funext fun m => ComponentIdx.complexify_comp_succSuccAbove b m)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The map `toComplex` commutes with `contrT`. -/
 lemma contrT_toComplex {n : ℕ}
     {c : Fin (n + 1 + 1) → realLorentzTensor.Color} {i j : Fin (n + 1 + 1)}
     (h : i ≠ j ∧ (realLorentzTensor).τ (c i) = c j) (t : ℝT(3, c)) :
-    toComplex (c := c ∘ Pure.dropPairEmb i j) (contrT (S := realLorentzTensor) n i j h t)
+    toComplex (c := c ∘ Fin.succSuccAbove i j) (contrT (S := realLorentzTensor) n i j h t)
       =
     contrT (S := complexLorentzTensor) n i j (by
         simpa [Function.comp_apply] using
@@ -801,7 +801,7 @@ lemma contrT_toComplex {n : ℕ}
   classical
   -- We prove the statement by induction on the tensor `t` using the tensor basis.
   -- After contracting two indices, the resulting colour function lives on `Fin n`.
-  let c' : Fin n → realLorentzTensor.Color := c ∘ Pure.dropPairEmb i j
+  let c' : Fin n → realLorentzTensor.Color := c ∘ Fin.succSuccAbove i j
   have hP :
       ∀ t : ℝT(3, c),
         toComplex (c := c') (contrT (S := realLorentzTensor) n i j h t) =

--- a/scripts/MetaPrograms/spellingWords.txt
+++ b/scripts/MetaPrograms/spellingWords.txt
@@ -815,9 +815,9 @@ downr
 downstream
 dr
 droppair
-droppairemb
-droppairembpre
-droppairofmap
+succSuccAbove
+predPredAbove
+funPredPredAbove
 dropped
 dropping
 drops


### PR DESCRIPTION
Rename `dropPairEmb` to the more descriptive name `Fin.succSuccAbove`, and seperate results surrounding this into there own file. 