### PR TITLE
feat(QuantumInfo): Bargmann invariant and geometric phase

### DIFF
--- a/QuantumInfo/Finite/Braket.lean
+++ b/QuantumInfo/Finite/Braket.lean
@@ -226,6 +226,13 @@ theorem Braket.dot_self_eq_one (ψ : Ket d) :〈ψ‖ψ〉= 1 := by
     rw [Complex.normSq_eq_conj_mul_self]
   simpa [dot, Bra.eq_conj, h₁] using congr(Complex.ofReal $ψ.normalized)
 
+/-- Swapping the arguments conjugates the bra-ket product:
+    `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`. -/
+theorem Braket.dot_swap_conj (ψ₁ ψ₂ : Ket d) :
+    〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
+  simp +decide [Braket.dot]
+  ac_rfl
+
 section prod
 variable {d d₁ d₂ : Type*} [Fintype d] [Fintype d₁] [Fintype d₂]
 

--- a/QuantumInfo/Finite/Braket.lean
+++ b/QuantumInfo/Finite/Braket.lean
@@ -228,7 +228,7 @@ theorem Braket.dot_self_eq_one (ψ : Ket d) :〈ψ‖ψ〉= 1 := by
 
 /-- Swapping the arguments conjugates the bra-ket product:
     `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`. -/
-theorem Braket.dot_swap_conj (ψ₁ ψ₂ : Ket d) :
+lemma Braket.dot_swap_conj (ψ₁ ψ₂ : Ket d) :
     〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
   simp +decide [Braket.dot]
   ac_rfl

--- a/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
@@ -64,20 +64,12 @@ lemma bargmannPhaseThree_degenerate (ψ : Ket d) :
 
 /-! ## Conjugacy -/
 
-/-- Swapping the arguments conjugates the bra-ket product:
-    `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`.
-    TODO: this is a general property of `dot` and should be moved to `Braket.lean`. -/
-lemma dot_swap_conj (ψ₁ ψ₂ : Ket d) :
-    〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
-  simp +decide [Braket.dot]
-  ac_rfl
-
 /-- Reversing the cyclic order conjugates the invariant. -/
 lemma bargmannInvariantThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
     bargmannInvariantThree ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariantThree ψ₁ ψ₂ ψ₃) := by
   unfold bargmannInvariantThree
   conv_lhs =>
