### PR TITLE
feat(QuantumInfo): Cauchy-Schwarz norm bound for Bargmann invariant

### DIFF
--- a/QuantumInfo/States/Pure/BargmannInvariant.lean
+++ b/QuantumInfo/States/Pure/BargmannInvariant.lean
@@ -26,6 +26,7 @@ geodesic triangle in projective Hilbert space.
  * `bargmannPhaseThree_reverse`: reversing negates the phase (mod 2π)
  * `bargmannInvariantThree_cyclic`: cyclic permutation preserves `Δ₃`
  * `bargmannPhaseThree_cyclic`: cyclic permutation preserves the phase
+ * `norm_bargmannInvariantThree_le_one`: `‖Δ₃‖ ≤ 1` (via `Braket.norm_dot_le_one`)
 
 ## References
  * [V. Bargmann, *Note on Wigner's theorem on symmetry operations*,
@@ -99,4 +100,18 @@ omit [DecidableEq d] in
 lemma bargmannPhaseThree_cyclic (ψ₁ ψ₂ ψ₃ : Ket d) :
     bargmannPhaseThree ψ₂ ψ₃ ψ₁ = bargmannPhaseThree ψ₁ ψ₂ ψ₃ := by
   unfold bargmannPhaseThree; rw [bargmannInvariantThree_cyclic]
+
+/-! ## Norm bounds -/
+
+omit [DecidableEq d] in
+/-- The Bargmann invariant has norm at most 1: each inner product factor
+    is bounded by Cauchy-Schwarz on unit vectors. -/
+lemma norm_bargmannInvariantThree_le_one (ψ₁ ψ₂ ψ₃ : Ket d) :
+    ‖bargmannInvariantThree ψ₁ ψ₂ ψ₃‖ ≤ 1 := by
+  unfold bargmannInvariantThree
+  calc ‖〈ψ₁‖ψ₂〉 * 〈ψ₂‖ψ₃〉 * 〈ψ₃‖ψ₁〉‖
+      = ‖〈ψ₁‖ψ₂〉‖ * ‖〈ψ₂‖ψ₃〉‖ * ‖〈ψ₃‖ψ₁〉‖ := by rw [norm_mul, norm_mul]
+    _ ≤ 1 * 1 * 1 := by
+        gcongr <;> exact Braket.norm_dot_le_one _ _
+    _ = 1 := by ring
 

--- a/QuantumInfo/States/Pure/Braket.lean
+++ b/QuantumInfo/States/Pure/Braket.lean
@@ -419,4 +419,37 @@ theorem KetUpToPhase.surjective_mk : Function.Surjective (KetUpToPhase.mk (d := 
   fun q => @Quotient.ind _ Ket.PhaseEquiv (fun q => ∃ a, KetUpToPhase.mk a = q) (fun a => ⟨a, rfl⟩) q
 
 end equiv
+
+/-! ## Norm bounds -/
+
+section norm_bounds
+open Braket
+
+variable {d : Type*} [Fintype d]
+
+private def ketToEuclidean (ψ : Ket d) : EuclideanSpace ℂ d :=
+  (WithLp.equiv 2 _).symm ψ.vec
+
+private lemma ketToEuclidean_norm (ψ : Ket d) : ‖ketToEuclidean ψ‖ = 1 := by
+  rw [EuclideanSpace.norm_eq]; convert Real.sqrt_one
+  simp only [ketToEuclidean]; convert ψ.normalized'
+
+private lemma dot_eq_euclidean_inner (ψ₁ ψ₂ : Ket d) :
+    〈ψ₁‖ψ₂〉 = @inner ℂ (EuclideanSpace ℂ d) _
+      (ketToEuclidean ψ₁) (ketToEuclidean ψ₂) := by
+  unfold dot ketToEuclidean
+  simp only [Bra.eq_conj, PiLp.inner_apply]
+  congr 1; ext x
+  rw [RCLike.inner_apply']
+  simp [WithLp.equiv, Ket.apply]
+
+/-- The bra-ket product of normalized states has norm at most 1 (Cauchy-Schwarz). -/
+lemma Braket.norm_dot_le_one (ψ₁ ψ₂ : Ket d) : ‖〈ψ₁‖ψ₂〉‖ ≤ 1 := by
+  rw [dot_eq_euclidean_inner]
+  calc ‖@inner ℂ (EuclideanSpace ℂ d) _ (ketToEuclidean ψ₁) (ketToEuclidean ψ₂)‖
+      ≤ ‖ketToEuclidean ψ₁‖ * ‖ketToEuclidean ψ₂‖ := norm_inner_le_norm _ _
+    _ = 1 := by rw [ketToEuclidean_norm, ketToEuclidean_norm, mul_one]
+
+end norm_bounds
+
 end braket


### PR DESCRIPTION
## Summary

- Add `Braket.norm_dot_le_one` to `Braket.lean`: the bra-ket product of normalized states satisfies `‖⟨ψ₁|ψ₂⟩‖ ≤ 1`, proved via Cauchy-Schwarz
- Add `norm_bargmannInvariantThree_le_one` to `BargmannInvariant.lean`: the Bargmann invariant satisfies `‖Δ₃‖ ≤ 1`, as a product of three unit-bounded factors

## Approach

The proof connects `Braket.dot` to the `EuclideanSpace ℂ d` inner product via private helpers in `Braket.lean`, then applies Mathlib's `norm_inner_le_norm` (Cauchy-Schwarz on unit vectors). The Bargmann bound follows by factoring `‖a · b · c‖ = ‖a‖ · ‖b‖ · ‖c‖` and bounding each factor.

Per review feedback, `norm_dot_le_one` and the `EuclideanSpace` bridge live in `Braket.lean` (where the bra-ket product is defined), not in `BargmannInvariant.lean`. The `PiL2` import is already available transitively via `ForMathlib.LinearEquiv`.

## Motivation

The norm bound is needed for connecting the Bargmann invariant to the solid angle on the Bloch sphere (Pancharatnam's theorem), where `|Δ₃| = cos(Ω/4)` requires `|Δ₃| ≤ 1`.

## Build

Rebased onto master (includes #1133 and #1124 reorganization). Zero warnings, zero errors on `lake build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)