### PR TITLE
feat(QuantumMechanics): Defect number and numerical range (Toeplitz-Hausdorff theorem)

### DIFF
--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -225,7 +225,7 @@ lemma defectNumber_closure [CompleteSpace H]
     simp [← closure_range_sub_eq_range_closure_sub hT hz]
   · rw [closure_def' hT]
 
-lemma inf_ne_bot_of_rank_lt [CompleteSpace H] {E F : Submodule ℂ H} [E.HasOrthogonalProjection]
+lemma inf_ne_bot_of_rank_lt {E F : Submodule ℂ H} [E.HasOrthogonalProjection]
     (hlt : Module.rank ℂ E < Module.rank ℂ F) :
     Eᗮ ⊓ F ≠ ⊥ := by
   let Φ : F →L[ℂ] E := E.orthogonalProjection ∘L F.subtypeL

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -22,11 +22,11 @@ Definitions
 - `LinearPMap.regularityDomain` : The set of regular points for a partial linear map `T`.
     A complex number `z` is a regular point for `T` if there exists `c > 0` such that
     `c * ‖x‖ ≤ ‖T x - z • x‖` for all `x : T.domain`.
-- `LinearPMap.deficiencySubspace` : For an operator `T` and complex number `z`, the submodule
-    orthogonal to the range of `T - z • 1`.
-- `LinearPMap.defectNumber` : The rank of the deficiency subspace.
+- `LinearPMap.deficiencySubspace` : For an operator `T` any complex number `z`, the closed submodule
+    which is orthogonal to the range of `T - z • 1`.
+- `LinearPMap.defectNumber` : The rank of the deficiency subspace as a (possibly infinite) cardinal.
 - `LinearPMap.numericalRange` : For an operator `T`, the set of complex numbers `⟪x, T x⟫_ℂ`
-    with `x ∈ T.domain` and `‖x‖ = 1`.
+    as `x` ranges over the unit sphere in `T.domain`.
 
 Main results
 - `regularityDomain_isOpen` : The regularity domain is an open subset of `ℂ`.
@@ -34,15 +34,16 @@ Main results
     then the closure of `(T - z • 1).range` is `(T.closure - z • 1).range`.
 - `defectNumber_same_of_same_connectedComponent` : The defect number is constant on each connected
     component of the regularity domain.
-- `numericalRange_convex` : The Toeplitz-Hausdorff theorem — the numerical range is a convex set.
 - `mem_regularityDomain_of_not_mem_numericalRange_closure` : The regularity domain contains the
     exterior of the numerical range.
+- `numericalRange_convex` : The Toeplitz-Hausdorff theorem — the numerical range is a convex set.
 
 ## iii. Table of contents
 
 - A. Regularity domain
 - B. Deficiency subspace & defect number
 - C. Numerical range
+  - C.1. The Toeplitz-Hausdorff theorem
 
 ## iv. References
 
@@ -373,6 +374,43 @@ lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) :
     refine ⟨⟨x, by simp [sub_domain]⟩, hx, ?_⟩
     simp_all [← hcz, ← hxz, sub_apply, inner_sub_right, inner_smul_right]
 
+/-- The regularity domain contains the exterior of the numerical range. -/
+lemma mem_regularityDomain_of_not_mem_numericalRange_closure
+    {T : H →ₗ.[ℂ] H} {z : ℂ} (h : z ∉ _root_.closure T.numericalRange) :
+    z ∈ T.regularityDomain := by
+  by_cases hT : T.domain = ⊥
+  · refine ⟨1, zero_lt_one, fun ⟨x, hx⟩ ↦ ?_⟩
+    rw [hT] at hx
+    simp_all
+  · use infDist z T.numericalRange
+    constructor
+    · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp h
+    · intro x
+      rcases eq_or_ne x 0 with rfl | hx
+      · simp
+      · let y : T.domain := ofReal ‖x‖⁻¹ • x
+        have hy : ‖y‖ = 1 := by
+          simp only [y, norm_smul, ofReal_inv, norm_inv, norm_real, norm_norm]
+          exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx)
+        have hy' : ‖x‖ ^ 2 * ⟪↑y, T y⟫_ℂ = ⟪↑x, T x⟫_ℂ := by
+          simp_rw [y, map_smul, SetLike.val_smul, inner_smul_left, inner_smul_right, conj_ofReal,
+            ← mul_assoc, pow_two, ← ofReal_mul]
+          field_simp
+          simp
+        apply (mul_le_mul_iff_left₀ <| norm_pos_iff.mpr hx).mp
+        rw [mul_assoc, ← pow_two, mul_comm _ ‖x‖]
+        calc
+          _ ≤ ‖z - ⟪↑y, T y⟫_ℂ‖ * ‖x‖ ^ 2 := mul_le_mul_of_nonneg_right
+            (dist_eq z _ ▸ infDist_le_dist_of_mem ⟨y, hy, rfl⟩) (pow_two_nonneg _)
+          _ = ‖⟪↑y, T y⟫_ℂ * ‖x‖ ^ 2 - z * ‖x‖ ^ 2‖ := by simp [norm_sub_rev, ← sub_mul]
+          _ = ‖⟪↑x, T x⟫_ℂ - z * ‖x‖ ^ 2‖ := by rw [mul_comm, hy']
+          _ = ‖⟪↑x, T x - z • x⟫_ℂ‖ := by simp [inner_sub_right, inner_smul_right]
+          _ ≤ ‖x‖ * ‖T x - z • x‖ := norm_inner_le_norm _ _
+
+/-!
+### C.1. The Toeplitz-Hausdorff theorem
+-/
+
 private lemma exists_phase_add_im_eq_zero (z₁ z₂ : ℂ) :
     ∃ θ : ℝ, (exp (I * θ) * z₁ + exp (-I * θ) * z₂).im = 0 := by
   let g : ℝ → ℝ := fun θ ↦ (exp (I * θ) * z₁ + exp (-I * θ) * z₂).im
@@ -462,39 +500,6 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
         zero_add, ofReal_neg, neg_mul, mul_neg, mul_one, add_re, ofReal_add, ofReal_mul,
         ofReal_sub, ofReal_one, ofReal_pow]
       ring
