### PR TITLE
feat: distLaplacian and dist operator notations

### DIFF
--- a/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
+++ b/Physlib/ClassicalMechanics/WaveEquation/Basic.lean
@@ -58,7 +58,7 @@ open InnerProductSpace
 /-- The general form of the wave equation where `c` is the propagation speed. -/
 def WaveEquation {d} (f : Time → Space d → EuclideanSpace ℝ (Fin d))
     (t : Time) (x : Space d) (c : ℝ) : Prop :=
-    c^2 • Δ (f t) x - ∂ₜ (fun t => (∂ₜ (fun t => f t x) t)) t = 0
+    c^2 • Δᵥ (f t) x - ∂ₜ (fun t => (∂ₜ (fun t => f t x) t)) t = 0
 
 /-!
 
@@ -174,7 +174,7 @@ open InnerProductSpace
 
 lemma planeWave_space_deriv {d f₀ c} {s : Direction d}
     (h' : Differentiable ℝ f₀) (i : Fin d) :
-    Space.deriv i (planeWave f₀ c s t) =
+    ∂[i] (planeWave f₀ c s t) =
     s.unit i • fun x => planeWave (fderiv ℝ f₀ · 1) c s t x:= by
   ext x j
   rw [Space.deriv_eq]
@@ -193,7 +193,7 @@ lemma planeWave_space_deriv {d f₀ c} {s : Direction d}
 
 lemma planeWave_apply_space_deriv {d f₀ c} {s : Direction d}
     (h' : Differentiable ℝ f₀) (i j : Fin d) :
-    Space.deriv i (fun x => planeWave f₀ c s t x j) =
+    ∂[i] (fun x => planeWave f₀ c s t x j) =
     s.unit i • fun x => planeWave (fderiv ℝ f₀ · 1) c s t x j := by
   funext x
   rw [Space.deriv_eq_fderiv_basis]
@@ -209,7 +209,7 @@ lemma planeWave_apply_space_deriv {d f₀ c} {s : Direction d}
 
 lemma planeWave_space_deriv_space_deriv {d f₀ c} {s : Direction d}
     (h' : ContDiff ℝ 2 f₀) (i : Fin d) :
-    Space.deriv i (Space.deriv i (planeWave f₀ c s t)) =
+    ∂[i] (∂[i] (planeWave f₀ c s t)) =
     s.unit i ^ 2 • fun x => planeWave (iteratedDeriv 2 f₀ ·) c s t x := by
   conv_lhs =>
     enter [2, j]
@@ -231,8 +231,8 @@ lemma planeWave_space_deriv_space_deriv {d f₀ c} {s : Direction d}
 
 lemma planeWave_apply_space_deriv_space_deriv {d f₀ c} {s : Direction d}
     (h' : ContDiff ℝ 2 f₀) (i j : Fin d) :
-    Space.deriv i (Space.deriv i (fun x => planeWave f₀ c s t x j)) =
-    (s.unit i) ^ 2 •fun x => planeWave (iteratedDeriv 2 f₀ ·) c s t x j := by
+    ∂[i] (∂[i] (fun x => planeWave f₀ c s t x j)) =
+    (s.unit i) ^ 2 • fun x => planeWave (iteratedDeriv 2 f₀ ·) c s t x j := by
   conv_lhs =>
     enter [2, j]
     rw [planeWave_apply_space_deriv (h'.differentiable (by simp)) i]
@@ -257,11 +257,13 @@ lemma planeWave_apply_space_deriv_space_deriv {d f₀ c} {s : Direction d}
 -/
 
 lemma planeWave_laplacian {d f₀ c} {s : Direction d} (h' : ContDiff ℝ 2 f₀) :
-    Δ (planeWave f₀ c s t) = fun x => planeWave (iteratedDeriv 2 f₀ ·) c s t x := by
+    Δᵥ (planeWave f₀ c s t) = fun x => planeWave (iteratedDeriv 2 f₀ ·) c s t x := by
   ext x j
-  simp [laplacianVec, laplacian]
+  rw [laplacianVec]
   conv_lhs =>
-    enter [2, i]
+    enter [1, 2, i]
+    rw [laplacian_eq_sum_snd_deriv]
+    enter [0, x, 2, i]
     rw [planeWave_apply_space_deriv_space_deriv h']
   simp only [Pi.smul_apply, smul_eq_mul]
   rw [← Finset.sum_mul]

--- a/Physlib/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
+++ b/Physlib/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
@@ -799,14 +799,14 @@ protected lemma gradient {d} (u : Space d → ℝ) (hu : ContDiff ℝ ∞ u) :
     fun_prop
   · intro φ1 φ2 h1 h2
     rw [Space.gradient_eq_grad]
-    rw [Space.grad_add, Space.grad_eq_gradiant, Space.grad_eq_gradiant]
+    rw [Space.grad_add, Space.grad_eq_gradient, Space.grad_eq_gradient]
     simp
     rfl
     · exact h1.differentiable (by simp)
     · exact h2.differentiable (by simp)
   · intro c φ hφ
     rw [Space.gradient_eq_grad]
-    rw [Space.grad_smul, Space.grad_eq_gradiant]
+    rw [Space.grad_smul, Space.grad_eq_gradient]
     simp
     rfl
     exact hφ.differentiable (by simp)

--- a/Physlib/Mathematics/VariationalCalculus/HasVarAdjoint.lean
+++ b/Physlib/Mathematics/VariationalCalculus/HasVarAdjoint.lean
@@ -726,7 +726,7 @@ lemma grad {d} : HasVarAdjoint (fun (φ : Space d → ℝ) x => Space.grad φ x)
   have h2 := HasVarAdjoint.comp h1 (HasVarAdjoint.gradient (d := d))
   convert h2 using 1
   · funext x t
-    rw [Space.grad_eq_gradiant]
+    rw [Space.grad_eq_gradient]
     simp
 
 lemma div {d} : HasVarAdjoint (fun (φ : Space d → EuclideanSpace ℝ (Fin d)) x => Space.div φ x)

--- a/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Basic.lean
@@ -500,6 +500,9 @@ noncomputable def distDeriv {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     simp
   map_smul' a f := by simp
 
+@[inherit_doc distDeriv]
+macro "∂ᵈ[" i:term "]" : term => `(distDeriv $i)
+
 /-!
 
 ### B.2. Basic equality
@@ -508,7 +511,7 @@ noncomputable def distDeriv {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
 
 lemma distDeriv_apply {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (μ : Fin d) (f : (Space d) →d[ℝ] M) (ε : 𝓢(Space d, ℝ)) :
-    (distDeriv μ f) ε = fderivD ℝ f ε (basis μ) := by
+    (∂ᵈ[μ] f) ε = fderivD ℝ f ε (basis μ) := by
   simp [distDeriv, Distribution.fderivD]
 
 /-!
@@ -544,7 +547,7 @@ lemma schwartMap_fderiv_comm {d}
 
 lemma distDeriv_commute {M d} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (μ ν : Fin d) (f : (Space d) →d[ℝ] M) :
-    (distDeriv ν (distDeriv μ f)) = (distDeriv μ (distDeriv ν f)) := by
+    (∂ᵈ[ν] (∂ᵈ[μ] f)) = (∂ᵈ[μ] (∂ᵈ[ν] f)) := by
   ext η
   simp [distDeriv, Distribution.fderivD]
   congr 1

--- a/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Curl.lean
@@ -248,7 +248,7 @@ lemma curl_of_grad_eq_zero (f : Space → ℝ) (hf : ContDiff ℝ 2 f) :
 -/
 
 lemma curl_of_curl (f : Space → EuclideanSpace ℝ (Fin 3)) (hf : ContDiff ℝ 2 f) :
-    ∇ ⨯ (∇ ⨯ f) = ∇ (∇ ⬝ f) - Δ f := by
+    ∇ ⨯ (∇ ⨯ f) = ∇ (∇ ⬝ f) - Δᵥ f := by
   unfold laplacianVec laplacian div grad curl Finset.sum
   simp only [Fin.isValue, Fin.univ_val_map, List.ofFn_succ, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, List.ofFn_zero, Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero]
@@ -755,6 +755,9 @@ noncomputable def distCurl : (Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) →�
     ext x
     simp
 
+@[inherit_doc distCurl]
+macro (name := distCurlNotation) "∇ᵈ" "⨯" f:term:100 : term => `(distCurl $f)
+
 /-!
 
 ### B.1. The components of the curl
@@ -762,21 +765,21 @@ noncomputable def distCurl : (Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) →�
 -/
 
 lemma distCurl_apply_zero (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η : 𝓢(Space, ℝ)) :
-    distCurl f η 0 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 2) (fderivCLM ℝ Space ℝ η)) 1
+    (∇ᵈ ⨯ f) η 0 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 2) (fderivCLM ℝ Space ℝ η)) 1
     + f (SchwartzMap.evalCLM ℝ Space ℝ (basis 1) (fderivCLM ℝ Space ℝ η)) 2 := by
   simp [distCurl]
   rw [fderivD_apply, fderivD_apply]
   simp
 
 lemma distCurl_apply_one (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η : 𝓢(Space, ℝ)) :
-    distCurl f η 1 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 0) (fderivCLM ℝ Space ℝ η)) 2
+    (∇ᵈ ⨯ f) η 1 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 0) (fderivCLM ℝ Space ℝ η)) 2
     + f (SchwartzMap.evalCLM ℝ Space ℝ (basis 2) (fderivCLM ℝ Space ℝ η)) 0 := by
   simp [distCurl]
   rw [fderivD_apply, fderivD_apply]
   simp
 
 lemma distCurl_apply_two (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η : 𝓢(Space, ℝ)) :
-    distCurl f η 2 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 1) (fderivCLM ℝ Space ℝ η)) 0
+    (∇ᵈ ⨯ f) η 2 = - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 1) (fderivCLM ℝ Space ℝ η)) 0
     + f (SchwartzMap.evalCLM ℝ Space ℝ (basis 0) (fderivCLM ℝ Space ℝ η)) 1 := by
   simp [distCurl]
   rw [fderivD_apply, fderivD_apply]
