### PR TITLE
feat(QM): `mulOperator` adjoint

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -174,18 +174,15 @@ private lemma exists_monotone_sets_hasFiniteIntegral
     ∃ s : ℕ → Set (Space d), Monotone s ∧ ⋃ n, s n = Set.univ ∧ (∀ n, MeasurableSet (s n))
       ∧ ∀ k, k = 1 ∨ k = 2 →
         ∀ n, HasFiniteIntegral (fun x ↦ ‖f x ^ k * g x‖ ^ 2) (volume.restrict (s n)) := by
-  have hfg : AEStronglyMeasurable (fun x ↦ f x * g x) := by measurability
-  have hffg : AEStronglyMeasurable (fun x ↦ f x ^ 2 * g x) := by measurability
-  obtain ⟨w₁, hw₁, hw₁'⟩ := hfg
-  obtain ⟨w₂, hw₂, hw₂'⟩ := hffg
+  obtain ⟨w₁, hw₁, hw₁'⟩ : AEStronglyMeasurable (fun x ↦ f x * g x) := by measurability
+  obtain ⟨w₂, hw₂, hw₂'⟩ : AEStronglyMeasurable (fun x ↦ f x ^ 2 * g x) := by measurability
   let s : ℕ → Set (Space d) :=
     fun n ↦ Metric.closedBall 0 n ∩ (w₁ ⁻¹' Metric.closedBall 0 n ∩ w₂ ⁻¹' Metric.closedBall 0 n)
   refine ⟨s, ?_, ?_, by measurability, ?_⟩
-  · intro _ _ hmn _ hx
-    refine ⟨?_, ?_, ?_⟩
-    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.1
-    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.1
-    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.2
+  · exact fun _ _ hmn _ hx ↦
+      ⟨ Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.1,
+        Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.1,
+        Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.2⟩
   · ext x
     simp only [Set.mem_iUnion, Set.mem_univ, iff_true]
     use max ⌈‖x‖⌉.toNat (max ⌈‖w₁ x‖⌉.toNat ⌈‖w₂ x‖⌉.toNat)
@@ -227,12 +224,13 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
     intro n
     apply memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
     refine lt_of_eq_of_lt ?_ (hs_int 2 (Or.inr rfl) n)
-    trans ∫⁻ x, ‖‖(f • w n) x‖ ^ 2‖ₑ
-    · refine lintegral_congr_ae ?_
-      filter_upwards [coe_mk_ae (hw n)] with _ h
-      simp [φ, h]
-    trans ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ
-    · exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
+    calc
+      _ = ∫⁻ x, ‖‖(f • w n) x‖ ^ 2‖ₑ := by
+        refine lintegral_congr_ae ?_
+        filter_upwards [coe_mk_ae (hw n)] with _ h
+        simp [φ, h]
+      _ = ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ := by
+        exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
     exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, ← mul_assoc, ← pow_two]
   suffices ∀ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ≤ ∫⁻ x, ‖‖ξ x‖ ^ 2‖ₑ by
     apply mem_mulOperator_domain_iff.mpr

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -208,6 +208,86 @@ private lemma exists_monotone_sets_hasFiniteIntegral
     · refine ENNReal.mul_lt_top (by norm_num) ?_
       exact measure_inter_lt_top_of_left_ne_top measure_closedBall_lt_top.ne
 
