### PR TITLE
feat(QM): Add `SpaceDQuantumSystem`

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -237,6 +237,7 @@ public import Physlib.QFT.QED.AnomalyCancellation.Odd.Parameterization
 public import Physlib.QFT.QED.AnomalyCancellation.Permutations
 public import Physlib.QFT.QED.AnomalyCancellation.Sorts
 public import Physlib.QFT.QED.AnomalyCancellation.VectorLike
+public import Physlib.QuantumMechanics.DDimensions.Basic
 public import Physlib.QuantumMechanics.DDimensions.Hydrogen.Basic
 public import Physlib.QuantumMechanics.DDimensions.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.DDimensions.Operators.AngularMomentum

--- a/Physlib/QuantumMechanics/DDimensions/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Basic.lean
@@ -42,7 +42,7 @@ open SpaceDHilbertSpace
 
 /-- A single-particle quantum system with Hilbert space `SpaceDHilbertSpace d`,
   characterized by the number of spatial dimensions `d : ℕ`, particle's mass `m > 0`
-  and potential function `potential : Space d → ℝ` (assumed to be a.e. strongly measurable). -/
+  and potential function `potential : Space d → ℝ`. -/
 @[ext]
 structure SpaceDQuantumSystem where
   /-- The number of spatial dimensions. -/
@@ -50,9 +50,8 @@ structure SpaceDQuantumSystem where
   /-- The mass (positive). -/
   m : ℝ
   hm : 0 < m
-  /-- The potential function (a.e. strongly measurable). -/
+  /-- The potential function. -/
   potential : Space d → ℝ
-  hAESM : AEStronglyMeasurable potential
 
 variable {Q : SpaceDQuantumSystem}
 
@@ -74,12 +73,6 @@ lemma m_nonneg : 0 ≤ Q.m := Q.hm.le
 
 @[simp]
 lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
-
-@[fun_prop]
-lemma potential_aestronglymeasurable : AEStronglyMeasurable Q.potential := Q.hAESM
-
-@[fun_prop]
-lemma potential_aemeasurable : AEMeasurable Q.potential := Q.hAESM.aemeasurable
 
 /-!
 ## B. Operators
@@ -130,7 +123,8 @@ def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 (ofReal ∘ Q.potential)
 
 lemma potentialOperator_eq : Q.potentialOperator = 𝓜 (ofReal ∘ Q.potential) := rfl
 
-lemma potentialOperator_isSelfAdjoint : IsSelfAdjoint Q.potentialOperator :=
+lemma potentialOperator_isSelfAdjoint (h_AESM : AEStronglyMeasurable Q.potential) :
+    IsSelfAdjoint Q.potentialOperator :=
   mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
 
 lemma potentialOperator_domain_ge (h_HTG : Q.potential.HasTemperateGrowth) :

