### PR TITLE
docs(QM): Unbounded operators

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -89,21 +89,21 @@ def momentumOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d wh
   toFun := schwartzIncl.toLinearMap ∘ₗ (𝐩 i).toLinearMap ∘ₗ schwartzEquiv.symm.toLinearMap
 
 @[inherit_doc momentumOperator]
-notation "𝐏" => momentumOperator
+notation "𝓟" => momentumOperator
 
 lemma momentumOperator_apply (ψ : schwartzSubmodule d) :
-    𝐏 i ψ = schwartzEquiv (𝐩 i (schwartzEquiv.symm ψ)) := rfl
+    𝓟 i ψ = schwartzEquiv (𝐩 i (schwartzEquiv.symm ψ)) := rfl
 
 lemma momentumOperator_apply_ae (ψ : schwartzSubmodule d) :
-    𝐏 i ψ =ᵐ[volume] 𝐩 i (schwartzEquiv.symm ψ) :=
+    𝓟 i ψ =ᵐ[volume] 𝐩 i (schwartzEquiv.symm ψ) :=
   schwartzEquiv_coe_ae _
 
-lemma momentumOperator_range (ψ : schwartzSubmodule d) : 𝐏 i ψ ∈ schwartzSubmodule d := by
+lemma momentumOperator_range (ψ : schwartzSubmodule d) : 𝓟 i ψ ∈ schwartzSubmodule d := by
   simp [momentumOperator_apply]
 
-lemma momentumOperator_hasDenseDomain : (𝐏 i).HasDenseDomain := SchwartzSubmodule.dense d
+lemma momentumOperator_hasDenseDomain : (𝓟 i).HasDenseDomain := SchwartzSubmodule.dense d
 
-lemma momentumOperator_isSymmetric : (𝐏 i).IsSymmetric := by
+lemma momentumOperator_isSymmetric : (𝓟 i).IsSymmetric := by
   intro ψ φ
   obtain ⟨f, rfl⟩ := schwartzEquiv.surjective ψ
   obtain ⟨g, rfl⟩ := schwartzEquiv.surjective φ
@@ -132,14 +132,14 @@ lemma momentumOperator_isSymmetric : (𝐏 i).IsSymmetric := by
   congr 2
   exact integral_mul_fderiv_eq_neg_fderiv_mul_of_integrable hI₂ hI₃ hI₄ (by fun_prop) (by fun_prop)
 
-lemma momentumOperator_isUnbounded : (𝐏 i).IsUnbounded := by
+lemma momentumOperator_isUnbounded : (𝓟 i).IsUnbounded := by
   refine (LinearPMap.IsSymmetric.isUnbounded_iff_hasDenseDomain ?_).mpr ?_
   · exact momentumOperator_isSymmetric i
   · exact momentumOperator_hasDenseDomain i
 
 /-- The square of the momentum operator. -/
 def momentumSqOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  ∑ i, (𝐏 i).comp (𝐏 i) (momentumOperator_range i)
+  ∑ i, (𝓟 i).comp (𝓟 i) (momentumOperator_range i)
 
 end
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -21,9 +21,9 @@ In this module we introduce unbounded operators defined by multiplication by a f
 ## ii. Key results
 
 - `mulOperator f` : Given a function `f : Space d → ℂ`, the operator defined by `ψ ↦ f • ψ`
-  (with maximal domain) with notation `ℳ f`.
-- `mulOperator_adjoint_eq_conj` : For a.e. strongly measurable `f`, `(ℳ f)† = ℳ (conj ∘ f)`
-- `mulOperator_isUnbounded` : For a.e. strongly measurable `f`, `ℳ f` is an unbounded operator.
+  (with maximal domain) with notation `𝓜 f`.
+- `mulOperator_adjoint_eq_conj` : For a.e. strongly measurable `f`, `(𝓜 f)† = 𝓜 (conj ∘ f)`
+- `mulOperator_isUnbounded` : For a.e. strongly measurable `f`, `𝓜 f` is an unbounded operator.
 
 ## iii. Table of contents
 
@@ -89,13 +89,13 @@ def mulOperator (f : Space d → ℂ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceD
   }
 
 @[inherit_doc mulOperator]
-notation "ℳ" => mulOperator
+notation "𝓜" => mulOperator
 
 lemma mem_mulOperator_domain_iff
-    {f : Space d → ℂ} {ψ : SpaceDHilbertSpace d} : ψ ∈ (ℳ f).domain ↔ MemHS (f • ψ.val.cast) :=
+    {f : Space d → ℂ} {ψ : SpaceDHilbertSpace d} : ψ ∈ (𝓜 f).domain ↔ MemHS (f • ψ.val.cast) :=
   Iff.rfl
 
