### PR TITLE
feat(ClassicalMechanics): add damped harmonic oscillator solutions

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -3,6 +3,7 @@ module
 public import Physlib.ClassicalFieldTheory.Local.Variation
 public import Physlib.ClassicalMechanics.Basic
 public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Basic
+public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Solution
 public import Physlib.ClassicalMechanics.EulerLagrange
 public import Physlib.ClassicalMechanics.FreeParticle.Basic
 public import Physlib.ClassicalMechanics.HamiltonsEquations

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -295,6 +295,25 @@ lemma isCriticallyDamped_decayRate (hS : S.IsCriticallyDamped) : S.ω = S.decayR
     linarith
   nlinarith [S.decayRate_nonneg, S.ω_pos]
 
+/-- The damping coefficient is twice mass times the decay rate. -/
+lemma gamma_eq_two_mul_m_mul_decayRate : S.γ = 2 * S.m * S.decayRate := by
+  rw [decayRate]
+  field_simp [S.m_ne_zero]
+
+/-- The spring constant is `m * ω^2`. -/
+lemma k_eq_m_mul_ω_sq : S.k = S.m * S.ω^2 := by
+  rw [S.ω_sq]
+  field_simp [S.m_ne_zero]
+
+/-- In the critically damped regime, `k = m * decayRate^2`. -/
+lemma k_eq_m_mul_decayRate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
+    S.k = S.m * S.decayRate^2 := by
+  have hωa : S.ω = S.decayRate := S.isCriticallyDamped_decayRate hS
+  have hωsq : S.decayRate ^ 2 = S.k / S.m := by
+    simpa [hωa] using S.ω_sq
+  field_simp [S.m_ne_zero] at hωsq
+  nlinarith
+
 /-- An overdamped system has decay rate greater than the natural frequency. -/
 lemma isOverdamped_decayRate (hS : S.IsOverdamped) : S.ω < S.decayRate := by
   rw [IsOverdamped] at hS

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -255,39 +255,39 @@ def IsOverdamped : Prop := S.discriminant > 0
 def IsUndamped : Prop := S.γ = 0
 
 /-- The relationship between the discriminant, decay rate, and natural angular frequency. -/
-lemma discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq :
+lemma discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq :
     S.discriminant = 4 * S.m^2 * (S.decayRate^2 - S.ω^2) := by
   rw [discriminant, decayRate, S.ω_sq]
   field_simp [S.m_ne_zero]
   ring
 
 /-- The decay rate is nonnegative. -/
-lemma decay_rate_nonneg : 0 ≤ S.decayRate := by
+lemma decayRate_nonneg : 0 ≤ S.decayRate := by
   rw [decayRate]
   exact div_nonneg S.γ_nonneg (by nlinarith [S.m_pos])
 
 /-- An undamped oscillator lies in the underdamped regime. -/
 lemma isUnderdamped_of_gamma_eq_zero (hγ : S.γ = 0) : S.IsUnderdamped := by
-  rw [IsUnderdamped, discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq S, decayRate]
+  rw [IsUnderdamped, discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq S, decayRate]
   rw [hγ]
   ring_nf
   nlinarith [sq_pos_of_pos S.m_pos, sq_pos_of_pos S.ω_pos]
 
 /-- An underdamped system has decay rate less than the natural frequency. -/
-lemma isUnderdamped_decay_rate (hS : S.IsUnderdamped) : S.ω > S.decayRate := by
+lemma isUnderdamped_decayRate (hS : S.IsUnderdamped) : S.ω > S.decayRate := by
   rw [IsUnderdamped] at hS
-  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq] at hS
   have hm_sq_pos : 0 < 4 * S.m^2 := by
     have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
     nlinarith
   have hsq : S.decayRate^2 < S.ω^2 := by
     nlinarith
-  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+  nlinarith [S.decayRate_nonneg, S.ω_pos]
 
 /-- A critically damped system has decay rate equal to the natural frequency. -/
-lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decayRate := by
+lemma isCriticallyDamped_decayRate (hS : S.IsCriticallyDamped) : S.ω = S.decayRate := by
   rw [IsCriticallyDamped] at hS
-  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq] at hS
   have hm_sq_ne_zero : 4 * S.m^2 ≠ 0 := by
     have hm_sq_pos : 0 < 4 * S.m^2 := by
       have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
@@ -297,24 +297,24 @@ lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decay
     have hsub : S.decayRate^2 - S.ω^2 = 0 := by
       exact (mul_eq_zero.mp hS).resolve_left hm_sq_ne_zero
     linarith
-  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+  nlinarith [S.decayRate_nonneg, S.ω_pos]
 
 /-- An overdamped system has decay rate greater than the natural frequency. -/
-lemma isOverdamped_decay_rate (hS : S.IsOverdamped) : S.ω < S.decayRate := by
+lemma isOverdamped_decayRate (hS : S.IsOverdamped) : S.ω < S.decayRate := by
   rw [IsOverdamped] at hS
-  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq] at hS
   have hm_sq_pos : 0 < 4 * S.m^2 := by
     have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
     nlinarith
   have hsq : S.ω^2 < S.decayRate^2 := by
     nlinarith
-  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+  nlinarith [S.decayRate_nonneg, S.ω_pos]
 
-/-- In the underdamped regime, the damped angular frequency squares to `ω^2 - decay_rate^2`. -/
+/-- In the underdamped regime, the damped angular frequency squares to `ω^2 - decayRate^2`. -/
 lemma underdampedAngularFrequency_sq (hS : S.IsUnderdamped) :
     S.underdampedAngularFrequency^2 = S.ω^2 - S.decayRate^2 := by
   rw [underdampedAngularFrequency, div_pow, sq_sqrt]
-  · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
+  · rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]
     ring
   · rw [IsUnderdamped] at hS
@@ -334,11 +334,11 @@ lemma underdampedAngularFrequency_ne_zero (hS : S.IsUnderdamped) :
     S.underdampedAngularFrequency ≠ 0 :=
   Ne.symm (ne_of_lt (S.underdampedAngularFrequency_pos hS))
 
-/-- In the overdamped regime, the split rate squares to `decay_rate^2 - ω^2`. -/
+/-- In the overdamped regime, the split rate squares to `decayRate^2 - ω^2`. -/
 lemma overdampedSplitRate_sq (hS : S.IsOverdamped) :
     S.overdampedSplitRate^2 = S.decayRate^2 - S.ω^2 := by
   rw [overdampedSplitRate, div_pow, sq_sqrt]
-  · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
+  · rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]
     ring
   · rw [IsOverdamped] at hS

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -1,20 +1,20 @@
 /-
-Copyright (c) 2025 Nicola Bernini. All rights reserved.
+Copyright (c) 2026 Nicola Bernini. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicola Bernini
+Authors: Nicola Bernini, Joseph Tooby-Smith, Lode Vermeulen, Florian Wiesner
 -/
 module
 
-public import Physlib.SpaceAndTime.Time.Derivatives
+public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
 /-!
 
-# The Damped Harmonic Oscillator
+# The damped harmonic oscillator
 
 ## i. Overview
 