-    rw [dot_swap_conj ψ₂ ψ₃, dot_swap_conj ψ₁ ψ₂, dot_swap_conj ψ₃ ψ₁,
+    rw [Braket.dot_swap_conj ψ₂ ψ₃, Braket.dot_swap_conj ψ₁ ψ₂, Braket.dot_swap_conj ψ₃ ψ₁,
         ← map_mul, ← map_mul]
   congr 1; ring
 

--- a/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Xylem Group. All rights reserved.
+Copyright (c) 2026 Anand Nambakam. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude (Anthropic), Aristotle (Harmonic)
+Authors: Anand Nambakam
 -/
 module
 
@@ -16,20 +16,20 @@ the geometric (Pancharatnam-Berry) phase accumulated around the
 geodesic triangle in projective Hilbert space.
 
 ## Important definitions
- * `bargmannInvariant3`: the 3-vertex Bargmann invariant `Δ₃`
- * `bargmannPhase3`: the geometric phase `arg(Δ₃)`
+ * `bargmannInvariantThree`: the 3-vertex Bargmann invariant `Δ₃`
+ * `bargmannPhaseThree`: the geometric phase `arg(Δ₃)`
 
 ## Important results
- * `bargmannInvariant3_degenerate`: identical states give `Δ₃ = 1`
- * `bargmannPhase3_degenerate`: identical states give phase `= 0`
- * `bargmannInvariant3_reverse`: reversing conjugates `Δ₃`
- * `bargmannPhase3_reverse`: reversing negates the phase (mod 2π)
+ * `bargmannInvariantThree_degenerate`: identical states give `Δ₃ = 1`
+ * `bargmannPhaseThree_degenerate`: identical states give phase `= 0`
+ * `bargmannInvariantThree_reverse`: reversing conjugates `Δ₃`
+ * `bargmannPhaseThree_reverse`: reversing negates the phase (mod 2π)
 
 ## References
- * V. Bargmann, "Note on Wigner's theorem on symmetry operations",
-   J. Math. Phys. 5, 862 (1964)
- * S. Pancharatnam, "Generalized theory of interference, and its
-   applications", Proc. Indian Acad. Sci. A 44, 247 (1956)
+ * [V. Bargmann, *Note on Wigner's theorem on symmetry operations*,
+   J. Math. Phys. 5, 862–868 (1964)][bargmann1964]
+ * [S. Pancharatnam, *Generalized theory of interference, and its
+   applications*, Proc. Indian Acad. Sci. A 44, 247–262 (1956)][pancharatnam1956]
 -/
 
 open Braket Complex
@@ -38,51 +38,53 @@ variable {d : Type*} [Fintype d] [DecidableEq d]
 
 noncomputable section
 
-/-- The 3-vertex Bargmann invariant: `⟨ψ₁|ψ₂⟩ · ⟨ψ₂|ψ₃⟩ · ⟨ψ₃|ψ₁⟩`.
+/-- The three-vertex Bargmann invariant: `⟨ψ₁|ψ₂⟩ · ⟨ψ₂|ψ₃⟩ · ⟨ψ₃|ψ₁⟩`.
     This is a gauge-invariant complex number whose argument is the
     geometric phase of the geodesic triangle. -/
-def bargmannInvariant3 (ψ₁ ψ₂ ψ₃ : Ket d) : ℂ :=
+def bargmannInvariantThree (ψ₁ ψ₂ ψ₃ : Ket d) : ℂ :=
   〈ψ₁‖ψ₂〉 * 〈ψ₂‖ψ₃〉 * 〈ψ₃‖ψ₁〉
 
 /-- The geometric (Pancharatnam-Berry) phase of three states. -/
-def bargmannPhase3 (ψ₁ ψ₂ ψ₃ : Ket d) : ℝ :=
-  Complex.arg (bargmannInvariant3 ψ₁ ψ₂ ψ₃)
+def bargmannPhaseThree (ψ₁ ψ₂ ψ₃ : Ket d) : ℝ :=
+  Complex.arg (bargmannInvariantThree ψ₁ ψ₂ ψ₃)
 
 /-! ## Degenerate triangles -/
 
 /-- The Bargmann invariant of three identical states is 1. -/
 @[simp]
-lemma bargmannInvariant3_degenerate (ψ : Ket d) :
-    bargmannInvariant3 ψ ψ ψ = 1 := by
-  unfold bargmannInvariant3
+lemma bargmannInvariantThree_degenerate (ψ : Ket d) :
+    bargmannInvariantThree ψ ψ ψ = 1 := by
+  unfold bargmannInvariantThree
   simp [Braket.dot_self_eq_one]
 
 /-- The geometric phase of three identical states is 0. -/
-lemma bargmannPhase3_degenerate (ψ : Ket d) :
-    bargmannPhase3 ψ ψ ψ = 0 := by
-  unfold bargmannPhase3; simp [Complex.arg_one]
+lemma bargmannPhaseThree_degenerate (ψ : Ket d) :
+    bargmannPhaseThree ψ ψ ψ = 0 := by
+  unfold bargmannPhaseThree; simp [Complex.arg_one]
 
 /-! ## Conjugacy -/
 
-/-- Swapping the arguments conjugates the overlap: `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`. -/
+/-- Swapping the arguments conjugates the bra-ket product:
+    `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`.
+    TODO: this is a general property of `dot` and should be moved to `Braket.lean`. -/
 lemma dot_swap_conj (ψ₁ ψ₂ : Ket d) :
     〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
   simp +decide [Braket.dot]
   ac_rfl
 
 /-- Reversing the cyclic order conjugates the invariant. -/
-lemma bargmannInvariant3_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
-    bargmannInvariant3 ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariant3 ψ₁ ψ₂ ψ₃) := by
-  unfold bargmannInvariant3
+lemma bargmannInvariantThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
+    bargmannInvariantThree ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariantThree ψ₁ ψ₂ ψ₃) := by
+  unfold bargmannInvariantThree
   conv_lhs =>
     rw [dot_swap_conj ψ₂ ψ₃, dot_swap_conj ψ₁ ψ₂, dot_swap_conj ψ₃ ψ₁,
         ← map_mul, ← map_mul]
   congr 1; ring
 
 /-- Reversing the cyclic order negates the geometric phase (mod 2π). -/
