### PR TITLE
feat(QuantumInfo): cyclic symmetry for Bargmann invariant and phase

### DIFF
--- a/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
+++ b/QuantumInfo/Finite/GeometricPhase/BargmannInvariant.lean
@@ -24,6 +24,8 @@ geodesic triangle in projective Hilbert space.
  * `bargmannPhaseThree_degenerate`: identical states give phase `= 0`
  * `bargmannInvariantThree_reverse`: reversing conjugates `Δ₃`
  * `bargmannPhaseThree_reverse`: reversing negates the phase (mod 2π)
+ * `bargmannInvariantThree_cyclic`: cyclic permutation preserves `Δ₃`
+ * `bargmannPhaseThree_cyclic`: cyclic permutation preserves the phase
 
 ## References
  * [V. Bargmann, *Note on Wigner's theorem on symmetry operations*,
@@ -50,6 +52,7 @@ def bargmannPhaseThree (ψ₁ ψ₂ ψ₃ : Ket d) : ℝ :=
 
 /-! ## Degenerate triangles -/
 
+omit [DecidableEq d] in
 /-- The Bargmann invariant of three identical states is 1. -/
 @[simp]
 lemma bargmannInvariantThree_degenerate (ψ : Ket d) :
@@ -57,6 +60,7 @@ lemma bargmannInvariantThree_degenerate (ψ : Ket d) :
   unfold bargmannInvariantThree
   simp [Braket.dot_self_eq_one]
 
+omit [DecidableEq d] in
 /-- The geometric phase of three identical states is 0. -/
 lemma bargmannPhaseThree_degenerate (ψ : Ket d) :
     bargmannPhaseThree ψ ψ ψ = 0 := by
@@ -64,6 +68,7 @@ lemma bargmannPhaseThree_degenerate (ψ : Ket d) :
 
 /-! ## Conjugacy -/
 
+omit [DecidableEq d] in
 /-- Reversing the cyclic order conjugates the invariant. -/
 lemma bargmannInvariantThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
     bargmannInvariantThree ψ₃ ψ₂ ψ₁ = starRingEnd ℂ (bargmannInvariantThree ψ₁ ψ₂ ψ₃) := by
@@ -73,10 +78,25 @@ lemma bargmannInvariantThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
         ← map_mul, ← map_mul]
   congr 1; ring
 
+omit [DecidableEq d] in
 /-- Reversing the cyclic order negates the geometric phase (mod 2π). -/
-lemma bargmannPhaseThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d)
-    (h : bargmannInvariantThree ψ₁ ψ₂ ψ₃ ≠ 0) :
+lemma bargmannPhaseThree_reverse (ψ₁ ψ₂ ψ₃ : Ket d) :
     (bargmannPhaseThree ψ₃ ψ₂ ψ₁ : Real.Angle) =
     -(bargmannPhaseThree ψ₁ ψ₂ ψ₃ : Real.Angle) := by
   unfold bargmannPhaseThree; rw [bargmannInvariantThree_reverse]
   exact Complex.arg_conj_coe_angle (bargmannInvariantThree ψ₁ ψ₂ ψ₃)
+
+/-! ## Cyclic symmetry -/
+
+omit [DecidableEq d] in
+/-- Cyclic permutation of the three states preserves the Bargmann invariant. -/
+lemma bargmannInvariantThree_cyclic (ψ₁ ψ₂ ψ₃ : Ket d) :
+    bargmannInvariantThree ψ₂ ψ₃ ψ₁ = bargmannInvariantThree ψ₁ ψ₂ ψ₃ := by
+  unfold bargmannInvariantThree; ring
+
+omit [DecidableEq d] in
+/-- Cyclic permutation preserves the geometric phase. -/
+lemma bargmannPhaseThree_cyclic (ψ₁ ψ₂ ψ₃ : Ket d) :
+    bargmannPhaseThree ψ₂ ψ₃ ψ₁ = bargmannPhaseThree ψ₁ ψ₂ ψ₃ := by
+  unfold bargmannPhaseThree; rw [bargmannInvariantThree_cyclic]
+


### PR DESCRIPTION
## Summary

- Add `bargmannInvariantThree_cyclic`: cyclic permutation `(ψ₂, ψ₃, ψ₁)` preserves `Δ₃`, proved by `ring`
- Add `bargmannPhaseThree_cyclic`: cyclic permutation preserves the geometric phase, via rewrite
- Fix `DecidableEq` section variable warnings on all existing lemmas (`omit [DecidableEq d] in`)
- Remove unused non-zero hypothesis `h` from `bargmannPhaseThree_reverse` — `Complex.arg_conj_coe_angle` does not require it

## Context

Cyclic invariance is a fundamental property of the Bargmann invariant: since `Δ₃ = ⟨ψ₁|ψ₂⟩ · ⟨ψ₂|ψ₃⟩ · ⟨ψ₃|ψ₁⟩` is a cyclic product, permuting `(1,2,3) → (2,3,1)` is an algebraic identity. Together with the existing `_reverse` lemma (anti-cyclic order conjugates), this completes the symmetry group of the three-vertex invariant.

## Build

Zero warnings, zero errors on `lake build QuantumInfo.Finite.GeometricPhase.BargmannInvariant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)