+open Complex InnerProductSpace in
+lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
+    (𝓜 f)†.domain ≤ (𝓜 (conj ∘ f)).domain := by
+  intro ψ hψ
+  let ξ : SpaceDHilbertSpace d := (𝓜 f)† ⟨ψ, hψ⟩
+  obtain ⟨s, hs_mono, hs_univ, hs_meas, hs_int⟩ :=
+    exists_monotone_sets_hasFiniteIntegral (conj ∘ f) ψ (by fun_prop) ψ.val.aestronglyMeasurable
+  let w : ℕ → Space d → ℂ := fun n ↦ (s n).indicator ((conj ∘ f) • ψ)
+  have hw : ∀ n, MemHS (w n) := by
+    intro n
+    apply memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
+    refine lt_of_eq_of_lt ?_ (hs_int 1 (Or.inl rfl) n)
+    trans ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ
+    · exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
+    exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, mul_pow]
+  let φ : ℕ → SpaceDHilbertSpace d := fun n ↦ mk (hw n)
+  have hφ : ∀ n, φ n ∈ (𝓜 f).domain := by
+    intro n
+    apply memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
+    refine lt_of_eq_of_lt ?_ (hs_int 2 (Or.inr rfl) n)
+    trans ∫⁻ x, ‖‖(f • w n) x‖ ^ 2‖ₑ
+    · refine lintegral_congr_ae ?_
+      filter_upwards [coe_mk_ae (hw n)] with _ h
+      simp [φ, h]
+    trans ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ
+    · exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
+    exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, ← mul_assoc, ← pow_two]
+  suffices ∀ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ≤ ∫⁻ x, ‖‖ξ x‖ ^ 2‖ₑ by
+    apply mem_mulOperator_domain_iff.mpr
+    refine memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
+    refine lt_of_le_of_lt ?_ (memHS_iff.mp <| coe_hilbertSpace_memHS ξ).2.2
+    trans ⨆ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ
+    · rw [← setLIntegral_univ, ← hs_univ]
+      rw [setLIntegral_iUnion_of_directed _ (directed_of_isDirected_le hs_mono)]
+      simp [mul_pow]
+    exact iSup_le this
+  intro n
+  suffices ‖φ n‖ ^ 2 ≤ ‖ξ‖ ^ 2 by
+    refine le_of_eq_of_le (b := ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ) ?_ <| (ENNReal.toReal_le_toReal ?_ ?_).mp ?_
+    · calc
+        _ = ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ :=
+          setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, mul_pow]
+        _ = ∫⁻ x, ‖‖w n x‖ ^ 2‖ₑ :=
+          setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]
+        _ = ∫⁻ x, ‖‖φ n x‖ ^ 2‖ₑ := by
+          refine lintegral_congr_ae ?_
+          filter_upwards [coe_mk_ae (hw n)] with x h₁
+          simp [φ, h₁]
+    · exact (memHS_iff.mp <| coe_hilbertSpace_memHS (φ n)).2.2.ne
+    · exact (memHS_iff.mp <| coe_hilbertSpace_memHS ξ).2.2.ne
+    · suffices h : ∀ ψ : SpaceDHilbertSpace d, ‖ψ‖ ^ 2 = (∫⁻ x, ‖‖ψ x‖ ^ 2‖ₑ).toReal by
+        simp only [← h, this]
+      intro ψ
+      rw [Lp.norm_def, eLpNorm_eq_lintegral_rpow_enorm_toReal two_ne_zero ENNReal.ofNat_ne_top]
+      simp [← ENNReal.toReal_pow, ← ENNReal.rpow_mul_natCast]
+  suffices (‖φ n‖ ^ 2) ^ 2 ≤ (‖ξ‖ * ‖φ n‖) ^ 2 by
+    by_cases! h : ‖φ n‖ = 0
+    · rw [h, zero_pow two_ne_zero]
+      exact pow_two_nonneg _
+    · rw [pow_two, mul_pow] at this
+      refine (mul_le_mul_iff_left₀ <| sq_pos_iff.mpr h).mp this
+  calc
+    _ = ‖⟪φ n, φ n⟫_ℂ‖ ^ 2 := by simp
+    _ = ‖⟪ψ, 𝓜 f ⟨φ n, hφ n⟩⟫_ℂ‖ ^ 2 := by
+      refine congrArg (fun r ↦ ‖r‖ ^ 2) ?_
+      refine integral_congr_ae ?_
+      filter_upwards [coe_mk_ae (hw n), mulOperator_apply_ae ⟨φ n, hφ n⟩] with x h₁ h₂
+      by_cases hx : x ∈ s n
+      · simp only [φ, h₁, h₂, inner_self_eq_norm_sq_to_K, coe_algebraMap, RCLike.inner_apply,
+          Pi.smul_apply', smul_eq_mul]
+        calc
+          _ = ofReal (‖f x‖ ^ 2 * ‖ψ x‖ ^ 2) := by simp [w, hx, mul_pow]
+          _ = (f x * conj (f x)) * (ψ x * conj (ψ x)) := by
+            simp_rw [← normSq_eq_norm_sq, Complex.ofReal_mul, normSq_eq_conj_mul_self, mul_comm]
+          _ = f x * w n x * conj (ψ x) := by simp [w, hx, mul_assoc]
+      · simp [φ, h₁, h₂, w, hx]
+    _ = ‖⟪ξ, φ n⟫_ℂ‖ ^ 2 := by
+      rw [(adjoint_isFormalAdjoint (mulOperator_hasDenseDomain hf) ⟨ψ, hψ⟩ ⟨φ n, hφ n⟩).symm]
+    _ ≤ (‖ξ‖ * ‖φ n‖) ^ 2 := pow_le_pow_left₀ (norm_nonneg _) (norm_inner_le_norm ξ (φ n)) 2
+
 lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
     (𝓜 f)† = 𝓜 (conj ∘ f) := by
   refine eq_of_eq_graph ?_

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -214,7 +214,7 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
   let w : ℕ → Space d → ℂ := fun n ↦ (s n).indicator ((conj ∘ f) • ψ)
   have hw : ∀ n, MemHS (w n) := by
     intro n
-    apply memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
+    refine memHS_iff.mpr ⟨by measurability, by measurability, ?_⟩
     refine lt_of_eq_of_lt ?_ (hs_int 1 (Or.inl rfl) n)
     trans ∫⁻ x in s n, ‖‖w n x‖ ^ 2‖ₑ
     · exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
@@ -229,8 +229,8 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
         refine lintegral_congr_ae ?_
         filter_upwards [coe_mk_ae (hw n)] with _ h
         simp [φ, h]
-      _ = ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ := by
-        exact (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
+      _ = ∫⁻ x in s n, ‖‖(f • w n) x‖ ^ 2‖ₑ :=
+        (setLIntegral_eq_of_support_subset fun x hx ↦ by simp_all [w]).symm
     exact setLIntegral_congr_fun (hs_meas n) fun x hx ↦ by simp [w, hx, ← mul_assoc, ← pow_two]
   suffices ∀ n, ∫⁻ x in s n, ‖‖f x‖ ^ 2 * ‖ψ x‖ ^ 2‖ₑ ≤ ∫⁻ x, ‖‖ξ x‖ ^ 2‖ₑ by
     apply mem_mulOperator_domain_iff.mpr

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -170,7 +170,44 @@ lemma mulOperator_conj_domain {f : Space d → ℂ} (hf : AEStronglyMeasurable f
   simp only [mulOperator, smul_eq_mul, memHS_iff]
   exact and_congr (iff_of_true (by fun_prop) (by fun_prop)) (by simp)
 
-@[sorryful]
+private lemma exists_monotone_sets_hasFiniteIntegral
+    (f g : Space d → ℂ) (hf : AEStronglyMeasurable f) (hg : AEStronglyMeasurable g) :
+    ∃ s : ℕ → Set (Space d), Monotone s ∧ ⋃ n, s n = Set.univ ∧ (∀ n, MeasurableSet (s n))
+      ∧ ∀ k, k = 1 ∨ k = 2 →
+        ∀ n, HasFiniteIntegral (fun x ↦ ‖f x ^ k * g x‖ ^ 2) (volume.restrict (s n)) := by
+  have hfg : AEStronglyMeasurable (fun x ↦ f x * g x) := by measurability
+  have hffg : AEStronglyMeasurable (fun x ↦ f x ^ 2 * g x) := by measurability
+  obtain ⟨w₁, hw₁, hw₁'⟩ := hfg
+  obtain ⟨w₂, hw₂, hw₂'⟩ := hffg
+  let s : ℕ → Set (Space d) :=
+    fun n ↦ Metric.closedBall 0 n ∩ (w₁ ⁻¹' Metric.closedBall 0 n ∩ w₂ ⁻¹' Metric.closedBall 0 n)
+  refine ⟨s, ?_, ?_, by measurability, ?_⟩
+  · intro _ _ hmn _ hx
+    refine ⟨?_, ?_, ?_⟩
+    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.1
+    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.1
+    · exact Metric.closedBall_subset_closedBall (Nat.cast_le.mpr hmn) hx.2.2
+  · ext x
+    simp only [Set.mem_iUnion, Set.mem_univ, iff_true]
+    use max ⌈‖x‖⌉.toNat (max ⌈‖w₁ x‖⌉.toNat ⌈‖w₂ x‖⌉.toNat)
+    suffices ∀ r : ℝ, 0 ≤ r → r ≤ ⌈r⌉.toNat by simp [s, this]
+    intro r hr
+    calc
+      r ≤ ⌈r⌉ := Int.le_ceil r
+      _ = (⌈r⌉.toNat : ℤ) := by simp [Int.ceil_nonneg hr]
+      _ = ⌈r⌉.toNat := AddGroupWithOne.intCast_ofNat _
+  · intro k hk n
+    refine lt_of_le_of_lt (b := ‖(n : ℝ) ^ 2‖ₑ * volume (s n)) ?_ ?_
+    · rw [← setLIntegral_const]
+      refine setLIntegral_mono_ae' (by measurability) ?_
+      filter_upwards [hw₁', hw₂'] with x h₁ h₂ ⟨h₃, h₃'⟩
+      apply enorm_le_iff_norm_le.mpr
+      simp_rw [norm_pow, norm_norm, RCLike.norm_natCast]
+      refine pow_le_pow_left₀ (norm_nonneg _) ?_ 2
+      rcases hk <;> simp_all
+    · refine ENNReal.mul_lt_top (by norm_num) ?_
+      exact measure_inter_lt_top_of_left_ne_top measure_closedBall_lt_top.ne
+
 lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
     (𝓜 f)† = 𝓜 (conj ∘ f) := by
   refine eq_of_eq_graph ?_

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -7,7 +7,6 @@ module
 
 public import Physlib.QuantumMechanics.DDimensions.Operators.Unbounded
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
-import Physlib.Meta.Linters.Sorry
 /-!
 
 # Multiplication operators on `SpaceDHilbertSpace`
@@ -304,7 +303,6 @@ lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurab
 ### C.1. Self-adjoint
 -/
 
-@[sorryful]
 lemma mulOperator_isSelfAdjoint_ofReal
     {f : Space d → ℂ} (hf : AEStronglyMeasurable f) (hf' : conj ∘ f = f) :
     IsSelfAdjoint (𝓜 f) := by
@@ -315,7 +313,6 @@ lemma mulOperator_isSelfAdjoint_ofReal
 ## D. Closable & unbounded
 -/
 
-@[sorryful]
 lemma mulOperator_isClosable {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
     (𝓜 f).IsClosable := by
   refine isClosable_of_exists_dense_formalAdjoint ?_ ?_
@@ -325,7 +322,6 @@ lemma mulOperator_isClosable {f : Space d → ℂ} (hf : AEStronglyMeasurable f)
     · rw [← mulOperator_adjoint_eq_conj hf]
       exact adjoint_isFormalAdjoint (mulOperator_hasDenseDomain hf)
 
-@[sorryful]
 lemma mulOperator_isUnbounded {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
     (𝓜 f).IsUnbounded :=
   ⟨mulOperator_hasDenseDomain hf, mulOperator_isClosable hf⟩

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -290,39 +290,15 @@ lemma mulOperator_adjoint_domain_le {f : Space d → ℂ} (hf : AEStronglyMeasur
 
 lemma mulOperator_adjoint_eq_conj {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
     (𝓜 f)† = 𝓜 (conj ∘ f) := by
-  refine eq_of_eq_graph ?_
-  ext u
-  rw [adjoint_graph_eq_graph_adjoint (mulOperator_hasDenseDomain hf), Submodule.mem_adjoint_iff]
-  constructor
-  · intro h
-    let g : Space d → ℂ := fun x ↦ conj (f x) * u.1 x - u.2 x
-    have hg : AEStronglyMeasurable g := by measurability
-    have h_int : ∀ ψ : (𝓜 f).domain, ∫ x, (AEEqFun.mk g hg) x * conj (ψ.val x) = 0 := by
-      intro ψ
-      have h_int₁ : Integrable fun x ↦ u.1 x * conj (𝓜 f ψ x) := L2.integrable_inner (𝓜 f ψ) u.1
-      have h_int₂ : Integrable fun x ↦ u.2 x * conj (ψ.val x) := L2.integrable_inner ψ.val u.2
-      symm
-      trans ∫ x, u.1 x * conj (𝓜 f ψ x) - u.2 x * conj (ψ.val x)
-      · exact (h ψ (𝓜 f ψ) (mem_graph (𝓜 f) ψ)) ▸ (integral_sub h_int₁ h_int₂).symm
-      refine integral_congr_ae ?_
-      filter_upwards [mulOperator_apply_ae ψ, AEEqFun.coeFn_mk g hg] with x h₁ h₂
-      simp [h₁, h₂, g, sub_mul, mul_assoc, mul_left_comm]
-    have hu₂ : u.2 =ᵐ[volume] (conj ∘ f) • u.1 := by
-      sorry
-    have hu₁ : u.1 ∈ (𝓜 (conj ∘ f)).domain :=
-      mem_mulOperator_domain_iff.mpr <| memHS_of_ae u.2 (coe_hilbertSpace_memHS u.2) hu₂
-    apply (mem_graph_iff _).mpr
-    refine ⟨⟨u.1, hu₁⟩, rfl, ?_⟩
-    apply ext_iff.mpr
-    filter_upwards [mulOperator_apply_ae ⟨u.1, hu₁⟩, hu₂] with x h₁ h₂
-    rw [h₁, h₂]
-  · intro hu v₁ v₂ hv
-    obtain ⟨ψ, hu₁, hu₂⟩ := (mem_graph_iff _).mp hu
-    obtain ⟨φ, rfl, rfl⟩ := (mem_graph_iff _).mp hv
-    rw [sub_eq_zero]
+  have hFA : (𝓜 f).IsFormalAdjoint (𝓜 (conj ∘ f)) := by
+    intro ψ φ
     refine integral_congr_ae ?_
-    filter_upwards [mulOperator_apply_ae ψ, mulOperator_apply_ae φ]
-    simp_all [mul_assoc, mul_left_comm]
+    filter_upwards [mulOperator_apply_ae ψ, mulOperator_apply_ae φ] with x h₁ h₂
+    simp [h₁, h₂, mul_assoc, mul_left_comm]
+  refine eq_of_le_of_ge ?_ (hFA.le_adjoint <| mulOperator_hasDenseDomain hf)
+  refine ⟨mulOperator_adjoint_domain_le hf, fun ψ ψ' hψ ↦ ?_⟩
+  refine adjoint_apply_eq (mulOperator_hasDenseDomain hf) ψ fun φ ↦ ?_
+  rw [← inner_conj_symm, hψ, (hFA φ ψ').symm, inner_conj_symm]
 
 /-!
 ### C.1. Self-adjoint

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Position.lean
@@ -9,7 +9,6 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.Multiplication
 public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.PolyBddSchwartzSubmodule
 public import Physlib.SpaceAndTime.Space.Integrals.NormPow
 public import Physlib.SpaceAndTime.Space.Derivatives.Basic
-import Physlib.Meta.Linters.Sorry
 /-!
 
 # Position operators
@@ -398,11 +397,9 @@ notation "𝓧" => positionOperator
 lemma positionOperator_hasDenseDomain : (𝓧 i).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
-@[sorryful]
 lemma positionOperator_isSelfAdjoint : IsSelfAdjoint (𝓧 i) :=
   mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
-@[sorryful]
 lemma positionOperator_isUnbounded : (𝓧 i).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
   · exact positionOperator_isSelfAdjoint i
@@ -426,11 +423,9 @@ notation "𝓡₀[" d' "]" => radiusRegPowOperator (d := d')
 lemma radiusRegPowOperator_hasDenseDomain (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).HasDenseDomain :=
   mulOperator_hasDenseDomain (by fun_prop)
 
-@[sorryful]
 lemma radiusRegPowOperator_isSelfAdjoint (ε : ℝˣ) (s : ℝ) : IsSelfAdjoint (𝓡₀[d] ε s) := by
   refine mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
-@[sorryful]
 lemma radiusRegPowOperator_isUnbounded (ε : ℝˣ) (s : ℝ) : (𝓡₀[d] ε s).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
   · exact radiusRegPowOperator_isSelfAdjoint ε s
@@ -456,14 +451,12 @@ lemma radiusPowOperator_hasDenseDomain (s : ℝ) : (𝓡[d] s).HasDenseDomain :=
   ext x
   simp [normRegularizedPow, ← Real.rpow_natCast_mul (norm_nonneg x), mul_div_cancel₀ s two_ne_zero]
 
-@[sorryful]
 lemma radiusPowOperator_isSelfAdjoint (s : ℝ) : IsSelfAdjoint (𝓡[d] s) := by
   refine mulOperator_isSelfAdjoint_ofReal ?_ (by ext; simp)
   suffices (fun x ↦ ‖x‖ ^ s) = normRegularizedPow d 0 s by rw[this]; fun_prop
   ext x
   simp [normRegularizedPow, ← Real.rpow_natCast_mul (norm_nonneg x), mul_div_cancel₀ s two_ne_zero]
 
-@[sorryful]
 lemma radiusPowOperator_isUnbounded (s : ℝ) : (𝓡[d] s).IsUnbounded := by
   refine LinearPMap.IsSelfAdjoint.isUnbounded ?_ ?_
   · exact radiusPowOperator_isSelfAdjoint s


### PR DESCRIPTION
Completes the proof for multiplication operators that `(𝓜 f)† = 𝓜 (conj ∘ f)`.
The only non-trivial step, `(𝓜 f)†.domain ≤ (𝓜 (conj ∘ f)).domain`, is extracted into a separate lemma (+ one helper lemma).