-lemma mulOperator_apply_ae {f : Space d → ℂ} (ψ : (ℳ f).domain) : (ℳ f) ψ =ᵐ[volume] f • ψ :=
+lemma mulOperator_apply_ae {f : Space d → ℂ} (ψ : (𝓜 f).domain) : (𝓜 f) ψ =ᵐ[volume] f • ψ :=
   coe_mk_ae ψ.prop
 
 /-!
@@ -103,7 +103,7 @@ lemma mulOperator_apply_ae {f : Space d → ℂ} (ψ : (ℳ f).domain) : (ℳ f)
 -/
 
 lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (ℳ f).HasDenseDomain := by
+    (𝓜 f).HasDenseDomain := by
   intro ψ
   apply mem_closure_iff_seq_limit.mpr
   obtain ⟨u, hu, hfu⟩ := AEStronglyMeasurable.aemeasurable hf
@@ -165,14 +165,14 @@ lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurabl
 
 -- Can the AEStronglyMeasurable hypothesis be removed?
 lemma mulOperator_conj_domain {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (ℳ (conj ∘ f)).domain = (ℳ f).domain := by
+    (𝓜 (conj ∘ f)).domain = (𝓜 f).domain := by
   ext
   simp only [mulOperator, smul_eq_mul, memHS_iff]
   exact and_congr (iff_of_true (by fun_prop) (by fun_prop)) (by simp)
 
 @[sorryful]
 lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (ℳ f)† = ℳ (conj ∘ f) := by
+    (𝓜 f)† = 𝓜 (conj ∘ f) := by
   refine eq_of_eq_graph ?_
   ext u
   rw [adjoint_graph_eq_graph_adjoint (mulOperator_hasDenseDomain hf), Submodule.mem_adjoint_iff]
@@ -180,19 +180,19 @@ lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurab
   · intro h
     let g : Space d → ℂ := fun x ↦ conj (f x) * u.1 x - u.2 x
     have hg : AEStronglyMeasurable g := by measurability
-    have h_int : ∀ ψ : (ℳ f).domain, ∫ x, (AEEqFun.mk g hg) x * conj (ψ.val x) = 0 := by
+    have h_int : ∀ ψ : (𝓜 f).domain, ∫ x, (AEEqFun.mk g hg) x * conj (ψ.val x) = 0 := by
       intro ψ
-      have h_int₁ : Integrable fun x ↦ u.1 x * conj (ℳ f ψ x) := L2.integrable_inner (ℳ f ψ) u.1
+      have h_int₁ : Integrable fun x ↦ u.1 x * conj (𝓜 f ψ x) := L2.integrable_inner (𝓜 f ψ) u.1
       have h_int₂ : Integrable fun x ↦ u.2 x * conj (ψ.val x) := L2.integrable_inner ψ.val u.2
       symm
-      trans ∫ x, u.1 x * conj (ℳ f ψ x) - u.2 x * conj (ψ.val x)
-      · exact (h ψ (ℳ f ψ) (mem_graph (ℳ f) ψ)) ▸ (integral_sub h_int₁ h_int₂).symm
+      trans ∫ x, u.1 x * conj (𝓜 f ψ x) - u.2 x * conj (ψ.val x)
+      · exact (h ψ (𝓜 f ψ) (mem_graph (𝓜 f) ψ)) ▸ (integral_sub h_int₁ h_int₂).symm
       refine integral_congr_ae ?_
       filter_upwards [mulOperator_apply_ae ψ, AEEqFun.coeFn_mk g hg] with x h₁ h₂
       simp [h₁, h₂, g, sub_mul, mul_assoc, mul_left_comm]
     have hu₂ : u.2 =ᵐ[volume] (conj ∘ f) • u.1 := by
       sorry
-    have hu₁ : u.1 ∈ (ℳ (conj ∘ f)).domain :=
+    have hu₁ : u.1 ∈ (𝓜 (conj ∘ f)).domain :=
       mem_mulOperator_domain_iff.mpr <| memHS_of_ae u.2 (coe_hilbertSpace_memHS u.2) hu₂
     apply (mem_graph_iff _).mpr
     refine ⟨⟨u.1, hu₁⟩, rfl, ?_⟩
@@ -214,7 +214,7 @@ lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurab
 @[sorryful]
 lemma mulOperator_isSelfAdjoint_ofReal
     {f : Space d → ℂ} (hf : AEStronglyMeasurable f) (hf' : conj ∘ f = f) :
-    IsSelfAdjoint (ℳ f) := by
+    IsSelfAdjoint (𝓜 f) := by
   apply isSelfAdjoint_def.mpr
   rw [mulOperator_adjoint_eq_conj hf, hf']
 
@@ -224,17 +224,17 @@ lemma mulOperator_isSelfAdjoint_ofReal
 
 @[sorryful]
 lemma mulOperator_isClosable {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (ℳ f).IsClosable := by
+    (𝓜 f).IsClosable := by
   refine isClosable_of_exists_dense_formalAdjoint ?_ ?_
   · exact mulOperator_hasDenseDomain hf
-  · refine ⟨ℳ (conj ∘ f), ?_, ?_⟩
+  · refine ⟨𝓜 (conj ∘ f), ?_, ?_⟩
     · exact mulOperator_hasDenseDomain (by measurability)
     · rw [← mulOperator_adjoint_eq_conj hf]
       exact adjoint_isFormalAdjoint (mulOperator_hasDenseDomain hf)
 
 @[sorryful]
 lemma mulOperator_isUnbounded {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
-    (ℳ f).IsUnbounded :=
+    (𝓜 f).IsUnbounded :=
   ⟨mulOperator_hasDenseDomain hf, mulOperator_isClosable hf⟩
 
 end

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -390,20 +390,20 @@ noncomputable section
 
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by `fun x ↦ xᵢ`. -/
 def positionOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  ℳ (Complex.ofRealCLM ∘L Space.coordCLM i)
+  𝓜 (Complex.ofRealCLM ∘L Space.coordCLM i)
 
 @[inherit_doc positionOperator]
-notation "𝐗" => positionOperator
+notation "𝓧" => positionOperator
 
-lemma positionOperator_hasDenseDomain : (𝐗 i).HasDenseDomain :=
+lemma positionOperator_hasDenseDomain : (𝓧 i).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
 @[sorryful]
-lemma positionOperator_isSelfAdjoint : IsSelfAdjoint (𝐗 i) :=
+lemma positionOperator_isSelfAdjoint : IsSelfAdjoint (𝓧 i) :=
   mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
 @[sorryful]
-lemma positionOperator_isUnbounded : (𝐗 i).IsUnbounded := by
+lemma positionOperator_isUnbounded : (𝓧 i).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
   · exact positionOperator_isSelfAdjoint i
   · exact positionOperator_hasDenseDomain i
@@ -415,23 +415,23 @@ lemma positionOperator_isUnbounded : (𝐗 i).IsUnbounded := by
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by
   `fun x ↦ (‖x‖² + ε²)^(s/2)`. -/
 def radiusRegPowOperator (ε : ℝˣ) (s : ℝ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  ℳ (Complex.ofReal ∘ normRegularizedPow d ε s)
+  𝓜 (Complex.ofReal ∘ normRegularizedPow d ε s)
 
 @[inherit_doc radiusRegPowOperator]
-notation "𝐑₀" => radiusRegPowOperator
+notation "𝓡₀" => radiusRegPowOperator
 
 @[inherit_doc radiusRegPowOperator]
-notation "𝐑₀[" d' "]" => radiusRegPowOperator (d := d')
+notation "𝓡₀[" d' "]" => radiusRegPowOperator (d := d')
 
-lemma radiusRegPowOperator_hasDenseDomain (ε : ℝˣ) (s : ℝ) : (𝐑₀[d] ε s).HasDenseDomain :=
+lemma radiusRegPowOperator_hasDenseDomain (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
 @[sorryful]
-lemma radiusRegPowOperator_isSelfAdjoint (ε : ℝˣ) (s : ℝ) : IsSelfAdjoint (𝐑₀[d] ε s) := by
+lemma radiusRegPowOperator_isSelfAdjoint (ε : ℝˣ) (s : ℝ) : IsSelfAdjoint (𝓡₀[d] ε s) := by
   refine mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
 @[sorryful]
-lemma radiusRegPowOperator_isUnbounded (ε : ℝˣ) (s : ℝ) : (𝐑₀[d] ε s).IsUnbounded := by
+lemma radiusRegPowOperator_isUnbounded (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
   · exact radiusRegPowOperator_isSelfAdjoint ε s
   · exact radiusRegPowOperator_hasDenseDomain ε s
@@ -442,32 +442,32 @@ lemma radiusRegPowOperator_isUnbounded (ε : ℝˣ) (s : ℝ) : (𝐑₀[d] ε s
 
 /-- The operator on `SpaceDHilbertSpace d` acting by multiplication by `fun x ↦ ‖x‖ˢ`. -/
 def radiusPowOperator (s : ℝ) : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  ℳ (Complex.ofReal ∘ fun x ↦ ‖x‖ ^ s)
+  𝓜 (Complex.ofReal ∘ fun x ↦ ‖x‖ ^ s)
 
 @[inherit_doc radiusPowOperator]
-notation "𝐑" => radiusPowOperator
+notation "𝓡" => radiusPowOperator
 
 @[inherit_doc radiusPowOperator]
-notation "𝐑[" d' "]" => radiusPowOperator (d := d')
+notation "𝓡[" d' "]" => radiusPowOperator (d := d')
 
-lemma radiusPowOperator_hasDenseDomain (s : ℝ) : (𝐑[d] s).HasDenseDomain := by
+lemma radiusPowOperator_hasDenseDomain (s : ℝ) : (𝓡[d] s).HasDenseDomain := by
   refine mulOperator_hasDenseDomain ?_
   suffices (fun x ↦ ‖x‖ ^ s) = normRegularizedPow d 0 s by rw[this]; fun_prop
   ext x
   simp [normRegularizedPow, ← Real.rpow_natCast_mul (norm_nonneg x), mul_div_cancel₀ s two_ne_zero]
 
 @[sorryful]
-lemma radiusPowOperator_isSelfAdjoint (s : ℝ) : IsSelfAdjoint (𝐑[d] s) := by
+lemma radiusPowOperator_isSelfAdjoint (s : ℝ) : IsSelfAdjoint (𝓡[d] s) := by
   refine mulOperator_isSelfAdjoint_ofReal ?_ (by ext; simp)
   suffices (fun x ↦ ‖x‖ ^ s) = normRegularizedPow d 0 s by rw[this]; fun_prop
   ext x
   simp [normRegularizedPow, ← Real.rpow_natCast_mul (norm_nonneg x), mul_div_cancel₀ s two_ne_zero]
 
 @[sorryful]
-lemma radiusPowOperator_isUnbounded : (𝐑₀[d] ε s).IsUnbounded := by
+lemma radiusPowOperator_isUnbounded (s : ℝ) : (𝓡[d] s).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
-  · exact radiusRegPowOperator_isSelfAdjoint ε s
-  · exact radiusRegPowOperator_hasDenseDomain ε s
+  · exact radiusPowOperator_isSelfAdjoint s
+  · exact radiusPowOperator_hasDenseDomain s
 
 open Complex
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -12,7 +12,31 @@ public import Physlib.Mathematics.InnerProductSpace.Submodule
 
 ## i. Overview
 
+In this module we introduce unbounded operators on inner product spaces. By "unbounded operator"
+we mean a partially-defined linear map (`LinearPMap`) which is both densely defined and closable.
+These provide the mathematical structure appropriate for describing operators in non-relativistic
+quantum mechanics. Of particular interest are (essentially) self-adjoint unbounded operators since
+these correspond to physical observables.
+
+### Notes
+
+- Naming convention : Definitions of `LinearPMap`s for quantum mechanical unbounded operators should
+    have a name of the form `[…]Operator` and notation should use calligraphic capital letters,
+    e.g. `mulOperator f` (`𝓜 f`) for the multiplication operator associated with the function `f`.
+
+- Implementation : Although operators encountered in quantum mechanics are almost always unbounded,
+    we opt to implement unbounded operators via the property `IsUnbounded` on `LinearPMap` rather
+    than as a structure `UnboundedOperator` extending `LinearPMap`. The basic reason for this
+    is that addition/subtraction and composition of unbounded operators in general does not result
+    in another unbounded operator. This means, for example, that any attempt to define addition of
+    `UnboundedOperator`s would inevitably require introducing junk values that spoil associativity.
+
 ## ii. Key results
+
+- `IsUnbounded.adjoint` : The adjoint of an unbounded operator is also unbounded.
+- `IsUnbounded.adjoint_closure_eq_adjoint` : An unbounded operator and its closure have
+    the same adjoint.
+- `IsUnbounded.adjoint_adjoint_eq_closure` : An unbounded operator `U` satisfies `U†† = U.closure`.
 
 ## iii. Table of contents
 
@@ -51,6 +75,9 @@ variable
 
 /-!
 ## A. Definitions
+
+See `LinearPMap.instStar` and `LinearPMap.isSelfAdjoint_def` for the definition of `IsSelfAdjoint`
+for `LinearPMap`s.
 -/
 
 /-- A LinearPMap `U` has dense domain iff `U.domain` is dense in `H`. -/


### PR DESCRIPTION
Adds to module docs for `Unbounded.lean`.
This includes a note on naming conventions and implementation design.