### PR TITLE
feat(QM): Add `LinearPMap.sum`

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Momentum.lean
@@ -79,6 +79,7 @@ lemma momentumCLM_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐩 i ψ x = 
 
 -/
 
+open LinearPMap
 open MeasureTheory
 open SpaceDHilbertSpace
 open SchwartzSubmodule
@@ -139,7 +140,18 @@ lemma momentumOperator_isUnbounded : (𝓟 i).IsUnbounded := by
 
 /-- The square of the momentum operator. -/
 def momentumSqOperator : SpaceDHilbertSpace d →ₗ.[ℂ] SpaceDHilbertSpace d :=
-  ∑ i, (𝓟 i).comp (𝓟 i) (momentumOperator_range i)
+  sum fun i ↦ (𝓟 i).comp (𝓟 i) (momentumOperator_range i)
+
+lemma momentumSqOperator_eq :
+    momentumSqOperator (d := d) = sum fun i ↦ (𝓟 i).comp (𝓟 i) (momentumOperator_range i) := rfl
+
+lemma momentumSqOperator_domain_eq : momentumSqOperator.domain = schwartzSubmodule d := by
+  rw [momentumSqOperator_eq, sum_domain]
+  rcases eq_zero_or_pos d with rfl | hd
+  · simp [SchwartzSubmodule.zero_eq_top]
+  · letI := Fin.pos_iff_nonempty.mp hd
+    rw [← iInf_const (a := schwartzSubmodule d) (ι := Fin d)]
+    congr
 
 end
 end QuantumMechanics

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -44,14 +44,17 @@ these correspond to physical observables.
 
 ## iii. Table of contents
 
-- A. Definitions
-- B. Dense domain
-- C. Closability
-- D. Adjoints
-- E. Symmetric operators
-- F. Self-adjoint operators
-- G. Essentially self-adjoint operators
-- H. Unbounded operators
+- A. General
+  - A.1. Finite sums
+- B. Operators on inner product/Hilbert spaces
+  - B.1. Definitions
+  - B.2. Dense domain
+  - B.3. Closability
+  - B.4. Adjoints
+  - B.5. Symmetric operators
+  - B.6. Self-adjoint operators
+  - B.7. Essentially self-adjoint operators
+  - B.8. Unbounded operators
 
 ## iv. References
 
@@ -70,6 +73,14 @@ open Submodule
 open InnerProductSpace
 open InnerProductSpaceSubmodule
 open Complex ComplexConjugate
+
+/-!
+## A. General
+
+This section contains useful general results for partial linear maps which do not rely
+on an inner product/Hilbert space structure.
+-/
+
 section General
 
 variable {R : Type*} [Ring R]
@@ -103,6 +114,11 @@ end
 
 end General
 