-
-/-- The regularity domain contains the exterior of the numerical range. -/
-lemma mem_regularityDomain_of_not_mem_numericalRange_closure
-    {T : H →ₗ.[ℂ] H} {z : ℂ} (h : z ∉ _root_.closure T.numericalRange) :
-    z ∈ T.regularityDomain := by
-  by_cases hT : T.domain = ⊥
-  · refine ⟨1, zero_lt_one, fun ⟨x, hx⟩ ↦ ?_⟩
-    rw [hT] at hx
-    simp_all
-  · use infDist z T.numericalRange
-    constructor
-    · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp h
-    · intro x
-      rcases eq_or_ne x 0 with rfl | hx
-      · simp
-      · let y : T.domain := ofReal ‖x‖⁻¹ • x
-        have hy : ‖y‖ = 1 := by
-          simp only [y, norm_smul, ofReal_inv, norm_inv, norm_real, norm_norm]
-          exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx)
-        have hy' : ‖x‖ ^ 2 * ⟪↑y, T y⟫_ℂ = ⟪↑x, T x⟫_ℂ := by
-          simp_rw [y, map_smul, SetLike.val_smul, inner_smul_left, inner_smul_right, conj_ofReal,
-            ← mul_assoc, pow_two, ← ofReal_mul]
-          field_simp
-          simp
-        apply (mul_le_mul_iff_left₀ <| norm_pos_iff.mpr hx).mp
-        rw [mul_assoc, ← pow_two, mul_comm _ ‖x‖]
-        calc
-          _ ≤ ‖z - ⟪↑y, T y⟫_ℂ‖ * ‖x‖ ^ 2 := mul_le_mul_of_nonneg_right
-            (dist_eq z _ ▸ infDist_le_dist_of_mem ⟨y, hy, rfl⟩) (pow_two_nonneg _)
-          _ = ‖⟪↑y, T y⟫_ℂ * ‖x‖ ^ 2 - z * ‖x‖ ^ 2‖ := by simp [norm_sub_rev, ← sub_mul]
-          _ = ‖⟪↑x, T x⟫_ℂ - z * ‖x‖ ^ 2‖ := by rw [mul_comm, hy']
-          _ = ‖⟪↑x, T x - z • x⟫_ℂ‖ := by simp [inner_sub_right, inner_smul_right]
-          _ ≤ ‖x‖ * ‖T x - z • x‖ := norm_inner_le_norm _ _
 
 end
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -225,7 +225,7 @@ lemma defectNumber_closure [CompleteSpace H]
     simp [← hT.closure_range_sub_eq_range_closure_sub hz]
   · rw [closure_def' hT]
 
-lemma inf_ne_bot_of_rank_lt
+lemma _root_.Submodule.inf_ne_bot_of_rank_lt
     {E F : Submodule ℂ H} [E.HasOrthogonalProjection] (h_rank : Module.rank ℂ E < Module.rank ℂ F) :
     Eᗮ ⊓ F ≠ ⊥ := by
   let Φ : F →L[ℂ] E := E.orthogonalProjection ∘L F.subtypeL
@@ -237,7 +237,8 @@ lemma inf_ne_bot_of_rank_lt
   have hE : y ∈ Eᗮ := orthogonalProjection_eq_zero_iff.mp (_root_.map_sub Φ _ _ ▸ sub_eq_zero.mpr h)
   exact fun hEF ↦ hy ((mem_bot ℂ).mp <| hEF ▸ ⟨hE, hF⟩)
 
-lemma exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT : T.IsClosed)
+lemma IsClosed.exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} (hT : T.IsClosed)
     {z₁ z₂ : ℂ} (hz₁ : z₁ ∈ T.regularityDomain) (h : T.defectNumber z₁ < T.defectNumber z₂) :
     ∃ x : T.domain, x ≠ 0 ∧ ⟪T x - z₁ • x, T x - z₂ • x⟫_ℂ = 0 := by
   obtain ⟨y, h_inf, hy⟩ := (Submodule.ne_bot_iff _).mp (inf_ne_bot_of_rank_lt h)
@@ -250,8 +251,8 @@ lemma exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H] {T : H →ₗ.[�
   · apply (mem_orthogonal' _ _).mp at hy₂
     simp [← hy₂ ((T - z₂ • 1) ⟨x, hx.1, by simp⟩) (by simp), sub_apply, ← hxy]
 
-lemma defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT : T.IsClosable) {z₁ z₂ : ℂ}
-    {c : ℝ} (h : IsLowerBound T z₁ c) (h_ball : z₂ ∈ ball z₁ c) :
+lemma IsClosable.defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT : T.IsClosable)
+    {z₁ z₂ : ℂ} {c : ℝ} (h : IsLowerBound T z₁ c) (h_ball : z₂ ∈ ball z₁ c) :
     T.defectNumber z₁ = T.defectNumber z₂ := by
   by_cases hz₁ : z₁ ∈ T.regularityDomain
   · have hz₂ : z₂ ∈ T.regularityDomain := ball_subset_regularityDomain h h_ball
@@ -262,8 +263,8 @@ lemma defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT :
     obtain ⟨x, hx, h'⟩ : ∃ x : Tcl.domain, x ≠ 0 ∧ ⟪Tcl x - z₂ • x, Tcl x - z₁ • x⟫_ℂ = 0 := by
       rcases lt_or_gt_of_ne hne with hle | hle
       · simp_rw [inner_eq_zero_symm]
-        exact exists_inner_eq_zero_of_defectNumber_lt hT.closure_isClosed hz₁ hle
-      · exact exists_inner_eq_zero_of_defectNumber_lt hT.closure_isClosed hz₂ hle
+        exact hT.closure_isClosed.exists_inner_eq_zero_of_defectNumber_lt hz₁ hle
+      · exact hT.closure_isClosed.exists_inner_eq_zero_of_defectNumber_lt hz₂ hle
     refine not_le (a := ‖z₁ - z₂‖ * ‖x‖).mpr ?_ le_rfl
     refine lt_of_lt_of_le (b := ‖Tcl x - z₁ • x‖) ?_ ?_
     · refine lt_of_lt_of_le ?_ (isLowerBound_closure h x)
@@ -279,7 +280,7 @@ lemma defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT :
     exact hz₁ ⟨c, lt_of_le_of_lt dist_nonneg h_ball, h⟩
 
 /-- `T.defectNumber` is constant on each connected component of `T.regularityDomain`. -/
-lemma defectNumber_same_of_same_connectedComponent [CompleteSpace H]
+lemma IsClosable.defectNumber_same_of_same_connectedComponent [CompleteSpace H]
     {T : H →ₗ.[ℂ] H} (hT : T.IsClosable)
     {z₁ z₂ : T.regularityDomain} (h : connectedComponent z₁ = connectedComponent z₂) :
     T.defectNumber z₁ = T.defectNumber z₂ := by

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -34,8 +34,8 @@ Main results
     then the closure of `(T - z • 1).range` is `(T.closure - z • 1).range`.
 - `defectNumber_same_of_same_connectedComponent` : The defect number is constant on each connected
     component of the regularity domain.
-- `mem_regularityDomain_of_not_mem_numericalRange_closure` : The regularity domain contains the
-    exterior of the numerical range.
+- `compl_closure_numericalRange_le_regularityDomain` : The regularity domain contains the exterior
+    of the numerical range.
 - `numericalRange_convex` : The Toeplitz-Hausdorff theorem — the numerical range is a convex set.
 
 ## iii. Table of contents
@@ -375,16 +375,16 @@ lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) :
     simp_all [← hcz, ← hxz, sub_apply, inner_sub_right, inner_smul_right]
 
 /-- The regularity domain contains the exterior of the numerical range. -/
-lemma mem_regularityDomain_of_not_mem_numericalRange_closure
-    {T : H →ₗ.[ℂ] H} {z : ℂ} (h : z ∉ _root_.closure T.numericalRange) :
-    z ∈ T.regularityDomain := by
+lemma compl_closure_numericalRange_le_regularityDomain (T : H →ₗ.[ℂ] H) :
+    (_root_.closure T.numericalRange)ᶜ ≤ T.regularityDomain := by
+  intro z hz
   by_cases hT : T.domain = ⊥
   · refine ⟨1, zero_lt_one, fun ⟨x, hx⟩ ↦ ?_⟩
     rw [hT] at hx
     simp_all
   · use infDist z T.numericalRange
     constructor
