### PR TITLE
feat(QuantumMechanics): Add operator inequalities

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -55,6 +55,7 @@ these correspond to physical observables.
   - A.2. Finite sums
   - A.3. Restricted composition
   - A.4. Monoid
+  - A.5. Inequalities
 - B. Operators on inner product/Hilbert spaces
   - B.1. Definitions
   - B.2. Dense domain
@@ -256,6 +257,67 @@ lemma mul_def (f₁ f₂ : E →ₗ.[R] E) : f₁ * f₂ = f₁ ∘ᵣ f₂ := r
 
 @[simp]
 lemma one_domain : (1 : E →ₗ.[R] E).domain = ⊤ := rfl
+
+/-!
+### A.5. Inequalities
+-/
+
+section
+
+variable (f f₁ f₂ f₃ : E →ₗ.[R] F) {g g₁ g₂ : E →ₗ.[R] F}
+
+lemma sub_self_le_zero : f - f ≤ 0 := ⟨le_top, by simp [sub_apply]⟩
+
+lemma neg_add_self_le_zero : -f + f ≤ 0 := ⟨le_top, by simp [add_apply]⟩
+
+lemma le_iff_neg_le_neg : g₁ ≤ g₂ ↔ -g₁ ≤ -g₂ :=
+  ⟨fun ⟨h, h'⟩ ↦ ⟨h, fun _ _ h'' ↦ by simp [h' h'']⟩, fun ⟨h, _⟩ ↦ ⟨h, fun _ _ _ ↦ by aesop⟩⟩
+
+lemma le_neg_iff_neg_le : g₁ ≤ -g₂ ↔ -g₁ ≤ g₂ := by rw [le_iff_neg_le_neg, neg_neg]
+
+lemma add_sub_cancel_le : f₁ + (f₂ - f₁) ≤ f₂ :=
+  ⟨by simp [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
+
+lemma add_sub_cancel_left_le : f₁ + f₂ - f₁ ≤ f₂ := add_sub_assoc f₁ f₂ f₁ ▸ add_sub_cancel_le f₁ f₂
+
+lemma add_sub_cancel_right_le : f₁ + f₂ - f₂ ≤ f₁ := add_comm f₁ f₂ ▸ add_sub_cancel_left_le f₂ f₁
+
+lemma add_add_sub_cancel_le : f₁ + f₂ + (f₃ - f₂) ≤ f₁ + f₃ :=
+  ⟨fun _ _ ↦ by simp_all [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
+
+lemma add_sub_sub_cancel_le : f₁ + f₂ - (f₁ - f₃) ≤ f₂ + f₃ :=
+  ⟨fun _ _ ↦ by simp_all [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
+
+lemma sub_le_of_le_add (h : g ≤ g₁ + g₂) : g - g₂ ≤ g₁ := by
+  constructor
+  · exact (inf_le_of_left_le le_rfl).trans (le_inf_iff.mp <| add_domain g₁ g₂ ▸ h.1).1
+  · intro ⟨x, hx⟩ ⟨y, hy⟩ rfl
+    simp [sub_apply, @h.2 ⟨x, hx.1⟩ ⟨x, ⟨hy, hx.2⟩⟩ rfl, add_apply]
+
+lemma add_le_of_le_sub (h : g ≤ g₁ - g₂) : g + g₂ ≤ g₁ :=
+  sub_neg_eq_add g g₂ ▸ sub_le_of_le_add (sub_eq_add_neg g₁ g₂ ▸ h)
+
+lemma add_left_le_of_le (h : g₁ ≤ g₂) : f + g₁ ≤ f + g₂ := by
+  constructor
+  · simp only [add_domain, le_inf_iff, inf_le_left, true_and]
+    exact (inf_le_of_right_le le_rfl).trans h.1
+  · intro x y hxy
+    simp_rw [add_apply, @h.2 ⟨x, x.2.2⟩ ⟨y, y.2.2⟩ hxy, hxy]
+
+lemma add_right_le_of_le (h : g₁ ≤ g₂) : g₁ + f ≤ g₂ + f :=
+  add_comm f g₁ ▸ add_comm f g₂ ▸ add_left_le_of_le f h
+
+lemma sub_right_le_of_le (h : g₁ ≤ g₂) : g₁ - f ≤ g₂ - f := by
+  constructor
+  · simp only [sub_domain, le_inf_iff, inf_le_right, and_true]
+    exact inf_le_of_left_le h.1
+  · intro x y hxy
+    simp_rw [sub_apply, @h.2 ⟨x, x.2.1⟩ ⟨y, y.2.1⟩ hxy, hxy]
+
+lemma sub_left_le_of_le (h : g₁ ≤ g₂) : f - g₁ ≤ f - g₂ :=
+  neg_sub g₁ f ▸ neg_sub g₂ f ▸ le_iff_neg_le_neg.mp (sub_right_le_of_le f h)
+
+end
 
 end General
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -266,26 +266,26 @@ section
 
 variable (f f₁ f₂ f₃ : E →ₗ.[R] F) {g g₁ g₂ : E →ₗ.[R] F}
 
-lemma sub_self_le_zero : f - f ≤ 0 := ⟨le_top, by simp [sub_apply]⟩
+lemma sub_le_zero : f - f ≤ 0 := ⟨le_top, by simp [sub_apply]⟩
 
-lemma neg_add_self_le_zero : -f + f ≤ 0 := ⟨le_top, by simp [add_apply]⟩
+lemma neg_add_le_zero : -f + f ≤ 0 := ⟨le_top, by simp [add_apply]⟩
 
 lemma le_iff_neg_le_neg : g₁ ≤ g₂ ↔ -g₁ ≤ -g₂ :=
   ⟨fun ⟨h, h'⟩ ↦ ⟨h, fun _ _ h'' ↦ by simp [h' h'']⟩, fun ⟨h, _⟩ ↦ ⟨h, fun _ _ _ ↦ by aesop⟩⟩
 
 lemma le_neg_iff_neg_le : g₁ ≤ -g₂ ↔ -g₁ ≤ g₂ := by rw [le_iff_neg_le_neg, neg_neg]
 
-lemma add_sub_cancel_le : f₁ + (f₂ - f₁) ≤ f₂ :=
+lemma add_sub_le_cancel : f₁ + (f₂ - f₁) ≤ f₂ :=
   ⟨by simp [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
 
-lemma add_sub_cancel_left_le : f₁ + f₂ - f₁ ≤ f₂ := add_sub_assoc f₁ f₂ f₁ ▸ add_sub_cancel_le f₁ f₂
+lemma add_sub_le_cancel_left : f₁ + f₂ - f₁ ≤ f₂ := add_sub_assoc f₁ f₂ f₁ ▸ add_sub_le_cancel f₁ f₂
 
-lemma add_sub_cancel_right_le : f₁ + f₂ - f₂ ≤ f₁ := add_comm f₁ f₂ ▸ add_sub_cancel_left_le f₂ f₁
+lemma add_sub_le_cancel_right : f₁ + f₂ - f₂ ≤ f₁ := add_comm f₁ f₂ ▸ add_sub_le_cancel_left f₂ f₁
 
-lemma add_add_sub_cancel_le : f₁ + f₂ + (f₃ - f₂) ≤ f₁ + f₃ :=
+lemma add_add_sub_le_cancel : f₁ + f₂ + (f₃ - f₂) ≤ f₁ + f₃ :=
   ⟨fun _ _ ↦ by simp_all [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
 
-lemma add_sub_sub_cancel_le : f₁ + f₂ - (f₁ - f₃) ≤ f₂ + f₃ :=
+lemma add_sub_sub_le_cancel : f₁ + f₂ - (f₁ - f₃) ≤ f₂ + f₃ :=
   ⟨fun _ _ ↦ by simp_all [add_domain, sub_domain], fun _ _ h ↦ by simp [add_apply, sub_apply, h]⟩
 
 lemma sub_le_of_le_add (h : g ≤ g₁ + g₂) : g - g₂ ≤ g₁ := by

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -307,12 +307,8 @@ lemma add_left_le_of_le (h : g₁ ≤ g₂) : f + g₁ ≤ f + g₂ := by
 lemma add_right_le_of_le (h : g₁ ≤ g₂) : g₁ + f ≤ g₂ + f :=
   add_comm f g₁ ▸ add_comm f g₂ ▸ add_left_le_of_le f h
 
-lemma sub_right_le_of_le (h : g₁ ≤ g₂) : g₁ - f ≤ g₂ - f := by
-  constructor
-  · simp only [sub_domain, le_inf_iff, inf_le_right, and_true]
-    exact inf_le_of_left_le h.1
-  · intro x y hxy
-    simp_rw [sub_apply, @h.2 ⟨x, x.2.1⟩ ⟨y, y.2.1⟩ hxy, hxy]
+lemma sub_right_le_of_le (h : g₁ ≤ g₂) : g₁ - f ≤ g₂ - f :=
+  sub_eq_add_neg g₁ f ▸ sub_eq_add_neg g₂ f ▸ add_right_le_of_le (-f) h
 
 lemma sub_left_le_of_le (h : g₁ ≤ g₂) : f - g₁ ≤ f - g₂ :=
   neg_sub g₁ f ▸ neg_sub g₂ f ▸ le_iff_neg_le_neg.mp (sub_right_le_of_le f h)


### PR DESCRIPTION
Adds `LinearPMap` inequalities useful for when terms in a sum cancel.

I've tried to mimic the names of analogous equalities in mathlib where possible.