### PR TITLE
feat(QuantumInfo): Bloch sphere + solid angle definitions for Pancharatnam

### DIFF
--- a/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
@@ -16,17 +16,17 @@ The Bloch sphere is the unit sphere S² in ℝ³, used to represent
 pure states of a two-level quantum system (qubit). Each point on the
 sphere corresponds to a qubit state up to global phase.
 
-This file defines the Bloch sphere type, the Bloch vector parameterization
-by polar and azimuthal angles, and the solid angle of a geodesic triangle
-via the Van Vleck formula.
+This file defines the Bloch sphere type and its angular parameterization,
+then builds the solid angle and dot product API on sphere points.
 
 ## Important definitions
- * `BlochSphere`: the unit sphere in ℝ³
- * `blochVec`: vector on S² parameterized by (α, θ)
- * `solidAngle`: solid angle via Van Vleck formula using `Complex.arg`
+ * `BlochSphere`: the unit sphere `Metric.sphere 0 1` in `EuclideanSpace ℝ (Fin 3)`
+ * `blochPoint`: point on the Bloch sphere from polar angle α and azimuthal angle θ
+ * `solidAngle`: solid angle of a geodesic triangle via Van Vleck formula
 
 ## Important results
- * `dot_blochVec`: dot product of Bloch vectors in terms of angles
+ * `blochPoint_norm`: the Bloch vector has unit norm
+ * `dot_blochPoint`: dot product of Bloch vectors in terms of angle differences
 
 ## References
  * [S. Pancharatnam, *Generalized theory of interference, and its
@@ -43,38 +43,64 @@ namespace GeometricPhase
 
 /-! ## The Bloch sphere -/
 
-/-- The Bloch sphere: unit sphere in ℝ³. Points are vectors with ‖v‖ = 1. -/
-def BlochSphere := Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1
+/-- The Bloch sphere: unit sphere in `EuclideanSpace ℝ (Fin 3)`. -/
+abbrev BlochSphere := Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1
 
-/-- The Bloch vector for polar angle `α` and azimuthal angle `θ`,
-    as a raw vector in ℝ³. -/
-def blochVec (α θ : ℝ) : Fin 3 → ℝ :=
+/-- The raw Bloch vector for angles (α, θ). Internal helper for `blochPoint`. -/
+private def blochVecRaw (α θ : ℝ) : Fin 3 → ℝ :=
   ![Real.sin α * Real.cos θ, Real.sin α * Real.sin θ, Real.cos α]
+
+/-- The Bloch vector has unit norm: sin²α(cos²θ + sin²θ) + cos²α = 1. -/
+private lemma blochVecRaw_norm (α θ : ℝ) :
+    Real.sqrt ((blochVecRaw α θ 0) ^ 2 + (blochVecRaw α θ 1) ^ 2 +
+      (blochVecRaw α θ 2) ^ 2) = 1 := by
+  have : (blochVecRaw α θ 0) ^ 2 + (blochVecRaw α θ 1) ^ 2 +
+    (blochVecRaw α θ 2) ^ 2 = 1 := by
+    simp [blochVecRaw, Fin.sum_univ_three]
+    have h1 := Real.sin_sq_add_cos_sq α
+    have h2 := Real.sin_sq_add_cos_sq θ
+    nlinarith [sq_nonneg (Real.sin α * Real.cos θ),
+      sq_nonneg (Real.sin α * Real.sin θ), sq_nonneg (Real.cos α),
+      sq_abs (Real.sin α), sq_abs (Real.cos θ)]
+  rw [this, Real.sqrt_one]
+
+/-- A point on the Bloch sphere parameterized by polar angle `α` and
+    azimuthal angle `θ`. -/
+def blochPoint (α θ : ℝ) : BlochSphere :=
+  ⟨(WithLp.equiv 2 _).symm (blochVecRaw α θ), by
+    rw [Metric.mem_sphere, dist_comm, EuclideanSpace.dist_eq]
+    simp [EuclideanSpace.norm_eq, Fin.sum_univ_three, sub_zero, blochVecRaw_norm α θ,
+      Real.sqrt_one]⟩
+
+/-- The underlying vector of a `blochPoint`. -/
+lemma blochPoint_val (α θ : ℝ) :
+    (blochPoint α θ : EuclideanSpace ℝ (Fin 3)) =
+    (WithLp.equiv 2 _).symm (blochVecRaw α θ) := rfl
 
 /-! ## Solid angle via Van Vleck formula -/
 
-/-- Solid angle of a geodesic triangle on S² with vertices given by
-    angle pairs, computed via the Van Vleck formula using `Complex.arg`
-    for full-quadrant support.
+/-- Solid angle of a geodesic triangle on the Bloch sphere, computed via
+    the Van Vleck formula using `Complex.arg` for full-quadrant support.
 
     `Ω = 2 · arg(den + num · i)` where
     `den = 1 + n₁·n₂ + n₂·n₃ + n₃·n₁` and `num = n₁ · (n₂ × n₃)`. -/
-def solidAngle (α₁ θ₁ α₂ θ₂ α₃ θ₃ : ℝ) : ℝ :=
-  let n₁ := blochVec α₁ θ₁
-  let n₂ := blochVec α₂ θ₂
-  let n₃ := blochVec α₃ θ₃
+def solidAngle (p₁ p₂ p₃ : BlochSphere) : ℝ :=
+  let n₁ := (p₁ : EuclideanSpace ℝ (Fin 3))
+  let n₂ := (p₂ : EuclideanSpace ℝ (Fin 3))
+  let n₃ := (p₃ : EuclideanSpace ℝ (Fin 3))
   let num := n₁ ⬝ᵥ n₂ ⨯₃ n₃
   let den := 1 + n₁ ⬝ᵥ n₂ + n₂ ⬝ᵥ n₃ + n₃ ⬝ᵥ n₁
   2 * Complex.arg ((den : ℝ) + (num : ℝ) * Complex.I)
 
 /-! ## Dot product of Bloch vectors -/
 
-/-- The dot product of two Bloch vectors expressed in angle differences. -/
-lemma dot_blochVec (α₁ θ₁ α₂ θ₂ : ℝ) :
-    blochVec α₁ θ₁ ⬝ᵥ blochVec α₂ θ₂ =
+/-- The dot product of two Bloch points expressed in angle differences. -/
+lemma dot_blochPoint (α₁ θ₁ α₂ θ₂ : ℝ) :
+    (blochPoint α₁ θ₁ : EuclideanSpace ℝ (Fin 3)) ⬝ᵥ
+    (blochPoint α₂ θ₂ : EuclideanSpace ℝ (Fin 3)) =
     Real.sin α₁ * Real.sin α₂ * Real.cos (θ₂ - θ₁) +
     Real.cos α₁ * Real.cos α₂ := by
-  simp [blochVec, dotProduct, Fin.sum_univ_three]
+  simp [blochPoint_val, dotProduct, blochVecRaw, Fin.sum_univ_three, WithLp.equiv]
   rw [show Real.cos (θ₂ - θ₁) = Real.cos θ₁ * Real.cos θ₂ +
     Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
   ring

--- a/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
@@ -39,12 +39,10 @@ open Complex Matrix
 
 noncomputable section
 
-namespace GeometricPhase
-
-/-! ## The Bloch sphere -/
-
 /-- The Bloch sphere: unit sphere in `EuclideanSpace ℝ (Fin 3)`. -/
 abbrev BlochSphere := Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1
+
+namespace BlochSphere
 
 /-- The raw Bloch vector for angles (α, θ). Internal helper for `blochPoint`. -/
 private def blochVecRaw (α θ : ℝ) : Fin 3 → ℝ :=
@@ -105,4 +103,4 @@ lemma dot_blochPoint (α₁ θ₁ α₂ θ₂ : ℝ) :
     Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
   ring
 
-end GeometricPhase
+end BlochSphere

--- a/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BlochSphere.lean
@@ -7,20 +7,26 @@ module
 
 public import QuantumInfo.Finite.GeometricPhase.BargmannInvariant
 public import Mathlib.LinearAlgebra.CrossProduct
+public import Mathlib.Analysis.InnerProductSpace.PiL2
 
 /-!
-# Pancharatnam's Theorem: Solid Angle on the Bloch Sphere
+# Bloch Sphere
 
-Infrastructure for Pancharatnam's theorem connecting the Bargmann phase
-to the solid angle on the Bloch sphere. This file defines the Bloch
-vector parameterization and the solid angle via the Van Vleck formula.
+The Bloch sphere is the unit sphere S² in ℝ³, used to represent
+pure states of a two-level quantum system (qubit). Each point on the
+sphere corresponds to a qubit state up to global phase.
+
+This file defines the Bloch sphere type, the Bloch vector parameterization
+by polar and azimuthal angles, and the solid angle of a geodesic triangle
+via the Van Vleck formula.
 
 ## Important definitions
- * `blochVector`: unit vector on S² parameterized by (α, θ)
+ * `BlochSphere`: the unit sphere in ℝ³
+ * `blochVec`: vector on S² parameterized by (α, θ)
  * `solidAngle`: solid angle via Van Vleck formula using `Complex.arg`
 
 ## Important results
- * `dot_blochVector`: dot product of Bloch vectors in terms of angles
+ * `dot_blochVec`: dot product of Bloch vectors in terms of angles
 
 ## References
  * [S. Pancharatnam, *Generalized theory of interference, and its
@@ -35,24 +41,28 @@ noncomputable section
 
 namespace GeometricPhase
 
-/-! ## Bloch sphere coordinates for qubits -/
+/-! ## The Bloch sphere -/
 
-/-- The Bloch vector on S² for polar angle `α` and azimuthal angle `θ`. -/
-def blochVector (α θ : ℝ) : Fin 3 → ℝ :=
+/-- The Bloch sphere: unit sphere in ℝ³. Points are vectors with ‖v‖ = 1. -/
+def BlochSphere := Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1
+
+/-- The Bloch vector for polar angle `α` and azimuthal angle `θ`,
+    as a raw vector in ℝ³. -/
+def blochVec (α θ : ℝ) : Fin 3 → ℝ :=
   ![Real.sin α * Real.cos θ, Real.sin α * Real.sin θ, Real.cos α]
 
 /-! ## Solid angle via Van Vleck formula -/
 
-/-- Solid angle of a geodesic triangle on S² with vertices at three
-    Bloch vectors, computed via the Van Vleck formula using `Complex.arg`
+/-- Solid angle of a geodesic triangle on S² with vertices given by
+    angle pairs, computed via the Van Vleck formula using `Complex.arg`
     for full-quadrant support.
 
     `Ω = 2 · arg(den + num · i)` where
     `den = 1 + n₁·n₂ + n₂·n₃ + n₃·n₁` and `num = n₁ · (n₂ × n₃)`. -/
 def solidAngle (α₁ θ₁ α₂ θ₂ α₃ θ₃ : ℝ) : ℝ :=
-  let n₁ := blochVector α₁ θ₁
-  let n₂ := blochVector α₂ θ₂
-  let n₃ := blochVector α₃ θ₃
+  let n₁ := blochVec α₁ θ₁
+  let n₂ := blochVec α₂ θ₂
+  let n₃ := blochVec α₃ θ₃
   let num := n₁ ⬝ᵥ n₂ ⨯₃ n₃
   let den := 1 + n₁ ⬝ᵥ n₂ + n₂ ⬝ᵥ n₃ + n₃ ⬝ᵥ n₁
   2 * Complex.arg ((den : ℝ) + (num : ℝ) * Complex.I)
@@ -60,11 +70,11 @@ def solidAngle (α₁ θ₁ α₂ θ₂ α₃ θ₃ : ℝ) : ℝ :=
 /-! ## Dot product of Bloch vectors -/
 
 /-- The dot product of two Bloch vectors expressed in angle differences. -/
-lemma dot_blochVector (α₁ θ₁ α₂ θ₂ : ℝ) :
-    (blochVector α₁ θ₁) ⬝ᵥ (blochVector α₂ θ₂) =
+lemma dot_blochVec (α₁ θ₁ α₂ θ₂ : ℝ) :
+    blochVec α₁ θ₁ ⬝ᵥ blochVec α₂ θ₂ =
     Real.sin α₁ * Real.sin α₂ * Real.cos (θ₂ - θ₁) +
     Real.cos α₁ * Real.cos α₂ := by
-  simp [blochVector, dotProduct, Fin.sum_univ_three]
+  simp [blochVec, dotProduct, Fin.sum_univ_three]
   rw [show Real.cos (θ₂ - θ₁) = Real.cos θ₁ * Real.cos θ₂ +
     Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
   ring

--- a/QuantumInfo/Finite/GeometricPhase/Pancharatnam.lean
+++ b/QuantumInfo/Finite/GeometricPhase/Pancharatnam.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Anand Nambakam. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anand Nambakam
+-/
+module
+
+public import QuantumInfo.Finite.GeometricPhase.BargmannInvariant
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+
+/-!
+# Pancharatnam's Theorem: Solid Angle on the Bloch Sphere
+
+For three qubit states (two-level systems), the Bargmann phase equals
+minus half the solid angle of the geodesic triangle on the Bloch sphere.
+
+This file defines the Bloch vector, dot product, cross product, and solid
+angle in ℝ³, then proves the real and imaginary parts of the three-vertex
+Bargmann invariant in terms of dot products and the triple product.
+
+## Important definitions
+ * `blochVector`: unit vector on S² parameterized by (α, θ)
+ * `solidAngle`: solid angle via Van Vleck formula using `Complex.arg`
+
+## Important results
+ * `bargmannInvariantThree_re_eq`: Re(Δ₃) = (1 + Σnᵢ·nⱼ)/4
+ * `bargmannInvariantThree_im_eq`: Im(Δ₃) = -(n₁·(n₂×n₃))/4
+ * `bargmannOverlapNormSq_eq`: |⟨ψᵢ|ψⱼ⟩|² = (1 + nᵢ·nⱼ)/2
+
+## References
+ * [S. Pancharatnam, *Generalized theory of interference, and its
+   applications*, Proc. Indian Acad. Sci. A 44, 247–262 (1956)][pancharatnam1956]
+ * [M. V. Berry, *Quantal phase factors accompanying adiabatic changes*,
+   Proc. R. Soc. Lond. A 392, 45–57 (1984)][berry1984]
+-/
+
+open Braket Complex Real
+
+variable {d : Type*} [Fintype d] [DecidableEq d]
+
+noncomputable section
+
+namespace GeometricPhase
+
+/-! ## Bloch sphere coordinates for qubits -/
+
+/-- The Bloch vector on S² for angles (α, θ). -/
+def blochVector (α θ : ℝ) : Fin 3 → ℝ := fun i =>
+  match i with
+  | 0 => Real.sin α * Real.cos θ
+  | 1 => Real.sin α * Real.sin θ
+  | 2 => Real.cos α
+
+/-- Dot product of two vectors in ℝ³. -/
+def dot3 (u v : Fin 3 → ℝ) : ℝ :=
+  u 0 * v 0 + u 1 * v 1 + u 2 * v 2
+
+/-- Cross product of two vectors in ℝ³. -/
+def cross3 (u v : Fin 3 → ℝ) : Fin 3 → ℝ := fun i =>
+  match i with
+  | 0 => u 1 * v 2 - u 2 * v 1
+  | 1 => u 2 * v 0 - u 0 * v 2
+  | 2 => u 0 * v 1 - u 1 * v 0
+
+/-- Scalar triple product n₁ · (n₂ × n₃). -/
+def tripleProduct (n₁ n₂ n₃ : Fin 3 → ℝ) : ℝ :=
+  dot3 n₁ (cross3 n₂ n₃)
+
+/-- Solid angle of a geodesic triangle on S² via the Van Vleck formula,
+    using `Complex.arg` for full-quadrant support. -/
+def solidAngle (α₁ θ₁ α₂ θ₂ α₃ θ₃ : ℝ) : ℝ :=
+  let n₁ := blochVector α₁ θ₁
+  let n₂ := blochVector α₂ θ₂
+  let n₃ := blochVector α₃ θ₃
+  let num := tripleProduct n₁ n₂ n₃
+  let den := 1 + dot3 n₁ n₂ + dot3 n₂ n₃ + dot3 n₃ n₁
+  2 * Complex.arg ((den : ℝ) + (num : ℝ) * Complex.I)
+
+/-! ## Dot product of Bloch vectors -/
+
+/-- The dot product of two Bloch vectors in terms of their angles. -/
+lemma dot3_blochVector (α₁ θ₁ α₂ θ₂ : ℝ) :
+    dot3 (blochVector α₁ θ₁) (blochVector α₂ θ₂) =
+    Real.sin α₁ * Real.sin α₂ * Real.cos (θ₂ - θ₁) +
+    Real.cos α₁ * Real.cos α₂ := by
+  unfold dot3 blochVector; simp only
+  rw [show Real.cos (θ₂ - θ₁) = Real.cos θ₁ * Real.cos θ₂ +
+       Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
+  ring
+
+end GeometricPhase

--- a/QuantumInfo/Finite/GeometricPhase/Pancharatnam.lean
+++ b/QuantumInfo/Finite/GeometricPhase/Pancharatnam.lean
@@ -6,37 +6,30 @@ Authors: Anand Nambakam
 module
 
 public import QuantumInfo.Finite.GeometricPhase.BargmannInvariant
-public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.LinearAlgebra.CrossProduct
 
 /-!
 # Pancharatnam's Theorem: Solid Angle on the Bloch Sphere
 
-For three qubit states (two-level systems), the Bargmann phase equals
-minus half the solid angle of the geodesic triangle on the Bloch sphere.
-
-This file defines the Bloch vector, dot product, cross product, and solid
-angle in ℝ³, then proves the real and imaginary parts of the three-vertex
-Bargmann invariant in terms of dot products and the triple product.
+Infrastructure for Pancharatnam's theorem connecting the Bargmann phase
+to the solid angle on the Bloch sphere. This file defines the Bloch
+vector parameterization and the solid angle via the Van Vleck formula.
 
 ## Important definitions
  * `blochVector`: unit vector on S² parameterized by (α, θ)
  * `solidAngle`: solid angle via Van Vleck formula using `Complex.arg`
 
 ## Important results
- * `bargmannInvariantThree_re_eq`: Re(Δ₃) = (1 + Σnᵢ·nⱼ)/4
- * `bargmannInvariantThree_im_eq`: Im(Δ₃) = -(n₁·(n₂×n₃))/4
- * `bargmannOverlapNormSq_eq`: |⟨ψᵢ|ψⱼ⟩|² = (1 + nᵢ·nⱼ)/2
+ * `dot_blochVector`: dot product of Bloch vectors in terms of angles
 
 ## References
  * [S. Pancharatnam, *Generalized theory of interference, and its
    applications*, Proc. Indian Acad. Sci. A 44, 247–262 (1956)][pancharatnam1956]
  * [M. V. Berry, *Quantal phase factors accompanying adiabatic changes*,
-   Proc. R. Soc. Lond. A 392, 45–57 (1984)][berry1984]
+   Proc. R. Soc. London A 392, 45–57 (1984)][berry1984]
 -/
 
-open Braket Complex Real
-
-variable {d : Type*} [Fintype d] [DecidableEq d]
+open Complex Matrix
 
 noncomputable section
 
@@ -44,48 +37,36 @@ namespace GeometricPhase
 
 /-! ## Bloch sphere coordinates for qubits -/
 
-/-- The Bloch vector on S² for angles (α, θ). -/
-def blochVector (α θ : ℝ) : Fin 3 → ℝ := fun i =>
-  match i with
-  | 0 => Real.sin α * Real.cos θ
-  | 1 => Real.sin α * Real.sin θ
-  | 2 => Real.cos α
+/-- The Bloch vector on S² for polar angle `α` and azimuthal angle `θ`. -/
+def blochVector (α θ : ℝ) : Fin 3 → ℝ :=
+  ![Real.sin α * Real.cos θ, Real.sin α * Real.sin θ, Real.cos α]
 
-/-- Dot product of two vectors in ℝ³. -/
-def dot3 (u v : Fin 3 → ℝ) : ℝ :=
-  u 0 * v 0 + u 1 * v 1 + u 2 * v 2
+/-! ## Solid angle via Van Vleck formula -/
 
-/-- Cross product of two vectors in ℝ³. -/
-def cross3 (u v : Fin 3 → ℝ) : Fin 3 → ℝ := fun i =>
-  match i with
-  | 0 => u 1 * v 2 - u 2 * v 1
-  | 1 => u 2 * v 0 - u 0 * v 2
-  | 2 => u 0 * v 1 - u 1 * v 0
+/-- Solid angle of a geodesic triangle on S² with vertices at three
+    Bloch vectors, computed via the Van Vleck formula using `Complex.arg`
+    for full-quadrant support.
 
-/-- Scalar triple product n₁ · (n₂ × n₃). -/
-def tripleProduct (n₁ n₂ n₃ : Fin 3 → ℝ) : ℝ :=
-  dot3 n₁ (cross3 n₂ n₃)
-
-/-- Solid angle of a geodesic triangle on S² via the Van Vleck formula,
-    using `Complex.arg` for full-quadrant support. -/
+    `Ω = 2 · arg(den + num · i)` where
+    `den = 1 + n₁·n₂ + n₂·n₃ + n₃·n₁` and `num = n₁ · (n₂ × n₃)`. -/
 def solidAngle (α₁ θ₁ α₂ θ₂ α₃ θ₃ : ℝ) : ℝ :=
   let n₁ := blochVector α₁ θ₁
   let n₂ := blochVector α₂ θ₂
   let n₃ := blochVector α₃ θ₃
-  let num := tripleProduct n₁ n₂ n₃
-  let den := 1 + dot3 n₁ n₂ + dot3 n₂ n₃ + dot3 n₃ n₁
+  let num := n₁ ⬝ᵥ n₂ ⨯₃ n₃
+  let den := 1 + n₁ ⬝ᵥ n₂ + n₂ ⬝ᵥ n₃ + n₃ ⬝ᵥ n₁
   2 * Complex.arg ((den : ℝ) + (num : ℝ) * Complex.I)
 
 /-! ## Dot product of Bloch vectors -/
 
-/-- The dot product of two Bloch vectors in terms of their angles. -/
-lemma dot3_blochVector (α₁ θ₁ α₂ θ₂ : ℝ) :
-    dot3 (blochVector α₁ θ₁) (blochVector α₂ θ₂) =
+/-- The dot product of two Bloch vectors expressed in angle differences. -/
+lemma dot_blochVector (α₁ θ₁ α₂ θ₂ : ℝ) :
+    (blochVector α₁ θ₁) ⬝ᵥ (blochVector α₂ θ₂) =
     Real.sin α₁ * Real.sin α₂ * Real.cos (θ₂ - θ₁) +
     Real.cos α₁ * Real.cos α₂ := by
-  unfold dot3 blochVector; simp only
+  simp [blochVector, dotProduct, Fin.sum_univ_three]
   rw [show Real.cos (θ₂ - θ₁) = Real.cos θ₁ * Real.cos θ₂ +
-       Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
+    Real.sin θ₁ * Real.sin θ₂ from by rw [Real.cos_sub]; ring]
   ring
 
 end GeometricPhase


### PR DESCRIPTION
## Summary

Adds `QuantumInfo/Finite/GeometricPhase/BlochSphere.lean` (108 lines, zero sorry) — the Bloch sphere type and API for qubit geometric phase.

### Definitions
- `BlochSphere`: the unit sphere `Metric.sphere 0 1` in `EuclideanSpace ℝ (Fin 3)`
- `blochPoint α θ`: a point on the Bloch sphere from polar and azimuthal angles, with a proof of unit norm
- `solidAngle p₁ p₂ p₃`: solid angle of a geodesic triangle on the Bloch sphere via the Van Vleck formula, using `Complex.arg` for full-quadrant support

### Results
- `blochVecRaw_norm`: the raw Bloch vector satisfies sin²α(cos²θ + sin²θ) + cos²α = 1
- `dot_blochPoint`: dot product of two Bloch points in terms of angle differences

All definitions operate on `BlochSphere` points rather than raw vectors. Uses Mathlib's `dotProduct` and `crossProduct`.

Builds on the merged `BargmannInvariant.lean` (#1121).