--- a/Physlib/QuantumMechanics/DDimensions/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Basic.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.DDimensions.Operators.Momentum
+public import Physlib.QuantumMechanics.DDimensions.Operators.Multiplication
+/-!
+
+# Single-particle quantum system on `Space d`
+
+## i. Overview
+
+In this module we introduce the general notion of a single-particle quantum system on `Space d`.
+
+The structure `SpaceDQuantumSystem` encompasses the basic information needed to specify the system,
+namely the number of spatial dimensions, the particle's mass and the potential function.
+
+## ii. Key results
+
+## iii. Table of contents
+
+- A. Basic properties
+- B. Operators
+  - B.1. Kinetic energy
+  - B.2. Potential energy
+  - B.3. Hamiltonian
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace QuantumMechanics
+
+open Complex
+open MeasureTheory
+open SpaceDHilbertSpace
+
+/-- A single-particle quantum system with Hilbert space `SpaceDHilbertSpace d`,
+  characterized by the number of spatial dimensions `d : ℕ`, particle's mass `m > 0`
+  and potential function `potential : Space d → ℝ` (assumed to be a.e. strongly measurable). -/
+@[ext]
+structure SpaceDQuantumSystem where
+  /-- The number of spatial dimensions. -/
+  d : ℕ
+  /-- The mass (positive). -/
+  m : ℝ
+  hm : 0 < m
+  /-- The potential function (a.e. strongly measurable). -/
+  potential : Space d → ℝ
+  hAESM : AEStronglyMeasurable potential
+
+variable {Q : SpaceDQuantumSystem}
+
+namespace SpaceDQuantumSystem
+noncomputable section
+
+/-- The Hilbert space, `SpaceDHilbertSpace Q.d`. -/
+abbrev HS := SpaceDHilbertSpace Q.d
+
+/-!
+## A. Basic properties
+-/
+
+@[simp]
+lemma m_pos : 0 < Q.m := Q.hm
+
+@[simp]
+lemma m_nonneg : 0 ≤ Q.m := Q.hm.le
+
+@[simp]
+lemma m_ne_zero : Q.m ≠ 0 := Q.hm.ne'
+
+@[fun_prop]
+lemma potential_aestronglymeasurable : AEStronglyMeasurable Q.potential := Q.hAESM
+
+@[fun_prop]
+lemma potential_aemeasurable : AEMeasurable Q.potential := Q.hAESM.aemeasurable
+
+/-!
+## B. Operators
+-/
+
+section
+open SchwartzMap
+open LinearPMap
+
+/-!
+### B.1. Kinetic energy
+-/
+
+/-- The kinetic operator `(2m)⁻¹𝐩²` as a continuous linear map on Schwartz space. -/
+def kineticCLM : 𝓢(Space Q.d, ℂ) →L[ℂ] 𝓢(Space Q.d, ℂ) := (2 * Q.m)⁻¹ • (𝐩 ⬝ᵥ 𝐩)
+
+lemma kineticCLM_eq : Q.kineticCLM = (2 * Q.m)⁻¹ • (𝐩 ⬝ᵥ 𝐩) := rfl
+
+/-- The kinetic operator as an unbounded operator with domain `schwartzSubmodule Q.d`. -/
+def kineticOperator : Q.HS →ₗ.[ℂ] Q.HS := ofReal (2 * Q.m)⁻¹ • momentumSqOperator
+
+lemma kineticOperator_eq : Q.kineticOperator = ofReal (2 * Q.m)⁻¹ • momentumSqOperator := rfl
+
+/-!
+### B.2. Potential energy
+-/
+
+/-- The potential operator as a continuous linear map on Schwartz space,
+  where `Q.potential` is a function of temperate growth. -/
+def potentialCLM : 𝓢(Space Q.d, ℂ) →L[ℂ] 𝓢(Space Q.d, ℂ) := smulLeftCLM ℂ (ofReal ∘ Q.potential)
+
+lemma potentialCLM_eq : Q.potentialCLM = smulLeftCLM ℂ (ofReal ∘ Q.potential) := rfl
+
+lemma potentialCLM_apply (h_HTG : Q.potential.HasTemperateGrowth) (ψ : 𝓢(Space Q.d, ℂ)) :
+    Q.potentialCLM ψ = fun x ↦ Q.potential x • ψ x := by
+  rw [potentialCLM_eq, smulLeftCLM_apply (by fun_prop)]
+  simp
+
+@[simp]
+lemma potentialCLM_apply_apply
+    (h_HTG : Q.potential.HasTemperateGrowth) (ψ : 𝓢(Space Q.d, ℂ)) (x : Space Q.d) :
+    Q.potentialCLM ψ x = Q.potential x • ψ x := by
+  rw [potentialCLM_apply h_HTG]
+
+/-- The potential operator as a self-adjoint, unbounded multiplication operator
+  with domain `{ψ ∈ Q.HS | Q.potential • ψ ∈ Q.HS}`. -/
+def potentialOperator : Q.HS →ₗ.[ℂ] Q.HS := 𝓜 (ofReal ∘ Q.potential)
+
+lemma potentialOperator_eq : Q.potentialOperator = 𝓜 (ofReal ∘ Q.potential) := rfl
+
+lemma potentialOperator_isSelfAdjoint : IsSelfAdjoint Q.potentialOperator :=
+  mulOperator_isSelfAdjoint_ofReal (by fun_prop) (by ext; simp)
+
+lemma potentialOperator_domain_ge (h_HTG : Q.potential.HasTemperateGrowth) :
+    schwartzSubmodule Q.d ≤ Q.potentialOperator.domain :=
+  mulOperator_domain_ge_of_hasTemperateGrowth (by fun_prop)
+
+/-!
+### B.3. Hamiltonian
+-/
+
+/-- The Hamiltonian operator as a continuous linear map on Schwartz space,
+  where `Q.potential` is a function of temperate growth. -/
+def hamiltonianCLM : 𝓢(Space Q.d, ℂ) →L[ℂ] 𝓢(Space Q.d, ℂ) := Q.kineticCLM + Q.potentialCLM
+
+lemma hamiltonianCLM_eq : Q.hamiltonianCLM = Q.kineticCLM + Q.potentialCLM := rfl
+
+/-- The Hamilontian operator as a symmetric unbounded operator. -/
+def hamiltonianOperator : Q.HS →ₗ.[ℂ] Q.HS := Q.kineticOperator + Q.potentialOperator
+
+lemma hamiltonianOperator_eq : Q.hamiltonianOperator = Q.kineticOperator + Q.potentialOperator :=
+  rfl
+
+end
+
+end
+end SpaceDQuantumSystem
+end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/Basic.lean
@@ -5,7 +5,7 @@ Authors: Gregory J. Loges
 -/
 module
 