-lemma bargmannPhase3_reverse (ψ₁ ψ₂ ψ₃ : Ket d)
-    (h : bargmannInvariant3 ψ₁ ψ₂ ψ₃ ≠ 0) :
-    (bargmannPhase3 ψ₃ ψ₂ ψ₁ : Real.Angle) =
-    -(bargmannPhase3 ψ₁ ψ₂ ψ₃ : Real.Angle) := by
-  unfold bargmannPhase3; rw [bargmannInvariant3_reverse]
-  exact Complex.arg_conj_coe_angle (bargmannInvariant3 ψ₁ ψ₂ ψ₃)
+lemma bargmannPhaseThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d)
+    (h : bargmannInvariantThree ψ₁ ψ₂ ψ₃ ≠ 0) :
+    (bargmannPhaseThree ψ₃ ψ₂ ψ₁ : Real.Angle) =
+    -(bargmannPhaseThree ψ₁ ψ₂ ψ₃ : Real.Angle) := by
+  unfold bargmannPhaseThree; rw [bargmannInvariantThree_reverse]
+  exact Complex.arg_conj_coe_angle (bargmannInvariantThree ψ₁ ψ₂ ψ₃)

--- a/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Xylem Group. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude (Anthropic), Aristotle (Harmonic)
+-/
+module
+
+public import QuantumInfo.Finite.Braket
+
+/-!
+# Bargmann Invariant and Geometric Phase
+
+The Bargmann invariant for three quantum states is the cyclic product
+of inner products `⟨ψ₁|ψ₂⟩ · ⟨ψ₂|ψ₃⟩ · ⟨ψ₃|ψ₁⟩`. Its argument is
+the geometric (Pancharatnam-Berry) phase accumulated around the
+geodesic triangle in projective Hilbert space.
+
+## Important definitions
+ * `bargmannInvariant3`: the 3-vertex Bargmann invariant `Δ₃`
+ * `bargmannPhase3`: the geometric phase `arg(Δ₃)`
+
+## Important results
+ * `bargmannInvariant3_degenerate`: identical states give `Δ₃ = 1`
+ * `bargmannPhase3_degenerate`: identical states give phase `= 0`
+ * `bargmannInvariant3_reverse`: reversing conjugates `Δ₃`
+ * `bargmannPhase3_reverse`: reversing negates the phase (mod 2π)
+
+## References
+ * V. Bargmann, "Note on Wigner's theorem on symmetry operations",
+   J. Math. Phys. 5, 862 (1964)
+ * S. Pancharatnam, "Generalized theory of interference, and its
+   applications", Proc. Indian Acad. Sci. A 44, 247 (1956)
+-/
+
+open Braket Complex
+
+variable {d : Type*} [Fintype d] [DecidableEq d]
+
+noncomputable section
+
+/-- The 3-vertex Bargmann invariant: `⟨ψ₁|ψ₂⟩ · ⟨ψ₂|ψ₃⟩ · ⟨ψ₃|ψ₁⟩`.
+    This is a gauge-invariant complex number whose argument is the
+    geometric phase of the geodesic triangle. -/
+def bargmannInvariant3 (ψ₁ ψ₂ ψ₃ : Ket d) : ℂ :=
+  〈ψ₁‖ψ₂〉 * 〈ψ₂‖ψ₃〉 * 〈ψ₃‖ψ₁〉
+
+/-- The geometric (Pancharatnam-Berry) phase of three states. -/
+def bargmannPhase3 (ψ₁ ψ₂ ψ₃ : Ket d) : ℝ :=
+  Complex.arg (bargmannInvariant3 ψ₁ ψ₂ ψ₃)
+
+/-! ## Degenerate triangles -/
+
+/-- The Bargmann invariant of three identical states is 1. -/
+@[simp]
+lemma bargmannInvariant3_degenerate (ψ : Ket d) :
+    bargmannInvariant3 ψ ψ ψ = 1 := by
+  unfold bargmannInvariant3
+  simp [Braket.dot_self_eq_one]
+
+/-- The geometric phase of three identical states is 0. -/
+lemma bargmannPhase3_degenerate (ψ : Ket d) :
+    bargmannPhase3 ψ ψ ψ = 0 := by
+  unfold bargmannPhase3; simp [Complex.arg_one]
+
+/-! ## Conjugacy -/
+
+/-- Swapping the arguments conjugates the overlap: `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`. -/
+lemma dot_swap_conj (ψ₁ ψ₂ : Ket d) :
+    〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
+  sorry
+
+/-- Reversing the cyclic order conjugates the invariant. -/
+lemma bargmannInvariant3_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
+    bargmannInvariant3 ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariant3 ψ₁ ψ₂ ψ₃) := by
+  unfold bargmannInvariant3
+  sorry
+
+/-- Reversing the cyclic order negates the geometric phase (mod 2π). -/
+lemma bargmannPhase3_reverse (ψ₁ ψ₂ ψ₃ : Ket d)
+    (h : bargmannInvariant3 ψ₁ ψ₂ ψ₃ ≠ 0) :
+    (bargmannPhase3 ψ₃ ψ₂ ψ₁ : Real.Angle) =
+    -(bargmannPhase3 ψ₁ ψ₂ ψ₃ : Real.Angle) := by
+  unfold bargmannPhase3; rw [bargmannInvariant3_reverse]
+  exact Complex.arg_conj_coe_angle (bargmannInvariant3 ψ₁ ψ₂ ψ₃)