-    · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp h
+    · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp hz
     · intro x
       rcases eq_or_ne x 0 with rfl | hx
       · simp

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -22,8 +22,8 @@ Definitions
 - `LinearPMap.regularityDomain` : The set of regular points for a partial linear map `T`.
     A complex number `z` is a regular point for `T` if there exists `c > 0` such that
     `c * ‖x‖ ≤ ‖T x - z • x‖` for all `x : T.domain`.
-- `LinearPMap.deficiencySubspace` : For an operator `T` any complex number `z`, the closed submodule
-    which is orthogonal to the range of `T - z • 1`.
+- `LinearPMap.deficiencySubspace` : For an operator `T` and any complex number `z`,
+    the closed submodule which is orthogonal to the range of `T - z • 1`.
 - `LinearPMap.defectNumber` : The rank of the deficiency subspace as a (possibly infinite) cardinal.
 - `LinearPMap.numericalRange` : For an operator `T`, the set of complex numbers `⟪x, T x⟫_ℂ`
     as `x` ranges over the unit sphere in `T.domain`.
@@ -98,7 +98,7 @@ lemma isLowerBound_closure
 /-- The regular points for `T`.
 
   `z : ℂ` is a regular point for `T` iff there exists a constant `c > 0` such that
-  `c * ‖x‖ ≤ ‖(T - z • 1) x‖` for all `x ∈ (T - z • 1).domain`. -/
+  `c * ‖x‖ ≤ ‖(T - z • 1) x‖` for all `x ∈ T.domain`. -/
 def regularityDomain (T : H →ₗ.[ℂ] H) : Set ℂ := {z : ℂ | ∃ c > 0, IsLowerBound T z c}
 
 /-- `T ≤ T'` implies `T'.regularityDomain ⊆ T.regularityDomain`. -/
@@ -202,7 +202,10 @@ lemma IsClosed.sub_range_isClosed [CompleteSpace H]
 ## B. Deficiency subspace & defect number
 -/
 
-/-- The closed submodule `(T - z • 1).rangeᗮ`. -/
+/-- For a partial linear map `T` and any complex number `z`, the closed submodule which
+  is orthogonal to the range of `T - z • 1`.
+
+  `T.defectNumber z` is defined as the rank of this subspace. -/
 def deficiencySubspace (T : H →ₗ.[ℂ] H) (z : ℂ) : ClosedSubmodule ℂ H :=
   ⟨(T - z • 1).toFun.rangeᗮ, isClosed_orthogonal _⟩
 