-public import Physlib.QuantumMechanics.DDimensions.Operators.Momentum
+public import Physlib.QuantumMechanics.DDimensions.Basic
 public import Physlib.QuantumMechanics.DDimensions.Operators.Position
 /-!
 
@@ -27,34 +27,48 @@ e.g. see https://doi.org/10.1103/PhysRevA.80.032507 and https://doi.org/10.1063/
 @[expose] public section
 
 namespace QuantumMechanics
+open MeasureTheory
 open SchwartzMap
 
 /-- A hydrogen atom is characterized by the number of spatial dimensions `d`,
   the mass `m` and the coefficient `k` for the `1/r` potential. -/
-structure HydrogenAtom where
-  /-- Number of spatial dimensions -/
-  d : ℕ
-
-  /-- Mass (positive) -/
-  m : ℝ
-  hm : 0 < m
-
-  /-- Coefficient in potential (positive for attractive) -/
+structure HydrogenAtom extends SpaceDQuantumSystem where
+  /-- Coefficient in the Coulomb potential (positive for attractive) -/
   k : ℝ
+  coulomb_potential : potential = fun x ↦ -k * ‖x‖⁻¹
 
 namespace HydrogenAtom
 noncomputable section
 
 variable (H : HydrogenAtom)
 
+/-!
+## A. Basic
+-/
+
 @[simp]
-lemma m_ne_zero : H.m ≠ 0 := by linarith [H.hm]
+lemma potential_eq : H.potential = fun x ↦ -H.k * ‖x‖⁻¹ := H.coulomb_potential
+
+@[fun_prop]
+lemma potential_AESM : AEStronglyMeasurable H.potential := by
+  rw [potential_eq]
+  exact AEMeasurable.aestronglyMeasurable (by fun_prop)
+
+@[fun_prop]
+lemma potential_AEM : AEMeasurable H.potential := H.potential_AESM.aemeasurable
+
+/-!
+## B. Regularization
+-/
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The hydrogen atom Hamiltonian regularized by `ε ≠ 0` is defined to be
   `𝐇(ε) ≔ (2m)⁻¹𝐩² - k·𝐫(ε)⁻¹`. -/
-def hamiltonianReg (ε : ℝˣ) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d, ℂ) :=
+def hamiltonianRegCLM (ε : ℝˣ) : 𝓢(Space H.d, ℂ) →L[ℂ] 𝓢(Space H.d, ℂ) :=
   (2 * H.m)⁻¹ • (𝐩 ⬝ᵥ 𝐩) - H.k • 𝐫₀ ε (-1)
+
+lemma hamiltonianRegCLM_eq (ε : ℝˣ) :
+    H.hamiltonianRegCLM ε = (2 * H.m)⁻¹ • (𝐩 ⬝ᵥ 𝐩) - H.k • 𝐫₀ ε (-1) := rfl
 
 end
 end HydrogenAtom

--- a/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Hydrogen/LaplaceRungeLenzVector.lean
@@ -269,7 +269,7 @@ private lemma radiusRegInvCompPosition_comm {d : ℕ} (ε : ℝˣ) (i j : Fin d)
 
 /-- `⁅𝐀(ε)ᵢ, 𝐀(ε)ⱼ⁆ = (-2iℏm·𝐇(ε) + iℏmkε²·𝐫(ε)⁻³)𝐋ᵢⱼ` -/
 lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