--- a/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
@@ -67,13 +67,17 @@ lemma bargmannPhase3_degenerate (ψ : Ket d) :
 /-- Swapping the arguments conjugates the overlap: `⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)`. -/
 lemma dot_swap_conj (ψ₁ ψ₂ : Ket d) :
     〈ψ₂‖ψ₁〉 = starRingEnd ℂ 〈ψ₁‖ψ₂〉 := by
-  sorry
+  simp +decide [Braket.dot]
+  ac_rfl
 
 /-- Reversing the cyclic order conjugates the invariant. -/
 lemma bargmannInvariant3_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
     bargmannInvariant3 ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariant3 ψ₁ ψ₂ ψ₃) := by
   unfold bargmannInvariant3
-  sorry
+  conv_lhs =>
+    rw [dot_swap_conj ψ₂ ψ₃, dot_swap_conj ψ₁ ψ₂, dot_swap_conj ψ₃ ψ₁,
+        ← map_mul, ← map_mul]
+  congr 1; ring
 
 /-- Reversing the cyclic order negates the geometric phase (mod 2π). -/
 lemma bargmannPhase3_reverse (ψ₁ ψ₂ ψ₃ : Ket d)


### PR DESCRIPTION
## Summary

Adds `QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean` (88 lines, zero sorry) with the 3-vertex Bargmann invariant and Pancharatnam-Berry geometric phase for `Ket d`.

### Definitions
- `bargmannInvariant3`: cyclic product ⟨ψ₁|ψ₂⟩·⟨ψ₂|ψ₃⟩·⟨ψ₃|ψ₁⟩
- `bargmannPhase3`: geometric phase `arg(Δ₃)`

### Results
- `bargmannInvariant3_degenerate`: identical states → Δ₃ = 1
- `bargmannPhase3_degenerate`: identical states → phase = 0
- `dot_swap_conj`: ⟨ψ₂|ψ₁⟩ = conj(⟨ψ₁|ψ₂⟩)
- `bargmannInvariant3_reverse`: reversing conjugates Δ₃
- `bargmannPhase3_reverse`: reversing negates the phase (mod 2π)

Builds on `Braket.lean` and its `Ket`/`dot` infrastructure. All proofs use only standard axioms.

This is the first PR of a planned series covering Pancharatnam's theorem (solid angle), polygon fan triangulation, convergence analysis, and N-level generalization. Discussed in #Physlib on Zulip.

## Notes
- Placement at `QuantumInfo/Finite/GeometricPhase/` per discussion with @jstoobysmith — happy to relocate if the file system reorganization proceeds first
- Follows review guidelines: under 100 lines, single concept, `lemma` not `theorem`

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Aristotle](https://aristotle.harmonic.fun)