@@ -789,7 +792,7 @@ lemma distCurl_apply_two (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η 
 -/
 
 lemma distCurl_apply (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η : 𝓢(Space, ℝ)) :
-    distCurl f η = WithLp.toLp 2 fun
+    (∇ᵈ ⨯ f) η = WithLp.toLp 2 fun
     | 0 => - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 2) (fderivCLM ℝ Space ℝ η)) 1
       + f (SchwartzMap.evalCLM ℝ Space ℝ (basis 1) (fderivCLM ℝ Space ℝ η)) 2
     | 1 => - f (SchwartzMap.evalCLM ℝ Space ℝ (basis 0) (fderivCLM ℝ Space ℝ η)) 2
@@ -811,7 +814,7 @@ lemma distCurl_apply (f : Space →d[ℝ] (EuclideanSpace ℝ (Fin 3))) (η : �
 /-- The curl of a grad is equal to zero. -/
 @[simp]
 lemma distCurl_distGrad_eq_zero (f : (Space) →d[ℝ] ℝ) :
-    distCurl (distGrad f) = 0 := by
+    ∇ᵈ ⨯ (∇ᵈ f) = 0 := by
   ext η i
   fin_cases i
   all_goals

--- a/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Div.lean
@@ -57,11 +57,9 @@ variable {W} [NormedAddCommGroup W] [NormedSpace ℝ W]
 noncomputable def div {d} (f : Space d → EuclideanSpace ℝ (Fin d)) :
     Space d → ℝ := fun x =>
   -- get i-th component of `f`
-  let fi i x := (f x) i
   -- derivative of i-th component in i-th coordinate
-  -- ∂fᵢ/∂xⱼ
-  let df i x := ∂[i] (fi i) x
-  ∑ i, df i x
+  -- ∂fᵢ/∂xᵢ
+  ∑ i, ∂[i] (fun x => (f x) i) x
 
 @[inherit_doc div]
 macro (name := divNotation) "∇" "⬝" f:term:100 : term => `(div $f)
@@ -199,6 +197,9 @@ noncomputable def distDiv {d} :
     ext x
     simp
 
+@[inherit_doc distDiv]
+macro (name := distDivNotation) "∇ᵈ" "⬝" f:term:100 : term => `(distDiv $f)
+
 /-!
 
 ### B.1. Basic equalities
@@ -208,12 +209,12 @@ noncomputable def distDiv {d} :
 set_option backward.isDefEq.respectTransparency false in
 lemma distDiv_apply_eq_sum_fderivD {d}
     (f : (Space d) →d[ℝ] EuclideanSpace ℝ (Fin d)) (η : 𝓢(Space d, ℝ)) :
-    distDiv f η = ∑ i, fderivD ℝ f η (basis i) i := by
+    (∇ᵈ ⬝ f) η = ∑ i, fderivD ℝ f η (basis i) i := by
   simp [distDiv, EuclideanSpace.inner_single_right]
 
 lemma distDiv_apply_eq_sum_distDeriv {d}
     (f : (Space d) →d[ℝ] EuclideanSpace ℝ (Fin d)) (η : 𝓢(Space d, ℝ)) :
-    distDiv f η = ∑ i, distDeriv i f η i := by
+    (∇ᵈ ⬝ f) η = ∑ i, ∂ᵈ[i] f η i := by
   rw [distDiv_apply_eq_sum_fderivD]
   rfl
 
@@ -227,8 +228,8 @@ set_option backward.isDefEq.respectTransparency false in
 /-- The divergence of a distribution from a bounded function. -/
 lemma distDiv_ofFunction {dm1 : ℕ} {f : Space dm1.succ → EuclideanSpace ℝ (Fin dm1.succ)}
     {hf : IsDistBounded f} (η : 𝓢(Space dm1.succ, ℝ)) :
-    distDiv (distOfFunction f hf) η =
-    - ∫ x : Space dm1.succ, ⟪f x, Space.grad η x⟫_ℝ := by
+    (∇ᵈ ⬝ (distOfFunction f hf)) η =
+    - ∫ x : Space dm1.succ, ⟪f x, ∇ η x⟫_ℝ := by
   rw [distDiv_apply_eq_sum_fderivD]
   conv_rhs =>
     enter [1, 2, x]

--- a/Physlib/SpaceAndTime/Space/Derivatives/Grad.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Grad.lean
@@ -160,7 +160,7 @@ lemma grad_neg (f : Space d → ℝ) :
 -/
 
 lemma grad_eq_sum {d} (f : Space d → ℝ) (x : Space d) :
-    ∇ f x = ∑ i, deriv i f x • EuclideanSpace.single i 1 := by
+    ∇ f x = ∑ i, ∂[i] f x • EuclideanSpace.single i 1 := by
   ext i
   simp [grad, deriv_eq, - WithLp.ofLp_sum]
   trans ∑ x_1, (fderiv ℝ f x) (basis x_1) • (EuclideanSpace.single x_1 1).ofLp i; swap
@@ -182,7 +182,7 @@ lemma grad_eq_sum {d} (f : Space d → ℝ) (x : Space d) :
 -/
 
 lemma grad_apply {d} (f : Space d → ℝ) (x : Space d) (i : Fin d) :
-    (∇ f x) i = deriv i f x := by
+    (∇ f x) i = ∂[i] f x := by
   rw [grad_eq_sum]
   change WithLp.linearEquiv 2 ℝ (Fin d → ℝ) (∑ x_1, (fderiv ℝ f x) (basis x_1) •
     EuclideanSpace.single x_1 1) i = _
@@ -200,7 +200,7 @@ open InnerProductSpace
 
 set_option backward.isDefEq.respectTransparency false in
 lemma grad_inner_single {d} (f : Space d → ℝ) (x : Space d) (i : Fin d) :
-    ⟪∇ f x, EuclideanSpace.single i 1⟫_ℝ = deriv i f x := by
+    ⟪∇ f x, EuclideanSpace.single i 1⟫_ℝ = ∂[i] f x := by
   simp only [EuclideanSpace.inner_single_right, conj_trivial,
     one_mul]
   exact rfl
@@ -234,7 +234,7 @@ lemma repr_grad_inner_eq {d} (f : Space d → ℝ) (x y : Space d) :
 
 -/
 
-lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
+lemma grad_eq_gradient {d} (f : Space d → ℝ) :
     ∇ f = basis.repr ∘ gradient f := by
   funext x
   have hx (y : EuclideanSpace ℝ (Fin d)) : ⟪(Space.basis).repr (gradient f x), y⟫_ℝ =
@@ -251,17 +251,17 @@ lemma grad_eq_gradiant {d} (f : Space d → ℝ) :
 
 lemma gradient_eq_grad {d} (f : Space d → ℝ) :
     gradient f = basis.repr.symm ∘ ∇ f := by
-  rw [grad_eq_gradiant f]
+  rw [grad_eq_gradient f]
   ext x
   simp
 
 lemma gradient_apply_eq_grad {d} (f : Space d → ℝ) (x : Space d) :
     gradient f x = basis.repr.symm (∇ f x) := by
-  rw [grad_eq_gradiant f]
+  rw [grad_eq_gradient f]
   simp
 
 lemma gradient_eq_sum {d} (f : Space d → ℝ) (x : Space d) :
-    gradient f x = ∑ i, deriv i f x • basis i := by
+    gradient f x = ∑ i, ∂[i] f x • basis i := by
   simp [gradient_eq_grad, grad_eq_sum f x]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -522,6 +522,9 @@ noncomputable def distGrad {d} :
     ext x
     simp
 
+@[inherit_doc distGrad]
+scoped[Space] notation "∇ᵈ" => distGrad
+
 /-!
 
 ### B.2. The gradient of inner products
@@ -530,7 +533,7 @@ noncomputable def distGrad {d} :
 
 set_option backward.isDefEq.respectTransparency false in
 lemma distGrad_inner_eq {d} (f : (Space d) →d[ℝ] ℝ) (η : 𝓢(Space d, ℝ))
-    (y : EuclideanSpace ℝ (Fin d)) : ⟪distGrad f η, y⟫_ℝ = fderivD ℝ f η (basis.repr.symm y) := by
+    (y : EuclideanSpace ℝ (Fin d)) : ⟪∇ᵈ f η, y⟫_ℝ = fderivD ℝ f η (basis.repr.symm y) := by
   rw [distGrad]
   simp only [LinearIsometryEquiv.toLinearEquiv_symm, LinearMap.coe_mk, AddHom.coe_mk,
     ContinuousLinearMap.coe_comp', LinearMap.coe_toContinuousLinearMap', LinearEquiv.coe_coe,
@@ -540,7 +543,7 @@ lemma distGrad_inner_eq {d} (f : (Space d) →d[ℝ] ℝ) (η : 𝓢(Space d, �
 lemma distGrad_eq_of_inner {d} (f : (Space d) →d[ℝ] ℝ)
     (g : (Space d) →d[ℝ] EuclideanSpace ℝ (Fin d))
     (h : ∀ η y, fderivD ℝ f η y = ⟪g η, basis.repr y⟫_ℝ) :
-    distGrad f = g := by
+    ∇ᵈ f = g := by
   ext1 η
   apply ext_inner_right (𝕜 := ℝ) fun v => ?_
   simp [distGrad_inner_eq, h]
@@ -553,7 +556,7 @@ lemma distGrad_eq_of_inner {d} (f : (Space d) →d[ℝ] ℝ)
 
 set_option backward.isDefEq.respectTransparency false in
 lemma distGrad_eq_sum_basis {d} (f : (Space d) →d[ℝ] ℝ) (η : 𝓢(Space d, ℝ)) :
-    distGrad f η =
+    ∇ᵈ f η =
       ∑ i, - f (SchwartzMap.evalCLM ℝ (Space d) ℝ (basis i) (fderivCLM ℝ (Space d) ℝ η)) •
       EuclideanSpace.single i 1 := by
   have h1 (y : EuclideanSpace ℝ (Fin d)) :
@@ -566,17 +569,17 @@ lemma distGrad_eq_sum_basis {d} (f : (Space d) →d[ℝ] ℝ) (η : 𝓢(Space d
     rw [hy]
     simp [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, map_sum, map_smul, smul_eq_mul,
       Pi.single_apply, fderivD_apply]
-  have hx (y : EuclideanSpace ℝ (Fin d)) : ⟪distGrad f η, y⟫_ℝ =
+  have hx (y : EuclideanSpace ℝ (Fin d)) : ⟪∇ᵈ f η, y⟫_ℝ =
       ⟪∑ i, - f (SchwartzMap.evalCLM ℝ (Space d) ℝ (basis i) (fderivCLM ℝ (Space d) ℝ η)) •
         EuclideanSpace.single i 1, y⟫_ℝ := by
     rw [distGrad_inner_eq, h1]
-  have h1 : ∀ y, ⟪distGrad f η -
+  have h1 : ∀ y, ⟪∇ᵈ f η -
     (∑ i, - f (SchwartzMap.evalCLM ℝ (Space d) ℝ (basis i) (fderivCLM ℝ (Space d) ℝ η)) •
       EuclideanSpace.single i 1), y⟫_ℝ = 0 := by
     intro y
     rw [inner_sub_left, hx y]
     simp
-  have h2 := h1 (distGrad f η -
+  have h2 := h1 (∇ᵈ f η -
     (∑ i, - f (SchwartzMap.evalCLM ℝ (Space d) ℝ (basis i) (fderivCLM ℝ (Space d) ℝ η)) •
     EuclideanSpace.single i 1))
   rw [inner_self_eq_zero, sub_eq_zero] at h2
@@ -589,7 +592,7 @@ lemma distGrad_eq_sum_basis {d} (f : (Space d) →d[ℝ] ℝ) (η : 𝓢(Space d
 -/
 
 lemma distGrad_toFun_eq_distDeriv {d} (f : (Space d) →d[ℝ] ℝ) :
-    (distGrad f).toFun = fun ε => WithLp.toLp 2 fun i => distDeriv i f ε := by
+    (∇ᵈ f).toFun = fun ε => WithLp.toLp 2 fun i => ∂ᵈ[i] f ε := by
   ext ε i
   simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ContinuousLinearMap.coe_coe]
   rw [distGrad_eq_sum_basis]
@@ -605,8 +608,8 @@ lemma distGrad_toFun_eq_distDeriv {d} (f : (Space d) →d[ℝ] ℝ) :
 -/
 
 lemma distGrad_apply {d} (f : (Space d) →d[ℝ] ℝ) (ε : 𝓢(Space d, ℝ)) :
-    (distGrad f) ε = fun i => distDeriv i f ε := by
-  change (distGrad f).toFun ε = fun i => distDeriv i f ε
+    (∇ᵈ f) ε = fun i => ∂ᵈ[i] f ε := by
+  change (∇ᵈ f).toFun ε = fun i => ∂ᵈ[i] f ε
   rw [distGrad_toFun_eq_distDeriv]
 
 /-!
@@ -623,7 +626,7 @@ noncomputable def gradSchwartz {d} : 𝓢(Space d, ℝ) →L[ℝ] 𝓢(Space d, 
       ∘L SchwartzMap.fderivCLM ℝ (Space d) ℝ
 
 lemma gradSchwartz_apply_eq_grad {d} (η : 𝓢(Space d, ℝ)) (x : Space d) :
-    gradSchwartz η x = grad η x := by
+    gradSchwartz η x = ∇ η x := by
   simp [gradSchwartz, grad_eq_sum]
   rfl
 

--- a/Physlib/SpaceAndTime/Space/Derivatives/Laplacian.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Laplacian.lean
@@ -58,10 +58,6 @@ lemma laplacian_eq_sum_snd_deriv {d} (f : Space d → ℝ) :
   unfold laplacian div grad
   simp
 
-lemma laplacian_eq_sum_snd_deriv_apply {d} (f : Space d → ℝ) (x : Space d) :
-    Δ f x = ∑ i, ∂[i] (∂[i] f) x := by
-  rw [laplacian_eq_sum_snd_deriv]
-
 /-!
 
 ## B. Laplacian on vector valued functions

--- a/Physlib/SpaceAndTime/Space/Derivatives/Laplacian.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Laplacian.lean
@@ -41,12 +41,8 @@ namespace Space
 -/
 
 /-- The scalar `laplacian` operator. -/
-noncomputable def laplacian {d} (f : Space d → ℝ) :
-    Space d → ℝ := fun x =>
-  -- second derivative of f in i-th coordinate
-  -- ∂²f/∂xᵢ²
-  let df2 i x := ∂[i] (∂[i] f) x
-  ∑ i, df2 i x
+noncomputable def laplacian {d} (f : Space d → ℝ) : Space d → ℝ :=
+    ∇ ⬝ ∇ f
 
 @[inherit_doc laplacian]
 scoped[Space] notation "Δ" => laplacian
@@ -57,11 +53,14 @@ scoped[Space] notation "Δ" => laplacian
 
 -/
 
-lemma laplacian_eq_div_of_grad (f : Space → ℝ) :
-    Δ f = ∇ ⬝ ∇ f := by
-  unfold laplacian div grad Finset.sum
-  simp only [Fin.univ_val_map, List.ofFn_succ, Fin.isValue, Fin.succ_zero_eq_one,
-    Fin.succ_one_eq_two, List.ofFn_zero, Multiset.sum_coe, List.sum_cons, List.sum_nil, add_zero]
+lemma laplacian_eq_sum_snd_deriv {d} (f : Space d → ℝ) :
+    Δ f = fun x => ∑ i, ∂[i] (∂[i] f) x := by
+  unfold laplacian div grad
+  simp
+
+lemma laplacian_eq_sum_snd_deriv_apply {d} (f : Space d → ℝ) (x : Space d) :
+    Δ f x = ∑ i, ∂[i] (∂[i] f) x := by
+  rw [laplacian_eq_sum_snd_deriv]
 
 /-!
 
@@ -73,10 +72,18 @@ lemma laplacian_eq_div_of_grad (f : Space → ℝ) :
 noncomputable def laplacianVec {d} (f : Space d → EuclideanSpace ℝ (Fin d)) :
     Space d → EuclideanSpace ℝ (Fin d) := fun x => WithLp.toLp 2 fun i =>
   -- get i-th component of `f`
-  let fi i x := (f x) i
-  Δ (fi i) x
+  Δ (fun x => f x i) x
 
 @[inherit_doc laplacianVec]
-scoped[Space] notation "Δ" => laplacianVec
+scoped[Space] notation "Δᵥ" => laplacianVec
+
+open Physlib Distribution
+
+/-- The distributional `distLaplacian` operator. -/
+noncomputable def distLaplacian {d : ℕ} (f : (Space d) →d[ℝ] ℝ) : (Space d) →d[ℝ] ℝ :=
+  ∇ᵈ ⬝ (∇ᵈ f)
+
+@[inherit_doc distLaplacian]
+scoped[Space] notation "Δᵈ" => distLaplacian
 
 end Space

--- a/Physlib/SpaceAndTime/Space/Norm.lean
+++ b/Physlib/SpaceAndTime/Space/Norm.lean
@@ -489,7 +489,7 @@ lemma fderiv_log_normPowerSeries {d : ℕ} {n : ℕ} (x y : Space d) :
 -/
 
 lemma gradient_dist_normPowerSeries_zpow {d : ℕ} {n : ℕ} (m : ℤ) :
-    distGrad (distOfFunction (fun x : Space d => (normPowerSeries n x) ^ m) (by fun_prop)) =
+    ∇ᵈ (distOfFunction (fun x : Space d => (normPowerSeries n x) ^ m) (by fun_prop)) =
     distOfFunction (fun x : Space d => (m * (normPowerSeries n x) ^ (m - 2)) • basis.repr x)
     (by fun_prop) := by
   ext1 η
@@ -534,10 +534,10 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} (m : �
     (hm : - (d.succ - 1 : ℕ) ≤ m) (η : 𝓢(Space d.succ, ℝ))
     (y : EuclideanSpace ℝ (Fin d.succ)) :
     Filter.Tendsto (fun n =>
-    ⟪(distGrad (distOfFunction
+    ⟪(∇ᵈ (distOfFunction
     (fun x : Space d.succ => (normPowerSeries n x) ^ m) (by fun_prop))) η, y⟫_ℝ)
     Filter.atTop
-    (𝓝 (⟪distGrad (distOfFunction (fun x : Space d.succ => ‖x‖ ^ m)
+    (𝓝 (⟪∇ᵈ (distOfFunction (fun x : Space d.succ => ‖x‖ ^ m)
     (IsDistBounded.pow m hm)) η, y⟫_ℝ)) := by
   simp only [distGrad_inner_eq, Distribution.fderivD_apply, distOfFunction_apply]
   change Filter.Tendsto (fun n => - ∫ (x : Space d.succ),
@@ -593,7 +593,7 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo_distGrad_norm {d : ℕ} (m : �
 lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} (m : ℤ) (hm : - (d.succ - 1 : ℕ) + 1 ≤ m)
     (η : 𝓢(Space d.succ, ℝ)) (y : EuclideanSpace ℝ (Fin d.succ)) :
     Filter.Tendsto (fun n =>
-    ⟪(distGrad (distOfFunction (fun x : Space d.succ => (normPowerSeries n x) ^ m)
+    ⟪(∇ᵈ (distOfFunction (fun x : Space d.succ => (normPowerSeries n x) ^ m)
     (by fun_prop))) η, y⟫_ℝ)
     Filter.atTop
     (𝓝 (⟪distOfFunction (fun x : Space d.succ => (m * ‖x‖ ^ (m - 2)) • basis.repr x) (by
@@ -716,7 +716,7 @@ lemma gradient_dist_normPowerSeries_zpow_tendsTo {d : ℕ} (m : ℤ) (hm : - (d.
 -/
 
 lemma gradient_dist_normPowerSeries_log {d : ℕ} {n : ℕ} :
-    distGrad (distOfFunction (fun x : Space d => Real.log (normPowerSeries n x)) (by fun_prop)) =
+    ∇ᵈ (distOfFunction (fun x : Space d => Real.log (normPowerSeries n x)) (by fun_prop)) =
     distOfFunction (fun x : Space d => ((normPowerSeries n x) ^ (- 2 : ℤ)) • basis.repr x)
     (by fun_prop) := by
   ext1 η
@@ -760,10 +760,10 @@ lemma gradient_dist_normPowerSeries_log {d : ℕ} {n : ℕ} :
 lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ}
     (η : 𝓢(Space d.succ.succ, ℝ)) (y : EuclideanSpace ℝ (Fin d.succ.succ)) :
     Filter.Tendsto (fun n =>
-    ⟪(distGrad (distOfFunction
+    ⟪(∇ᵈ (distOfFunction
     (fun x : Space d.succ.succ => Real.log (normPowerSeries n x)) (by fun_prop))) η, y⟫_ℝ)
     Filter.atTop
-    (𝓝 (⟪distGrad (distOfFunction (fun x : Space d.succ.succ => Real.log ‖x‖)
+    (𝓝 (⟪∇ᵈ (distOfFunction (fun x : Space d.succ.succ => Real.log ‖x‖)
     (IsDistBounded.log_norm)) η, y⟫_ℝ)) := by
   simp only [distGrad_inner_eq, Distribution.fderivD_apply, distOfFunction_apply]
   change Filter.Tendsto (fun n => -
@@ -812,7 +812,7 @@ lemma gradient_dist_normPowerSeries_log_tendsTo_distGrad_norm {d : ℕ}
 lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ}
     (η : 𝓢(Space d.succ.succ, ℝ)) (y : EuclideanSpace ℝ (Fin d.succ.succ)) :
     Filter.Tendsto (fun n =>
-    ⟪(distGrad (distOfFunction (fun x : Space d.succ.succ => Real.log (normPowerSeries n x))
+    ⟪(∇ᵈ (distOfFunction (fun x : Space d.succ.succ => Real.log (normPowerSeries n x))
     (by fun_prop))) η, y⟫_ℝ)
     Filter.atTop
     (𝓝 (⟪distOfFunction (fun x : Space d.succ.succ => (‖x‖ ^ (- 2 : ℤ)) • basis.repr x) (by
@@ -905,7 +905,7 @@ lemma gradient_dist_normPowerSeries_log_tendsTo {d : ℕ}
 -/
 
 lemma distGrad_distOfFunction_norm_zpow {d : ℕ} (m : ℤ) (hm : - (d.succ - 1 : ℕ) + 1 ≤ m) :
-    distGrad (distOfFunction (fun x : Space d.succ => ‖x‖ ^ m)
+    ∇ᵈ (distOfFunction (fun x : Space d.succ => ‖x‖ ^ m)
       (IsDistBounded.pow m (by simp_all; omega)))
     = distOfFunction (fun x : Space d.succ => (m * ‖x‖ ^ (m - 2)) • basis.repr x) (by
       simp [← smul_smul]
@@ -925,7 +925,7 @@ lemma distGrad_distOfFunction_norm_zpow {d : ℕ} (m : ℤ) (hm : - (d.succ - 1 
 -/
 
 lemma distGrad_distOfFunction_log_norm {d : ℕ} :
-    distGrad (distOfFunction (fun x : Space d.succ.succ => Real.log ‖x‖)
+    ∇ᵈ (distOfFunction (fun x : Space d.succ.succ => Real.log ‖x‖)
       (IsDistBounded.log_norm))
     = distOfFunction (fun x : Space d.succ.succ => (‖x‖ ^ (- 2 : ℤ)) • basis.repr x) (by
       refine (IsDistBounded.zpow_smul_repr_self _ ?_)
@@ -951,7 +951,7 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Auxiliary lemma with dimension defined as d.succ to handle `homeomorphUnitSphereProd`.
 The dimension correct version is declared in `distDiv_inv_pow_eq_dim`. -/
 private lemma distDiv_inv_pow_eq_dim' {d : ℕ} :
-    distDiv (distOfFunction (fun x : Space d.succ => ‖x‖ ^ (- d.succ : ℤ) • basis.repr x)
+    ∇ᵈ ⬝ (distOfFunction (fun x : Space d.succ => ‖x‖ ^ (- d.succ : ℤ) • basis.repr x)
       (IsDistBounded.zpow_smul_repr_self (- d.succ : ℤ) (by omega))) =
       (d.succ * (volume (α := Space d.succ)).real (Metric.ball 0 1)) • diracDelta ℝ 0 := by
   ext η
@@ -1098,11 +1098,12 @@ private lemma distDiv_inv_pow_eq_dim' {d : ℕ} :
     Pi.smul_apply, diracDelta_apply, smul_eq_mul]
   ring
 
-lemma distDiv_inv_pow_eq_dim {d : ℕ} (hd : d ≥ 1) :
-    distDiv (distOfFunction (fun x : Space d => ‖x‖ ^ (- d : ℤ) • basis.repr x)
+lemma distDiv_inv_pow_eq_dim {d : ℕ} :
+    ∇ᵈ ⬝ (distOfFunction (fun x : Space d => ‖x‖ ^ (- d : ℤ) • basis.repr x)
       (IsDistBounded.zpow_smul_repr_self (- d : ℤ) (by omega))) =
       (d * (volume (α := Space d)).real (Metric.ball 0 1)) • diracDelta ℝ 0 := by
-  obtain ⟨d', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : d ≠ 0)
-  exact distDiv_inv_pow_eq_dim'
+  rcases d with _ | d'
+  · simp; rfl
+  · exact distDiv_inv_pow_eq_dim'
 
 end Space


### PR DESCRIPTION
Several changes (in preparation for Green's functions in electrostatics):

1. add distLaplacian
- 1.1 change def of laplacian to ∇ ⬝ ∇ f and change original def to a lemma `laplacian_eq_sum_snd_deriv `

2. add corresponding notation for dist operators: ∂ᵈ ∇ᵈ Δᵈ
- 2.1 change notation for laplacianVec to Δᵥ for clarity
- 2.2 updated notation where appropriate for these files

misc: 
fix spelling error of `gradiant`
remove (hd : d ≥ 1) condition from `distDiv_inv_pow_eq_dim `

My intention was to make the statements of distribution lemmas more readable, hope they make sense.