@@ -279,7 +282,7 @@ lemma IsClosable.defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[�
   · false_or_by_contra -- `z₁ ∉ T.regularityDomain` ⇒ `c ≤ 0` ⇒ `z₂ ∈ ∅`
     exact hz₁ ⟨c, lt_of_le_of_lt dist_nonneg h_ball, h⟩
 
-/-- `T.defectNumber` is constant on each connected component of `T.regularityDomain`. -/
+/-- The defect number is constant on each connected component of the regularity domain. -/
 lemma IsClosable.defectNumber_same_of_same_connectedComponent [CompleteSpace H]
     {T : H →ₗ.[ℂ] H} (hT : T.IsClosable)
     {z₁ z₂ : T.regularityDomain} (h : connectedComponent z₁ = connectedComponent z₂) :
@@ -462,7 +465,7 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
     have h₂ : ⟪↑y₂, S y₂⟫_ℂ = 1 := by
       simp [y₂, map_smul, inner_smul_left, inner_smul_right, h₁, ← exp_conj, ← exp_add]
     -- `f` parametrizes the line connecting `y₀` and `y₂` and never vanishes because `y₀` and `y₂`
-    -- are linearly independent (since `y₀ = λy₂` implies `0 = ⟪y₀, S y₀⟫ = |λ|²⟪y₂, S y₂⟫ = λ²`).
+    -- are linearly independent (since `y₀ = λy₂` implies `0 = ⟪y₀, S y₀⟫ = |λ|²⟪y₂, S y₂⟫ = |λ|²`).
     let f : ℝ → S.domain := fun r ↦ (1 - r : ℂ) • y₀ + (r : ℂ) • y₂
     have hf : ∀ r, f r ≠ 0 := by
       intro r hr

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -49,6 +49,7 @@ noncomputable section
 
 open Submodule
 open Metric
+open InnerProductSpace
 open Complex
 
 /-!
@@ -224,6 +225,104 @@ lemma inf_ne_bot_of_rank_lt [CompleteSpace H]
   have hF : y ∈ F := sub_mem (coe_mem x₁) (coe_mem x₂)
   have hE : y ∈ Eᗮ := orthogonalProjection_eq_zero_iff.mp (_root_.map_sub Φ _ _ ▸ sub_eq_zero.mpr h)
   exact fun hEF ↦ hy ((mem_bot ℂ).mp <| hEF ▸ ⟨hE, hF⟩)
+
+lemma exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT : T.IsClosed)
+    {z₁ z₂ : ℂ} (hz₁ : z₁ ∈ T.regularityDomain) (h : T.defectNumber z₁ < T.defectNumber z₂) :
+    ∃ x : T.domain, x ≠ 0 ∧ ⟪T x - z₁ • x, T x - z₂ • x⟫_ℂ = 0 := by
+  obtain ⟨y, h_inf, hy⟩ := (Submodule.ne_bot_iff _).mp (inf_ne_bot_of_rank_lt h)
+  obtain ⟨hy₁, hy₂⟩ := mem_inf.mp h_inf
+  haveI := sub_range_isClosed hT hz₁ -- needed for `orthogonal_orthogonal`
+  simp only [deficiencySubspace_coe, orthogonal_orthogonal] at hy₁ hy₂
+  obtain ⟨⟨x, hx⟩, hxy⟩ := hy₁
+  refine ⟨⟨x, hx.1⟩, fun h ↦ hy ?_, ?_⟩
+  · simp [← hxy, coe_eq_zero.mp, (mk_eq_zero _ _).mp h]
+  · apply (mem_orthogonal' _ _).mp at hy₂
+    simp [← hy₂ ((T - z₂ • 1) ⟨x, hx.1, by simp⟩) (by simp), sub_apply, ← hxy]
+
+lemma defectNumber_eq_of_mem_ball [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} (hT : T.IsClosable) {z₁ z₂ : ℂ}
+    {c : ℝ} (h : IsLowerBound T z₁ c) (h_ball : z₂ ∈ ball z₁ c) :
+    T.defectNumber z₁ = T.defectNumber z₂ := by
+  by_cases hz₁ : z₁ ∈ T.regularityDomain
+  · have hz₂ : z₂ ∈ T.regularityDomain := ball_subset_regularityDomain h h_ball
+    rw [← defectNumber_closure hz₁, ← defectNumber_closure hz₂]
+    rw [← regularityDomain_closure] at hz₁ hz₂
+    by_contra! hne
+    let Tcl : H →ₗ.[ℂ] H := T.closure
+    obtain ⟨x, hx, h'⟩ : ∃ x : Tcl.domain, x ≠ 0 ∧ ⟪Tcl x - z₂ • x, Tcl x - z₁ • x⟫_ℂ = 0 := by
+      rcases lt_or_gt_of_ne hne with hle | hle
+      · simp_rw [inner_eq_zero_symm]
+        exact exists_inner_eq_zero_of_defectNumber_lt hT.closure_isClosed hz₁ hle
+      · exact exists_inner_eq_zero_of_defectNumber_lt hT.closure_isClosed hz₂ hle
+    refine not_le (a := ‖z₁ - z₂‖ * ‖x‖).mpr ?_ le_rfl
+    refine lt_of_lt_of_le (b := ‖Tcl x - z₁ • x‖) ?_ ?_
+    · refine lt_of_lt_of_le ?_ (isLowerBound_closure h x)
+      exact (mul_lt_mul_iff_left₀ <| norm_pos_iff.mpr hx).mpr (mem_ball_iff_norm'.mp h_ball)
+    · rcases eq_or_ne (Tcl x - z₁ • x) 0 with heq | hne
+      · exact heq ▸ norm_zero (E := H) ▸ mul_nonneg (norm_nonneg _) (norm_nonneg x)
+      · apply (mul_le_mul_iff_left₀ (norm_pos_iff.mpr hne)).mp
+        trans ‖⟪Tcl x - z₂ • x - (z₁ - z₂) • x, Tcl x - z₁ • x⟫_ℂ‖
+        · simp [sub_smul, pow_two]
+        rw [inner_sub_left, h', zero_sub, inner_smul_left, norm_neg, norm_mul, norm_conj, mul_assoc]
+        exact mul_le_mul_of_nonneg_left (norm_inner_le_norm _ _) (norm_nonneg _)
+  · false_or_by_contra -- `z₁ ∉ T.regularityDomain` ⇒ `c ≤ 0` ⇒ `z₂ ∈ ∅`
+    exact hz₁ ⟨c, lt_of_le_of_lt dist_nonneg h_ball, h⟩
+
+/-- `T.defectNumber` is constant on each connected component of `T.regularityDomain`. -/
+lemma defectNumber_eq_of_same_connectedComponent [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} (hT : T.IsClosable)
+    {z₁ z₂ : T.regularityDomain} (h : connectedComponent z₁ = connectedComponent z₂) :
+    T.defectNumber z₁ = T.defectNumber z₂ := by
+  have h_joined : Joined z₁ z₂ := by
+    haveI := T.regularityDomain_isOpen.locPathConnectedSpace
+    rw [← mem_pathComponent_iff, pathComponent_symm, pathComponent_eq_connectedComponent, ← h]
+    exact mem_connectedComponent
+  let path : Path z₁ z₂ := h_joined.somePath
+  by_contra! hne
+  let a : unitInterval := sSup {r | ∀ r' ≤ r, T.defectNumber (path r') = T.defectNumber z₁}
+  have ha : ∀ r < a, T.defectNumber (path r) = T.defectNumber z₁ := by
+    intro r hr
+    obtain ⟨b, hb, hrb⟩ := lt_sSup_iff.mp hr
+    exact hb r hrb.le
+  let c : ℝ := (path a).prop.choose
+  have hc_pos : 0 < c := (path a).prop.choose_spec.1
+  have hc_bound : IsLowerBound T (path a) c := (path a).prop.choose_spec.2
+  obtain ⟨ε, hε, hε_ball⟩ : ∃ ε > 0, ball a ε ⊆ path ⁻¹' ball (path a) c := by
+    apply Metric.mem_nhds_iff.mp
+    refine (IsOpen.mem_nhds_iff ?_).mpr ?_
+    · exact path.continuous.isOpen_preimage _ isOpen_ball
+    · simp [hc_pos]
+  obtain ⟨b₁, h₁, h₁'⟩ : ∃ b ∈ ball a ε, T.defectNumber (path b) = T.defectNumber z₁ := by
+    rcases le_or_gt ε a with hle | hlt
+    · let r : ℝ := a - ε / 2
+      have hr : 0 ≤ r := by dsimp [r]; linarith
+      have hr' : r < a := sub_lt_self _ (half_pos hε)
+      use ⟨r, hr, by linarith [a.2.2]⟩
+      exact ⟨by simp [dist, r, abs_div, abs_of_nonneg hε.le, hε], ha _ hr'⟩
+    · exact ⟨0, by simp [dist, abs_of_nonneg a.2.1, hlt], by rw [path.source]⟩
+  obtain ⟨b₂, h₂, h₂'⟩ : ∃ b ∈ ball a ε, T.defectNumber (path b) ≠ T.defectNumber z₁ := by
+    by_cases! h₀ : a < 1
+    · by_contra! h'
+      let r : unitInterval :=
+        ⟨min (a + ε / 2) 1, le_inf_iff.mpr ⟨by linarith [a.2.1], zero_le_one⟩, inf_le_right⟩
+      refine not_le_of_gt (a := a) (b := r) ?_ ?_
+      · apply (Set.inclusion_lt_inclusion <| Set.subset_univ _).mp
+        simp [r, hε, h₀]
+      · refine le_sSup_iff.mpr fun _ hub ↦ hub fun b hbr ↦ ?_
+        rcases lt_or_ge b a with hlt | hle
+        · exact ha b hlt
+        · refine h' b ?_
+          apply mem_ball.mpr
+          calc
+            _ = (b : ℝ) - a := by simp [dist, hle]
+            _ ≤ r - a := by simp [hbr]
+            _ = min (ε / 2) (1 - a) := by simp [r, ← min_sub_sub_right]
+            _ < ε := by simp [hε]
+    · have : a = 1 := eq_of_le_of_ge a.2.2 h₀
+      refine ⟨a, mem_ball_self hε, by rw [this, path.target]; exact hne.symm⟩
+  apply h₁' ▸ h₂'
+  rw [← defectNumber_eq_of_mem_ball hT hc_bound (hε_ball h₁)]
+  rw [← defectNumber_eq_of_mem_ball hT hc_bound (hε_ball h₂)]
 
 end
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -22,16 +22,27 @@ Definitions
 - `LinearPMap.regularityDomain` : The set of regular points for a partial linear map `T`.
     A complex number `z` is a regular point for `T` if there exists `c > 0` such that
     `c * ‖x‖ ≤ ‖T x - z • x‖` for all `x : T.domain`.
+- `LinearPMap.deficiencySubspace` : For an operator `T` and complex number `z`, the submodule
+    orthogonal to the range of `T - z • 1`.
+- `LinearPMap.defectNumber` : The rank of the deficiency subspace.
+- `LinearPMap.numericalRange` : For an operator `T`, the set of complex numbers `⟪x, T x⟫_ℂ`
+    with `x ∈ T.domain` and `‖x‖ = 1`.
 
 Main results
 - `regularityDomain_isOpen` : The regularity domain is an open subset of `ℂ`.
 - `closure_range_sub_eq_range_closure_sub` : If `z` is a regular point for a closable operator `T`
     then the closure of `(T - z • 1).range` is `(T.closure - z • 1).range`.
+- `defectNumber_same_of_same_connectedComponent` : The defect number is constant on each connected
+    component of the regularity domain.
+- `numericalRange_convex` : The Toeplitz-Hausdorff theorem — the numerical range is a convex set.
+- `mem_regularityDomain_of_not_mem_numericalRange_closure` : The regularity domain contains the
+    exterior of the numerical range.
 
 ## iii. Table of contents
 
 - A. Regularity domain
 - B. Deficiency subspace & defect number
+- C. Numerical range
 
 ## iv. References
 
@@ -268,7 +279,7 @@ lemma defectNumber_eq_of_mem_ball [CompleteSpace H]
     exact hz₁ ⟨c, lt_of_le_of_lt dist_nonneg h_ball, h⟩
 
 /-- `T.defectNumber` is constant on each connected component of `T.regularityDomain`. -/
-lemma defectNumber_eq_of_same_connectedComponent [CompleteSpace H]
+lemma defectNumber_same_of_same_connectedComponent [CompleteSpace H]
     {T : H →ₗ.[ℂ] H} (hT : T.IsClosable)
     {z₁ z₂ : T.regularityDomain} (h : connectedComponent z₁ = connectedComponent z₂) :
     T.defectNumber z₁ = T.defectNumber z₂ := by

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -151,7 +151,7 @@ lemma regularityDomain_closure (T : H →ₗ.[ℂ] H) :
   refine eq_of_le_of_ge (regularityDomain_antitone T.le_closure) ?_
   exact fun _ ⟨c, hc, h⟩ ↦ ⟨c, hc, isLowerBound_closure h⟩
 
-lemma closure_range_sub_eq_range_closure_sub [CompleteSpace H]
+lemma IsClosable.closure_range_sub_eq_range_closure_sub [CompleteSpace H]
     {T : H →ₗ.[ℂ] H} (hT : T.IsClosable) {z : ℂ} (hz : z ∈ T.regularityDomain) :
     (T - z • 1).toFun.range.closure = (T.closure - z • 1).toFun.range := by
   ext y
@@ -192,11 +192,11 @@ lemma closure_range_sub_eq_range_closure_sub [CompleteSpace H]
     use ⟨u, by simp [sub_domain]⟩
     simp [sub_apply, ← hu₁, hu₂]
 
-lemma sub_range_isClosed [CompleteSpace H]
+lemma IsClosed.sub_range_isClosed [CompleteSpace H]
     {T : H →ₗ.[ℂ] H} (hT : T.IsClosed) {z : ℂ} (hz : z ∈ T.regularityDomain) :
     _root_.IsClosed ((T - z • 1).toFun.range : Set H) := by
   have hT' : T.closure = T := hT.isClosable.isClosed_iff.mp hT
-  exact (hT' ▸ closure_range_sub_eq_range_closure_sub hT.isClosable hz) ▸ isClosed_closure
+  exact (hT' ▸ hT.isClosable.closure_range_sub_eq_range_closure_sub hz) ▸ isClosed_closure
 
 /-!
 ## B. Deficiency subspace & defect number
@@ -222,14 +222,14 @@ lemma defectNumber_closure [CompleteSpace H]
     T.closure.defectNumber z = T.defectNumber z := by
   by_cases hT : T.IsClosable
   · refine congrArg (fun p : Submodule ℂ H ↦ Module.rank ℂ p) ?_
-    simp [← closure_range_sub_eq_range_closure_sub hT hz]
+    simp [← hT.closure_range_sub_eq_range_closure_sub hz]
   · rw [closure_def' hT]
 
-lemma inf_ne_bot_of_rank_lt {E F : Submodule ℂ H} [E.HasOrthogonalProjection]
-    (hlt : Module.rank ℂ E < Module.rank ℂ F) :
+lemma inf_ne_bot_of_rank_lt
+    {E F : Submodule ℂ H} [E.HasOrthogonalProjection] (h_rank : Module.rank ℂ E < Module.rank ℂ F) :
     Eᗮ ⊓ F ≠ ⊥ := by
   let Φ : F →L[ℂ] E := E.orthogonalProjection ∘L F.subtypeL
-  have hΦ : ¬(⇑Φ).Injective := fun h' ↦ not_le_of_gt hlt (Φ.rank_le_of_injective h')
+  have hΦ : ¬(⇑Φ).Injective := fun h' ↦ not_le_of_gt h_rank (Φ.rank_le_of_injective h')
   obtain ⟨x₁, x₂, h, hx⟩ := Function.not_injective_iff.mp hΦ
   let y : H := x₁ - x₂
   have hy : y ≠ 0 := fun h' ↦ hx (SetLike.coe_eq_coe.mp <| sub_eq_zero.mp h')
@@ -242,7 +242,7 @@ lemma exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H] {T : H →ₗ.[�
     ∃ x : T.domain, x ≠ 0 ∧ ⟪T x - z₁ • x, T x - z₂ • x⟫_ℂ = 0 := by
   obtain ⟨y, h_inf, hy⟩ := (Submodule.ne_bot_iff _).mp (inf_ne_bot_of_rank_lt h)
   obtain ⟨hy₁, hy₂⟩ := mem_inf.mp h_inf
-  haveI := sub_range_isClosed hT hz₁ -- needed for `orthogonal_orthogonal`
+  haveI := hT.sub_range_isClosed hz₁ -- needed for `orthogonal_orthogonal`
   simp only [deficiencySubspace_coe, orthogonal_orthogonal] at hy₁ hy₂
   obtain ⟨⟨x, hx⟩, hxy⟩ := hy₁
   refine ⟨⟨x, hx.1⟩, fun h ↦ hy ?_, ?_⟩
@@ -250,8 +250,7 @@ lemma exists_inner_eq_zero_of_defectNumber_lt [CompleteSpace H] {T : H →ₗ.[�
   · apply (mem_orthogonal' _ _).mp at hy₂
     simp [← hy₂ ((T - z₂ • 1) ⟨x, hx.1, by simp⟩) (by simp), sub_apply, ← hxy]
 
-lemma defectNumber_eq_of_mem_ball [CompleteSpace H]
-    {T : H →ₗ.[ℂ] H} (hT : T.IsClosable) {z₁ z₂ : ℂ}
+lemma defectNumber_eq_of_mem_ball [CompleteSpace H] {T : H →ₗ.[ℂ] H} (hT : T.IsClosable) {z₁ z₂ : ℂ}
     {c : ℝ} (h : IsLowerBound T z₁ c) (h_ball : z₂ ∈ ball z₁ c) :
     T.defectNumber z₁ = T.defectNumber z₂ := by
   by_cases hz₁ : z₁ ∈ T.regularityDomain
@@ -344,7 +343,7 @@ section
 open Set
 open Pointwise
 
-/-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1}`. -/
+/-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1} ⊆ ℂ`. -/
 def numericalRange (T : H →ₗ.[ℂ] H) : Set ℂ := (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x : T.domain | ‖x‖ = 1}
 
 lemma numericalRange_eq (T : H →ₗ.[ℂ] H) :
@@ -452,7 +451,7 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
       simp_rw [hxd, hba, ofReal_sub, ofReal_one, ← hca, ← hdc]
       field_simp
       simp [mul_sub, mul_comm]
-    -- Now pick `θ` so that `y₂ ≔ eⁱᶿy₁` satisfies `⟪y₀, S y₂⟫_ℂ + ⟪y₂, S y₀⟫ ∈ ℝ`
+    -- First pick `θ` so that `y₂ ≔ eⁱᶿy₁` satisfies `⟪y₀, S y₂⟫ + ⟪y₂, S y₀⟫ ∈ ℝ`
     obtain ⟨θ, hθ⟩ := exists_phase_add_im_eq_zero ⟪↑y₀, S y₁⟫_ℂ ⟪↑y₁, S y₀⟫_ℂ
     let y₂ : S.domain := exp (I * θ) • y₁
     have hy₂ : ‖y₂‖ = 1 := by simp [y₂, norm_smul, hy₁]
@@ -461,7 +460,8 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
       simp [← hθ, y₂, map_smul, SetLike.val_smul, inner_smul_left, inner_smul_right, ← exp_conj]
     have h₂ : ⟪↑y₂, S y₂⟫_ℂ = 1 := by
       simp [y₂, map_smul, inner_smul_left, inner_smul_right, h₁, ← exp_conj, ← exp_add]
-    -- `f` is a parametrization of the line connecting `y₀` and `y₂`
+    -- `f` parametrizes the line connecting `y₀` and `y₂` and never vanishes because `y₀` and `y₂`
+    -- are linearly independent (since `y₀ = λy₂` implies `0 = ⟪y₀, S y₀⟫ = |λ|²⟪y₂, S y₂⟫ = λ²`).
     let f : ℝ → S.domain := fun r ↦ (1 - r : ℂ) • y₀ + (r : ℂ) • y₂
     have hf : ∀ r, f r ≠ 0 := by
       intro r hr

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -212,6 +212,19 @@ lemma defectNumber_closure [CompleteSpace H]
     simp [← closure_range_sub_eq_range_closure_sub hT hz]
   · rw [closure_def' hT]
 
+lemma inf_ne_bot_of_rank_lt [CompleteSpace H]
+    {E F : Submodule ℂ H} [E.HasOrthogonalProjection] [F.HasOrthogonalProjection]
+    (hlt : Module.rank ℂ E < Module.rank ℂ F) :
+    Eᗮ ⊓ F ≠ ⊥ := by
+  let Φ : F →L[ℂ] E := E.orthogonalProjection ∘L F.subtypeL
+  have hΦ : ¬(⇑Φ).Injective := fun h' ↦ not_le_of_gt hlt (Φ.rank_le_of_injective h')
+  obtain ⟨x₁, x₂, h, hx⟩ := Function.not_injective_iff.mp hΦ
+  let y : H := x₁ - x₂
+  have hy : y ≠ 0 := fun h' ↦ hx (SetLike.coe_eq_coe.mp <| sub_eq_zero.mp h')
+  have hF : y ∈ F := sub_mem (coe_mem x₁) (coe_mem x₂)
+  have hE : y ∈ Eᗮ := orthogonalProjection_eq_zero_iff.mp (_root_.map_sub Φ _ _ ▸ sub_eq_zero.mpr h)
+  exact fun hEF ↦ hy ((mem_bot ℂ).mp <| hEF ▸ ⟨hE, hF⟩)
+
 end
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -324,6 +324,60 @@ lemma defectNumber_eq_of_same_connectedComponent [CompleteSpace H]
   rw [← defectNumber_eq_of_mem_ball hT hc_bound (hε_ball h₁)]
   rw [← defectNumber_eq_of_mem_ball hT hc_bound (hε_ball h₂)]
 
+/-!
+## C. Numerical range
+-/
+
+/-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1}`. -/
+def numericalRange (T : H →ₗ.[ℂ] H) : Set ℂ := (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x : T.domain | ‖x‖ = 1}
+
+lemma numericalRange_eq (T : H →ₗ.[ℂ] H) :
+    T.numericalRange = (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x | ‖x‖ = 1} := rfl
+
+lemma numericalRange_nonempty {T : H →ₗ.[ℂ] H} (hT : T.domain ≠ ⊥) : T.numericalRange.Nonempty := by
+  obtain ⟨x, hx, hx'⟩ := exists_mem_ne_zero_of_ne_bot hT
+  refine ⟨(‖x‖ ^ 2)⁻¹ * ⟪x, T ⟨x, hx⟩⟫_ℂ, ofReal ‖x‖⁻¹ • ⟨x, hx⟩, ?_, ?_⟩
+  · simp [norm_smul, inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx')]
+  · simp_rw [map_smul]
+    simp [inner_smul_left, inner_smul_right, ← mul_assoc, pow_two]
+
+/-- The Toeplitz-Hausdorff theorem. -/
+lemma numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRange := by
+  sorry
+
+/-- The regularity domain contains the exterior of the numerical range. -/
+lemma mem_regularityDomain_of_not_mem_numericalRange_closure
+    {T : H →ₗ.[ℂ] H} {z : ℂ} (h : z ∉ _root_.closure T.numericalRange) :
+    z ∈ T.regularityDomain := by
+  by_cases hT : T.domain = ⊥
+  · refine ⟨1, zero_lt_one, fun ⟨x, hx⟩ ↦ ?_⟩
+    rw [hT] at hx
+    simp_all
+  · use infDist z T.numericalRange
+    constructor
+    · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp h
+    · intro x
+      rcases eq_or_ne x 0 with rfl | hx
+      · simp
+      · let y : T.domain := ofReal ‖x‖⁻¹ • x
+        have hy : ‖y‖ = 1 := by
+          simp only [y, norm_smul, ofReal_inv, norm_inv, norm_real, norm_norm]
+          exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx)
+        have hy' : ‖x‖ ^ 2 * ⟪↑y, T y⟫_ℂ = ⟪↑x, T x⟫_ℂ := by
+          simp_rw [y, map_smul, SetLike.val_smul, inner_smul_left, inner_smul_right, conj_ofReal,
+            ← mul_assoc, pow_two, ← ofReal_mul]
+          field_simp
+          simp
+        apply (mul_le_mul_iff_left₀ <| norm_pos_iff.mpr hx).mp
+        rw [mul_assoc, ← pow_two, mul_comm _ ‖x‖]
+        calc
+          _ ≤ ‖z - ⟪↑y, T y⟫_ℂ‖ * ‖x‖ ^ 2 := mul_le_mul_of_nonneg_right
+            (dist_eq z _ ▸ infDist_le_dist_of_mem ⟨y, hy, rfl⟩) (pow_two_nonneg _)
+          _ = ‖⟪↑y, T y⟫_ℂ * ‖x‖ ^ 2 - z * ‖x‖ ^ 2‖ := by simp [norm_sub_rev, ← sub_mul]
+          _ = ‖⟪↑x, T x⟫_ℂ - z * ‖x‖ ^ 2‖ := by rw [mul_comm, hy']
+          _ = ‖⟪↑x, T x - z • x⟫_ℂ‖ := by simp [inner_sub_right, inner_smul_right]
+          _ ≤ ‖x‖ * ‖T x - z • x‖ := norm_inner_le_norm _ _
+
 end
 
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -213,8 +213,7 @@ lemma defectNumber_closure [CompleteSpace H]
     simp [← closure_range_sub_eq_range_closure_sub hT hz]
   · rw [closure_def' hT]
 
-lemma inf_ne_bot_of_rank_lt [CompleteSpace H]
-    {E F : Submodule ℂ H} [E.HasOrthogonalProjection] [F.HasOrthogonalProjection]
+lemma inf_ne_bot_of_rank_lt [CompleteSpace H] {E F : Submodule ℂ H} [E.HasOrthogonalProjection]
     (hlt : Module.rank ℂ E < Module.rank ℂ F) :
     Eᗮ ⊓ F ≠ ⊥ := by
   let Φ : F →L[ℂ] E := E.orthogonalProjection ∘L F.subtypeL
@@ -328,6 +327,11 @@ lemma defectNumber_eq_of_same_connectedComponent [CompleteSpace H]
 ## C. Numerical range
 -/
 
+section
+
+open Set
+open Pointwise
+
 /-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1}`. -/
 def numericalRange (T : H →ₗ.[ℂ] H) : Set ℂ := (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x : T.domain | ‖x‖ = 1}
 
@@ -340,6 +344,36 @@ lemma numericalRange_nonempty {T : H →ₗ.[ℂ] H} (hT : T.domain ≠ ⊥) : T
   · simp [norm_smul, inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx')]
   · simp_rw [map_smul]
     simp [inner_smul_left, inner_smul_right, ← mul_assoc, pow_two]
+
+lemma numericalRange_smul (T : H →ₗ.[ℂ] H) (c : ℂ) :
+    (c • T).numericalRange = c • T.numericalRange := by
+  ext
+  simp [numericalRange_eq, inner_smul_right, mem_smul_set]
+
+lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) :
+    (T - c • 1).numericalRange = T.numericalRange - {c} := by
+  ext z
+  constructor
+  · intro ⟨x, hx, hxz⟩
+    refine ⟨z + c, ⟨⟨x, x.2.1⟩, hx, ?_⟩, by simp⟩
+    simp_all [← hxz, sub_apply, inner_sub_right, inner_smul_right]
+  · intro ⟨z', ⟨x, hx, hxz⟩, hcz⟩
+    simp only [mem_singleton_iff, exists_eq_left] at hcz
+    refine ⟨⟨x, by simp [sub_domain]⟩, hx, ?_⟩
+    simp_all [← hcz, ← hxz, sub_apply, inner_sub_right, inner_smul_right]
+
+private lemma exists_phase_add_im_eq_zero (z₁ z₂ : ℂ) :
+    ∃ θ : ℝ, (exp (I * θ) * z₁ + exp (-I * θ) * z₂).im = 0 := by
+  let g : ℝ → ℝ := fun θ ↦ (exp (I * θ) * z₁ + exp (-I * θ) * z₂).im
+  suffices ∃ θ ∈ Icc 0 Real.pi, g θ = 0 by exact ⟨this.choose, this.choose_spec.2⟩
+  have hg : g Real.pi = -g 0 := by simp [g, mul_comm I, exp_neg, add_comm]
+  have hg' : Continuous g := by fun_prop
+  rcases le_or_gt (g 0) 0 with hle | hlt
+  · have hIVT := hg ▸ intermediate_value_Icc Real.pi_nonneg hg'.continuousOn
+    exact (mem_image _ _ _).mp (hIVT ⟨by linarith, by linarith⟩)
+  · simp_rw [← neg_eq_zero (a := g _)]
+    have hIVT := neg_neg (g 0) ▸ hg ▸ intermediate_value_Icc Real.pi_nonneg hg'.neg.continuousOn
+    exact (mem_image _ _ _).mp (hIVT ⟨by linarith, by linarith⟩)
 
 /-- The Toeplitz-Hausdorff theorem. -/
 lemma numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRange := by
@@ -377,6 +411,8 @@ lemma mem_regularityDomain_of_not_mem_numericalRange_closure
           _ = ‖⟪↑x, T x⟫_ℂ - z * ‖x‖ ^ 2‖ := by rw [mul_comm, hy']
           _ = ‖⟪↑x, T x - z • x⟫_ℂ‖ := by simp [inner_sub_right, inner_smul_right]
           _ ≤ ‖x‖ * ‖T x - z • x‖ := norm_inner_le_norm _ _
+
+end
 
 end
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -376,8 +376,81 @@ private lemma exists_phase_add_im_eq_zero (z₁ z₂ : ℂ) :
     exact (mem_image _ _ _).mp (hIVT ⟨by linarith, by linarith⟩)
 
 /-- The Toeplitz-Hausdorff theorem. -/
-lemma numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRange := by
-  sorry
+theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRange := by
+  intro z₀ hz₀ z₁ hz₁ a b ha hb hab
+  rcases eq_or_ne z₁ z₀ with rfl | hz
+  · simp [← add_mul, eq_sub_iff_add_eq.mpr hab, hz₁]
+  · apply sub_ne_zero.mpr at hz
+    obtain ⟨x₀, hx₀, _⟩ := hz₀
+    obtain ⟨x₁, hx₁, _⟩ := hz₁
+    -- Apply an affine transformation to effectively move the endpoints `z₀` and `z₁` to `0` and `1`
+    let S : H →ₗ.[ℂ] H := (z₁ - z₀)⁻¹ • (T - z₀ • 1)
+    let y₀ : S.domain := ⟨x₀, by simp [S, sub_domain]⟩
+    let y₁ : S.domain := ⟨x₁, by simp [S, sub_domain]⟩
+    have hy₀ : ‖y₀‖ = 1 := hx₀
+    have hy₁ : ‖y₁‖ = 1 := hx₁
+    have h₀ : ⟪↑y₀, S y₀⟫_ℂ = 0 := by simp_all [S, y₀, sub_apply, inner_smul_right, inner_sub_right]
+    have h₁ : ⟪↑y₁, S y₁⟫_ℂ = 1 := by simp_all [S, y₁, sub_apply, inner_smul_right, inner_sub_right]
+    suffices ofReal '' unitInterval ⊆ S.numericalRange by
+      have hba : a = 1 - b := by linarith
+      rw [numericalRange_smul, numericalRange_sub_const] at this
+      obtain ⟨c, hc, hca⟩ := (image_subset_iff.mp this) ⟨hb, by linarith⟩
+      obtain ⟨d, hd, hdc⟩ := hc
+      obtain ⟨x, hx, hxd⟩ := hd
+      simp only [mem_singleton_iff, exists_eq_left] at hca hdc hxd
+      simp only [real_smul, smul_eq_mul] at *
+      use x, hx
+      simp_rw [hxd, hba, ofReal_sub, ofReal_one, ← hca, ← hdc]
+      field_simp
+      simp [mul_sub, mul_comm]
+    -- Now pick `θ` so that `y₂ ≔ eⁱᶿy₁` satisfies `⟪y₀, S y₂⟫_ℂ + ⟪y₂, S y₀⟫ ∈ ℝ`
+    obtain ⟨θ, hθ⟩ := exists_phase_add_im_eq_zero ⟪↑y₀, S y₁⟫_ℂ ⟪↑y₁, S y₀⟫_ℂ
+    let y₂ : S.domain := exp (I * θ) • y₁
+    have hy₂ : ‖y₂‖ = 1 := by simp [y₂, norm_smul, hy₁]
+    have hy_im : (⟪↑y₀, S y₂⟫_ℂ).im = -(⟪↑y₂, S y₀⟫_ℂ).im := by
+      apply eq_neg_iff_add_eq_zero.mpr
+      simp [← hθ, y₂, map_smul, SetLike.val_smul, inner_smul_left, inner_smul_right, ← exp_conj]
+    have h₂ : ⟪↑y₂, S y₂⟫_ℂ = 1 := by
+      simp [y₂, map_smul, inner_smul_left, inner_smul_right, h₁, ← exp_conj, ← exp_add]
+    -- `f` is a parametrization of the line connecting `y₀` and `y₂`
+    let f : ℝ → S.domain := fun r ↦ (1 - r : ℂ) • y₀ + (r : ℂ) • y₂
+    have hf : ∀ r, f r ≠ 0 := by
+      intro r hr
+      rcases eq_or_ne r 0 with rfl | hr'
+      · exact (hy₁ ▸ zero_ne_one).symm (norm_eq_zero.mpr (by simp_all [f]))
+      · apply (pow_ne_zero 2 hr').symm
+        apply ofReal_inj.mp
+        calc
+          _ = (1 - r) ^ 2 * ⟪↑y₀, S y₀⟫_ℂ := by simp [h₀]
+          _ = ⟪↑((1 - r : ℂ) • y₀), S ((1 - r : ℂ) • y₀)⟫_ℂ := by
+            simp [map_smul, inner_smul_left, inner_smul_right, ← mul_assoc, pow_two]
+          _ = ⟪↑(-(r • y₂)), S (-(r • y₂))⟫_ℂ := by simp [eq_neg_iff_add_eq_zero.mpr hr]
+        simp [map_neg, ← Complex.coe_smul, map_smul, inner_smul_left, inner_smul_right, pow_two, h₂]
+    -- `g r = ⟪f r, S (f r)⟫_ℂ / ‖f r‖²` is real (by def of `θ`) and clearly in `S.numericalRange`.
+    -- `g 0 = 0`, `g 1 = 1` and continuity ensure that all of `[0,1]` is also in `S.numericalRange`.
+    let g : ℝ → ℝ := fun t ↦ (t ^ 2 + (1 - t) * t * (⟪↑y₀, S y₂⟫_ℂ + ⟪↑y₂, S y₀⟫_ℂ).re) / ‖f t‖ ^ 2
+    have hg₀ : g 0 = 0 := by simp [g]
+    have hg₁ : g 1 = 1 := by simp [g, f, coe_norm y₂ ▸ hy₂]
+    have hg_cont : Continuous g := Continuous.div₀ (by fun_prop) (by fun_prop) (by simp [hf])
+    intro c ⟨t, ht, htc⟩
+    obtain ⟨r, hr, hrt⟩ := (hg₀ ▸ hg₁ ▸ intermediate_value_Icc zero_le_one hg_cont.continuousOn) ht
+    rw [← htc, ← hrt]
+    refine ⟨‖f r‖⁻¹ • f r, ?_, ?_⟩
+    · simp only [mem_setOf_eq, norm_smul, norm_inv, norm_norm]
+      exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr (hf r))
+    · have hf_sq : ofReal (‖f r‖ ^ 2) ≠ 0 := by simp [hf]
+      simp_rw [← Complex.coe_smul, map_smul, SetLike.val_smul, inner_smul_left,inner_smul_right,
+        ← mul_assoc, conj_ofReal, ← pow_two, ← ofReal_pow, inv_pow, ofReal_inv]
+      apply (inv_mul_eq_iff_eq_mul₀ hf_sq).mpr
+      simp_rw [g, ofReal_div, mul_div_cancel₀ _ hf_sq, add_comm (r ^ 2)]
+      simp only [f, map_add, map_smul, coe_add, inner_add_left, inner_add_right,
+        SetLike.val_smul, inner_smul_left, inner_smul_right, h₀, h₂]
+      nth_rw 1 [← re_add_im ⟪↑y₀, S y₂⟫_ℂ]
+      nth_rw 1 [← re_add_im ⟪↑y₂, S y₀⟫_ℂ]
+      simp only [hy_im, mul_add, RingHom.map_sub, RingHom.map_one, conj_ofReal, mul_zero,
+        zero_add, ofReal_neg, neg_mul, mul_neg, mul_one, add_re, ofReal_add, ofReal_mul,
+        ofReal_sub, ofReal_one, ofReal_pow]
+      ring
 
 /-- The regularity domain contains the exterior of the numerical range. -/
 lemma mem_regularityDomain_of_not_mem_numericalRange_closure

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -31,6 +31,7 @@ Main results
 ## iii. Table of contents
 
 - A. Regularity domain
+- B. Deficiency subspace & defect number
 
 ## iv. References
 
@@ -183,6 +184,33 @@ lemma sub_range_isClosed [CompleteSpace H]
     _root_.IsClosed ((T - z • 1).toFun.range : Set H) := by
   have hT' : T.closure = T := hT.isClosable.isClosed_iff.mp hT
   exact (hT' ▸ closure_range_sub_eq_range_closure_sub hT.isClosable hz) ▸ isClosed_closure
+
+/-!
+## B. Deficiency subspace & defect number
+-/
+
+/-- The closed submodule `(T - z • 1).rangeᗮ`. -/
+def deficiencySubspace (T : H →ₗ.[ℂ] H) (z : ℂ) : ClosedSubmodule ℂ H :=
+  ⟨(T - z • 1).toFun.rangeᗮ, isClosed_orthogonal _⟩
+
+@[simp]
+lemma deficiencySubspace_coe (T : H →ₗ.[ℂ] H) (z : ℂ) :
+    T.deficiencySubspace z = (T - z • 1).toFun.rangeᗮ := rfl
+
+/-- The rank of `T.deficiencySubspace z = (T - z • 1).rangeᗮ`. -/
+def defectNumber (T : H →ₗ.[ℂ] H) (z : ℂ) : Cardinal := Module.rank ℂ (T.deficiencySubspace z)
+
+lemma defectNumber_eq (T : H →ₗ.[ℂ] H) (z : ℂ) :
+    T.defectNumber z = Module.rank ℂ (T.deficiencySubspace z) := rfl
+
+/-- `T` and `T.closure` have the same defect number at points in their regularity domain. -/
+lemma defectNumber_closure [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} {z : ℂ} (hz : z ∈ T.regularityDomain) :
+    T.closure.defectNumber z = T.defectNumber z := by
+  by_cases hT : T.IsClosable
+  · refine congrArg (fun p : Submodule ℂ H ↦ Module.rank ℂ p) ?_
+    simp [← closure_range_sub_eq_range_closure_sub hT hz]
+  · rw [closure_def' hT]
 
 end
 


### PR DESCRIPTION
Defines the deficiency subspaces, defect numbers and numerical range for any partial linear map `T : H →ₗ.[ℂ] H`, building on #1141.

The main results are:
- The defect number is constant on each connected component of the regularity domain.
- The regularity domain contains the exterior of the numerical range.
- The Toeplitz-Hausdorff theorem: the numerical range is a convex set.