### PR TITLE
feat(PhyslibAlpha): Surfaces

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -1,3 +1,5 @@
 module
 
 public import PhyslibAlpha.Basic
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Ring
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
@@ -88,7 +88,8 @@ lemma integrable_ringMeasure_of_continuous (f : Space → ℝ) (hf : Continuous 
     exact BoundedContinuousFunction.integrable _ f'
   · exact ring_measurableEmbedding
 
-lemma integrable_ringMeasure_of_continuous_euclid (f : Space → EuclideanSpace ℝ (Fin n)) (hf : Continuous (f ∘ ring)) :
+lemma integrable_ringMeasure_of_continuous_euclid (f : Space → EuclideanSpace ℝ (Fin n))
+    (hf : Continuous (f ∘ ring)) :
     Integrable f ringMeasure := by
   rw [ringMeasure]
   rw [MeasurableEmbedding.integrable_map_iff]
@@ -109,7 +110,8 @@ lemma ringMeasure_prod_volume_map :
 @[simp]
 lemma ringMeasure_univ : ringMeasure Set.univ = ENNReal.ofReal ((2 : ℝ) * π) := by
   rw [ringMeasure, Measure.map_apply]
-  simp
+  simp only [Set.preimage_univ, Measure.toSphere_apply_univ, finrank_eq_dim, Nat.cast_ofNat,
+    volume_metricBall_two, Nat.ofNat_nonneg, ENNReal.ofReal_mul, ENNReal.ofReal_ofNat]
   · fun_prop
   · exact MeasurableSet.univ
 

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell
+public import Physlib.SpaceAndTime.Space.Translations
+public import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+/-!
+
+## Ring surface in `Space 3`
+
+-/
+@[expose] public section
+open SchwartzMap NNReal
+noncomputable section
+open Physlib Distribution
+variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]
+  [NormedAddCommGroup F'] [NormedSpace ℝ E] [NormedSpace ℝ F]
+
+namespace Space
+
+open MeasureTheory Real
+
+/-!
+
+## A. The definition of the ring surface
+
+-/
+
+/-- The map embedding the unit ring in `Space d.succ` into `Space d.succ`. -/
+def ring : Metric.sphere (0 : Space 2) 1 → Space 3 := fun x =>
+  (slice 2).symm (0, Space.sphericalShell 1 x)
+
+lemma ring_eq : ring = (slice 2).symm ∘ (fun x => (0, sphericalShell 1 x)) := rfl
+
+lemma ring_injective : Function.Injective ring := by
+  intro x y h
+  simp [ring] at h
+  exact sphericalShell_injective _ h
+
+@[fun_prop]
+lemma ring_continuous : Continuous ring := by
+  apply Continuous.comp
+  · fun_prop
+  · fun_prop
+
+lemma ring_measurableEmbedding : MeasurableEmbedding ring :=
+  Continuous.measurableEmbedding ring_continuous ring_injective
+
+
+/-!
+
+## B. The measure associated with the ring
+
+-/
+
+/-- The measure on `Space 3` corresponding to integration around a ring. -/
+def ringMeasure : Measure (Space 3) :=
+  MeasureTheory.Measure.map ring (MeasureTheory.Measure.toSphere volume)
+
+instance ringMeasure_hasTemperateGrowth :
+    ringMeasure.HasTemperateGrowth := by
+  rw [ringMeasure]
+  refine { exists_integrable := ?_ }
+  use 0
+  simp
+
+instance ringMeasure_prod_volume_hasTemperateGrowth :
+    (ringMeasure.prod (volume (α := Space))).HasTemperateGrowth := by
+  exact IsDistBounded.instHasTemperateGrowthProdProdOfOpensMeasurableSpace ringMeasure volume
+
+instance ringMeasure_sFinite: SFinite ringMeasure := by
+  rw [ringMeasure]
+  exact Measure.instSFiniteMap volume.toSphere ring
+
+instance ringMeasure_finite: IsFiniteMeasure ringMeasure := by
+  rw [ringMeasure]
+  exact Measure.isFiniteMeasure_map volume.toSphere ring
+
+lemma integrable_ringMeasure_of_continuous (f : Space → ℝ) (hf : Continuous (f ∘ ring)) :
+    Integrable f ringMeasure := by
+  rw [ringMeasure]
+  rw [MeasurableEmbedding.integrable_map_iff]
+  · let f' : BoundedContinuousFunction (Metric.sphere (0 : Space 2) 1) ℝ :=
+      BoundedContinuousFunction.mkOfCompact ⟨f ∘ ring, hf⟩
+    exact BoundedContinuousFunction.integrable _ f'
+  · exact ring_measurableEmbedding
+
+lemma integrable_ringMeasure_of_continuous_euclid (f : Space → EuclideanSpace ℝ (Fin n)) (hf : Continuous (f ∘ ring)) :
+    Integrable f ringMeasure := by
+  rw [ringMeasure]
+  rw [MeasurableEmbedding.integrable_map_iff]
+  · exact BoundedContinuousFunction.integrable _
+      (BoundedContinuousFunction.mkOfCompact ⟨f ∘ ring, hf⟩)
+  · exact ring_measurableEmbedding
+
+lemma ringMeasure_prod_volume_map :
+    (ringMeasure.prod (volume (α := Space))).map (fun x : Space × Space => (x.1, x.2 + x.1))
+     = (ringMeasure.prod (volume (α := Space))) := by
+  refine (MeasureTheory.MeasurePreserving.skew_product (f := id) (g := fun x => fun y => y + x)
+    ?_ ?_ ?_).map_eq
+  · exact MeasurePreserving.id ringMeasure
+  · fun_prop
+  · filter_upwards with x
+    exact Measure.IsAddRightInvariant.map_add_right_eq_self (x)
+
+@[simp]
+lemma ringMeasure_univ : ringMeasure Set.univ = ENNReal.ofReal ((2 : ℝ) * π) := by
+  rw [ringMeasure, Measure.map_apply]
+  simp
+  · fun_prop
+  · exact MeasurableSet.univ
+
+
+/-!
+
+## C. The distribution associated with the ring
+
+-/
+
+/-- The distribution on `Space 3` corresponding to integration around a ring. -/
+def ringDist : (Space 3) →d[ℝ] ℝ  :=
+  SchwartzMap.integralCLM ℝ ringMeasure
+
+lemma ringDist_apply_eq_integral_ringMeasure (f : 𝓢(Space 3, ℝ)) :
+    ringDist f = ∫ x, f x ∂ringMeasure := by
+  rw [ringDist, SchwartzMap.integralCLM_apply]
+
+lemma ringDist_eq_integral_delta (f : 𝓢(Space 3, ℝ)) :
+    ringDist f = ∫ z, diracDelta ℝ z f ∂ringMeasure := by
+  rw [ringDist_apply_eq_integral_ringMeasure]
+  simp
+
+end Space

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalShell.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalShell.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+public import Physlib.SpaceAndTime.Space.ConstantSliceDist
+public import Physlib.SpaceAndTime.Space.Norm
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+/-!
+
+## Spherical surfaces on Space.
+
+
+-/
+@[expose] public section
+
+open SchwartzMap NNReal
+noncomputable section
+open Physlib Distribution
+variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]
+  [NormedAddCommGroup F'] [NormedSpace ℝ E] [NormedSpace ℝ F]
+
+namespace Space
+
+open MeasureTheory Real
+
+/-!
+
+## A. The definition of the spherical shell surface
+
+-/
+
+/-- The map embedding the unit sphere in `Space d.succ` into `Space d.succ`. -/
+def sphericalShell (d : ℕ) : Metric.sphere (0 : Space d.succ) 1 → Space d.succ := fun x => x.1
+
+lemma sphericalShell_injective (d : ℕ) : Function.Injective (sphericalShell d) := by
+  intro x y h
+  simp [sphericalShell] at h
+  grind
+
+lemma sphericalShell_continuous (d : ℕ) : Continuous (sphericalShell d) := continuous_subtype_val
+
+lemma sphericalShell_measurableEmbedding (d : ℕ) : MeasurableEmbedding (sphericalShell d) := by
+  apply Continuous.measurableEmbedding
+  · exact sphericalShell_continuous d
+  · exact sphericalShell_injective d
+
+@[simp]
+lemma norm_sphericalShell (d : ℕ) (x : Metric.sphere (0 : Space d.succ) 1) :
+    ‖sphericalShell d x‖ = 1 := by
+  simp [sphericalShell, Metric.sphere]
+
+/-!
+
+## B. The measure associated with the spherical shell
+
+-/
+
+/-- The measure on `Space d.succ` corresponding to integration around a spherical shell. -/
+def sphericalShellMeasure (d : ℕ) : Measure (Space d.succ) :=
+  MeasureTheory.Measure.map (sphericalShell d) (MeasureTheory.Measure.toSphere volume)
+
+instance sphericalShellMeasure_hasTemperateGrowth (d : ℕ) :
+    (sphericalShellMeasure d).HasTemperateGrowth := by
+  rw [sphericalShellMeasure]
+  refine { exists_integrable := ?_ }
+  use 0
+  simp
+
+/-!
+
+## C. The distribution associated with the spherical shell
+
+-/
+
+/-- The distribution associated with a spherical shell.
+  One can roughly think of this distribution as the distribution which
+  takes test functions `f (r)` to `∫ d³r f(r) ρ(r)` where `ρ(r)` is the
+  mass, charge or current etc. distribution. -/
+def sphericalShellDist (d : ℕ) : (Space d.succ) →d[ℝ] ℝ  :=
+  SchwartzMap.integralCLM ℝ (sphericalShellMeasure d)
+
+
+lemma sphericalShellDist_apply_eq_integral_sphericalShellMeasure (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
+    sphericalShellDist d f = ∫ x, f x ∂sphericalShellMeasure d := by
+  rw [sphericalShellDist, SchwartzMap.integralCLM_apply]
+
+lemma sphericalShellDist_apply_eq_integral_sphere_volume (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
+    sphericalShellDist d f =
+    ∫ x, f (sphericalShell d x) ∂(MeasureTheory.Measure.toSphere volume) := by
+  rw [sphericalShellDist_apply_eq_integral_sphericalShellMeasure, sphericalShellMeasure,
+   MeasurableEmbedding.integral_map (sphericalShell_measurableEmbedding d)]
+
+end Space


### PR DESCRIPTION
Add some surfaces which were part of #942 to PhyslibAlpha. 

This includes the surface associated with a spherical shell and the surface associated with a ring. 