### PR TITLE
refactor: fix dimension of distDiv_inv_pow_eq_dim and remove several transparency options

### DIFF
--- a/Physlib/Electromagnetism/Current/InfiniteWire.lean
+++ b/Physlib/Electromagnetism/Current/InfiniteWire.lean
@@ -70,7 +70,6 @@ noncomputable def wireCurrentDensity (c : SpeedOfLight) :
   map_add' I1 I2 := by simp [add_smul]
   map_smul' r I := by simp [smul_smul]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma wireCurrentDensity_chargeDesnity (c : SpeedOfLight) (I : ℝ) :
     (wireCurrentDensity c I).chargeDensity c = 0 := by
@@ -78,7 +77,6 @@ lemma wireCurrentDensity_chargeDesnity (c : SpeedOfLight) (I : ℝ) :
   simp [DistLorentzCurrentDensity.chargeDensity, wireCurrentDensity, constantTime_apply,
   constantSliceDist_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma wireCurrentDensity_currentDensity_fst (c : SpeedOfLight) (I : ℝ)
     (η : 𝓢(Time × Space 3, ℝ)) :
     (wireCurrentDensity c I).currentDensity c η 0 =
@@ -88,7 +86,6 @@ lemma wireCurrentDensity_currentDensity_fst (c : SpeedOfLight) (I : ℝ)
   simp [wireCurrentDensity, DistLorentzCurrentDensity.currentDensity,
     constantTime_apply, constantSliceDist_apply, diracDelta'_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma wireCurrentDensity_currentDensity_snd (c : SpeedOfLight) (I : ℝ)
     (ε : 𝓢(Time × Space 3, ℝ)) :
@@ -96,7 +93,6 @@ lemma wireCurrentDensity_currentDensity_snd (c : SpeedOfLight) (I : ℝ)
   simp [wireCurrentDensity, DistLorentzCurrentDensity.currentDensity,
     constantTime_apply, constantSliceDist_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma wireCurrentDensity_currentDensity_thrd (c : SpeedOfLight) (I : ℝ)
     (ε : 𝓢(Time × Space 3, ℝ)) :
@@ -134,7 +130,6 @@ $$V(t, x, y, z) = 0.$$
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma infiniteWire_scalarPotential (𝓕 : FreeSpace) (I : ℝ) :
     (infiniteWire 𝓕 I).scalarPotential 𝓕.c = 0 := by
@@ -155,7 +150,6 @@ a system with translational symmetry along the x-axis.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma infiniteWire_vectorPotential (𝓕 : FreeSpace) (I : ℝ) :
     (infiniteWire 𝓕 I).vectorPotential 𝓕.c =
     (constantTime <|
@@ -272,7 +266,7 @@ lemma infiniteWire_isExterma {𝓕 : FreeSpace} {I : ℝ} :
         conv_rhs => rw [distDeriv_apply, fderivD_apply]
         simp [distGrad_apply]
     rw [distGrad_distOfFunction_log_norm]
-    have h1 := distDiv_inv_pow_eq_dim (d := 1)
+    have h1 := distDiv_inv_pow_eq_dim (d := 2)
     simp at h1
     simp [h1]
   · simp only [Fin.mk_one, Fin.isValue, neg_sub, Finset.sum_sub_distrib, Fin.sum_univ_three,

--- a/Physlib/Electromagnetism/Distributional/VectorPotential.lean
+++ b/Physlib/Electromagnetism/Distributional/VectorPotential.lean
@@ -59,7 +59,6 @@ open minkowskiMatrix SchwartzMap
 attribute [-simp] Fintype.sum_sum_type
 attribute [-simp] Nat.succ_eq_add_one
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The vector potential of an electromagnetic potential which is a distribution. -/
 noncomputable def vectorPotential {d} (c : SpeedOfLight) :
     DistElectromagneticPotential d →ₗ[ℝ]

--- a/Physlib/Electromagnetism/PointParticle/OneDimension.lean
+++ b/Physlib/Electromagnetism/PointParticle/OneDimension.lean
@@ -72,7 +72,6 @@ lemma oneDimPointParticleCurrentDensity_eq_distTranslate (c : SpeedOfLight) (q :
   ext η
   simp [distTranslate_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma oneDimPointParticleCurrentDensity_currentDensity (c : SpeedOfLight) (q : ℝ) (r₀ : Space 1) :
     (oneDimPointParticleCurrentDensity c q r₀).currentDensity c = 0 := by
@@ -80,7 +79,6 @@ lemma oneDimPointParticleCurrentDensity_currentDensity (c : SpeedOfLight) (q : �
   simp [oneDimPointParticleCurrentDensity, DistLorentzCurrentDensity.currentDensity,
     Lorentz.Vector.spatialCLM, constantTime_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma oneDimPointParticleCurrentDensity_chargeDensity (c : SpeedOfLight) (q : ℝ) (r₀ : Space 1) :
     (oneDimPointParticleCurrentDensity c q r₀).chargeDensity c =
@@ -130,7 +128,6 @@ lemma oneDimPointParticle_eq_distTranslate (𝓕 : FreeSpace) (q : ℝ) (r₀ : 
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma oneDimPointParticle_vectorPotential (𝓕 : FreeSpace) (q : ℝ) (r₀ : Space 1) :
     (oneDimPointParticle 𝓕 q r₀).vectorPotential 𝓕.c = 0 := by
@@ -144,7 +141,6 @@ lemma oneDimPointParticle_vectorPotential (𝓕 : FreeSpace) (q : ℝ) (r₀ : S
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma oneDimPointParticle_scalarPotential (𝓕 : FreeSpace) (q : ℝ) (r₀ : Space 1) :
     (oneDimPointParticle 𝓕 q r₀).scalarPotential 𝓕.c =
     Space.constantTime (distOfFunction (fun x =>
@@ -220,7 +216,7 @@ lemma oneDimPointParticle_div_electricField {𝓕} (q : ℝ) (r₀ : Space 1) :
     (𝓕.μ₀ * 𝓕.c ^ 2) • constantTime (q • diracDelta ℝ r₀) := by
   rw [oneDimPointParticle_electricField]
   simp only [Int.reduceNeg, zpow_neg, zpow_one, map_smul, smul_smul]
-  have h1 := Space.distDiv_inv_pow_eq_dim (d := 0)
+  have h1 := Space.distDiv_inv_pow_eq_dim (d := 1)
   simp at h1
   trans (q * 𝓕.μ₀ * 𝓕.c.val ^ 2 / 2) •
     distSpaceDiv (constantTime <|

--- a/Physlib/Electromagnetism/PointParticle/ThreeDimension.lean
+++ b/Physlib/Electromagnetism/PointParticle/ThreeDimension.lean
@@ -93,7 +93,6 @@ where $q$ is the charge of the particle and $r₀$ is the position of the partic
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma threeDimPointParticleCurrentDensity_chargeDensity (c : SpeedOfLight) (q : ℝ) (r₀ : Space 3) :
     (threeDimPointParticleCurrentDensity c q r₀).chargeDensity c =
@@ -118,7 +117,6 @@ In other words, there is no current flow for a point particle at rest.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma threeDimPointParticleCurrentDensity_currentDensity (c : SpeedOfLight) (q : ℝ) (r₀ : Space 3) :
     (threeDimPointParticleCurrentDensity c q r₀).currentDensity c = 0 := by
@@ -177,7 +175,6 @@ $$V(r) = \frac{q}{4 π \epsilon_0 |r - r_0|}.$$
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma threeDimPointParticle_scalarPotential (𝓕 : FreeSpace) (q : ℝ) (r₀ : Space 3) :
     (threeDimPointParticle 𝓕 q r₀).scalarPotential 𝓕.c =
     Space.constantTime (distOfFunction (fun x => (q/ (4 * π * 𝓕.ε₀))• ‖x - r₀‖⁻¹)
@@ -209,7 +206,6 @@ $$\vec A(r) = 0.$$
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma threeDimPointParticle_vectorPotential (𝓕 : FreeSpace) (q : ℝ) (r₀ : Space 3) :
     (threeDimPointParticle 𝓕 q r₀).vectorPotential 𝓕.c = 0 := by
@@ -281,13 +277,12 @@ satisfies Maxwell's equations for a point particle at rest.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma threeDimPointParticle_div_electricField {𝓕} (q : ℝ) (r₀ : Space 3) :
     distSpaceDiv ((threeDimPointParticle 𝓕 q r₀).electricField 𝓕.c) =
     (1/𝓕.ε₀) • constantTime (q • diracDelta ℝ r₀) := by
   rw [threeDimPointParticle_electricField]
   simp only [Int.reduceNeg, zpow_neg, map_smul, smul_smul]
-  have h1 := Space.distDiv_inv_pow_eq_dim (d := 2)
+  have h1 := Space.distDiv_inv_pow_eq_dim (d := 3)
   simp at h1
   trans (q / (4 * π * 𝓕.ε₀)) •
     distSpaceDiv (constantTime <|

--- a/Physlib/SpaceAndTime/Space/Norm.lean
+++ b/Physlib/SpaceAndTime/Space/Norm.lean
@@ -131,7 +131,6 @@ lemma normPowerSeries_tendsto {d} (x : Space d) (hx : x ≠ 0) :
   · left
     simpa using hx
 
-set_option backward.isDefEq.respectTransparency false in
 lemma normPowerSeries_inv_tendsto {d} (x : Space d) (hx : x ≠ 0) :
     Filter.Tendsto (fun n => (normPowerSeries n x)⁻¹) Filter.atTop (𝓝 (‖x‖⁻¹)) := by
   apply Filter.Tendsto.inv₀
@@ -591,7 +590,6 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} (m : �
         simpa using hx
     simpa using h1
 
-set_option backward.isDefEq.respectTransparency false in
 lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} (m : ℤ) (hm : - (d.succ - 1 : ℕ) + 1 ≤ m)
     (η : 𝓢(Space d.succ, ℝ)) (y : EuclideanSpace ℝ (Fin d.succ)) :
     Filter.Tendsto (fun n =>
@@ -950,7 +948,9 @@ The proof
 open Distribution
 
 set_option backward.isDefEq.respectTransparency false in
-lemma distDiv_inv_pow_eq_dim {d : ℕ} :
+/-- Auxiliary lemma with dimension defined as d.succ to handle `homeomorphUnitSphereProd`.
+The dimension correct version is declared in `distDiv_inv_pow_eq_dim`. -/
+private lemma distDiv_inv_pow_eq_dim' {d : ℕ} :
     distDiv (distOfFunction (fun x : Space d.succ => ‖x‖ ^ (- d.succ : ℤ) • basis.repr x)
       (IsDistBounded.zpow_smul_repr_self (- d.succ : ℤ) (by omega))) =
       (d.succ * (volume (α := Space d.succ)).real (Metric.ball 0 1)) • diracDelta ℝ 0 := by
@@ -1097,5 +1097,12 @@ lemma distDiv_inv_pow_eq_dim {d : ℕ} :
   simp only [Nat.succ_eq_add_one, Nat.cast_add, Nat.cast_one, ContinuousLinearMap.coe_smul',
     Pi.smul_apply, diracDelta_apply, smul_eq_mul]
   ring
+
+lemma distDiv_inv_pow_eq_dim {d : ℕ} (hd : d ≥ 1) :
+    distDiv (distOfFunction (fun x : Space d => ‖x‖ ^ (- d : ℤ) • basis.repr x)
+      (IsDistBounded.zpow_smul_repr_self (- d : ℤ) (by omega))) =
+      (d * (volume (α := Space d)).real (Metric.ball 0 1)) • diracDelta ℝ 0 := by
+  obtain ⟨d', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : d ≠ 0)
+  exact distDiv_inv_pow_eq_dim'
 
 end Space

--- a/Physlib/SpaceAndTime/SpaceTime/TimeSlice.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/TimeSlice.lean
@@ -114,7 +114,6 @@ lemma timeSliceLinearEquiv_symm_apply {d : ℕ} {M : Type} [AddCommGroup M] [Mod
 -/
 open Distribution SchwartzMap
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The time slice of a distribution on `SpaceTime d` to form a distribution
   on `Time × Space d`. -/
 noncomputable def distTimeSlice {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
@@ -159,7 +158,6 @@ lemma distTimeSlice_symm_apply {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma distTimeSlice_distDeriv_inl {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     {c : SpeedOfLight}
     (f : (SpaceTime d) →d[ℝ] M) :
@@ -205,7 +203,6 @@ lemma distTimeSlice_symm_distTimeDeriv_eq {M d} [NormedAddCommGroup M] [NormedSp
   rw [distDeriv_inl_distTimeSlice_symm]
   simp
 
-set_option backward.isDefEq.respectTransparency false in
 lemma distTimeSlice_distDeriv_inr {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     {c : SpeedOfLight}
     (i : Fin d) (f : (SpaceTime d) →d[ℝ] M) :


### PR DESCRIPTION
`distDiv_inv_pow_eq_dim` carries the wrong spatial dimensions which confuses me when I was looking at the point charge examples, hopefully this change makes sense.

