### PR TITLE
feat: Adding Distributional EM Constructors

### DIFF
--- a/Physlib/Electromagnetism/Distributional/Basic.lean
+++ b/Physlib/Electromagnetism/Distributional/Basic.lean
@@ -95,7 +95,22 @@ noncomputable def ofStaticScalarPotential {d} (c : SpeedOfLight) :
 TODO "Add a constructor for DistElectromagneticPotential from a scalar
   potential which is a function using an if...then...else... based on IsDistBounded."
 
-TODO "Add a constructor for DistElectromagneticPotential from vector potentials."
+/-- The creation of an electromagnetic potential from a vector potential. -/
+noncomputable def ofVectorPotential {d} (c : SpeedOfLight) :
+    ((Time × Space d) →d[ℝ] EuclideanSpace ℝ (Fin d)) →ₗ[ℝ]
+    DistElectromagneticPotential d where
+  toFun A := (distTimeSlice c).symm (Lorentz.Vector.ofSpatialComponent ∘L A)
+  map_add' A₁ A₂ := by
+    ext ε
+    simp
+  map_smul' r A := by
+    ext ε
+    simp
+
+/-- The creation of an electromagnetic potential from a static vector potential. -/
+noncomputable def ofStaticVectorPotential {d} (c : SpeedOfLight) :
+    ((Space d) →d[ℝ] EuclideanSpace ℝ (Fin d)) →ₗ[ℝ] DistElectromagneticPotential d :=
+  ofVectorPotential c ∘ₗ Space.constantTime
 
 TODO "Add a constructor for DistElectromagneticPotential from electric and
   magnetic fields."

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
@@ -638,6 +638,15 @@ def ofTemporalComponent {d : ℕ} : ℝ →L[ℝ] Vector d where
   map_add' := by simp [add_smul]
   map_smul' := by simp [smul_smul]
 
+/-- The continuous linear map corresponding to the creation of a
+  Lorentz Vector with only non-zero spatial components. -/
+def ofSpatialComponent {d : ℕ} : EuclideanSpace ℝ (Fin d) →L[ℝ] Vector d where
+  toFun xs := ∑ i, xs i • basis (Sum.inr i)
+  map_add' xs ys := by
+    simp [add_smul, Finset.sum_add_distrib]
+  map_smul' c xs := by
+    simp [smul_smul, Finset.smul_sum]
+
 /-!
 
 ## Smoothness


### PR DESCRIPTION
# Overview 

Added Lorentz.Vector.ofSpatialComponent in Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean:643.
Added distributional ofVectorPotential and ofStaticVectorPotential in Physlib/Electromagnetism/Distributional/Basic.lean:99.

Removed the vector-potential TODO while leaving the scalar-function and electric/magnetic TODOs intact.
