### PR TITLE
feat: TensorSpecies.ofFunction

### DIFF
--- a/Physlib/Relativity/Tensors/TensorSpecies/Basic.lean
+++ b/Physlib/Relativity/Tensors/TensorSpecies/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Physlib.Relativity.Tensors.Color.Discrete
 public import Physlib.Relativity.Tensors.Color.Lift
+public import Physlib.Meta.TODO.Basic
+
 /-!
 
 # Tensor species
@@ -31,7 +33,6 @@ structure TensorSpecies (k : Type) [CommRing k] (C : Type) (G : Type) [Group G]
   /-- A functor from `C` to `Rep k G` giving our building block representations.
     Equivalently a function `C → Re k G`. -/
   FD : Discrete C ⥤ Rep k G
-
   /-- A basis for each Module, determined by the evaluation map. -/
   basis : (c : C) → Basis (basisIdx c) k (FD.obj (Discrete.mk c)).V
   /-- A map from `C` to `C`. An involution. -/
@@ -46,7 +47,7 @@ structure TensorSpecies (k : Type) [CommRing k] (C : Type) (G : Type) [Group G]
     (contr.app (Discrete.mk c)).hom (x ⊗ₜ[k] y) = (contr.app (Discrete.mk (τ c))).hom
     (y ⊗ₜ (FD.map (Discrete.eqToHom (τ_involution c).symm)).hom x)
   /-- The natural transformation describing the unit. -/
-  unit : 𝟙_ (Discrete C ⥤ Rep k G) ⟶ OverColor.Discrete.τPair FD τ
+  unit  : 𝟙_ (Discrete C ⥤ Rep k G) ⟶ OverColor.Discrete.τPair FD τ
   /-- The unit is symmetric.
     The de-categorification of this lemma is: `unitTensor_eq_permT_dual`. -/
   unit_symm (c : C) :
@@ -87,6 +88,90 @@ open OverColor
 variable {k : Type} [CommRing k] {C : Type} [Group G]
   {basisIdx : C → Type}
 
+/-!
+
+## Non-categorial constructor
+
+-/
+open scoped TensorProduct
+
+TODO "Replace the definition of `TensorSpecies` with the
+  construction from functions `TensorSpecies.ofFunctions`."
+
+/-- The creation of an element of `TensorSpecies` from functions rather
+  than categorical objects.  -/
+def ofFunctions [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
+    /- The vector space associated with each color. -/
+    (V : C → Type) [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
+    /- The representation associated with each color. -/
+    (rep : (c : C) → Representation k G (V c))
+    /- The basis associated with each color. -/
+    (basis : (c : C) → Basis (basisIdx c) k (V c))
+    /- The map taking each color to its dual. -/
+    (τ : C → C)
+    (τ_involution : Function.Involutive τ)
+    /- The contraction of vectors with dual colors. -/
+    (contr : (c : C) → ((rep c).tprod (rep (τ c))).IntertwiningMap (Representation.trivial k G k))
+    /- The invariant unit tensor for a given color. -/
+    (unit : (c : C) → ((Representation.trivial k G k)).IntertwiningMap ((rep (τ c)).tprod (rep c)))
+    /- The invariant metric tensor for a given color. -/
+    (metric : (c : C) → ((Representation.trivial k G k)).IntertwiningMap ((rep c).tprod (rep c)))
+    /- Contraction is symmetric with respect to duals. -/
+    (contr_tmul_symm : ∀ c (x : V c) (y : V (τ c)),
+      contr c (x ⊗ₜ[k] y) = contr (τ c) (y ⊗ₜ Equiv.cast (congrArg V (τ_involution c).symm) x))
+    /- The unit is symmetric. -/
+    (unit_symm : ∀ c, unit c (1 : k) =
+      LinearMap.lTensor _ (LinearEquiv.cast (τ_involution c)).toLinearMap
+      (TensorProduct.comm k _ _ (unit (τ c) (1 : k))))
+    /- Contraction with unit leaves invariant. -/
+    (contr_unit : ∀ c (x : V c),
+      (TensorProduct.lid k _ <|
+      (contr c).toLinearMap.rTensor _ <|
+      (TensorProduct.assoc k (V c) (V (τ c)) (V c)).symm <|
+      x ⊗ₜ[k] (unit c (1 : k))) = x)
+    /- On contracting metrics we get the unit. -/
+    (contr_metric : ∀ c,
+      (TensorProduct.comm k _ _ <|
+        (TensorProduct.lid k _).lTensor _ <|
+        ((contr c).toLinearMap.rTensor (V (τ c))).lTensor (V c) <|
+        (TensorProduct.assoc k (V c) (V (τ c)) (V (τ c))).symm.toLinearMap.lTensor (V c) <|
+        TensorProduct.assoc k (V c) (V c) (V (τ c) ⊗[k] V (τ c)) <|
+        (metric c 1) ⊗ₜ[k] (metric (τ c) 1)) = unit c (1 : k)) :
+    TensorSpecies k C G basisIdx where
+  FD := Discrete.functor (fun x => Rep.of (rep x))
+  basis := basis
+  τ := τ
+  τ_involution := τ_involution
+  contr := Discrete.natTrans fun c => Rep.ofHom <| contr c.as
+  unit := Discrete.natTrans fun c => Rep.ofHom <| unit c.as
+  metric := Discrete.natTrans fun c => Rep.ofHom <| metric c.as
+  contr_tmul_symm c x y := by
+    simp [Rep.ofHom, Rep.Hom.hom, eqToHom_map]
+    convert contr_tmul_symm c x y
+    generalize_proofs h1 h2
+    congr 1
+    have τ_inv := τ_involution c
+    generalize τ (τ c) = c' at *
+    subst τ_inv
+    rfl
+  unit_symm c := by
+    simp [Rep.ofHom, Rep.Hom.hom]
+    change unit c (1 : k) = _
+    rw [unit_symm c]
+    congr
+    generalize_proofs h1 h2 h3
+    have τ_inv := τ_involution c
+    generalize τ (τ c) = c' at *
+    subst τ_inv
+    rfl
+  contr_metric c := by simpa [Rep.ofHom, Rep.Hom.hom] using contr_metric c
+  contr_unit c x := by simpa [Rep.ofHom, Rep.Hom.hom] using contr_unit c x
+
+/-!
+
+## Properties of TensorSpecies
+
+-/
 /-- The casting between `basisIdx c` and `basisIdx c1`. -/
 def basisIdxCongr {c c1 : C} (h : c = c1) :
     basisIdx c ≃ basisIdx c1 := Equiv.cast (by simp [h])


### PR DESCRIPTION
Add `TensorSpecies.ofFunction`. This is the first step in de-categorifying the Tensor notions in Physlib. It gives an illustration of what should be done. 