-The damped harmonic oscillator is a classical mechanical system corresponding to a
-mass `m` under a restoring force `- k x` and a damping force `- γ ẋ`, where `k` is the
-spring constant, `γ` is the damping coefficient, `x` is the position, and `ẋ` is the velocity.
+The damped harmonic oscillator is a classical mechanical system consisting of a mass `m`
+under a restoring force `- k x` and a damping force `- γ ẋ`, where `k` is the spring
+constant, `γ` is the damping coefficient, `x` is the position, and `ẋ` is the velocity.
 
 The equation of motion for the damped harmonic oscillator is:
 ```
@@ -23,33 +23,47 @@ m ẍ + γ ẋ + k x = 0
 
 Depending on the relationship between the damping coefficient and the natural frequency,
 the system exhibits three different behaviors:
-- **Underdamped** (γ² < 4mk) : Oscillatory motion with exponentially decaying amplitude
-- **Critically damped** (γ² = 4mk) : Fastest return to equilibrium without oscillation
-- **Overdamped** (γ² > 4mk) : Slow return to equilibrium without oscillation
+- **Underdamped** (`γ^2 < 4 * m * k`): oscillatory motion with exponentially decaying
+  amplitude.
+- **Critically damped** (`γ^2 = 4 * m * k`): fastest return to equilibrium without
+  oscillation.
+- **Overdamped** (`γ^2 > 4 * m * k`): slow return to equilibrium without oscillation.
+
+In this file, the position and velocity both have type `EuclideanSpace ℝ (Fin 1)`. This
+coordinate model is useful for a first formalization, but it works only because the
+one-dimensional configuration space and its tangent space are both isomorphic to
+one-dimensional Euclidean space. A more geometric formalization should represent the
+configuration space and its tangent bundle directly.
 
 ## ii. Key results
 
-This module is currently a placeholder for future implementation. The following results
-are planned to be formalized:
+The key results in the study of the classical damped harmonic oscillator are the following:
 
-- `DampedHarmonicOscillator`: Structure containing the input data (mass, spring constant,
-  damping coefficient)
-- `EquationOfMotion`: The equation of motion for the damped harmonic oscillator
-- Solutions for underdamped, critically damped, and overdamped cases
-- Energy dissipation properties
-- Quality factor and relaxation time
+In the `Basic` module:
+- `DampedHarmonicOscillator` contains the input data to the problem.
+- `EquationOfMotion` defines the damped oscillator equation `m ẍ + γ ẋ + k x = 0`.
+- `energy_dissipation_rate` computes the rate at which damping removes mechanical energy.
+- `IsUnderdamped`, `IsCriticallyDamped`, and `IsOverdamped` define the three damping
+  regimes from the discriminant `γ^2 - 4 * m * k`.
+- `toUndamped_equationOfMotion` relates the damped and undamped equations of motion when
+  the damping coefficient is zero.
+
+In the `Solution` module:
+- `InitialConditions` contains the initial position and velocity.
+- `trajectory_underdamped`, `trajectory_criticallydamped`, and `trajectory_overdamped` give the
+  explicit regime-specific solutions.
 
 ## iii. Table of contents
 
-- A. The input data (to be implemented)
-- B. The damped angular frequency (to be implemented)
-- C. The energies and energy dissipation (to be implemented)
-- D. The equation of motion (to be implemented)
-- E. Solutions (to be implemented)
-  - E.1. Underdamped case
-  - E.2. Critically damped case
-  - E.3. Overdamped case
-- F. Quality factor and decay time (to be implemented)
+- A. The input data
+- B. The equation of motion and energy dissipation
+  - B.1. The equation of motion
+  - B.2. Energy dissipation
+- C. Newton's second law
+  - C.1. The force
+  - C.2. Equation of motion if and only if Newton's second law
+- D. Damping regimes
+- E. To undamped oscillator
 
 ## iv. References
 
@@ -63,194 +77,175 @@ References for the damped harmonic oscillator include:
 
 namespace ClassicalMechanics
 open Real
+open Space
+open InnerProductSpace
+open MeasureTheory
 open ContDiff
 open Time
 
-TODO "Derive solutions for the underdamped case (oscillatory with exponential decay)."
-
-TODO "Derive solutions for the critically damped case (fastest non-oscillatory return)."
-
-TODO "Derive solutions for the overdamped case (slow non-oscillatory return)."
+TODO "Create a new file for the geometric model which properly models the
+ position as a configuration space and velocity as its tangent space, see the
+ HarmonicOscillator file."
 
 TODO "Define and prove properties of the quality factor Q."
 
 TODO "Define and prove properties of the relaxation time τ."
 
-TODO "Prove that the damped harmonic oscillator reduces to the undamped case when γ = 0."
-
 /-!
 
-## A. The input data (placeholder)
+## A. The input data
 
-The input data for the damped harmonic oscillator will consist of:
-- Mass `m > 0`
-- Spring constant `k > 0`
-- Damping coefficient `γ ≥ 0`
+We start by defining a structure containing the input data of the damped harmonic oscillator.
+The mass `m` and spring constant `k` are inherited from `HarmonicOscillator`; this file adds
+the damping coefficient `γ`.
 
 -/
 
-/-- Placeholder structure for the damped harmonic oscillator.
-  The damped harmonic oscillator is specified by a mass `m`, a spring constant `k`,
-  and a damping coefficient `γ`. All parameters are assumed to be positive (or non-negative
-  for the damping coefficient). -/
-structure DampedHarmonicOscillator where
-  /-- The mass of the oscillator. -/
-  m : ℝ
-  /-- The spring constant of the oscillator. -/
-  k : ℝ
+/-- The classical damped harmonic oscillator is specified by a mass `m`, a spring
+constant `k`, and a damping coefficient `γ`.
+
+The mass and spring constant are inherited from `HarmonicOscillator` and are positive.
+The damping coefficient is assumed to be nonnegative. -/
+@[ext]
+structure DampedHarmonicOscillator extends HarmonicOscillator where
   /-- The damping coefficient of the oscillator. -/
   γ : ℝ
-  m_pos : 0 < m
-  k_pos : 0 < k
+  /-- The damping coefficient is nonnegative. -/
   γ_nonneg : 0 ≤ γ
 
 namespace DampedHarmonicOscillator
 
 variable (S : DampedHarmonicOscillator)
 
-@[simp]
-lemma k_ne_zero : S.k ≠ 0 := Ne.symm (ne_of_lt S.k_pos)
-
-@[simp]
-lemma m_ne_zero : S.m ≠ 0 := Ne.symm (ne_of_lt S.m_pos)
-
 /-!
 
-## B. The natural angular frequency (placeholder)
+The mass/spring nonzero lemmas, the natural angular frequency, and the undamped energy API
+are inherited from `HarmonicOscillator`.
 
-The natural angular frequency ω₀ = √(k/m) will be defined here.
+## B. The equation of motion and energy dissipation
+
+### B.1. The equation of motion
 
 -/
 
-/-- The natural (undamped) angular frequency of the oscillator, ω₀ = √(k/m). -/
-noncomputable def ω₀ : ℝ := √(S.k / S.m)
-
-@[simp]
-lemma ω₀_pos : 0 < S.ω₀ := sqrt_pos.mpr (div_pos S.k_pos S.m_pos)
-
-lemma ω₀_sq : S.ω₀^2 = S.k / S.m := by
-  rw [ω₀, sq_sqrt]
-  exact div_nonneg (le_of_lt S.k_pos) (le_of_lt S.m_pos)
-
-/-!
-## C. Equation of motion (Tag: DHO03)
-
-The damped harmonic oscillator with mass `m`, spring
-constant `k`, and damping coefficient `γ` satisfies
-
-    m ẍ + γ ẋ + k x = 0,
-
-where `x : Time → ℝ` is the position as a function of time.
--/
-
-/-- The equation of motion for the damped harmonic oscillator.
-
-A function `x : Time → ℝ` is a solution if it satisfies
-
-    S.m * x¨ + S.γ * ẋ + S.k * x = 0
-
-for all times `t`. -/
-noncomputable def EquationOfMotion (x : Time → ℝ) : Prop :=
+/-- The equation of motion for the damped harmonic oscillator:
+`m ẍ + γ ẋ + k x = 0`. -/
+noncomputable def EquationOfMotion (xₜ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
   ∀ t : Time,
-    S.m * (Time.deriv (Time.deriv x) t) +
-    S.γ * (Time.deriv x t) +
-    S.k * x t = 0
+    S.m • ∂ₜ (∂ₜ xₜ) t +
+    S.γ • ∂ₜ xₜ t +
+    S.k • xₜ t = 0
 
 /-!
-## D. The energies and energy dissipation (Tag: DHO04)
 
-For the damped harmonic oscillator, the mechanical energy is
+### B.2. Energy dissipation
 
-  E(t) = ½ S.m (ẋ(t))^2 + ½ S.k (x(t))^2,
+The damped oscillator inherits the mechanical energy from the undamped harmonic oscillator.
+Along a solution of the damped equation of motion, that energy decreases at a rate
+proportional to `-γ ‖ẋ‖^2`.
 
-where `x : Time → ℝ` is the position as a function of time.
-
-If `x` satisfies the equation of motion
-
-  S.m * x¨ + S.γ * ẋ + S.k * x = 0,
-
-then differentiating `E` with respect to time and substituting the
-equation of motion yields
-
-  dE/dt = - S.γ * (ẋ(t))^2 ≤ 0
-
-Thus the energy is non-increasing in time, and it is strictly decreasing
-whenever `S.γ > 0` and `ẋ(t) ≠ 0`. In particular, for `S.γ > 0`
-the energy is not conserved, and the energy dissipation rate is
-proportional to the squared velocity.
 -/
 
-/-- The kinetic energy of the damped harmonic oscillator. -/
-noncomputable def kineticEnergy (x : Time → ℝ) : Time → ℝ :=
-  fun t => (1 / 2 : ℝ) * S.m * (Time.deriv x t)^2
+/-- The instantaneous energy dissipation rate along a trajectory. -/
+noncomputable def energyDissipationRate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ :=
+  fun t => - S.γ * ⟪∂ₜ xₜ t, ∂ₜ xₜ t⟫_ℝ
 
-/-- The potential energy of the damped harmonic oscillator. -/
-noncomputable def potentialEnergy (x : Time → ℝ) : Time → ℝ :=
-  fun t => (1 / 2 : ℝ) * S.k * (x t)^2
+/-- Along a smooth solution of the damped equation of motion, the derivative of the
+mechanical energy is `-γ ‖ẋ‖^2`. -/
+lemma energy_dissipation_rate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time)
+    (h1 : S.EquationOfMotion xₜ)
+    (hx : ContDiff ℝ ∞ xₜ) :
+    ∂ₜ (S.energy xₜ) t = - S.γ * ⟪∂ₜ xₜ t, ∂ₜ xₜ t⟫_ℝ := by
+  rw [S.energy_deriv xₜ hx]
+  simp only
+  have heom := h1 t
+  have hforce : S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t = - S.γ • ∂ₜ xₜ t := by
+    have hsum : (S.m • ∂ₜ (∂ₜ xₜ) t + S.k • xₜ t) + S.γ • ∂ₜ xₜ t = 0 := by
+      simpa [add_assoc, add_left_comm, add_comm] using heom
+    simpa [neg_smul] using eq_neg_of_add_eq_zero_left hsum
+  rw [hforce]
+  simp [inner_smul_right]
 
-/-- Mechanical energy of the damped harmonic oscillator. -/
-noncomputable def energy (x : Time → ℝ) : Time → ℝ :=
-  S.kineticEnergy x + S.potentialEnergy x
-
-/-- Equalties for energy eqns -/
-lemma kineticEnergy_eq (x: Time → ℝ) :
-    kineticEnergy S x = fun t => (1 / 2 : ℝ) * S.m * (Time.deriv x t)^2 := by rfl
-
-lemma potentialEnergy_eq (x: Time → ℝ) :
-    potentialEnergy S x = fun t => (1 / 2 : ℝ) * S.k * (x t)^2 := by rfl
-
-/-- Energy dissipation rate along a trajectory `x : Time → ℝ`.
-
-  if `x` satisfies `S.equationOfMotion x`, then
-
-  Time.deriv (S.energy x) t = - S.γ * (Time.deriv x t)^2,
-
-so the energy is non-increasing and not conserved when `S.γ > 0`. -/
-noncomputable def energyDissipationRate (x : Time → ℝ) : Time → ℝ :=
-  fun t => - S.γ * (Time.deriv x t)^2
-
-/-- Derives the energy dissipation rate from the equation of motion -/
-lemma energy_dissipation_rate (x: Time → ℝ) (h1 : S.EquationOfMotion x)
-    (hx : ContDiff ℝ ∞ x) :
-    Time.deriv (energy S x) t = - S.γ * (Time.deriv x t)^2 := by
-
-  -- Rearrange Equation of Motion
-  have heom' : S.m * Time.deriv (Time.deriv x) t + S.k * x t =
-              - S.γ * Time.deriv x t := by linarith [h1 t]
-
-  -- Break equation apart
-  rw [energy, kineticEnergy_eq, potentialEnergy_eq]
-  rw [Time.deriv_eq]
-
-  -- Perform derivative
-  have hdx : Differentiable ℝ x := hx.differentiable (by norm_num)
-  have hddx : Differentiable ℝ (∂ₜ x) := deriv_differentiable_of_contDiff x hx
-  have hKE := ((hddx t).hasFDerivAt.pow 2).const_mul (1/2 * S.m)
-  have hPE := ((hdx t).hasFDerivAt.pow 2).const_mul (1/2 * S.k)
-  rw [(hKE.add hPE).fderiv]
-  norm_num
-  rw [← Time.deriv, ← Time.deriv]
-  linear_combination (Time.deriv x t) * heom'
-
-lemma energy_not_conserved (x: Time → ℝ) (h1 : S.EquationOfMotion x)
-    (hx : ContDiff ℝ ∞ x)
-    (hdx : Time.deriv x t ≠ 0)
+/-- If `γ > 0` and the velocity is nonzero at a time, the mechanical energy is strictly
+decreasing at that time. -/
+lemma energy_not_conserved (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time)
+    (h1 : S.EquationOfMotion xₜ)
+    (hx : ContDiff ℝ ∞ xₜ)
+    (hdx : ∂ₜ xₜ t ≠ 0)
     (hγ : 0 < S.γ) :
-    Time.deriv (energy S x) t < 0 := by
-  rw [energy_dissipation_rate S x h1 hx]
-  rw [neg_mul S.γ (∂ₜ x t ^ 2)]
-  refine neg_neg_of_pos (mul_pos hγ (sq_pos_iff.mpr hdx))
+    ∂ₜ (S.energy xₜ) t < 0 := by
+  rw [energy_dissipation_rate S xₜ t h1 hx]
+  rw [neg_mul]
+  exact neg_neg_of_pos (mul_pos hγ (real_inner_self_pos.mpr hdx))
+
+/-!
+## C. Newton's second law
+
+We define the force of the damped oscillator, and show that the equation of
+motion is equivalent to Newton's second law.
+
+-/
 
 /-!
 
-## E. Damping regimes (placeholder)
+### C.1. The force
 
-The three damping regimes will be defined based on the discriminant γ² - 4mk.
+We define the force of the damped oscillator as `- k x - γ v`.
+
+-/
+
+noncomputable def force (S : DampedHarmonicOscillator)
+    (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    EuclideanSpace ℝ (Fin 1) :=
+  - S.k • xₜ t
+  - S.γ • ∂ₜ xₜ t
+
+/-!
+
+
+### C.2. Equation of motion if and only if Newton's second law
+
+We show that the equation of motion is equivalent to Newton's second law.
+
+-/
+
+lemma equationOfMotion_iff_newtons_2nd_law (xₜ : Time → EuclideanSpace ℝ (Fin 1)):
+    S.EquationOfMotion xₜ ↔
+    (∀ t : Time, S.m • ∂ₜ (∂ₜ xₜ) t = force S xₜ t) := by
+  simp only [EquationOfMotion, force]
+  constructor
+  · intro h t
+    have h' :
+        S.m • ∂ₜ (∂ₜ xₜ) t + (S.γ • ∂ₜ xₜ t + S.k • xₜ t) = 0 := by
+      simpa [add_assoc] using h t
+    have ha :
+        S.m • ∂ₜ (∂ₜ xₜ) t = -(S.γ • ∂ₜ xₜ t + S.k • xₜ t) :=
+      eq_neg_of_add_eq_zero_left h'
+    simpa [sub_eq_add_neg, neg_add, add_comm] using ha
+  · intro h t
+    rw [h t]
+    module
+
+/-!
+## D. Damping regimes
+
+The sign of the discriminant `γ^2 - 4 * m * k` separates the underdamped, critically
+damped, and overdamped regimes. We also define the decay rate and the real frequencies
+that appear in the explicit solution formulas.
 
 -/
 
 /-- The discriminant that determines the damping regime. -/
 noncomputable def discriminant : ℝ := S.γ^2 - 4 * S.m * S.k
+
+/-- The exponential decay rate `γ / (2 * m)`. -/
+noncomputable def decay_rate : ℝ := S.γ / (2 * S.m)
+
+/-- The oscillation frequency in the underdamped regime. -/
+noncomputable def underdampedAngularFrequency : ℝ := sqrt (- S.discriminant) / (2 * S.m)
+
+/-- The real split rate between the two roots in the overdamped regime. -/
+noncomputable def overdampedSplitRate : ℝ := sqrt S.discriminant / (2 * S.m)
 
 /-- The system is underdamped when γ² < 4mk. -/
 def IsUnderdamped : Prop := S.discriminant < 0
@@ -260,6 +255,151 @@ def IsCriticallyDamped : Prop := S.discriminant = 0
 
 /-- The system is overdamped when γ² > 4mk. -/
 def IsOverdamped : Prop := S.discriminant > 0
+
+/-- The system is undamped when γ = 0. -/
+def IsUndamped : Prop := S.γ = 0
+
+/-- The relationship between the discriminant, decay rate, and natural angular frequency. -/
+lemma discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq :
+    S.discriminant = 4 * S.m^2 * (S.decay_rate^2 - S.ω^2) := by
+  rw [discriminant, decay_rate, S.ω_sq]
+  field_simp [S.m_ne_zero]
+  ring
+
+/-- The decay rate is nonnegative. -/
+lemma decay_rate_nonneg : 0 ≤ S.decay_rate := by
+  rw [decay_rate]
+  exact div_nonneg S.γ_nonneg (by nlinarith [S.m_pos])
+
+/-- An undamped oscillator lies in the underdamped regime. -/
+lemma isUnderdamped_of_gamma_eq_zero (hγ : S.γ = 0) : S.IsUnderdamped := by
+  rw [IsUnderdamped, discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq S, decay_rate]
+  rw [hγ]
+  ring_nf
+  nlinarith [sq_pos_of_pos S.m_pos, sq_pos_of_pos S.ω_pos]
+
+/-- An underdamped system has decay rate less than the natural frequency. -/
+lemma isUnderdamped_decay_rate (hS : S.IsUnderdamped) : S.ω > S.decay_rate := by
+  rw [IsUnderdamped] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  have hm_sq_pos : 0 < 4 * S.m^2 := by
+    have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
+    nlinarith
+  have hsq : S.decay_rate^2 < S.ω^2 := by
+    nlinarith
+  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+
+/-- A critically damped system has decay rate equal to the natural frequency. -/
+lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decay_rate := by
+  rw [IsCriticallyDamped] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  have hm_sq_ne_zero : 4 * S.m^2 ≠ 0 := by
+    have hm_sq_pos : 0 < 4 * S.m^2 := by
+      have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
+      nlinarith
+    exact ne_of_gt hm_sq_pos
+  have hsq : S.decay_rate^2 = S.ω^2 := by
+    have hsub : S.decay_rate^2 - S.ω^2 = 0 := by
+      exact (mul_eq_zero.mp hS).resolve_left hm_sq_ne_zero
+    linarith
+  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+
+/-- An overdamped system has decay rate greater than the natural frequency. -/
+lemma isOverdamped_decay_rate (hS : S.IsOverdamped) : S.ω < S.decay_rate := by
+  rw [IsOverdamped] at hS
+  rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
+  have hm_sq_pos : 0 < 4 * S.m^2 := by
+    have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
+    nlinarith
+  have hsq : S.ω^2 < S.decay_rate^2 := by
+    nlinarith
+  nlinarith [S.decay_rate_nonneg, S.ω_pos]
+
+/-- In the underdamped regime, the damped angular frequency squares to `ω^2 - decay_rate^2`. -/
+lemma underdampedAngularFrequency_sq (hS : S.IsUnderdamped) :
+    S.underdampedAngularFrequency^2 = S.ω^2 - S.decay_rate^2 := by
+  rw [underdampedAngularFrequency, div_pow, sq_sqrt]
+  · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
+    field_simp [S.m_ne_zero]
+    ring
+  · rw [IsUnderdamped] at hS
+    exact le_of_lt (neg_pos.mpr hS)
+
+/-- The underdamped angular frequency is positive in the underdamped regime. -/
+lemma underdampedAngularFrequency_pos (hS : S.IsUnderdamped) :
+    0 < S.underdampedAngularFrequency := by
+  rw [underdampedAngularFrequency]
+  apply div_pos
+  · rw [IsUnderdamped] at hS
+    exact sqrt_pos.mpr (neg_pos.mpr hS)
+  · nlinarith [S.m_pos]
+
+/-- The underdamped angular frequency is nonzero in the underdamped regime. -/
+lemma underdampedAngularFrequency_ne_zero (hS : S.IsUnderdamped) :
+    S.underdampedAngularFrequency ≠ 0 :=
+  Ne.symm (ne_of_lt (S.underdampedAngularFrequency_pos hS))
+
+/-- In the overdamped regime, the split rate squares to `decay_rate^2 - ω^2`. -/
+lemma overdampedSplitRate_sq (hS : S.IsOverdamped) :
+    S.overdampedSplitRate^2 = S.decay_rate^2 - S.ω^2 := by
+  rw [overdampedSplitRate, div_pow, sq_sqrt]
+  · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
+    field_simp [S.m_ne_zero]
+    ring
+  · rw [IsOverdamped] at hS
+    exact le_of_lt hS
+
+/-- The overdamped split rate is positive in the overdamped regime. -/
+lemma overdampedSplitRate_pos (hS : S.IsOverdamped) : 0 < S.overdampedSplitRate := by
+  rw [overdampedSplitRate]
+  apply div_pos
+  · rw [IsOverdamped] at hS
+    exact sqrt_pos.mpr hS
+  · nlinarith [S.m_pos]
+
+/-- The overdamped split rate is nonzero in the overdamped regime. -/
+lemma overdampedSplitRate_ne_zero (hS : S.IsOverdamped) : S.overdampedSplitRate ≠ 0 :=
+  Ne.symm (ne_of_lt (S.overdampedSplitRate_pos hS))
+
+/-!
+## E. To undamped oscillator
+
+We show that the damped harmonic oscillator reduces to the undamped harmonic oscillator when the
+damping coefficient is zero. The underlying mass and spring data are already inherited from
+`HarmonicOscillator`; the proof argument records that this conversion is being used only in
+the zero-damping case.
+
+We also show that the equations of motion are equivalent in this case.
+-/
+
+/-- Convert a damped oscillator to its underlying undamped oscillator when `γ = 0`. -/
+def toUndamped (S : DampedHarmonicOscillator) (_hS : S.IsUndamped) :
+    HarmonicOscillator :=
+  S.toHarmonicOscillator
+
+/-- When `γ = 0`, the damped equation of motion is equivalent to the equation of motion
+for the corresponding undamped harmonic oscillator. -/
+lemma toUndamped_equationOfMotion (S : DampedHarmonicOscillator) (hS : S.IsUndamped)
+    (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (hx : ContDiff ℝ ∞ xₜ) :
+    S.EquationOfMotion xₜ ↔ (S.toUndamped hS).EquationOfMotion xₜ := by
+  have hγ : S.γ = 0 := by
+    simpa [IsUndamped] using hS
+  rw [S.equationOfMotion_iff_newtons_2nd_law xₜ,
+    (S.toUndamped hS).equationOfMotion_iff_newtons_2nd_law xₜ hx]
+  constructor
+  · intro h t
+    calc
+      (S.toUndamped hS).m • ∂ₜ (∂ₜ xₜ) t = S.m • ∂ₜ (∂ₜ xₜ) t := rfl
+      _ = force S xₜ t := h t
+      _ = HarmonicOscillator.force (S.toUndamped hS) (xₜ t) := by
+        simp [force, HarmonicOscillator.force_eq_linear, toUndamped, hγ]
+  · intro h t
+    calc
+      S.m • ∂ₜ (∂ₜ xₜ) t = (S.toUndamped hS).m • ∂ₜ (∂ₜ xₜ) t := rfl
+      _ = HarmonicOscillator.force (S.toUndamped hS) (xₜ t) := h t
+      _ = force S xₜ t := by
+        simp [force, HarmonicOscillator.force_eq_linear, toUndamped, hγ]
+
 
 end DampedHarmonicOscillator
 

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -27,7 +27,7 @@ the system exhibits three different behaviors:
   amplitude.
 - **Critically damped** (`γ^2 = 4 * m * k`): fastest return to equilibrium without
   oscillation.
-- **Overdamped** (`γ^2 > 4 * m * k`): slow return to equilibrium without oscillation.
+- **Overdamped** (`4 * m * k < γ^2`): slow return to equilibrium without oscillation.
 
 In this file, the position and velocity both have type `EuclideanSpace ℝ (Fin 1)`. This
 coordinate model is useful for a first formalization, but it works only because the
@@ -165,7 +165,7 @@ lemma energy_dissipation_rate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : 
   rw [hforce]
   simp [inner_smul_right]
 
-/-- If `γ > 0` and the velocity is nonzero at a time, the mechanical energy is strictly
+/-- If `0 < γ` and the velocity is nonzero at a time, the mechanical energy is strictly
 decreasing at that time. -/
 lemma energy_not_conserved (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time)
     (h1 : S.EquationOfMotion xₜ) (hx : ContDiff ℝ ∞ xₜ) (hdx : ∂ₜ xₜ t ≠ 0) (hγ : 0 < S.γ) :
@@ -248,8 +248,8 @@ def IsUnderdamped : Prop := S.discriminant < 0
 /-- The system is critically damped when γ² = 4mk. -/
 def IsCriticallyDamped : Prop := S.discriminant = 0
 
-/-- The system is overdamped when γ² > 4mk. -/
-def IsOverdamped : Prop := S.discriminant > 0
+/-- The system is overdamped when 4mk < γ². -/
+def IsOverdamped : Prop := 0 < S.discriminant
 
 /-- The system is undamped when γ = 0. -/
 def IsUndamped : Prop := S.γ = 0
@@ -274,7 +274,7 @@ lemma isUnderdamped_of_gamma_eq_zero (hγ : S.γ = 0) : S.IsUnderdamped := by
   nlinarith [sq_pos_of_pos S.m_pos, sq_pos_of_pos S.ω_pos]
 
 /-- An underdamped system has decay rate less than the natural frequency. -/
-lemma isUnderdamped_decayRate (hS : S.IsUnderdamped) : S.ω > S.decayRate := by
+lemma isUnderdamped_decayRate (hS : S.IsUnderdamped) : S.decayRate < S.ω := by
   rw [IsUnderdamped] at hS
   rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq] at hS
   have hm_sq_pos : 0 < 4 * S.m^2 := by

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -145,10 +145,6 @@ proportional to `-γ ‖ẋ‖^2`.
 
 -/
 
-/-- The instantaneous energy dissipation rate along a trajectory. -/
-noncomputable def energyDissipationRate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ :=
-  fun t => - S.γ * ⟪∂ₜ xₜ t, ∂ₜ xₜ t⟫_ℝ
-
 /-- Along a smooth solution of the damped equation of motion, the derivative of the
 mechanical energy is `-γ ‖ẋ‖^2`. -/
 lemma energy_dissipation_rate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time)

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicola Bernini. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicola Bernini, Joseph Tooby-Smith, Lode Vermeulen, Florian Wiesner
+Authors: Nicola Bernini, Florian Wiesner
 -/
 module
 
@@ -118,9 +118,11 @@ namespace DampedHarmonicOscillator
 variable (S : DampedHarmonicOscillator)
 
 /-!
-
 The mass/spring nonzero lemmas, the natural angular frequency, and the undamped energy API
 are inherited from `HarmonicOscillator`.
+-/
+
+/-!
 
 ## B. The equation of motion and energy dissipation
 
@@ -131,10 +133,7 @@ are inherited from `HarmonicOscillator`.
 /-- The equation of motion for the damped harmonic oscillator:
 `m ẍ + γ ẋ + k x = 0`. -/
 noncomputable def EquationOfMotion (xₜ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
-  ∀ t : Time,
-    S.m • ∂ₜ (∂ₜ xₜ) t +
-    S.γ • ∂ₜ xₜ t +
-    S.k • xₜ t = 0
+  ∀ t : Time, S.m • ∂ₜ (∂ₜ xₜ) t + S.γ • ∂ₜ xₜ t + S.k • xₜ t = 0
 
 /-!
 
@@ -169,10 +168,7 @@ lemma energy_dissipation_rate (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : 
 /-- If `γ > 0` and the velocity is nonzero at a time, the mechanical energy is strictly
 decreasing at that time. -/
 lemma energy_not_conserved (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time)
-    (h1 : S.EquationOfMotion xₜ)
-    (hx : ContDiff ℝ ∞ xₜ)
-    (hdx : ∂ₜ xₜ t ≠ 0)
-    (hγ : 0 < S.γ) :
+    (h1 : S.EquationOfMotion xₜ) (hx : ContDiff ℝ ∞ xₜ) (hdx : ∂ₜ xₜ t ≠ 0) (hγ : 0 < S.γ) :
     ∂ₜ (S.energy xₜ) t < 0 := by
   rw [energy_dissipation_rate S xₜ t h1 hx]
   rw [neg_mul]
@@ -194,11 +190,10 @@ We define the force of the damped oscillator as `- k x - γ v`.
 
 -/
 
+/-- The force of the damped harmonic oscillator at a given position and time. -/
 noncomputable def force (S : DampedHarmonicOscillator)
     (xₜ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
-    EuclideanSpace ℝ (Fin 1) :=
-  - S.k • xₜ t
-  - S.γ • ∂ₜ xₜ t
+    EuclideanSpace ℝ (Fin 1) := - S.k • xₜ t - S.γ • ∂ₜ xₜ t
 
 /-!
 

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -367,7 +367,9 @@ the zero-damping case.
 We also show that the equations of motion are equivalent in this case.
 -/
 
+set_option linter.unusedVariables false in
 /-- Convert a damped oscillator to its underlying undamped oscillator when `γ = 0`. -/
+@[nolint unusedArguments]
 def toUndamped (S : DampedHarmonicOscillator) (_hS : S.IsUndamped) :
     HarmonicOscillator :=
   S.toHarmonicOscillator

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -45,13 +45,13 @@ In the `Basic` module:
 - `energy_dissipation_rate` computes the rate at which damping removes mechanical energy.
 - `IsUnderdamped`, `IsCriticallyDamped`, and `IsOverdamped` define the three damping
   regimes from the discriminant `γ^2 - 4 * m * k`.
+- `angularFrequency` selects the real frequency parameter from the damping regime.
 - `toUndamped_equationOfMotion` relates the damped and undamped equations of motion when
   the damping coefficient is zero.
 
 In the `Solution` module:
 - `InitialConditions` contains the initial position and velocity.
-- `trajectoryUnderdamped`, `trajectoryCriticallyDamped`, and `trajectoryOverdamped` give the
-  explicit regime-specific solutions.
+- `trajectory` gives the explicit solution selected from the damping regime.
 
 ## iii. Table of contents
 
@@ -221,8 +221,8 @@ lemma equationOfMotion_iff_newtons_2nd_law (xₜ : Time → EuclideanSpace ℝ (
 ## D. Damping regimes
 
 The sign of the discriminant `γ^2 - 4 * m * k` separates the underdamped, critically
-damped, and overdamped regimes. We also define the decay rate and the real frequencies
-that appear in the explicit solution formulas.
+damped, and overdamped regimes. We also define the decay rate and the regime-selected
+real frequency that appears in the explicit solution formulas.
 
 -/
 
@@ -231,12 +231,6 @@ noncomputable def discriminant : ℝ := S.γ^2 - 4 * S.m * S.k
 
 /-- The exponential decay rate `γ / (2 * m)`. -/
 noncomputable def decayRate : ℝ := S.γ / (2 * S.m)
-
-/-- The oscillation frequency in the underdamped regime. -/
-noncomputable def underdampedAngularFrequency : ℝ := sqrt (- S.discriminant) / (2 * S.m)
-
-/-- The real split rate between the two roots in the overdamped regime. -/
-noncomputable def overdampedSplitRate : ℝ := sqrt S.discriminant / (2 * S.m)
 
 /-- The system is underdamped when γ² < 4mk. -/
 def IsUnderdamped : Prop := S.discriminant < 0
@@ -249,6 +243,21 @@ def IsOverdamped : Prop := 0 < S.discriminant
 
 /-- The system is undamped when γ = 0. -/
 def IsUndamped : Prop := S.γ = 0
+
+/-- The real frequency selected by the damping regime.
+
+In the underdamped regime this is the oscillation frequency. In the critically damped
+regime it is `0`. In the overdamped regime this is the real split rate between the two
+roots. -/
+noncomputable def angularFrequency : ℝ := by
+  classical
+  exact
+    if S.IsUnderdamped then
+      sqrt (- S.discriminant) / (2 * S.m)
+    else if S.IsCriticallyDamped then
+      0
+    else
+      sqrt S.discriminant / (2 * S.m)
 
 /-- The relationship between the discriminant, decay rate, and natural angular frequency. -/
 lemma discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq :
@@ -325,51 +334,88 @@ lemma isOverdamped_decayRate (hS : S.IsOverdamped) : S.ω < S.decayRate := by
     nlinarith
   nlinarith [S.decayRate_nonneg, S.ω_pos]
 
-/-- In the underdamped regime, the damped angular frequency squares to `ω^2 - decayRate^2`. -/
-lemma underdampedAngularFrequency_sq (hS : S.IsUnderdamped) :
-    S.underdampedAngularFrequency^2 = S.ω^2 - S.decayRate^2 := by
-  rw [underdampedAngularFrequency, div_pow, sq_sqrt]
+/-- In the underdamped regime, the selected frequency uses the oscillation frequency. -/
+lemma angularFrequency_eq_underdamped (hS : S.IsUnderdamped) :
+    S.angularFrequency = sqrt (- S.discriminant) / (2 * S.m) := by
+  classical
+  simp [angularFrequency, hS]
+
+/-- In the critically damped regime, the selected frequency is zero. -/
+lemma angularFrequency_eq_criticallyDamped (hS : S.IsCriticallyDamped) :
+    S.angularFrequency = 0 := by
+  classical
+  have hnotUnder : ¬ S.IsUnderdamped := by
+    intro hUnder
+    rw [IsUnderdamped] at hUnder
+    rw [IsCriticallyDamped] at hS
+    linarith
+  simp [angularFrequency, hnotUnder, hS]
+
+/-- In the overdamped regime, the selected frequency uses the real split rate. -/
+lemma angularFrequency_eq_overdamped (hS : S.IsOverdamped) :
+    S.angularFrequency = sqrt S.discriminant / (2 * S.m) := by
+  classical
+  have hnotUnder : ¬ S.IsUnderdamped := by
+    intro hUnder
+    rw [IsUnderdamped] at hUnder
+    rw [IsOverdamped] at hS
+    linarith
+  have hnotCritical : ¬ S.IsCriticallyDamped := by
+    intro hCritical
+    rw [IsCriticallyDamped] at hCritical
+    rw [IsOverdamped] at hS
+    linarith
+  simp [angularFrequency, hnotUnder, hnotCritical]
+
+/-- In the underdamped regime, the selected angular frequency squares to
+`ω^2 - decayRate^2`. -/
+lemma angularFrequency_sq_of_underdamped (hS : S.IsUnderdamped) :
+    S.angularFrequency^2 = S.ω^2 - S.decayRate^2 := by
+  rw [S.angularFrequency_eq_underdamped hS, div_pow, sq_sqrt]
   · rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]
     ring
   · rw [IsUnderdamped] at hS
     exact le_of_lt (neg_pos.mpr hS)
 
-/-- The underdamped angular frequency is positive in the underdamped regime. -/
-lemma underdampedAngularFrequency_pos (hS : S.IsUnderdamped) :
-    0 < S.underdampedAngularFrequency := by
-  rw [underdampedAngularFrequency]
+/-- The selected angular frequency is positive in the underdamped regime. -/
+lemma angularFrequency_pos_of_underdamped (hS : S.IsUnderdamped) :
+    0 < S.angularFrequency := by
+  rw [S.angularFrequency_eq_underdamped hS]
   apply div_pos
   · rw [IsUnderdamped] at hS
     exact sqrt_pos.mpr (neg_pos.mpr hS)
   · nlinarith [S.m_pos]
 
-/-- The underdamped angular frequency is nonzero in the underdamped regime. -/
-lemma underdampedAngularFrequency_ne_zero (hS : S.IsUnderdamped) :
-    S.underdampedAngularFrequency ≠ 0 :=
-  Ne.symm (ne_of_lt (S.underdampedAngularFrequency_pos hS))
+/-- The selected angular frequency is nonzero in the underdamped regime. -/
+lemma angularFrequency_ne_zero_of_underdamped (hS : S.IsUnderdamped) :
+    S.angularFrequency ≠ 0 :=
+  Ne.symm (ne_of_lt (S.angularFrequency_pos_of_underdamped hS))
 
-/-- In the overdamped regime, the split rate squares to `decayRate^2 - ω^2`. -/
-lemma overdampedSplitRate_sq (hS : S.IsOverdamped) :
-    S.overdampedSplitRate^2 = S.decayRate^2 - S.ω^2 := by
-  rw [overdampedSplitRate, div_pow, sq_sqrt]
+/-- In the overdamped regime, the selected angular frequency squares to
+`decayRate^2 - ω^2`. -/
+lemma angularFrequency_sq_of_overdamped (hS : S.IsOverdamped) :
+    S.angularFrequency^2 = S.decayRate^2 - S.ω^2 := by
+  rw [S.angularFrequency_eq_overdamped hS, div_pow, sq_sqrt]
   · rw [discriminant_eq_four_mul_m_sq_mul_decayRate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]
     ring
   · rw [IsOverdamped] at hS
     exact le_of_lt hS
 
-/-- The overdamped split rate is positive in the overdamped regime. -/
-lemma overdampedSplitRate_pos (hS : S.IsOverdamped) : 0 < S.overdampedSplitRate := by
-  rw [overdampedSplitRate]
+/-- The selected angular frequency is positive in the overdamped regime. -/
+lemma angularFrequency_pos_of_overdamped (hS : S.IsOverdamped) :
+    0 < S.angularFrequency := by
+  rw [S.angularFrequency_eq_overdamped hS]
   apply div_pos
   · rw [IsOverdamped] at hS
     exact sqrt_pos.mpr hS
   · nlinarith [S.m_pos]
 
-/-- The overdamped split rate is nonzero in the overdamped regime. -/
-lemma overdampedSplitRate_ne_zero (hS : S.IsOverdamped) : S.overdampedSplitRate ≠ 0 :=
-  Ne.symm (ne_of_lt (S.overdampedSplitRate_pos hS))
+/-- The selected angular frequency is nonzero in the overdamped regime. -/
+lemma angularFrequency_ne_zero_of_overdamped (hS : S.IsOverdamped) :
+    S.angularFrequency ≠ 0 :=
+  Ne.symm (ne_of_lt (S.angularFrequency_pos_of_overdamped hS))
 
 /-!
 ## E. To undamped oscillator

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -50,7 +50,7 @@ In the `Basic` module:
 
 In the `Solution` module:
 - `InitialConditions` contains the initial position and velocity.
-- `trajectory_underdamped`, `trajectory_criticallydamped`, and `trajectory_overdamped` give the
+- `trajectoryUnderdamped`, `trajectoryCriticallyDamped`, and `trajectoryOverdamped` give the
   explicit regime-specific solutions.
 
 ## iii. Table of contents

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Basic.lean
@@ -234,7 +234,7 @@ that appear in the explicit solution formulas.
 noncomputable def discriminant : ℝ := S.γ^2 - 4 * S.m * S.k
 
 /-- The exponential decay rate `γ / (2 * m)`. -/
-noncomputable def decay_rate : ℝ := S.γ / (2 * S.m)
+noncomputable def decayRate : ℝ := S.γ / (2 * S.m)
 
 /-- The oscillation frequency in the underdamped regime. -/
 noncomputable def underdampedAngularFrequency : ℝ := sqrt (- S.discriminant) / (2 * S.m)
@@ -256,36 +256,36 @@ def IsUndamped : Prop := S.γ = 0
 
 /-- The relationship between the discriminant, decay rate, and natural angular frequency. -/
 lemma discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq :
-    S.discriminant = 4 * S.m^2 * (S.decay_rate^2 - S.ω^2) := by
-  rw [discriminant, decay_rate, S.ω_sq]
+    S.discriminant = 4 * S.m^2 * (S.decayRate^2 - S.ω^2) := by
+  rw [discriminant, decayRate, S.ω_sq]
   field_simp [S.m_ne_zero]
   ring
 
 /-- The decay rate is nonnegative. -/
-lemma decay_rate_nonneg : 0 ≤ S.decay_rate := by
-  rw [decay_rate]
+lemma decay_rate_nonneg : 0 ≤ S.decayRate := by
+  rw [decayRate]
   exact div_nonneg S.γ_nonneg (by nlinarith [S.m_pos])
 
 /-- An undamped oscillator lies in the underdamped regime. -/
 lemma isUnderdamped_of_gamma_eq_zero (hγ : S.γ = 0) : S.IsUnderdamped := by
-  rw [IsUnderdamped, discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq S, decay_rate]
+  rw [IsUnderdamped, discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq S, decayRate]
   rw [hγ]
   ring_nf
   nlinarith [sq_pos_of_pos S.m_pos, sq_pos_of_pos S.ω_pos]
 
 /-- An underdamped system has decay rate less than the natural frequency. -/
-lemma isUnderdamped_decay_rate (hS : S.IsUnderdamped) : S.ω > S.decay_rate := by
+lemma isUnderdamped_decay_rate (hS : S.IsUnderdamped) : S.ω > S.decayRate := by
   rw [IsUnderdamped] at hS
   rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
   have hm_sq_pos : 0 < 4 * S.m^2 := by
     have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
     nlinarith
-  have hsq : S.decay_rate^2 < S.ω^2 := by
+  have hsq : S.decayRate^2 < S.ω^2 := by
     nlinarith
   nlinarith [S.decay_rate_nonneg, S.ω_pos]
 
 /-- A critically damped system has decay rate equal to the natural frequency. -/
-lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decay_rate := by
+lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decayRate := by
   rw [IsCriticallyDamped] at hS
   rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
   have hm_sq_ne_zero : 4 * S.m^2 ≠ 0 := by
@@ -293,26 +293,26 @@ lemma isCriticallyDamped_decay_rate (hS : S.IsCriticallyDamped) : S.ω = S.decay
       have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
       nlinarith
     exact ne_of_gt hm_sq_pos
-  have hsq : S.decay_rate^2 = S.ω^2 := by
-    have hsub : S.decay_rate^2 - S.ω^2 = 0 := by
+  have hsq : S.decayRate^2 = S.ω^2 := by
+    have hsub : S.decayRate^2 - S.ω^2 = 0 := by
       exact (mul_eq_zero.mp hS).resolve_left hm_sq_ne_zero
     linarith
   nlinarith [S.decay_rate_nonneg, S.ω_pos]
 
 /-- An overdamped system has decay rate greater than the natural frequency. -/
-lemma isOverdamped_decay_rate (hS : S.IsOverdamped) : S.ω < S.decay_rate := by
+lemma isOverdamped_decay_rate (hS : S.IsOverdamped) : S.ω < S.decayRate := by
   rw [IsOverdamped] at hS
   rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq] at hS
   have hm_sq_pos : 0 < 4 * S.m^2 := by
     have hsq : 0 < S.m^2 := sq_pos_of_pos S.m_pos
     nlinarith
-  have hsq : S.ω^2 < S.decay_rate^2 := by
+  have hsq : S.ω^2 < S.decayRate^2 := by
     nlinarith
   nlinarith [S.decay_rate_nonneg, S.ω_pos]
 
 /-- In the underdamped regime, the damped angular frequency squares to `ω^2 - decay_rate^2`. -/
 lemma underdampedAngularFrequency_sq (hS : S.IsUnderdamped) :
-    S.underdampedAngularFrequency^2 = S.ω^2 - S.decay_rate^2 := by
+    S.underdampedAngularFrequency^2 = S.ω^2 - S.decayRate^2 := by
   rw [underdampedAngularFrequency, div_pow, sq_sqrt]
   · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]
@@ -336,7 +336,7 @@ lemma underdampedAngularFrequency_ne_zero (hS : S.IsUnderdamped) :
 
 /-- In the overdamped regime, the split rate squares to `decay_rate^2 - ω^2`. -/
 lemma overdampedSplitRate_sq (hS : S.IsOverdamped) :
-    S.overdampedSplitRate^2 = S.decay_rate^2 - S.ω^2 := by
+    S.overdampedSplitRate^2 = S.decayRate^2 - S.ω^2 := by
   rw [overdampedSplitRate, div_pow, sq_sqrt]
   · rw [discriminant_eq_four_mul_m_sq_mul_decay_rate_sq_sub_ω_sq]
     field_simp [S.m_ne_zero]

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -150,8 +150,6 @@ lemma k_eq_m_mul_decayRate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
   field_simp [S.m_ne_zero] at hωsq
   nlinarith
 
-private abbrev TrajectorySpace := EuclideanSpace ℝ (Fin 1)
-
 /-!
 
 ### B.3. Shared calculus lemmas
@@ -163,7 +161,7 @@ equation-of-motion argument.
 -/
 
 private lemma exp_decay_smul_velocity
-    (a : ℝ) (y : Time → TrajectorySpace) (hy : Differentiable ℝ y) :
+    (a : ℝ) (y : Time → EuclideanSpace ℝ (Fin 1)) (hy : Differentiable ℝ y) :
     ∂ₜ (fun t : Time => exp (-a * t.val) • y t) =
       fun t : Time => exp (-a * t.val) • (∂ₜ y t - a • y t) := by
   funext t
@@ -178,7 +176,7 @@ private lemma exp_decay_smul_velocity
   module
 
 private lemma exp_decay_smul_acceleration
-    (a μ : ℝ) (y : Time → TrajectorySpace)
+    (a μ : ℝ) (y : Time → EuclideanSpace ℝ (Fin 1))
     (hy : Differentiable ℝ y) (hdy : Differentiable ℝ (∂ₜ y))
     (hy'' : ∂ₜ (∂ₜ y) = fun t => μ • y t) :
     ∂ₜ (∂ₜ (fun t : Time => exp (-a * t.val) • y t)) =
@@ -202,7 +200,7 @@ private lemma exp_decay_smul_acceleration
   module
 
 private lemma exp_decay_smul_equationOfMotion
-    (a μ : ℝ) (y : Time → TrajectorySpace)
+    (a μ : ℝ) (y : Time → EuclideanSpace ℝ (Fin 1))
     (hy : Differentiable ℝ y) (hdy : Differentiable ℝ (∂ₜ y))
     (hy'' : ∂ₜ (∂ₜ y) = fun t => μ • y t)
     (hγ : S.γ = 2 * S.m * a) (hk : S.k = S.m * (a^2 - μ)) :
@@ -236,7 +234,8 @@ private lemma criticallyDampedBase_velocity (IC : InitialConditions) :
   simp
 
 private lemma criticallyDampedBase_acceleration (IC : InitialConditions) :
-    ∂ₜ (∂ₜ (S.criticallyDampedBase IC)) = fun _ => (0 : TrajectorySpace) := by
+    ∂ₜ (∂ₜ (S.criticallyDampedBase IC)) =
+      fun _ => (0 : EuclideanSpace ℝ (Fin 1)) := by
   rw [criticallyDampedBase_velocity]
   funext t
   simp

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -211,7 +211,7 @@ private lemma criticallyDampedBase_acceleration (IC : InitialConditions) :
   funext t
   simp
 
-private lemma underdamped_base_velocity (IC : InitialConditions) (hS : S.IsUnderdamped) :
+private lemma underdampedBase_velocity (IC : InitialConditions) (hS : S.IsUnderdamped) :
     ∂ₜ (fun t : Time =>
       cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
@@ -254,7 +254,7 @@ private lemma underdamped_base_velocity (IC : InitialConditions) (hS : S.IsUnder
     simp [hΩ, mul_comm]
   simp [hcos, hsin]
 
-private lemma underdamped_base_acceleration (IC : InitialConditions) (hS : S.IsUnderdamped) :
+private lemma underdampedBase_acceleration (IC : InitialConditions) (hS : S.IsUnderdamped) :
     ∂ₜ (∂ₜ (fun t : Time =>
       cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
@@ -264,7 +264,7 @@ private lemma underdamped_base_acceleration (IC : InitialConditions) (hS : S.IsU
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
-  rw [S.underdamped_base_velocity IC hS]
+  rw [S.underdampedBase_velocity IC hS]
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
@@ -285,7 +285,7 @@ private lemma underdamped_base_acceleration (IC : InitialConditions) (hS : S.IsU
   simp [hsin, hcos, smul_add, smul_smul]
   field_simp [hΩ]
 
-private lemma overdamped_base_velocity (IC : InitialConditions) (hS : S.IsOverdamped) :
+private lemma overdampedBase_velocity (IC : InitialConditions) (hS : S.IsOverdamped) :
     ∂ₜ (fun t : Time =>
       cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
@@ -324,7 +324,7 @@ private lemma overdamped_base_velocity (IC : InitialConditions) (hS : S.IsOverda
     simp [hLambda, mul_comm]
   simp [hcosh, hsinh]
 
-private lemma overdamped_base_acceleration (IC : InitialConditions) (hS : S.IsOverdamped) :
+private lemma overdampedBase_acceleration (IC : InitialConditions) (hS : S.IsOverdamped) :
     ∂ₜ (∂ₜ (fun t : Time =>
       cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
@@ -334,7 +334,7 @@ private lemma overdamped_base_acceleration (IC : InitialConditions) (hS : S.IsOv
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
           (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
-  rw [S.overdamped_base_velocity IC hS]
+  rw [S.overdampedBase_velocity IC hS]
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
@@ -407,7 +407,7 @@ lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
         (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))
-    exact S.underdamped_base_acceleration IC hS
+    exact S.underdampedBase_acceleration IC hS
   exact S.exp_decay_smul_equationOfMotion S.decayRate
     (-S.underdampedAngularFrequency^2) (S.underdampedBase IC)
     (by
@@ -421,7 +421,7 @@ lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
         cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀)))
-      rw [S.underdamped_base_velocity IC hS]
+      rw [S.underdampedBase_velocity IC hS]
       fun_prop)
     hbase hγ hk
 
@@ -446,7 +446,7 @@ lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
         (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
             (IC.v₀ + S.decayRate • IC.x₀))
-    exact S.overdamped_base_acceleration IC hS
+    exact S.overdampedBase_acceleration IC hS
   exact S.exp_decay_smul_equationOfMotion S.decayRate (S.overdampedSplitRate^2)
     (S.overdampedBase IC)
     (by
@@ -460,7 +460,7 @@ lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
         cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
             (IC.v₀ + S.decayRate • IC.x₀)))
-      rw [S.overdamped_base_velocity IC hS]
+      rw [S.overdampedBase_velocity IC hS]
       fun_prop)
     hbase hγ hk
 

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -22,7 +22,7 @@ overdamped case.
 ## ii. Key results
 
 - `InitialConditions` is a structure for the initial position and velocity.
-- `trajectory_underdamped`, `trajectory_criticallydamped`, and `trajectory_overdamped` are the
+- `trajectoryUnderdamped`, `trajectoryCriticallyDamped`, and `trajectoryOverdamped` are the
   explicit regime-specific trajectories.
 - `trajectory_underdamped_equationOfMotion`,
   `trajectory_criticallydamped_equationOfMotion`, and
@@ -96,7 +96,7 @@ noncomputable def underdampedBase
       (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the underdamped regime. -/
-noncomputable def trajectory_underdamped
+noncomputable def trajectoryUnderdamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   exp (-S.decayRate * t) • S.underdampedBase IC t
 
@@ -106,7 +106,7 @@ noncomputable def criticallyDampedBase
   IC.x₀ + (t : ℝ) • (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the critically damped regime. -/
-noncomputable def trajectory_criticallydamped
+noncomputable def trajectoryCriticallyDamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   exp (-S.decayRate * t) • S.criticallyDampedBase IC t
 
@@ -118,7 +118,7 @@ noncomputable def overdampedBase
         (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the overdamped regime. -/
-noncomputable def trajectory_overdamped
+noncomputable def trajectoryOverdamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   exp (-S.decayRate * t) • S.overdampedBase IC t
 
@@ -395,7 +395,7 @@ oscillator.
 /-- The critically damped trajectory satisfies the damped equation of motion. -/
 lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsCriticallyDamped) :
-    S.EquationOfMotion (S.trajectory_criticallydamped IC) := by
+    S.EquationOfMotion (S.trajectoryCriticallyDamped IC) := by
   change S.EquationOfMotion
     (fun t : Time => exp (-S.decayRate * t.val) • S.criticallyDampedBase IC t)
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
@@ -418,7 +418,7 @@ lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
 /-- The underdamped trajectory satisfies the damped equation of motion. -/
 lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsUnderdamped) :
-    S.EquationOfMotion (S.trajectory_underdamped IC) := by
+    S.EquationOfMotion (S.trajectoryUnderdamped IC) := by
   change S.EquationOfMotion
     (fun t : Time => exp (-S.decayRate * t.val) • S.underdampedBase IC t)
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
@@ -457,7 +457,7 @@ lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
 /-- The overdamped trajectory satisfies the damped equation of motion. -/
 lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsOverdamped) :
-    S.EquationOfMotion (S.trajectory_overdamped IC) := by
+    S.EquationOfMotion (S.trajectoryOverdamped IC) := by
   change S.EquationOfMotion
     (fun t : Time => exp (-S.decayRate * t.val) • S.overdampedBase IC t)
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -134,14 +134,14 @@ noncomputable def trajectory
       fun t : Time => exp (-S.decayRate * t) • S.overdampedBase IC t
 
 /-- In the underdamped regime, the selected trajectory uses the trigonometric base. -/
-lemma trajectory_eq_underdamped (IC : InitialConditions) (hS : S.IsUnderdamped) :
+lemma trajectory_eq_of_underdamped (IC : InitialConditions) (hS : S.IsUnderdamped) :
     S.trajectory IC =
       fun t : Time => exp (-S.decayRate * t) • S.underdampedBase IC t := by
   classical
   simp [trajectory, hS]
 
 /-- In the critically damped regime, the selected trajectory uses the polynomial base. -/
-lemma trajectory_eq_criticallyDamped (IC : InitialConditions) (hS : S.IsCriticallyDamped) :
+lemma trajectory_eq_of_criticallyDamped (IC : InitialConditions) (hS : S.IsCriticallyDamped) :
     S.trajectory IC =
       fun t : Time => exp (-S.decayRate * t) • S.criticallyDampedBase IC t := by
   classical
@@ -153,7 +153,7 @@ lemma trajectory_eq_criticallyDamped (IC : InitialConditions) (hS : S.IsCritical
   simp [trajectory, hnotUnder, hS]
 
 /-- In the overdamped regime, the selected trajectory uses the hyperbolic base. -/
-lemma trajectory_eq_overdamped (IC : InitialConditions) (hS : S.IsOverdamped) :
+lemma trajectory_eq_of_overdamped (IC : InitialConditions) (hS : S.IsOverdamped) :
     S.trajectory IC =
       fun t : Time => exp (-S.decayRate * t) • S.overdampedBase IC t := by
   classical
@@ -417,7 +417,7 @@ of motion. -/
 lemma trajectory_equationOfMotion_of_criticallyDamped (IC : InitialConditions)
     (hS : S.IsCriticallyDamped) :
     S.EquationOfMotion (S.trajectory IC) := by
-  rw [S.trajectory_eq_criticallyDamped IC hS]
+  rw [S.trajectory_eq_of_criticallyDamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
   have hk : S.k = S.m * (S.decayRate^2 - 0) := by
     simpa [sub_zero] using S.k_eq_m_mul_decayRate_sq_of_criticallyDamped hS
@@ -440,7 +440,7 @@ motion. -/
 lemma trajectory_equationOfMotion_of_underdamped (IC : InitialConditions)
     (hS : S.IsUnderdamped) :
     S.EquationOfMotion (S.trajectory IC) := by
-  rw [S.trajectory_eq_underdamped IC hS]
+  rw [S.trajectory_eq_of_underdamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
   have hk : S.k = S.m * (S.decayRate^2 - (-S.angularFrequency^2)) := by
     rw [S.k_eq_m_mul_ω_sq, S.angularFrequency_sq_of_underdamped hS]
@@ -479,7 +479,7 @@ motion. -/
 lemma trajectory_equationOfMotion_of_overdamped (IC : InitialConditions)
     (hS : S.IsOverdamped) :
     S.EquationOfMotion (S.trajectory IC) := by
-  rw [S.trajectory_eq_overdamped IC hS]
+  rw [S.trajectory_eq_of_overdamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
   have hk : S.k = S.m * (S.decayRate^2 - S.angularFrequency^2) := by
     rw [S.k_eq_m_mul_ω_sq, S.angularFrequency_sq_of_overdamped hS]

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -1,0 +1,511 @@
+/-
+Copyright (c) 2026 Florian Wiesner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Florian Wiesner
+-/
+module
+
+public import Physlib.ClassicalMechanics.DampedHarmonicOscillator.Basic
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+/-!
+
+# Solutions to the damped harmonic oscillator
+
+## i. Overview
+
+In this module we define the regime-specific solutions to the damped harmonic oscillator
+and prove that they satisfy the equation of motion. The formulas are split into an
+exponential decay factor and a regime-specific base trajectory: trigonometric for the
+underdamped case, polynomial for the critically damped case, and hyperbolic for the
+overdamped case.
+
+## ii. Key results
+
+- `InitialConditions` is a structure for the initial position and velocity.
+- `trajectory_underdamped`, `trajectory_criticallydamped`, and `trajectory_overdamped` are the
+  explicit regime-specific trajectories.
+- `trajectory_underdamped_equationOfMotion`,
+  `trajectory_criticallydamped_equationOfMotion`, and
+  `trajectory_overdamped_equationOfMotion` prove that those trajectories satisfy the equation
+  of motion in their corresponding damping regimes.
+
+## iii. Table of contents
+
+- A. The initial conditions
+- B. Trajectories associated with the initial conditions
+  - B.1. Explicit regime-specific trajectories
+  - B.2. Parameter identities
+  - B.3. Shared calculus lemmas
+  - B.4. Derivatives of the base trajectories
+- C. Trajectories and equation of motion
+  - C.1. Uniqueness of the solutions
+
+## iv. References
+
+References for the damped harmonic oscillator include:
+- Landau & Lifshitz, Mechanics, page 76, section 25.
+- Goldstein, Classical Mechanics, Chapter 2.
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+open Real
+open Time
+open ContDiff
+
+namespace DampedHarmonicOscillator
+
+variable (S : DampedHarmonicOscillator)
+
+/-!
+
+## A. The initial conditions
+
+We define the type of initial conditions for the damped harmonic oscillator. The initial
+conditions are the position and velocity at time `0`.
+
+-/
+
+/-- The initial conditions for the damped harmonic oscillator, specified by an initial
+position and an initial velocity. -/
+@[ext]
+structure InitialConditions where
+  /-- The initial position of the damped harmonic oscillator. -/
+  x₀ : EuclideanSpace ℝ (Fin 1)
+  /-- The initial velocity of the damped harmonic oscillator. -/
+  v₀ : EuclideanSpace ℝ (Fin 1)
+
+/-!
+
+## B. Trajectories associated with the initial conditions
+
+For each damping regime, we give an explicit formula for the trajectory with the specified
+initial conditions.
+
+### B.1. Explicit regime-specific trajectories
+
+-/
+
+/-- The oscillatory part of the underdamped trajectory before exponential decay. -/
+noncomputable def underdampedBase
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  cos (S.underdampedAngularFrequency * t) • IC.x₀
+    + (sin (S.underdampedAngularFrequency * t)/S.underdampedAngularFrequency) •
+      (IC.v₀ + S.decay_rate • IC.x₀)
+
+/-- Given initial conditions, the solution in the underdamped regime. -/
+noncomputable def trajectory_underdamped
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  exp (-S.decay_rate * t) • S.underdampedBase IC t
+
+/-- The polynomial part of the critically damped trajectory before exponential decay. -/
+noncomputable def criticallyDampedBase
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  IC.x₀ + (t : ℝ) • (IC.v₀ + S.decay_rate • IC.x₀)
+
+/-- Given initial conditions, the solution in the critically damped regime. -/
+noncomputable def trajectory_criticallydamped
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  exp (-S.decay_rate * t) • S.criticallyDampedBase IC t
+
+/-- The hyperbolic part of the overdamped trajectory before exponential decay. -/
+noncomputable def overdampedBase
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  cosh (S.overdampedSplitRate * t) • IC.x₀
+      + (sinh (S.overdampedSplitRate * t) / S.overdampedSplitRate) •
+        (IC.v₀ + S.decay_rate • IC.x₀)
+
+/-- Given initial conditions, the solution in the overdamped regime. -/
+noncomputable def trajectory_overdamped
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  exp (-S.decay_rate * t) • S.overdampedBase IC t
+
+/-!
+
+### B.2. Parameter identities
+
+These identities rewrite `γ` and `k` in the form used by the shared proof for the
+exponentially decaying trajectories.
+
+-/
+
+/-- The damping coefficient is twice mass times the decay rate. -/
+lemma gamma_eq_two_mul_m_mul_decay_rate : S.γ = 2 * S.m * S.decay_rate := by
+  rw [decay_rate]
+  field_simp [S.m_ne_zero]
+
+/-- The spring constant is `m * ω^2`. -/
+lemma k_eq_m_mul_ω_sq : S.k = S.m * S.ω^2 := by
+  rw [S.ω_sq]
+  field_simp [S.m_ne_zero]
+
+/-- In the critically damped regime, `k = m * decay_rate^2`. -/
+lemma k_eq_m_mul_decay_rate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
+    S.k = S.m * S.decay_rate^2 := by
+  have hωa : S.ω = S.decay_rate := S.isCriticallyDamped_decay_rate hS
+  have hωsq : S.decay_rate ^ 2 = S.k / S.m := by
+    simpa [hωa] using S.ω_sq
+  field_simp [S.m_ne_zero] at hωsq
+  nlinarith
+
+private abbrev TrajectorySpace := EuclideanSpace ℝ (Fin 1)
+
+/-!
+
+### B.3. Shared calculus lemmas
+
+The three solution formulas all have the form `exp (-a * t) • y t`. The following private
+lemmas compute the first and second derivatives of that expression and package the common
+equation-of-motion argument.
+
+-/
+
+private lemma exp_decay_smul_velocity
+    (a : ℝ) (y : Time → TrajectorySpace) (hy : Differentiable ℝ y) :
+    ∂ₜ (fun t : Time => exp (-a * t.val) • y t) =
+      fun t : Time => exp (-a * t.val) • (∂ₜ y t - a • y t) := by
+  funext t
+  rw [Time.deriv]
+  rw [fderiv_fun_smul (by fun_prop) (hy t)]
+  rw [fderiv_exp (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smulRight_apply,
+    fderiv_fun_neg, fderiv_fun_const, Pi.zero_apply, Time.fderiv_val,
+    ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul]
+  rw [← Time.deriv_eq]
+  simp [smul_sub, smul_smul]
+  module
+
+private lemma exp_decay_smul_acceleration
+    (a μ : ℝ) (y : Time → TrajectorySpace)
+    (hy : Differentiable ℝ y) (hdy : Differentiable ℝ (∂ₜ y))
+    (hy'' : ∂ₜ (∂ₜ y) = fun t => μ • y t) :
+    ∂ₜ (∂ₜ (fun t : Time => exp (-a * t.val) • y t)) =
+      fun t : Time => exp (-a * t.val) •
+        (μ • y t - (2 * a) • ∂ₜ y t + a^2 • y t) := by
+  rw [exp_decay_smul_velocity a y hy]
+  funext t
+  rw [Time.deriv]
+  rw [fderiv_fun_smul (by fun_prop) (by fun_prop)]
+  rw [fderiv_exp (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+  rw [fderiv_fun_sub (hdy t) (by fun_prop)]
+  rw [fderiv_fun_const_smul (hy t)]
+  have hy''_t := congrFun hy'' t
+  rw [Time.deriv] at hy''_t
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.sub_apply,
+    ContinuousLinearMap.smulRight_apply, fderiv_fun_neg, fderiv_fun_const,
+    Pi.zero_apply, Time.fderiv_val, ContinuousLinearMap.neg_apply,
+    ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul]
+  rw [hy''_t, ← Time.deriv_eq]
+  simp [smul_add, smul_sub, smul_smul]
+  module
+
+private lemma exp_decay_smul_equationOfMotion
+    (a μ : ℝ) (y : Time → TrajectorySpace)
+    (hy : Differentiable ℝ y) (hdy : Differentiable ℝ (∂ₜ y))
+    (hy'' : ∂ₜ (∂ₜ y) = fun t => μ • y t)
+    (hγ : S.γ = 2 * S.m * a) (hk : S.k = S.m * (a^2 - μ)) :
+    S.EquationOfMotion (fun t : Time => exp (-a * t.val) • y t) := by
+  intro t
+  rw [exp_decay_smul_acceleration a μ y hy hdy hy'']
+  rw [exp_decay_smul_velocity a y hy]
+  rw [hγ, hk]
+  simp [smul_add, smul_sub, smul_smul]
+  module
+
+/-!
+
+### B.4. Derivatives of the base trajectories
+
+The remaining private lemmas compute the velocity and acceleration of the trigonometric,
+polynomial, and hyperbolic base trajectories before the exponential decay factor is applied.
+
+-/
+
+private lemma criticallyDampedBase_velocity (IC : InitialConditions) :
+    ∂ₜ (S.criticallyDampedBase IC) =
+      fun _ : Time => IC.v₀ + S.decay_rate • IC.x₀ := by
+  funext t
+  change ∂ₜ (fun t : Time =>
+    IC.x₀ + t.val • (IC.v₀ + S.decay_rate • IC.x₀)) t = _
+  rw [Time.deriv]
+  rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
+  rw [fderiv_fun_const]
+  rw [fderiv_smul_const (by fun_prop)]
+  simp
+
+private lemma criticallyDampedBase_acceleration (IC : InitialConditions) :
+    ∂ₜ (∂ₜ (S.criticallyDampedBase IC)) = fun _ => (0 : TrajectorySpace) := by
+  rw [criticallyDampedBase_velocity]
+  funext t
+  simp
+
+private lemma underdamped_base_velocity (IC : InitialConditions) (hS : S.IsUnderdamped) :
+    ∂ₜ (fun t : Time =>
+      cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+          (IC.v₀ + S.decay_rate • IC.x₀)) =
+    fun t : Time =>
+      (-S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * t.val)) • IC.x₀ +
+        cos (S.underdampedAngularFrequency * t.val) •
+          (IC.v₀ + S.decay_rate • IC.x₀) := by
+  funext t
+  rw [Time.deriv]
+  rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  have hΩ : S.underdampedAngularFrequency ≠ 0 := S.underdampedAngularFrequency_ne_zero hS
+  have hcos :
+      (fderiv ℝ (fun y : Time => cos (S.underdampedAngularFrequency * y.val)) t) 1 =
+        -S.underdampedAngularFrequency *
+          sin (S.underdampedAngularFrequency * t.val) := by
+    rw [fderiv_cos (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [mul_comm]
+  have hsin :
+      (fderiv ℝ (fun y : Time =>
+          sin (S.underdampedAngularFrequency * y.val) /
+            S.underdampedAngularFrequency) t) 1 =
+        cos (S.underdampedAngularFrequency * t.val) := by
+    have hscale :
+        fderiv ℝ (fun y : Time =>
+            sin (S.underdampedAngularFrequency * y.val) /
+              S.underdampedAngularFrequency) t =
+          (1 / S.underdampedAngularFrequency) •
+            fderiv ℝ (fun y : Time =>
+              sin (S.underdampedAngularFrequency * y.val)) t := by
+      rw [← fderiv_mul_const]
+      congr
+      funext y
+      field_simp [hΩ]
+      ring_nf
+      fun_prop
+    rw [hscale, fderiv_sin (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [hΩ, mul_comm]
+  simp [hcos, hsin]
+
+private lemma underdamped_base_acceleration (IC : InitialConditions) (hS : S.IsUnderdamped) :
+    ∂ₜ (∂ₜ (fun t : Time =>
+      cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+          (IC.v₀ + S.decay_rate • IC.x₀))) =
+    fun t : Time => -S.underdampedAngularFrequency^2 •
+      (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+          (IC.v₀ + S.decay_rate • IC.x₀)) := by
+  funext t
+  rw [S.underdamped_base_velocity IC hS]
+  rw [Time.deriv]
+  rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  have hΩ : S.underdampedAngularFrequency ≠ 0 := S.underdampedAngularFrequency_ne_zero hS
+  have hsin :
+      (fderiv ℝ (fun y : Time =>
+        S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * y.val)) t) 1 =
+      S.underdampedAngularFrequency^2 * cos (S.underdampedAngularFrequency * t.val) := by
+    rw [fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    rw [fderiv_sin (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [pow_two, mul_comm, mul_assoc]
+  have hcos :
+      (fderiv ℝ (fun y : Time => cos (S.underdampedAngularFrequency * y.val)) t) 1 =
+      -S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * t.val) := by
+    rw [fderiv_cos (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [mul_comm]
+  simp [hsin, hcos, smul_add, smul_smul]
+  field_simp [hΩ]
+
+private lemma overdamped_base_velocity (IC : InitialConditions) (hS : S.IsOverdamped) :
+    ∂ₜ (fun t : Time =>
+      cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+          (IC.v₀ + S.decay_rate • IC.x₀)) =
+    fun t : Time =>
+      (S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val)) • IC.x₀ +
+        cosh (S.overdampedSplitRate * t.val) •
+          (IC.v₀ + S.decay_rate • IC.x₀) := by
+  funext t
+  rw [Time.deriv]
+  rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  have hLambda : S.overdampedSplitRate ≠ 0 := S.overdampedSplitRate_ne_zero hS
+  have hcosh :
+      (fderiv ℝ (fun y : Time => cosh (S.overdampedSplitRate * y.val)) t) 1 =
+        S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val) := by
+    rw [fderiv_cosh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [mul_comm]
+  have hsinh :
+      (fderiv ℝ (fun y : Time =>
+          sinh (S.overdampedSplitRate * y.val) / S.overdampedSplitRate) t) 1 =
+        cosh (S.overdampedSplitRate * t.val) := by
+    have hscale :
+        fderiv ℝ (fun y : Time =>
+            sinh (S.overdampedSplitRate * y.val) / S.overdampedSplitRate) t =
+          (1 / S.overdampedSplitRate) •
+            fderiv ℝ (fun y : Time => sinh (S.overdampedSplitRate * y.val)) t := by
+      rw [← fderiv_mul_const]
+      congr
+      funext y
+      field_simp [hLambda]
+      ring_nf
+      fun_prop
+    rw [hscale, fderiv_sinh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [hLambda, mul_comm]
+  simp [hcosh, hsinh]
+
+private lemma overdamped_base_acceleration (IC : InitialConditions) (hS : S.IsOverdamped) :
+    ∂ₜ (∂ₜ (fun t : Time =>
+      cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+          (IC.v₀ + S.decay_rate • IC.x₀))) =
+    fun t : Time => S.overdampedSplitRate^2 •
+      (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+          (IC.v₀ + S.decay_rate • IC.x₀)) := by
+  funext t
+  rw [S.overdamped_base_velocity IC hS]
+  rw [Time.deriv]
+  rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  rw [fderiv_smul_const (by fun_prop)]
+  have hLambda : S.overdampedSplitRate ≠ 0 := S.overdampedSplitRate_ne_zero hS
+  have hsinh :
+      (fderiv ℝ (fun y : Time =>
+        S.overdampedSplitRate * sinh (S.overdampedSplitRate * y.val)) t) 1 =
+      S.overdampedSplitRate^2 * cosh (S.overdampedSplitRate * t.val) := by
+    rw [fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    rw [fderiv_sinh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [pow_two, mul_comm, mul_assoc]
+  have hcosh :
+      (fderiv ℝ (fun y : Time => cosh (S.overdampedSplitRate * y.val)) t) 1 =
+      S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val) := by
+    rw [fderiv_cosh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
+    simp [mul_comm]
+  simp [hsinh, hcosh, smul_add, smul_smul]
+  field_simp [hLambda]
+
+/-!
+## C. Trajectories and equation of motion
+
+The regime-specific trajectories satisfy the equation of motion for the damped harmonic
+oscillator.
+
+-/
+
+/-- The critically damped trajectory satisfies the damped equation of motion. -/
+lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
+    (hS : S.IsCriticallyDamped) :
+    S.EquationOfMotion (S.trajectory_criticallydamped IC) := by
+  change S.EquationOfMotion
+    (fun t : Time => exp (-S.decay_rate * t.val) • S.criticallyDampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
+  have hk : S.k = S.m * (S.decay_rate^2 - 0) := by
+    simpa [sub_zero] using S.k_eq_m_mul_decay_rate_sq_of_criticallyDamped hS
+  have hbase :
+      ∂ₜ (∂ₜ (S.criticallyDampedBase IC)) =
+        fun t => (0 : ℝ) • S.criticallyDampedBase IC t := by
+    simpa using S.criticallyDampedBase_acceleration IC
+  exact S.exp_decay_smul_equationOfMotion S.decay_rate 0 (S.criticallyDampedBase IC)
+    (by
+      change Differentiable ℝ (fun t : Time =>
+        IC.x₀ + t.val • (IC.v₀ + S.decay_rate • IC.x₀))
+      fun_prop)
+    (by
+      rw [S.criticallyDampedBase_velocity IC]
+      fun_prop)
+    hbase hγ hk
+
+/-- The underdamped trajectory satisfies the damped equation of motion. -/
+lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
+    (hS : S.IsUnderdamped) :
+    S.EquationOfMotion (S.trajectory_underdamped IC) := by
+  change S.EquationOfMotion
+    (fun t : Time => exp (-S.decay_rate * t.val) • S.underdampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
+  have hk : S.k = S.m * (S.decay_rate^2 - (-S.underdampedAngularFrequency^2)) := by
+    rw [S.k_eq_m_mul_ω_sq, S.underdampedAngularFrequency_sq hS]
+    ring
+  have hbase :
+      ∂ₜ (∂ₜ (S.underdampedBase IC)) =
+        fun t => (-S.underdampedAngularFrequency^2) • S.underdampedBase IC t := by
+    change ∂ₜ (∂ₜ (fun t : Time =>
+        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+            (IC.v₀ + S.decay_rate • IC.x₀))) =
+      fun t => -S.underdampedAngularFrequency^2 •
+        (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+            (IC.v₀ + S.decay_rate • IC.x₀))
+    exact S.underdamped_base_acceleration IC hS
+  exact S.exp_decay_smul_equationOfMotion S.decay_rate
+    (-S.underdampedAngularFrequency^2) (S.underdampedBase IC)
+    (by
+      change Differentiable ℝ (fun t : Time =>
+        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+            (IC.v₀ + S.decay_rate • IC.x₀))
+      fun_prop)
+    (by
+      change Differentiable ℝ (∂ₜ (fun t : Time =>
+        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
+          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+            (IC.v₀ + S.decay_rate • IC.x₀)))
+      rw [S.underdamped_base_velocity IC hS]
+      fun_prop)
+    hbase hγ hk
+
+/-- The overdamped trajectory satisfies the damped equation of motion. -/
+lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
+    (hS : S.IsOverdamped) :
+    S.EquationOfMotion (S.trajectory_overdamped IC) := by
+  change S.EquationOfMotion
+    (fun t : Time => exp (-S.decay_rate * t.val) • S.overdampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
+  have hk : S.k = S.m * (S.decay_rate^2 - S.overdampedSplitRate^2) := by
+    rw [S.k_eq_m_mul_ω_sq, S.overdampedSplitRate_sq hS]
+    ring
+  have hbase :
+      ∂ₜ (∂ₜ (S.overdampedBase IC)) =
+        fun t => S.overdampedSplitRate^2 • S.overdampedBase IC t := by
+    change ∂ₜ (∂ₜ (fun t : Time =>
+        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+            (IC.v₀ + S.decay_rate • IC.x₀))) =
+      fun t => S.overdampedSplitRate^2 •
+        (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+            (IC.v₀ + S.decay_rate • IC.x₀))
+    exact S.overdamped_base_acceleration IC hS
+  exact S.exp_decay_smul_equationOfMotion S.decay_rate (S.overdampedSplitRate^2)
+    (S.overdampedBase IC)
+    (by
+      change Differentiable ℝ (fun t : Time =>
+        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+            (IC.v₀ + S.decay_rate • IC.x₀))
+      fun_prop)
+    (by
+      change Differentiable ℝ (∂ₜ (fun t : Time =>
+        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
+          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+            (IC.v₀ + S.decay_rate • IC.x₀)))
+      rw [S.overdamped_base_velocity IC hS]
+      fun_prop)
+    hbase hγ hk
+
+/-!
+
+### C.1. Uniqueness of the solutions
+
+Future work: prove that, in each damping regime, the corresponding explicit trajectory is
+the unique solution of the damped equation of motion with the given initial conditions.
+
+-/
+
+/- The uniqueness theorem should compare an arbitrary smooth solution with the appropriate
+regime-specific trajectory and use the matching initial position and velocity at time `0`. -/
+
+end DampedHarmonicOscillator
+
+end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -34,9 +34,8 @@ overdamped case.
 - A. The initial conditions
 - B. Trajectories associated with the initial conditions
   - B.1. Explicit regime-specific trajectories
-  - B.2. Parameter identities
-  - B.3. Shared calculus lemmas
-  - B.4. Derivatives of the base trajectories
+  - B.2. Shared calculus lemmas
+  - B.3. Derivatives of the base trajectories
 - C. Trajectories and equation of motion
   - C.1. Uniqueness of the solutions
 
@@ -124,35 +123,7 @@ noncomputable def trajectoryOverdamped
 
 /-!
 
-### B.2. Parameter identities
-
-These identities rewrite `γ` and `k` in the form used by the shared proof for the
-exponentially decaying trajectories.
-
--/
-
-/-- The damping coefficient is twice mass times the decay rate. -/
-lemma gamma_eq_two_mul_m_mul_decayRate : S.γ = 2 * S.m * S.decayRate := by
-  rw [decayRate]
-  field_simp [S.m_ne_zero]
-
-/-- The spring constant is `m * ω^2`. -/
-lemma k_eq_m_mul_ω_sq : S.k = S.m * S.ω^2 := by
-  rw [S.ω_sq]
-  field_simp [S.m_ne_zero]
-
-/-- In the critically damped regime, `k = m * decayRate^2`. -/
-lemma k_eq_m_mul_decayRate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
-    S.k = S.m * S.decayRate^2 := by
-  have hωa : S.ω = S.decayRate := S.isCriticallyDamped_decayRate hS
-  have hωsq : S.decayRate ^ 2 = S.k / S.m := by
-    simpa [hωa] using S.ω_sq
-  field_simp [S.m_ne_zero] at hωsq
-  nlinarith
-
-/-!
-
-### B.3. Shared calculus lemmas
+### B.2. Shared calculus lemmas
 
 The three solution formulas all have the form `exp (-a * t) • y t`. The following private
 lemmas compute the first and second derivatives of that expression and package the common
@@ -214,7 +185,7 @@ private lemma exp_decay_smul_equationOfMotion
 
 /-!
 
-### B.4. Derivatives of the base trajectories
+### B.3. Derivatives of the base trajectories
 
 The remaining private lemmas compute the velocity and acceleration of the trigonometric,
 polynomial, and hyperbolic base trajectories before the exponential decay factor is applied.

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -93,34 +93,34 @@ noncomputable def underdampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   cos (S.underdampedAngularFrequency * t) • IC.x₀
     + (sin (S.underdampedAngularFrequency * t)/S.underdampedAngularFrequency) •
-      (IC.v₀ + S.decay_rate • IC.x₀)
+      (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the underdamped regime. -/
 noncomputable def trajectory_underdamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decay_rate * t) • S.underdampedBase IC t
+  exp (-S.decayRate * t) • S.underdampedBase IC t
 
 /-- The polynomial part of the critically damped trajectory before exponential decay. -/
 noncomputable def criticallyDampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  IC.x₀ + (t : ℝ) • (IC.v₀ + S.decay_rate • IC.x₀)
+  IC.x₀ + (t : ℝ) • (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the critically damped regime. -/
 noncomputable def trajectory_criticallydamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decay_rate * t) • S.criticallyDampedBase IC t
+  exp (-S.decayRate * t) • S.criticallyDampedBase IC t
 
 /-- The hyperbolic part of the overdamped trajectory before exponential decay. -/
 noncomputable def overdampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   cosh (S.overdampedSplitRate * t) • IC.x₀
       + (sinh (S.overdampedSplitRate * t) / S.overdampedSplitRate) •
-        (IC.v₀ + S.decay_rate • IC.x₀)
+        (IC.v₀ + S.decayRate • IC.x₀)
 
 /-- Given initial conditions, the solution in the overdamped regime. -/
 noncomputable def trajectory_overdamped
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decay_rate * t) • S.overdampedBase IC t
+  exp (-S.decayRate * t) • S.overdampedBase IC t
 
 /-!
 
@@ -132,8 +132,8 @@ exponentially decaying trajectories.
 -/
 
 /-- The damping coefficient is twice mass times the decay rate. -/
-lemma gamma_eq_two_mul_m_mul_decay_rate : S.γ = 2 * S.m * S.decay_rate := by
-  rw [decay_rate]
+lemma gamma_eq_two_mul_m_mul_decayRate : S.γ = 2 * S.m * S.decayRate := by
+  rw [decayRate]
   field_simp [S.m_ne_zero]
 
 /-- The spring constant is `m * ω^2`. -/
@@ -141,11 +141,11 @@ lemma k_eq_m_mul_ω_sq : S.k = S.m * S.ω^2 := by
   rw [S.ω_sq]
   field_simp [S.m_ne_zero]
 
-/-- In the critically damped regime, `k = m * decay_rate^2`. -/
-lemma k_eq_m_mul_decay_rate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
-    S.k = S.m * S.decay_rate^2 := by
-  have hωa : S.ω = S.decay_rate := S.isCriticallyDamped_decay_rate hS
-  have hωsq : S.decay_rate ^ 2 = S.k / S.m := by
+/-- In the critically damped regime, `k = m * decayRate^2`. -/
+lemma k_eq_m_mul_decayRate_sq_of_criticallyDamped (hS : S.IsCriticallyDamped) :
+    S.k = S.m * S.decayRate^2 := by
+  have hωa : S.ω = S.decayRate := S.isCriticallyDamped_decayRate hS
+  have hωsq : S.decayRate ^ 2 = S.k / S.m := by
     simpa [hωa] using S.ω_sq
   field_simp [S.m_ne_zero] at hωsq
   nlinarith
@@ -225,10 +225,10 @@ polynomial, and hyperbolic base trajectories before the exponential decay factor
 
 private lemma criticallyDampedBase_velocity (IC : InitialConditions) :
     ∂ₜ (S.criticallyDampedBase IC) =
-      fun _ : Time => IC.v₀ + S.decay_rate • IC.x₀ := by
+      fun _ : Time => IC.v₀ + S.decayRate • IC.x₀ := by
   funext t
   change ∂ₜ (fun t : Time =>
-    IC.x₀ + t.val • (IC.v₀ + S.decay_rate • IC.x₀)) t = _
+    IC.x₀ + t.val • (IC.v₀ + S.decayRate • IC.x₀)) t = _
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_fun_const]
@@ -245,11 +245,11 @@ private lemma underdamped_base_velocity (IC : InitialConditions) (hS : S.IsUnder
     ∂ₜ (fun t : Time =>
       cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-          (IC.v₀ + S.decay_rate • IC.x₀)) =
+          (IC.v₀ + S.decayRate • IC.x₀)) =
     fun t : Time =>
       (-S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * t.val)) • IC.x₀ +
         cos (S.underdampedAngularFrequency * t.val) •
-          (IC.v₀ + S.decay_rate • IC.x₀) := by
+          (IC.v₀ + S.decayRate • IC.x₀) := by
   funext t
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
@@ -288,11 +288,11 @@ private lemma underdamped_base_acceleration (IC : InitialConditions) (hS : S.IsU
     ∂ₜ (∂ₜ (fun t : Time =>
       cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-          (IC.v₀ + S.decay_rate • IC.x₀))) =
+          (IC.v₀ + S.decayRate • IC.x₀))) =
     fun t : Time => -S.underdampedAngularFrequency^2 •
       (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
         (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-          (IC.v₀ + S.decay_rate • IC.x₀)) := by
+          (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
   rw [S.underdamped_base_velocity IC hS]
   rw [Time.deriv]
@@ -319,11 +319,11 @@ private lemma overdamped_base_velocity (IC : InitialConditions) (hS : S.IsOverda
     ∂ₜ (fun t : Time =>
       cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-          (IC.v₀ + S.decay_rate • IC.x₀)) =
+          (IC.v₀ + S.decayRate • IC.x₀)) =
     fun t : Time =>
       (S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val)) • IC.x₀ +
         cosh (S.overdampedSplitRate * t.val) •
-          (IC.v₀ + S.decay_rate • IC.x₀) := by
+          (IC.v₀ + S.decayRate • IC.x₀) := by
   funext t
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
@@ -358,11 +358,11 @@ private lemma overdamped_base_acceleration (IC : InitialConditions) (hS : S.IsOv
     ∂ₜ (∂ₜ (fun t : Time =>
       cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-          (IC.v₀ + S.decay_rate • IC.x₀))) =
+          (IC.v₀ + S.decayRate • IC.x₀))) =
     fun t : Time => S.overdampedSplitRate^2 •
       (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
         (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-          (IC.v₀ + S.decay_rate • IC.x₀)) := by
+          (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
   rw [S.overdamped_base_velocity IC hS]
   rw [Time.deriv]
@@ -398,18 +398,18 @@ lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsCriticallyDamped) :
     S.EquationOfMotion (S.trajectory_criticallydamped IC) := by
   change S.EquationOfMotion
-    (fun t : Time => exp (-S.decay_rate * t.val) • S.criticallyDampedBase IC t)
-  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
-  have hk : S.k = S.m * (S.decay_rate^2 - 0) := by
-    simpa [sub_zero] using S.k_eq_m_mul_decay_rate_sq_of_criticallyDamped hS
+    (fun t : Time => exp (-S.decayRate * t.val) • S.criticallyDampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
+  have hk : S.k = S.m * (S.decayRate^2 - 0) := by
+    simpa [sub_zero] using S.k_eq_m_mul_decayRate_sq_of_criticallyDamped hS
   have hbase :
       ∂ₜ (∂ₜ (S.criticallyDampedBase IC)) =
         fun t => (0 : ℝ) • S.criticallyDampedBase IC t := by
     simpa using S.criticallyDampedBase_acceleration IC
-  exact S.exp_decay_smul_equationOfMotion S.decay_rate 0 (S.criticallyDampedBase IC)
+  exact S.exp_decay_smul_equationOfMotion S.decayRate 0 (S.criticallyDampedBase IC)
     (by
       change Differentiable ℝ (fun t : Time =>
-        IC.x₀ + t.val • (IC.v₀ + S.decay_rate • IC.x₀))
+        IC.x₀ + t.val • (IC.v₀ + S.decayRate • IC.x₀))
       fun_prop)
     (by
       rw [S.criticallyDampedBase_velocity IC]
@@ -421,9 +421,9 @@ lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsUnderdamped) :
     S.EquationOfMotion (S.trajectory_underdamped IC) := by
   change S.EquationOfMotion
-    (fun t : Time => exp (-S.decay_rate * t.val) • S.underdampedBase IC t)
-  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
-  have hk : S.k = S.m * (S.decay_rate^2 - (-S.underdampedAngularFrequency^2)) := by
+    (fun t : Time => exp (-S.decayRate * t.val) • S.underdampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
+  have hk : S.k = S.m * (S.decayRate^2 - (-S.underdampedAngularFrequency^2)) := by
     rw [S.k_eq_m_mul_ω_sq, S.underdampedAngularFrequency_sq hS]
     ring
   have hbase :
@@ -432,25 +432,25 @@ lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
     change ∂ₜ (∂ₜ (fun t : Time =>
         cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-            (IC.v₀ + S.decay_rate • IC.x₀))) =
+            (IC.v₀ + S.decayRate • IC.x₀))) =
       fun t => -S.underdampedAngularFrequency^2 •
         (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-            (IC.v₀ + S.decay_rate • IC.x₀))
+            (IC.v₀ + S.decayRate • IC.x₀))
     exact S.underdamped_base_acceleration IC hS
-  exact S.exp_decay_smul_equationOfMotion S.decay_rate
+  exact S.exp_decay_smul_equationOfMotion S.decayRate
     (-S.underdampedAngularFrequency^2) (S.underdampedBase IC)
     (by
       change Differentiable ℝ (fun t : Time =>
         cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-            (IC.v₀ + S.decay_rate • IC.x₀))
+            (IC.v₀ + S.decayRate • IC.x₀))
       fun_prop)
     (by
       change Differentiable ℝ (∂ₜ (fun t : Time =>
         cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
           (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
-            (IC.v₀ + S.decay_rate • IC.x₀)))
+            (IC.v₀ + S.decayRate • IC.x₀)))
       rw [S.underdamped_base_velocity IC hS]
       fun_prop)
     hbase hγ hk
@@ -460,9 +460,9 @@ lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
     (hS : S.IsOverdamped) :
     S.EquationOfMotion (S.trajectory_overdamped IC) := by
   change S.EquationOfMotion
-    (fun t : Time => exp (-S.decay_rate * t.val) • S.overdampedBase IC t)
-  have hγ : S.γ = 2 * S.m * S.decay_rate := S.gamma_eq_two_mul_m_mul_decay_rate
-  have hk : S.k = S.m * (S.decay_rate^2 - S.overdampedSplitRate^2) := by
+    (fun t : Time => exp (-S.decayRate * t.val) • S.overdampedBase IC t)
+  have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
+  have hk : S.k = S.m * (S.decayRate^2 - S.overdampedSplitRate^2) := by
     rw [S.k_eq_m_mul_ω_sq, S.overdampedSplitRate_sq hS]
     ring
   have hbase :
@@ -471,25 +471,25 @@ lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
     change ∂ₜ (∂ₜ (fun t : Time =>
         cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-            (IC.v₀ + S.decay_rate • IC.x₀))) =
+            (IC.v₀ + S.decayRate • IC.x₀))) =
       fun t => S.overdampedSplitRate^2 •
         (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-            (IC.v₀ + S.decay_rate • IC.x₀))
+            (IC.v₀ + S.decayRate • IC.x₀))
     exact S.overdamped_base_acceleration IC hS
-  exact S.exp_decay_smul_equationOfMotion S.decay_rate (S.overdampedSplitRate^2)
+  exact S.exp_decay_smul_equationOfMotion S.decayRate (S.overdampedSplitRate^2)
     (S.overdampedBase IC)
     (by
       change Differentiable ℝ (fun t : Time =>
         cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-            (IC.v₀ + S.decay_rate • IC.x₀))
+            (IC.v₀ + S.decayRate • IC.x₀))
       fun_prop)
     (by
       change Differentiable ℝ (∂ₜ (fun t : Time =>
         cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
           (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
-            (IC.v₀ + S.decay_rate • IC.x₀)))
+            (IC.v₀ + S.decayRate • IC.x₀)))
       rw [S.overdamped_base_velocity IC hS]
       fun_prop)
     hbase hγ hk

--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -13,31 +13,34 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
 
 ## i. Overview
 
-In this module we define the regime-specific solutions to the damped harmonic oscillator
-and prove that they satisfy the equation of motion. The formulas are split into an
-exponential decay factor and a regime-specific base trajectory: trigonometric for the
-underdamped case, polynomial for the critically damped case, and hyperbolic for the
-overdamped case.
+In this module we define the solution to the damped harmonic oscillator for given initial
+conditions and prove that it satisfies the equation of motion. The solution selects the
+appropriate closed form from the sign of the discriminant: trigonometric for the underdamped
+case, polynomial for the critically damped case, and hyperbolic for the overdamped case.
 
 ## ii. Key results
 
 - `InitialConditions` is a structure for the initial position and velocity.
-- `trajectoryUnderdamped`, `trajectoryCriticallyDamped`, and `trajectoryOverdamped` are the
-  explicit regime-specific trajectories.
-- `trajectory_underdamped_equationOfMotion`,
-  `trajectory_criticallydamped_equationOfMotion`, and
-  `trajectory_overdamped_equationOfMotion` prove that those trajectories satisfy the equation
-  of motion in their corresponding damping regimes.
+- `trajectory` selects the appropriate regime-specific trajectory from the sign of the
+  discriminant.
+- `trajectory_equationOfMotion_of_underdamped`,
+  `trajectory_equationOfMotion_of_criticallyDamped`, and
+  `trajectory_equationOfMotion_of_overdamped` prove the selected trajectory satisfies the
+  equation of motion in each damping regime.
+- `trajectory_equationOfMotion` proves that the selected trajectory satisfies the equation
+  of motion.
 
 ## iii. Table of contents
 
 - A. The initial conditions
 - B. Trajectories associated with the initial conditions
-  - B.1. Explicit regime-specific trajectories
-  - B.2. Shared calculus lemmas
-  - B.3. Derivatives of the base trajectories
+  - B.1. Regime-specific base trajectories
+  - B.2. The selected trajectory
+  - B.3. Shared calculus lemmas
+  - B.4. Derivatives of the base trajectories
 - C. Trajectories and equation of motion
-  - C.1. Uniqueness of the solutions
+  - C.1. The selected trajectory satisfies the equation of motion
+  - C.2. Uniqueness of the solutions
 
 ## iv. References
 
@@ -45,7 +48,12 @@ References for the damped harmonic oscillator include:
 - Landau & Lifshitz, Mechanics, page 76, section 25.
 - Goldstein, Classical Mechanics, Chapter 2.
 
+## v. TODOs
+
 -/
+TODO "Prove that the selected trajectory is the unique solution of the equation of motion with
+the given initial conditions."
+
 
 @[expose] public section
 
@@ -83,47 +91,87 @@ structure InitialConditions where
 For each damping regime, we give an explicit formula for the trajectory with the specified
 initial conditions.
 
-### B.1. Explicit regime-specific trajectories
+### B.1. Regime-specific base trajectories
 
 -/
 
 /-- The oscillatory part of the underdamped trajectory before exponential decay. -/
 noncomputable def underdampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  cos (S.underdampedAngularFrequency * t) • IC.x₀
-    + (sin (S.underdampedAngularFrequency * t)/S.underdampedAngularFrequency) •
+  cos (S.angularFrequency * t) • IC.x₀
+    + (sin (S.angularFrequency * t)/S.angularFrequency) •
       (IC.v₀ + S.decayRate • IC.x₀)
-
-/-- Given initial conditions, the solution in the underdamped regime. -/
-noncomputable def trajectoryUnderdamped
-    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decayRate * t) • S.underdampedBase IC t
 
 /-- The polynomial part of the critically damped trajectory before exponential decay. -/
 noncomputable def criticallyDampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
   IC.x₀ + (t : ℝ) • (IC.v₀ + S.decayRate • IC.x₀)
 
-/-- Given initial conditions, the solution in the critically damped regime. -/
-noncomputable def trajectoryCriticallyDamped
-    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decayRate * t) • S.criticallyDampedBase IC t
-
 /-- The hyperbolic part of the overdamped trajectory before exponential decay. -/
 noncomputable def overdampedBase
     (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  cosh (S.overdampedSplitRate * t) • IC.x₀
-      + (sinh (S.overdampedSplitRate * t) / S.overdampedSplitRate) •
+  cosh (S.angularFrequency * t) • IC.x₀
+      + (sinh (S.angularFrequency * t) / S.angularFrequency) •
         (IC.v₀ + S.decayRate • IC.x₀)
-
-/-- Given initial conditions, the solution in the overdamped regime. -/
-noncomputable def trajectoryOverdamped
-    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
-  exp (-S.decayRate * t) • S.overdampedBase IC t
 
 /-!
 
-### B.2. Shared calculus lemmas
+### B.2. The selected trajectory
+
+-/
+
+/-- Given initial conditions, the solution selected from the damping regime of the
+oscillator. -/
+noncomputable def trajectory
+    (IC : InitialConditions) : Time → EuclideanSpace ℝ (Fin 1) := by
+  classical
+  exact
+    if S.IsUnderdamped then
+      fun t : Time => exp (-S.decayRate * t) • S.underdampedBase IC t
+    else if S.IsCriticallyDamped then
+      fun t : Time => exp (-S.decayRate * t) • S.criticallyDampedBase IC t
+    else
+      fun t : Time => exp (-S.decayRate * t) • S.overdampedBase IC t
+
+/-- In the underdamped regime, the selected trajectory uses the trigonometric base. -/
+lemma trajectory_eq_underdamped (IC : InitialConditions) (hS : S.IsUnderdamped) :
+    S.trajectory IC =
+      fun t : Time => exp (-S.decayRate * t) • S.underdampedBase IC t := by
+  classical
+  simp [trajectory, hS]
+
+/-- In the critically damped regime, the selected trajectory uses the polynomial base. -/
+lemma trajectory_eq_criticallyDamped (IC : InitialConditions) (hS : S.IsCriticallyDamped) :
+    S.trajectory IC =
+      fun t : Time => exp (-S.decayRate * t) • S.criticallyDampedBase IC t := by
+  classical
+  have hnotUnder : ¬ S.IsUnderdamped := by
+    intro hUnder
+    rw [IsUnderdamped] at hUnder
+    rw [IsCriticallyDamped] at hS
+    linarith
+  simp [trajectory, hnotUnder, hS]
+
+/-- In the overdamped regime, the selected trajectory uses the hyperbolic base. -/
+lemma trajectory_eq_overdamped (IC : InitialConditions) (hS : S.IsOverdamped) :
+    S.trajectory IC =
+      fun t : Time => exp (-S.decayRate * t) • S.overdampedBase IC t := by
+  classical
+  have hnotUnder : ¬ S.IsUnderdamped := by
+    intro hUnder
+    rw [IsUnderdamped] at hUnder
+    rw [IsOverdamped] at hS
+    linarith
+  have hnotCritical : ¬ S.IsCriticallyDamped := by
+    intro hCritical
+    rw [IsCriticallyDamped] at hCritical
+    rw [IsOverdamped] at hS
+    linarith
+  simp [trajectory, hnotUnder, hnotCritical]
+
+/-!
+
+### B.3. Shared calculus lemmas
 
 The three solution formulas all have the form `exp (-a * t) • y t`. The following private
 lemmas compute the first and second derivatives of that expression and package the common
@@ -185,7 +233,7 @@ private lemma exp_decay_smul_equationOfMotion
 
 /-!
 
-### B.3. Derivatives of the base trajectories
+### B.4. Derivatives of the base trajectories
 
 The remaining private lemmas compute the velocity and acceleration of the trigonometric,
 polynomial, and hyperbolic base trajectories before the exponential decay factor is applied.
@@ -213,37 +261,37 @@ private lemma criticallyDampedBase_acceleration (IC : InitialConditions) :
 
 private lemma underdampedBase_velocity (IC : InitialConditions) (hS : S.IsUnderdamped) :
     ∂ₜ (fun t : Time =>
-      cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+      cos (S.angularFrequency * t.val) • IC.x₀ +
+        (sin (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀)) =
     fun t : Time =>
-      (-S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * t.val)) • IC.x₀ +
-        cos (S.underdampedAngularFrequency * t.val) •
+      (-S.angularFrequency * sin (S.angularFrequency * t.val)) • IC.x₀ +
+        cos (S.angularFrequency * t.val) •
           (IC.v₀ + S.decayRate • IC.x₀) := by
   funext t
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
-  have hΩ : S.underdampedAngularFrequency ≠ 0 := S.underdampedAngularFrequency_ne_zero hS
+  have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_underdamped hS
   have hcos :
-      (fderiv ℝ (fun y : Time => cos (S.underdampedAngularFrequency * y.val)) t) 1 =
-        -S.underdampedAngularFrequency *
-          sin (S.underdampedAngularFrequency * t.val) := by
+      (fderiv ℝ (fun y : Time => cos (S.angularFrequency * y.val)) t) 1 =
+        -S.angularFrequency *
+          sin (S.angularFrequency * t.val) := by
     rw [fderiv_cos (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [mul_comm]
   have hsin :
       (fderiv ℝ (fun y : Time =>
-          sin (S.underdampedAngularFrequency * y.val) /
-            S.underdampedAngularFrequency) t) 1 =
-        cos (S.underdampedAngularFrequency * t.val) := by
+          sin (S.angularFrequency * y.val) /
+            S.angularFrequency) t) 1 =
+        cos (S.angularFrequency * t.val) := by
     have hscale :
         fderiv ℝ (fun y : Time =>
-            sin (S.underdampedAngularFrequency * y.val) /
-              S.underdampedAngularFrequency) t =
-          (1 / S.underdampedAngularFrequency) •
+            sin (S.angularFrequency * y.val) /
+              S.angularFrequency) t =
+          (1 / S.angularFrequency) •
             fderiv ℝ (fun y : Time =>
-              sin (S.underdampedAngularFrequency * y.val)) t := by
+              sin (S.angularFrequency * y.val)) t := by
       rw [← fderiv_mul_const]
       congr
       funext y
@@ -256,12 +304,12 @@ private lemma underdampedBase_velocity (IC : InitialConditions) (hS : S.IsUnderd
 
 private lemma underdampedBase_acceleration (IC : InitialConditions) (hS : S.IsUnderdamped) :
     ∂ₜ (∂ₜ (fun t : Time =>
-      cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+      cos (S.angularFrequency * t.val) • IC.x₀ +
+        (sin (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀))) =
-    fun t : Time => -S.underdampedAngularFrequency^2 •
-      (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-        (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+    fun t : Time => -S.angularFrequency^2 •
+      (cos (S.angularFrequency * t.val) • IC.x₀ +
+        (sin (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
   rw [S.underdampedBase_velocity IC hS]
@@ -269,17 +317,17 @@ private lemma underdampedBase_acceleration (IC : InitialConditions) (hS : S.IsUn
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
-  have hΩ : S.underdampedAngularFrequency ≠ 0 := S.underdampedAngularFrequency_ne_zero hS
+  have hΩ : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_underdamped hS
   have hsin :
       (fderiv ℝ (fun y : Time =>
-        S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * y.val)) t) 1 =
-      S.underdampedAngularFrequency^2 * cos (S.underdampedAngularFrequency * t.val) := by
+        S.angularFrequency * sin (S.angularFrequency * y.val)) t) 1 =
+      S.angularFrequency^2 * cos (S.angularFrequency * t.val) := by
     rw [fderiv_fun_mul (by fun_prop) (by fun_prop)]
     rw [fderiv_sin (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [pow_two, mul_comm, mul_assoc]
   have hcos :
-      (fderiv ℝ (fun y : Time => cos (S.underdampedAngularFrequency * y.val)) t) 1 =
-      -S.underdampedAngularFrequency * sin (S.underdampedAngularFrequency * t.val) := by
+      (fderiv ℝ (fun y : Time => cos (S.angularFrequency * y.val)) t) 1 =
+      -S.angularFrequency * sin (S.angularFrequency * t.val) := by
     rw [fderiv_cos (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [mul_comm]
   simp [hsin, hcos, smul_add, smul_smul]
@@ -287,33 +335,33 @@ private lemma underdampedBase_acceleration (IC : InitialConditions) (hS : S.IsUn
 
 private lemma overdampedBase_velocity (IC : InitialConditions) (hS : S.IsOverdamped) :
     ∂ₜ (fun t : Time =>
-      cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+      cosh (S.angularFrequency * t.val) • IC.x₀ +
+        (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀)) =
     fun t : Time =>
-      (S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val)) • IC.x₀ +
-        cosh (S.overdampedSplitRate * t.val) •
+      (S.angularFrequency * sinh (S.angularFrequency * t.val)) • IC.x₀ +
+        cosh (S.angularFrequency * t.val) •
           (IC.v₀ + S.decayRate • IC.x₀) := by
   funext t
   rw [Time.deriv]
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
-  have hLambda : S.overdampedSplitRate ≠ 0 := S.overdampedSplitRate_ne_zero hS
+  have hLambda : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_overdamped hS
   have hcosh :
-      (fderiv ℝ (fun y : Time => cosh (S.overdampedSplitRate * y.val)) t) 1 =
-        S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val) := by
+      (fderiv ℝ (fun y : Time => cosh (S.angularFrequency * y.val)) t) 1 =
+        S.angularFrequency * sinh (S.angularFrequency * t.val) := by
     rw [fderiv_cosh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [mul_comm]
   have hsinh :
       (fderiv ℝ (fun y : Time =>
-          sinh (S.overdampedSplitRate * y.val) / S.overdampedSplitRate) t) 1 =
-        cosh (S.overdampedSplitRate * t.val) := by
+          sinh (S.angularFrequency * y.val) / S.angularFrequency) t) 1 =
+        cosh (S.angularFrequency * t.val) := by
     have hscale :
         fderiv ℝ (fun y : Time =>
-            sinh (S.overdampedSplitRate * y.val) / S.overdampedSplitRate) t =
-          (1 / S.overdampedSplitRate) •
-            fderiv ℝ (fun y : Time => sinh (S.overdampedSplitRate * y.val)) t := by
+            sinh (S.angularFrequency * y.val) / S.angularFrequency) t =
+          (1 / S.angularFrequency) •
+            fderiv ℝ (fun y : Time => sinh (S.angularFrequency * y.val)) t := by
       rw [← fderiv_mul_const]
       congr
       funext y
@@ -326,12 +374,12 @@ private lemma overdampedBase_velocity (IC : InitialConditions) (hS : S.IsOverdam
 
 private lemma overdampedBase_acceleration (IC : InitialConditions) (hS : S.IsOverdamped) :
     ∂ₜ (∂ₜ (fun t : Time =>
-      cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+      cosh (S.angularFrequency * t.val) • IC.x₀ +
+        (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀))) =
-    fun t : Time => S.overdampedSplitRate^2 •
-      (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-        (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+    fun t : Time => S.angularFrequency^2 •
+      (cosh (S.angularFrequency * t.val) • IC.x₀ +
+        (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
           (IC.v₀ + S.decayRate • IC.x₀)) := by
   funext t
   rw [S.overdampedBase_velocity IC hS]
@@ -339,17 +387,17 @@ private lemma overdampedBase_acceleration (IC : InitialConditions) (hS : S.IsOve
   rw [fderiv_fun_add (by fun_prop) (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
   rw [fderiv_smul_const (by fun_prop)]
-  have hLambda : S.overdampedSplitRate ≠ 0 := S.overdampedSplitRate_ne_zero hS
+  have hLambda : S.angularFrequency ≠ 0 := S.angularFrequency_ne_zero_of_overdamped hS
   have hsinh :
       (fderiv ℝ (fun y : Time =>
-        S.overdampedSplitRate * sinh (S.overdampedSplitRate * y.val)) t) 1 =
-      S.overdampedSplitRate^2 * cosh (S.overdampedSplitRate * t.val) := by
+        S.angularFrequency * sinh (S.angularFrequency * y.val)) t) 1 =
+      S.angularFrequency^2 * cosh (S.angularFrequency * t.val) := by
     rw [fderiv_fun_mul (by fun_prop) (by fun_prop)]
     rw [fderiv_sinh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [pow_two, mul_comm, mul_assoc]
   have hcosh :
-      (fderiv ℝ (fun y : Time => cosh (S.overdampedSplitRate * y.val)) t) 1 =
-      S.overdampedSplitRate * sinh (S.overdampedSplitRate * t.val) := by
+      (fderiv ℝ (fun y : Time => cosh (S.angularFrequency * y.val)) t) 1 =
+      S.angularFrequency * sinh (S.angularFrequency * t.val) := by
     rw [fderiv_cosh (by fun_prop), fderiv_fun_mul (by fun_prop) (by fun_prop)]
     simp [mul_comm]
   simp [hsinh, hcosh, smul_add, smul_smul]
@@ -361,14 +409,15 @@ private lemma overdampedBase_acceleration (IC : InitialConditions) (hS : S.IsOve
 The regime-specific trajectories satisfy the equation of motion for the damped harmonic
 oscillator.
 
+### C.1. The selected trajectory satisfies the equation of motion
 -/
 
-/-- The critically damped trajectory satisfies the damped equation of motion. -/
-lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
+/-- In the critically damped regime, the selected trajectory satisfies the damped equation
+of motion. -/
+lemma trajectory_equationOfMotion_of_criticallyDamped (IC : InitialConditions)
     (hS : S.IsCriticallyDamped) :
-    S.EquationOfMotion (S.trajectoryCriticallyDamped IC) := by
-  change S.EquationOfMotion
-    (fun t : Time => exp (-S.decayRate * t.val) • S.criticallyDampedBase IC t)
+    S.EquationOfMotion (S.trajectory IC) := by
+  rw [S.trajectory_eq_criticallyDamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
   have hk : S.k = S.m * (S.decayRate^2 - 0) := by
     simpa [sub_zero] using S.k_eq_m_mul_decayRate_sq_of_criticallyDamped hS
@@ -386,95 +435,107 @@ lemma trajectory_criticallydamped_equationOfMotion (IC : InitialConditions)
       fun_prop)
     hbase hγ hk
 
-/-- The underdamped trajectory satisfies the damped equation of motion. -/
-lemma trajectory_underdamped_equationOfMotion (IC : InitialConditions)
+/-- In the underdamped regime, the selected trajectory satisfies the damped equation of
+motion. -/
+lemma trajectory_equationOfMotion_of_underdamped (IC : InitialConditions)
     (hS : S.IsUnderdamped) :
-    S.EquationOfMotion (S.trajectoryUnderdamped IC) := by
-  change S.EquationOfMotion
-    (fun t : Time => exp (-S.decayRate * t.val) • S.underdampedBase IC t)
+    S.EquationOfMotion (S.trajectory IC) := by
+  rw [S.trajectory_eq_underdamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
-  have hk : S.k = S.m * (S.decayRate^2 - (-S.underdampedAngularFrequency^2)) := by
-    rw [S.k_eq_m_mul_ω_sq, S.underdampedAngularFrequency_sq hS]
+  have hk : S.k = S.m * (S.decayRate^2 - (-S.angularFrequency^2)) := by
+    rw [S.k_eq_m_mul_ω_sq, S.angularFrequency_sq_of_underdamped hS]
     ring
   have hbase :
       ∂ₜ (∂ₜ (S.underdampedBase IC)) =
-        fun t => (-S.underdampedAngularFrequency^2) • S.underdampedBase IC t := by
+        fun t => (-S.angularFrequency^2) • S.underdampedBase IC t := by
     change ∂ₜ (∂ₜ (fun t : Time =>
-        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+        cos (S.angularFrequency * t.val) • IC.x₀ +
+          (sin (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))) =
-      fun t => -S.underdampedAngularFrequency^2 •
-        (cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+      fun t => -S.angularFrequency^2 •
+        (cos (S.angularFrequency * t.val) • IC.x₀ +
+          (sin (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))
     exact S.underdampedBase_acceleration IC hS
   exact S.exp_decay_smul_equationOfMotion S.decayRate
-    (-S.underdampedAngularFrequency^2) (S.underdampedBase IC)
+    (-S.angularFrequency^2) (S.underdampedBase IC)
     (by
       change Differentiable ℝ (fun t : Time =>
-        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+        cos (S.angularFrequency * t.val) • IC.x₀ +
+          (sin (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))
       fun_prop)
     (by
       change Differentiable ℝ (∂ₜ (fun t : Time =>
-        cos (S.underdampedAngularFrequency * t.val) • IC.x₀ +
-          (sin (S.underdampedAngularFrequency * t.val) / S.underdampedAngularFrequency) •
+        cos (S.angularFrequency * t.val) • IC.x₀ +
+          (sin (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀)))
       rw [S.underdampedBase_velocity IC hS]
       fun_prop)
     hbase hγ hk
 
-/-- The overdamped trajectory satisfies the damped equation of motion. -/
-lemma trajectory_overdamped_equationOfMotion (IC : InitialConditions)
+/-- In the overdamped regime, the selected trajectory satisfies the damped equation of
+motion. -/
+lemma trajectory_equationOfMotion_of_overdamped (IC : InitialConditions)
     (hS : S.IsOverdamped) :
-    S.EquationOfMotion (S.trajectoryOverdamped IC) := by
-  change S.EquationOfMotion
-    (fun t : Time => exp (-S.decayRate * t.val) • S.overdampedBase IC t)
+    S.EquationOfMotion (S.trajectory IC) := by
+  rw [S.trajectory_eq_overdamped IC hS]
   have hγ : S.γ = 2 * S.m * S.decayRate := S.gamma_eq_two_mul_m_mul_decayRate
-  have hk : S.k = S.m * (S.decayRate^2 - S.overdampedSplitRate^2) := by
-    rw [S.k_eq_m_mul_ω_sq, S.overdampedSplitRate_sq hS]
+  have hk : S.k = S.m * (S.decayRate^2 - S.angularFrequency^2) := by
+    rw [S.k_eq_m_mul_ω_sq, S.angularFrequency_sq_of_overdamped hS]
     ring
   have hbase :
       ∂ₜ (∂ₜ (S.overdampedBase IC)) =
-        fun t => S.overdampedSplitRate^2 • S.overdampedBase IC t := by
+        fun t => S.angularFrequency^2 • S.overdampedBase IC t := by
     change ∂ₜ (∂ₜ (fun t : Time =>
-        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+        cosh (S.angularFrequency * t.val) • IC.x₀ +
+          (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))) =
-      fun t => S.overdampedSplitRate^2 •
-        (cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+      fun t => S.angularFrequency^2 •
+        (cosh (S.angularFrequency * t.val) • IC.x₀ +
+          (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))
     exact S.overdampedBase_acceleration IC hS
-  exact S.exp_decay_smul_equationOfMotion S.decayRate (S.overdampedSplitRate^2)
+  exact S.exp_decay_smul_equationOfMotion S.decayRate (S.angularFrequency^2)
     (S.overdampedBase IC)
     (by
       change Differentiable ℝ (fun t : Time =>
-        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+        cosh (S.angularFrequency * t.val) • IC.x₀ +
+          (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀))
       fun_prop)
     (by
       change Differentiable ℝ (∂ₜ (fun t : Time =>
-        cosh (S.overdampedSplitRate * t.val) • IC.x₀ +
-          (sinh (S.overdampedSplitRate * t.val) / S.overdampedSplitRate) •
+        cosh (S.angularFrequency * t.val) • IC.x₀ +
+          (sinh (S.angularFrequency * t.val) / S.angularFrequency) •
             (IC.v₀ + S.decayRate • IC.x₀)))
       rw [S.overdampedBase_velocity IC hS]
       fun_prop)
     hbase hγ hk
 
+/-- The selected trajectory satisfies the damped equation of motion. -/
+lemma trajectory_equationOfMotion (IC : InitialConditions) :
+    S.EquationOfMotion (S.trajectory IC) := by
+  by_cases hUnder : S.IsUnderdamped
+  · exact S.trajectory_equationOfMotion_of_underdamped IC hUnder
+  · by_cases hCritical : S.IsCriticallyDamped
+    · exact S.trajectory_equationOfMotion_of_criticallyDamped IC hCritical
+    · have hOver : S.IsOverdamped := by
+        rw [IsOverdamped, IsUnderdamped, IsCriticallyDamped] at *
+        by_contra hNotOver
+        have hNonneg : 0 ≤ S.discriminant := le_of_not_gt hUnder
+        have hNonpos : S.discriminant ≤ 0 := le_of_not_gt hNotOver
+        exact hCritical (le_antisymm hNonpos hNonneg)
+      exact S.trajectory_equationOfMotion_of_overdamped IC hOver
+
 /-!
 
-### C.1. Uniqueness of the solutions
+### C.2. Uniqueness of the solutions
 
-Future work: prove that, in each damping regime, the corresponding explicit trajectory is
-the unique solution of the damped equation of motion with the given initial conditions.
+Future work: prove that, in each damping regime, the selected explicit branch is the unique
+solution of the damped equation of motion with the given initial conditions.
 
 -/
-
-/- The uniqueness theorem should compare an arbitrary smooth solution with the appropriate
-regime-specific trajectory and use the matching initial position and velocity at time `0`. -/
 
 end DampedHarmonicOscillator
 


### PR DESCRIPTION
I guys. I am currently learning Lean and wanted to practice working with an actual Lean repository. Feel free to call out any issues or just reject the PR.

## Summary

Adds a fuller formalization of the classical damped harmonic oscillator mirroring the organization of the undamped oscillator.

This PR:
- refactors `structure DampedHarmonicOscillator extends HarmonicOscillator`
- defines the damped equation of motion, force, energy dissipation rate, and Newton's-law equivalence
- adds damping regime definitions and lemmas for underdamped, critically damped, overdamped, and undamped cases
- adds explicit regime-specific trajectories and proves that they satisfy the equation of motion
- imports the new solution module through `Physlib.lean`

## Details

- I used `structure DampedHarmonicOscillator extends HarmonicOscillator` to make conversion between both easier.
- I refactored the `DampedHarmonicOscillator` to use the same `xₜ : Time → EuclideanSpace ℝ (Fin 1)` vector space as the `HarmonicOscillator`. This way, the code looks more similar and some lemmas can be shared.

The new `Solution` module separates each trajectory into an exponential decay factor and a regime-specific base trajectory:
- trigonometric base for the underdamped case
- polynomial base for the critically damped case
- hyperbolic base for the overdamped case
- It also includes shared derivative lemmas for exponentially decaying trajectories to avoid duplicating the equation-of-motion
proof.