### PR TITLE
Replacing ACCSystemChargesMk with ⟨n⟩ notation

### DIFF
--- a/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/Basic.lean
+++ b/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/Basic.lean
@@ -22,11 +22,11 @@ open BigOperators
 
 /-- The vector space of charges corresponding to the SM fermions with RHN. -/
 @[simps!]
-def SMνCharges (n : ℕ) : ACCSystemCharges := ACCSystemChargesMk (6 * n)
+def SMνCharges (n : ℕ) : ACCSystemCharges := ⟨6 * n⟩
 
 /-- The vector spaces of charges of one species of fermions in the SM. -/
 @[simps!]
-def SMνSpecies (n : ℕ) : ACCSystemCharges := ACCSystemChargesMk n
+def SMνSpecies (n : ℕ) : ACCSystemCharges := ⟨n⟩
 
 namespace SMνCharges
 

--- a/Physlib/Particles/StandardModel/AnomalyCancellation/Basic.lean
+++ b/Physlib/Particles/StandardModel/AnomalyCancellation/Basic.lean
@@ -21,11 +21,11 @@ open BigOperators
 
 /-- Associate to each (including RHN) SM fermion a set of charges-/
 @[simps!]
-def SMCharges (n : ℕ) : ACCSystemCharges := ACCSystemChargesMk (5 * n)
+def SMCharges (n : ℕ) : ACCSystemCharges := ⟨5 * n⟩
 
 /-- The vector space associated with a single species of fermions. -/
 @[simps!]
-def SMSpecies (n : ℕ) : ACCSystemCharges := ACCSystemChargesMk n
+def SMSpecies (n : ℕ) : ACCSystemCharges := ⟨n⟩
 
 namespace SMCharges
 

--- a/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
@@ -21,11 +21,11 @@ open BigOperators
 
 /-- The vector space of charges corresponding to the MSSM fermions. -/
 @[simps!]
-def MSSMCharges : ACCSystemCharges := ACCSystemChargesMk 20
+def MSSMCharges : ACCSystemCharges := ⟨20⟩
 
 /-- The vector spaces of charges of one species of fermions in the MSSM. -/
 @[simps!]
-def MSSMSpecies : ACCSystemCharges := ACCSystemChargesMk 3
+def MSSMSpecies : ACCSystemCharges := ⟨3⟩
 
 namespace MSSMCharges
 

--- a/Physlib/QFT/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/AnomalyCancellation/Basic.lean
@@ -100,8 +100,6 @@ structure ACCSystemCharges where
   /-- The number of charges. -/
   numberCharges : ℕ
 
-/-!
-
 namespace ACCSystemCharges
 
 /-!

--- a/Physlib/QFT/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/AnomalyCancellation/Basic.lean
@@ -41,7 +41,6 @@ Related to these are the different types of spaces of charges:
 ## iii. Table of contents
 
 - A. The module of charges
-  - A.1. A constructor for `ACCSystemCharges`
 - B. The module of charges
   - B.1. The `ℚ`-module structure on the type `Charges`
   - B.2. The finiteness of the `ℚ`-module structure on `Charges`
@@ -102,19 +101,6 @@ structure ACCSystemCharges where
   numberCharges : ℕ
 
 /-!
-
-### A.1. A constructor for `ACCSystemCharges`
-
-We provide a constructor `ACCSystemChargesMk` for `ACCSystemCharges` given the number of charges.
-
--/
-
-TODO "Replace `ACCSystemChargesMk` with `⟨n⟩` notation everywhere. "
-/--
-  Creates an `ACCSystemCharges` object with the specified number of charges.
--/
-def ACCSystemChargesMk (n : ℕ) : ACCSystemCharges where
-  numberCharges := n
 
 namespace ACCSystemCharges
 

--- a/Physlib/QFT/QED/AnomalyCancellation/Basic.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Basic.lean
@@ -38,7 +38,7 @@ TODO "The implementation of pure U(1) anomaly cancellation conditions is done
 
 /-- The vector space of charges. -/
 @[simps!]
-def PureU1Charges (n : ℕ) : ACCSystemCharges := ACCSystemChargesMk n
+def PureU1Charges (n : ℕ) : ACCSystemCharges := ⟨n⟩
 
 open BigOperators in
 /-- The gravitational anomaly. -/


### PR DESCRIPTION
# Overview

Replacing ACCSystemChargesMk with ⟨n⟩ notation