+/-!
+## B. Operators on inner product/Hilbert spaces
+-/
+
+section InnerProductSpaces
 
 variable
   {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
@@ -112,7 +128,7 @@ variable
   {U U₁ U₂ : H →ₗ.[ℂ] H'} {V : α → H →ₗ.[ℂ] H'}
 
 /-!
-## A. Definitions
+### B.1. Definitions
 
 See `LinearPMap.instStar` and `LinearPMap.isSelfAdjoint_def` for the definition of `IsSelfAdjoint`
 for `LinearPMap`s.
@@ -140,7 +156,7 @@ lemma isEssentiallySelfAdjoint_def [CompleteSpace H] :
     T.IsEssentiallySelfAdjoint ↔ IsSelfAdjoint T.closure := Iff.rfl
 
 /-!
-## B. Dense domain
+### B.2. Dense domain
 -/
 
 lemma HasDenseDomain.isUnbounded_iff_isClosable (h : U.HasDenseDomain) :
@@ -184,7 +200,7 @@ lemma HasDenseDomain.sum_of_le
   hE.mono (by simp [sum_domain, h])
 
 /-!
-## C. Closability
+### B.3. Closability
 -/
 
 lemma IsClosable.isClosed_iff (h : U.IsClosable) : U.IsClosed ↔ U.closure = U := by
@@ -265,7 +281,7 @@ lemma closure_smul (U : H →ₗ.[ℂ] H') {c : ℂ} (hc : c ≠ 0) : (c • U).
   · rw [closure_def' h, closure_def' <| (not_congr <| IsClosable.smul_iff hc).mpr h]
 
 /-!
-## D. Adjoints
+### B.4. Adjoints
 -/
 
 /-- The adjoint of a zero LinearPMap (any domain) is zero (domain `⊤`). -/
@@ -332,7 +348,7 @@ lemma adjoint_add_le_add_adjoint [CompleteSpace H]
       adjoint_isFormalAdjoint h₂ ⟨u, u.2.2⟩ ⟨w, w.2.2⟩]
 
 /-!
-## E. Symmetric operators
+### B.5. Symmetric operators
 -/
 
 /-- The analogue of `inner_map_polarization` for LinearPMap. -/
@@ -430,7 +446,7 @@ lemma IsSymmetric.of_le (h₁ : T₁.IsSymmetric) (h_le : T₂ ≤ T₁) : T₂.
   exact hx ▸ hy ▸ h₁ ⟨x, h_le.1 x.2⟩ ⟨y, h_le.1 y.2⟩
 
 /-!
-## F. Self-adjoint operators
+### B.6. Self-adjoint operators
 -/
 
 lemma IsSelfAdjoint.isSymmetric [CompleteSpace H] (h : IsSelfAdjoint T) : T.IsSymmetric := by
@@ -473,7 +489,7 @@ lemma IsSelfAdjoint.neg [CompleteSpace H] (h : IsSelfAdjoint T) : IsSelfAdjoint 
   neg_eq_neg_one_smul T ▸ smul h (by norm_num) (by norm_num)
 
 /-!
-## G. Essentially self-adjoint operators
+### B.7. Essentially self-adjoint operators
 -/
 
 lemma IsEssentiallySelfAdjoint.isSymmetric [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
@@ -516,7 +532,7 @@ lemma IsEssentiallySelfAdjoint.neg [CompleteSpace H] (h : T.IsEssentiallySelfAdj
   neg_eq_neg_one_smul T ▸ h.smul (by norm_num) (by norm_num)
 
 /-!
-## H. Unbounded operators
+### B.8. Unbounded operators
 -/
 
 lemma IsUnbounded.hasDenseDomain (h : U.IsUnbounded) : U.HasDenseDomain := h.1
@@ -586,5 +602,7 @@ lemma isUnbounded_of_dense_of_isSymmetric' [CompleteSpace H]
     {E : Submodule ℂ H} (hE : Dense (E : Set H)) {f : E →ₗ[ℂ] E} (h : f.IsSymmetric) :
     (mk E (E.subtype ∘ₗ f)).IsUnbounded :=
   ⟨hE, IsSymmetric.isClosable h hE⟩
+
+end InnerProductSpaces
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -144,6 +144,8 @@ variable
   {T T₁ T₂ : H →ₗ.[ℂ] H} {S : α → H →ₗ.[ℂ] H}
   {U U₁ U₂ : H →ₗ.[ℂ] H'} {V : α → H →ₗ.[ℂ] H'}
 
+instance : IsScalarTower ℝ ℂ H := IsScalarTower.complexToReal
+
 /-!
 ### B.1. Definitions
 
@@ -448,7 +450,7 @@ lemma IsSymmetric.smul (h : T.IsSymmetric) {c : ℂ} (hc : conj c = c) : (c • 
   fun x y ↦ by simp only [smul_apply, inner_smul_left, inner_smul_right, hc, h x y]
 
 @[aesop safe apply]
-lemma IsSymmetric.smul_ofReal (h : T.IsSymmetric) (r : ℝ) : (ofReal r • T).IsSymmetric :=
+lemma IsSymmetric.real_smul (h : T.IsSymmetric) (r : ℝ) : (r • T).IsSymmetric :=
   h.smul (conj_ofReal r)
 
 @[aesop safe apply]
@@ -497,8 +499,8 @@ lemma IsSelfAdjoint.smul [CompleteSpace H]
   rw [isSelfAdjoint_def, T.adjoint_smul hc, hc', isSelfAdjoint_def.mp h]
 
 @[aesop safe apply]
-lemma IsSelfAdjoint.smul_ofReal [CompleteSpace H] (h : IsSelfAdjoint T) {r : ℝ} (hr : r ≠ 0) :
-    IsSelfAdjoint (ofReal r • T) :=
+lemma IsSelfAdjoint.real_smul [CompleteSpace H] (h : IsSelfAdjoint T) {r : ℝ} (hr : r ≠ 0) :
+    IsSelfAdjoint (r • T) :=
   smul h (ofReal_ne_zero.mpr hr) (conj_ofReal r)
 
 @[aesop safe apply]
@@ -542,9 +544,9 @@ lemma IsEssentiallySelfAdjoint.smul [CompleteSpace H]
   simp_all [isEssentiallySelfAdjoint_def, isSelfAdjoint_def, closure_smul _ hc, adjoint_smul _ hc]
 
 @[aesop safe apply]
-lemma IsEssentiallySelfAdjoint.smul_ofReal [CompleteSpace H]
+lemma IsEssentiallySelfAdjoint.real_smul [CompleteSpace H]
     (h : T.IsEssentiallySelfAdjoint) {r : ℝ} (hr : r ≠ 0) :
-    (ofReal r • T).IsEssentiallySelfAdjoint :=
+    (r • T).IsEssentiallySelfAdjoint :=
   h.smul (ofReal_ne_zero.mpr hr) (conj_ofReal r)
 
 @[aesop safe apply]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -45,7 +45,8 @@ these correspond to physical observables.
 ## iii. Table of contents
 
 - A. General
-  - A.1. Finite sums
+  - A.1. DistribMulAction
+  - A.2. Finite sums
 - B. Operators on inner product/Hilbert spaces
   - B.1. Definitions
   - B.2. Dense domain
@@ -69,11 +70,6 @@ these correspond to physical observables.
 
 namespace LinearPMap
 
-open Submodule
-open InnerProductSpace
-open InnerProductSpaceSubmodule
-open Complex ComplexConjugate
-
 /-!
 ## A. General
 
@@ -88,10 +84,26 @@ variable {E : Type*} [AddCommGroup E] [Module R E]
 variable {F : Type*} [AddCommGroup F] [Module R F]
 
 /-!
-### A.1. Finite sums
+### A.1. DistribMulAction
 -/
 
 section
+
+variable {M : Type*} [Monoid M] [DistribMulAction M F] [SMulCommClass R M F]
+
+instance instDistribMulAction : DistribMulAction M (E →ₗ.[R] F) where
+  smul_zero _ := by ext; rfl; simp
+  smul_add _ _ _ := by ext; rfl; simp [add_apply]
+
+end
+
+/-!
+### A.2. Finite sums
+-/
+
+section
+
+open Submodule
 
 variable {α : Type*} [Fintype α] (f : α → E →ₗ.[R] F)
 
@@ -119,6 +131,11 @@ end General
 -/
 
 section InnerProductSpaces
+
+open Submodule
+open InnerProductSpace
+open InnerProductSpaceSubmodule
+open Complex ComplexConjugate
 
 variable
   {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -513,7 +513,7 @@ lemma IsSelfAdjoint.neg [CompleteSpace H] (h : IsSelfAdjoint T) : IsSelfAdjoint 
 
 lemma IsEssentiallySelfAdjoint.hasDenseDomain [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
     T.HasDenseDomain :=
-  hasDenseDomain_iff_closure_hasDenseDomain.mpr (isEssentiallySelfAdjoint_def.mp h).dense_domain
+  hasDenseDomain_iff_closure_hasDenseDomain.mpr h.dense_domain
 
 lemma IsEssentiallySelfAdjoint.isSymmetric [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
     T.IsSymmetric :=

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -150,6 +150,22 @@ lemma HasDenseDomain.isUnbounded_iff_isClosable (h : U.HasDenseDomain) :
 lemma HasDenseDomain.closure (h : U.HasDenseDomain) : U.closure.HasDenseDomain :=
   h.mono U.le_closure.1
 
+lemma closure_domain_le_domain_closure (U : H →ₗ.[ℂ] H') : U.closure.domain ≤ U.domain.closure := by
+  by_cases h_cl : U.IsClosable
+  · intro ψ hψ
+    obtain ⟨φ, hψφ⟩ := h_cl.graph_closure_eq_closure_graph ▸ mem_domain_iff.mp hψ
+    obtain ⟨b, hb, hb'⟩ := mem_closure_iff_seq_limit.mp hψφ
+    apply mem_closure_iff_seq_limit.mpr
+    refine ⟨fun n ↦ (b n).1, fun n ↦ ?_, (nhds_prod_eq (x := ψ) (y := φ) ▸ hb').fst⟩
+    specialize hb n
+    simp only [coe_toAddSubmonoid, SetLike.mem_coe, mem_graph_iff, Subtype.exists,
+      exists_and_left, exists_eq_left] at hb
+    exact hb.choose
+  · simp [closure_def' h_cl, closure_le.mp]
+
+lemma hasDenseDomain_iff_closure_hasDenseDomain : U.HasDenseDomain ↔ U.closure.HasDenseDomain :=
+  ⟨HasDenseDomain.closure, fun h ↦ dense_closure.mp (h.mono U.closure_domain_le_domain_closure)⟩
+
 lemma HasDenseDomain.neg (h : U.HasDenseDomain) : (-U).HasDenseDomain := h
 
 lemma HasDenseDomain.smul (h : U.HasDenseDomain) (c : ℂ) : (c • U).HasDenseDomain := h

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -492,27 +492,31 @@ lemma IsSelfAdjoint.neg [CompleteSpace H] (h : IsSelfAdjoint T) : IsSelfAdjoint 
 ### B.7. Essentially self-adjoint operators
 -/
 
+lemma IsEssentiallySelfAdjoint.hasDenseDomain [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
+    T.HasDenseDomain :=
+  hasDenseDomain_iff_closure_hasDenseDomain.mpr (isEssentiallySelfAdjoint_def.mp h).dense_domain
+
 lemma IsEssentiallySelfAdjoint.isSymmetric [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
     T.IsSymmetric :=
   (IsSelfAdjoint.isSymmetric h).of_le T.le_closure
 
-lemma IsEssentiallySelfAdjoint.isClosable [CompleteSpace H]
-    (h : T.IsEssentiallySelfAdjoint) (h' : T.HasDenseDomain) : T.IsClosable :=
-  h.isSymmetric.isClosable h'
+lemma IsEssentiallySelfAdjoint.isClosable [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
+    T.IsClosable :=
+  h.isSymmetric.isClosable h.hasDenseDomain
 
-lemma IsEssentiallySelfAdjoint.isUnbounded [CompleteSpace H]
-    (h : T.IsEssentiallySelfAdjoint) (h' : T.HasDenseDomain) : T.IsUnbounded :=
-  h.isSymmetric.isUnbounded_iff_hasDenseDomain.mpr h'
+lemma IsEssentiallySelfAdjoint.isUnbounded [CompleteSpace H] (h : T.IsEssentiallySelfAdjoint) :
+    T.IsUnbounded :=
+  h.isSymmetric.isUnbounded_iff_hasDenseDomain.mpr h.hasDenseDomain
 
 /-- The closure is the unique self-adjoint extension of an essentially self-adjoint operator. -/
 lemma IsEssentiallySelfAdjoint.unique_self_adjoint_extension [CompleteSpace H]
-    (h : T.IsEssentiallySelfAdjoint) (h' : T.HasDenseDomain)
-    {T₂ : H →ₗ.[ℂ] H} (h_le : T ≤ T₂) (h₂ : IsSelfAdjoint T₂) :
+    (h : T.IsEssentiallySelfAdjoint) {T₂ : H →ₗ.[ℂ] H} (h_le : T ≤ T₂) (h₂ : IsSelfAdjoint T₂) :
     T₂ = T.closure := by
+  have h_dense : T.HasDenseDomain := h.hasDenseDomain
   have h_cl : T₂.IsClosed := IsSelfAdjoint.isClosed h₂
   have h_cl' : T₂.closure = T₂ := h_cl.isClosable.isClosed_iff.mp h_cl
   have h_le' : T.closure ≤ T₂ := h_cl' ▸ h_cl.isClosable.closure_mono h_le
-  exact eq_of_le_of_ge (h ▸ h₂ ▸ adjoint_antitone (Or.inl <| h'.closure) h_le') h_le'
+  exact eq_of_le_of_ge (h ▸ h₂ ▸ adjoint_antitone (Or.inl <| h_dense.closure) h_le') h_le'
 
 @[aesop safe apply]
 lemma IsEssentiallySelfAdjoint.smul [CompleteSpace H]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -70,12 +70,46 @@ open Submodule
 open InnerProductSpace
 open InnerProductSpaceSubmodule
 open Complex ComplexConjugate
+section General
+
+variable {R : Type*} [Ring R]
+variable {E : Type*} [AddCommGroup E] [Module R E]
+variable {F : Type*} [AddCommGroup F] [Module R F]
+
+/-!
+### A.1. Finite sums
+-/
+
+section
+
+variable {α : Type*} [Fintype α] (f : α → E →ₗ.[R] F)
+
+/-- A finite sum of partial linear maps.
+
+  `sum f` and `∑ a, f a` are equal, but not by definition.
+  With `sum f` both `domain` and `toFun` are made explicit. -/
+def sum : E →ₗ.[R] F where
+  domain := ⨅ a, (f a).domain
+  toFun := ∑ a, (f a).toFun ∘ₗ inclusion (fun _ _ ↦ by simp_all only [mem_iInf])
+
+lemma sum_domain : (sum f).domain = ⨅ a, (f a).domain := rfl
+
+lemma sum_domain_le (a : α) : (sum f).domain ≤ (f a).domain := fun _ _ ↦ by simp_all [sum, mem_iInf]
+
+lemma sum_apply (ψ : (sum f).domain) : sum f ψ = ∑ a, f a ⟨ψ, sum_domain_le f a ψ.2⟩ := by
+  simp [sum, inclusion_apply]
+
+end
+
+end General
+
 
 variable
   {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
   {H' : Type*} [NormedAddCommGroup H'] [InnerProductSpace ℂ H']
-  {T T₁ T₂ : H →ₗ.[ℂ] H}
-  {U U₁ U₂ : H →ₗ.[ℂ] H'}
+  {α : Type*} [Fintype α]
+  {T T₁ T₂ : H →ₗ.[ℂ] H} {S : α → H →ₗ.[ℂ] H}
+  {U U₁ U₂ : H →ₗ.[ℂ] H'} {V : α → H →ₗ.[ℂ] H'}
 
 /-!
 ## A. Definitions
@@ -127,6 +161,11 @@ lemma HasDenseDomain.add_of_le (h₁ : U₁.HasDenseDomain) (h_le : U₁.domain 
 lemma HasDenseDomain.sub_of_le (h₁ : U₁.HasDenseDomain) (h_le : U₁.domain ≤ U₂.domain) :
     (U₁ - U₂).HasDenseDomain :=
   h₁.mono (by simp [h_le, sub_domain])
+
+lemma HasDenseDomain.sum_of_le
+    {E : Submodule ℂ H} (hE : Dense (E : Set H)) (h : ∀ a, E ≤ (V a).domain) :
+    (sum V).HasDenseDomain :=
+  hE.mono (by simp [sum_domain, h])
 
 /-!
 ## C. Closability
@@ -362,6 +401,11 @@ lemma IsSymmetric.smul (h : T.IsSymmetric) {c : ℂ} (hc : conj c = c) : (c • 
 @[aesop safe apply]
 lemma IsSymmetric.smul_ofReal (h : T.IsSymmetric) (r : ℝ) : (ofReal r • T).IsSymmetric :=
   h.smul (conj_ofReal r)
+
+@[aesop safe apply]
+lemma IsSymmetric.sum (h : ∀ a, (S a).IsSymmetric) : (sum S).IsSymmetric := by
+  intro x y
+  simp [sum_apply, sum_inner, inner_sum, h _ ⟨x, sum_domain_le S _ x.2⟩ ⟨y, sum_domain_le S _ y.2⟩]
 
 lemma IsSymmetric.of_le (h₁ : T₁.IsSymmetric) (h_le : T₂ ≤ T₁) : T₂.IsSymmetric := by
   intro x y

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/PolyBddSchwartzSubmodule.lean
@@ -177,7 +177,7 @@ private lemma enorm_bump_mul_le_enorm {𝕜 E : Type*} [RCLike 𝕜] [NormedAddC
 private lemma dense_zero_top :
     Dense (polyBddSchwartzSubmodule 0 ⊤ : Set (SpaceDHilbertSpace 0)) := by
   suffices polyBddSchwartzMap 0 ⊤ = ⊤ by
-    simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, this, SchwartzSubmodule.dense]
+    simp [polyBddSchwartzSubmodule, polyBddSchwartzIncl, this]
   refine Submodule.eq_top_iff'.mpr (fun f k hk ↦ ?_)
   refine ⟨1 + ‖f 0‖, by positivity, fun x ↦ ?_⟩
   simp only [Space.point_dim_zero_eq, norm_zero, zpow_neg, zpow_natCast]

--- a/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
+++ b/Physlib/QuantumMechanics/DDimensions/SpaceDHilbertSpace/SchwartzSubmodule.lean
@@ -86,6 +86,27 @@ lemma schwartzEquiv_ae_eq (h : schwartzEquiv f =ᵐ[volume] schwartzEquiv g) : f
 ## C. Misc.
 -/
 
+@[simp]
+lemma zero_eq_top : schwartzSubmodule 0 = ⊤ := by
+  ext ψ
+  simp only [LinearMap.mem_range, ContinuousLinearMap.coe_coe, Submodule.mem_top, iff_true]
+  let g : 𝓢(Space 0, ℂ) := {
+    toFun x := ψ 0
+    smooth' := contDiff_const
+    decay' k n := by
+      refine ⟨‖ψ 0‖, fun x ↦ ?_⟩
+      rcases eq_zero_or_pos n with rfl | hn
+      · rw [← one_mul ‖ψ 0‖]
+        refine mul_le_mul ?_ (by simp) (norm_nonneg _) zero_le_one
+        simp [Space.point_dim_zero_eq, zero_pow_le_one]
+      · simp [iteratedFDeriv_const_of_ne hn.ne']
+  }
+  use g
+  ext
+  filter_upwards [schwartzEquiv_coe_ae g] with x hg
+  rw [← schwartzEquiv_apply_coe, hg, Space.point_dim_zero_eq x]
+  rfl
+
 lemma dense (d : ℕ) : Dense (schwartzSubmodule d : Set (SpaceDHilbertSpace d)) :=
   denseRange_toLpCLM ENNReal.top_ne_ofNat.symm
 


### PR DESCRIPTION
Adds to the functionality of unbounded operators:
- Defines `LinearPMap.sum` for finite sums of partial linear maps. While `sum f` and `∑ a, f a` are equal, it is not by definition and the latter is difficult to work with.
- Proves that `U` is densely defined iff `U.closure` is densely defined, allowing redundant hypotheses to be removed for essentially self-adjoint operators.