-    ⁅H.lrlOperator ε i, H.lrlOperator ε j⁆ = ((-2 * I * ℏ * H.m) • H.hamiltonianReg ε
+    ⁅H.lrlOperator ε i, H.lrlOperator ε j⁆ = ((-2 * I * ℏ * H.m) • H.hamiltonianRegCLM ε
     + (I * ℏ * H.m * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3)) ∘L 𝐋 i j := by
   repeat rw [lrlOperator_eq]
   let c₁ : ℂ := 2⁻¹ * I * ℏ * (H.d - 1)
@@ -299,7 +299,7 @@ lemma lrl_commutation_lrl (ε : ℝˣ) (i j : Fin H.d) :
   rw [momentum_comm_radiusRegInvCompPosition_add]
   rw [radiusRegInvCompPosition_comm]
   subst c₁ c₂
-  simp_rw [hamiltonianReg, smul_zero, add_zero, sub_zero, ← sub_smul, ← Complex.coe_smul,
+  simp_rw [hamiltonianRegCLM_eq, smul_zero, add_zero, sub_zero, ← sub_smul, ← Complex.coe_smul,
     ofReal_inv, ofReal_mul, ofReal_ofNat, smul_sub, smul_smul, add_comp, sub_comp, smul_comp]
   ring_nf
   simp
@@ -372,12 +372,13 @@ private lemma r_comm_pL_Lp {d : ℕ} (ε : ℝˣ) (i : Fin d) :
 set_option backward.isDefEq.respectTransparency false in
 /-- `⁅𝐇(ε), 𝐀(ε)ᵢ⁆ = iℏk·ε²𝐫(ε)⁻³𝐩ᵢ - 3ℏ²k/2·ε²𝐫(ε)⁻⁵𝐱ᵢ` -/
 lemma hamiltonianReg_commutation_lrl (ε : ℝˣ) (i : Fin H.d) :
-    ⁅H.hamiltonianReg ε, H.lrlOperator ε i⁆ = (I * ℏ * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i
+    ⁅H.hamiltonianRegCLM ε, H.lrlOperator ε i⁆ = (I * ℏ * H.k * ε.1 ^ 2) • 𝐫₀ ε (-3) ∘L 𝐩 i
     - (3 / 2 * ℏ ^ 2 * H.k * ε.1 ^ 2) • 𝐫₀ ε (-5) ∘L 𝐱 i := by
   trans (-2⁻¹ * H.k) • (⁅𝐩[H.d] ⬝ᵥ 𝐩, 𝐫₀ ε (-1) ∘L 𝐱 i⁆
       + ⁅𝐫₀[H.d] ε (-1), 𝐩 ⬝ᵥ 𝐋 i + 𝐋 i ⬝ᵥ 𝐩⁆)
-  · have h : H.m * H.k * (H.m⁻¹ * 2⁻¹) = 2⁻¹ * H.k := by grind [m_ne_zero]
-    simp only [hamiltonianReg, lrlOperator, lie_sub, sub_lie, smul_lie, lie_smul, pSqr_comm_pL_Lp]
+  · have h : H.m * H.k * (H.m⁻¹ * 2⁻¹) = 2⁻¹ * H.k := by grind [H.m_ne_zero]
+    simp only [hamiltonianRegCLM_eq, lrlOperator, lie_sub, sub_lie, smul_lie, lie_smul,
+      pSqr_comm_pL_Lp]
     simp [r_comm_rx, h, smul_smul, sub_eq_neg_add, add_comm]
   simp_rw [pSqr_comm_rx, r_comm_pL_Lp, add_neg_cancel_comm, smul_add, sub_eq_add_neg, ← neg_smul,
     ← neg_mul, ← Complex.coe_smul, smul_smul, ofReal_mul, ofReal_neg, ofReal_inv, ofReal_div,
@@ -508,7 +509,7 @@ set_option backward.isDefEq.respectTransparency false in
   `𝐇(ε)` of the hydrogen atom, square of the angular momentum `𝐋²` and powers of `𝐫(ε)` as
   `𝐀(ε)² = 2m·𝐇(ε)(𝐋² + ¼ℏ²(d-1)²) + m²k²(𝟙 - ε²·𝐫(ε)⁻²) - ½(d-1)mkℏ²ε²𝐫(ε)⁻³`. -/
 lemma lrlOperatorSqr_eq (ε : ℝˣ) : H.lrlOperator ε ⬝ᵥ H.lrlOperator ε =
-    (2 * H.m) • (H.hamiltonianReg ε) ∘L
+    (2 * H.m) • (H.hamiltonianRegCLM ε) ∘L
       (𝐋² + (4⁻¹ * ℏ ^ 2 * (H.d - 1) ^ 2 : ℝ) • ContinuousLinearMap.id ℂ 𝓢(Space H.d, ℂ))
     + (H.m ^ 2 * H.k ^ 2) • (ContinuousLinearMap.id ℂ 𝓢(Space H.d, ℂ) - ε.1 ^ 2 • 𝐫₀ ε (-2))
     - (2⁻¹ * ℏ^2 * H.m * H.k * (H.d - 1) * ε.1 ^ 2) • 𝐫₀ ε (-3) := by
@@ -518,15 +519,15 @@ lemma lrlOperatorSqr_eq (ε : ℝˣ) : H.lrlOperator ε ⬝ᵥ H.lrlOperator ε 
   simp_rw [dotProduct, mul_def, sub_eq_add_neg, ← neg_smul, add_comp, comp_add, smul_comp,
     comp_smul, finset_sum_comp, comp_finset_sum, Finset.sum_add_distrib, ← Finset.smul_sum,
     comp_assoc, sum_LppL, sum_Lpp, sum_Lprx, sum_ppL, sum_prx, sum_rxpL, sum_rxp, sum_rxrx]
-  simp only [hamiltonianReg, sub_eq_add_neg, ← neg_smul, smul_zero, zero_add, add_zero, ← neg_mul,
-    smul_smul, dotProduct, mul_def, ← Complex.coe_smul, ofReal_mul, ofReal_neg, ofReal_inv,
-    ofReal_pow, smul_add, ofReal_ofNat]
+  simp only [dotProduct, mul_def, ← neg_mul, smul_zero, add_zero, ← Complex.coe_smul, ofReal_mul,
+    ofReal_neg, smul_smul, zero_add, sub_eq_add_neg, ← neg_smul, smul_add, ofReal_pow,
+    hamiltonianRegCLM_eq, ofReal_inv, ofReal_ofNat]
   ring_nf
   ext
   simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply, SchwartzMap.add_apply,
     SchwartzMap.smul_apply, Function.comp_apply, coe_comp', coe_id', smul_eq_mul, ofReal_add,
     ofReal_neg, ofReal_one, ofReal_natCast]
-  grind [I_sq, m_ne_zero, mul_inv_cancel₀, ofReal_eq_zero]
+  grind [I_sq, H.m_ne_zero, mul_inv_cancel₀, ofReal_eq_zero]
 
 end
 end HydrogenAtom

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Multiplication.lean
@@ -6,7 +6,7 @@ Authors: Gregory J. Loges
 module
 
 public import Physlib.QuantumMechanics.DDimensions.Operators.Unbounded
-public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.Basic
+public import Physlib.QuantumMechanics.DDimensions.SpaceDHilbertSpace.SchwartzSubmodule
 import Physlib.Meta.Linters.Sorry
 /-!
 
@@ -28,7 +28,7 @@ In this module we introduce unbounded operators defined by multiplication by a f
 ## iii. Table of contents
 
 - A. Definition
-- B. Dense domain
+- B. Domain
 - C. Adjoint
   - C.1. Self-adjoint
 - D. Closable & unbounded
@@ -99,7 +99,7 @@ lemma mulOperator_apply_ae {f : Space d → ℂ} (ψ : (𝓜 f).domain) : (𝓜 
   coe_mk_ae ψ.prop
 
 /-!
-## B. Dense domain
+## B. Domain
 -/
 
 lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurable f) :
@@ -158,6 +158,18 @@ lemma mulOperator_hasDenseDomain {f : Space d → ℂ} (hf : AEStronglyMeasurabl
         _ ≤ (⌈‖u x‖⌉ : ℝ) := Int.le_ceil _
         _ ≤ ⌈‖u x‖⌉.toNat := Int.cast_le.mpr (Int.self_le_toNat _)
         _ ≤ n := Nat.cast_le.mpr hn
+
+open SchwartzMap SchwartzSubmodule in
+lemma mulOperator_domain_ge_of_hasTemperateGrowth
+    {f : Space d → ℂ} (hf : f.HasTemperateGrowth) : schwartzSubmodule d ≤ (𝓜 f).domain := by
+  intro ψ hψ
+  obtain ⟨g, hg⟩ := schwartzEquiv.surjective ⟨ψ, hψ⟩
+  let w : 𝓢(Space d, ℂ) := smulLeftCLM ℂ f g
+  let φ : SpaceDHilbertSpace d := schwartzEquiv w
+  apply mem_mulOperator_domain_iff.mpr
+  refine memHS_of_ae φ (coe_hilbertSpace_memHS φ) ?_
+  filter_upwards [schwartzEquiv_coe_ae w, schwartzEquiv_coe_ae g] with x h₁ h₂
+  simp [w, φ, h₁, ← h₂, hg, smulLeftCLM_apply_apply hf]
 
 /-!
 ## C. Adjoint


### PR DESCRIPTION
Introduces a general structure for single-particle QM with Hilbert space `SpaceDhilbertSpace`, characterized by the number of dimensions, mass and potential function.
- Defines kinetic/potential/hamiltonian operators and introduces some basic API.
- Adds some lemmas for the potential operators when the potential _function_ satisfies some basic properties.

As a trial, `HydrogenAtom` is changed to extend this structure with a specific form for the potential.