### PR TITLE
Removed sorry from realLorentzTensor.actionP_toComplexPure

### DIFF
--- a/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
@@ -110,7 +110,7 @@ lemma complexCoBasis_ρ_apply (M : SL(2,ℂ)) (i j : Fin 1 ⊕ Fin 3) :
   change ((LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ (Pi.single j 1)) i = _
   simp
 
-lemma complexCoBasis_ρ_val (M : SL(2,ℂ)) (v : CoℂModule) :
+lemma CoℂModule.SL2CRep_val (M : SL(2,ℂ)) (v : CoℂModule) :
     ((CoℂModule.SL2CRep M) v).val =
     (LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ v.val := by
   rfl
@@ -248,7 +248,7 @@ lemma inclCoRealLorentz_ρ (M : SL(2, ℂ)) (v : CoMod 3) :
     (CoℂModule.SL2CRep M) (inclCoRealLorentz v) =
     inclCoRealLorentz ((Co 3).ρ (SL2C.toLorentzGroup M) v) := by
   ext i
-  rw [complexCoBasis_ρ_val, inclCoRealLorentz_val, inclCoRealLorentz_val]
+  rw [CoℂModule.SL2CRep_val, inclCoRealLorentz_val, inclCoRealLorentz_val]
   change ((LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ
       (ofRealHom ∘ v.toFin1dℝ)) i =
     (ofRealHom ∘ ((LorentzGroup.transpose (SL2C.toLorentzGroup M)⁻¹).1 *ᵥ

--- a/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith
+Authors: Nikolai Kashcheev, Joseph Tooby-Smith
 -/
 module
 

--- a/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Basic.lean
@@ -110,6 +110,11 @@ lemma complexCoBasis_ρ_apply (M : SL(2,ℂ)) (i j : Fin 1 ⊕ Fin 3) :
   change ((LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ (Pi.single j 1)) i = _
   simp
 
+lemma complexCoBasis_ρ_val (M : SL(2,ℂ)) (v : CoℂModule) :
+    ((CoℂModule.SL2CRep M) v).val =
+    (LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ v.val := by
+  rfl
+
 /-- The standard basis of complex covariant Lorentz vectors indexed by `Fin 4`. -/
 def complexCoBasisFin4 : Basis (Fin 4) ℂ CoℂModule :=
   Basis.reindex complexCoBasis finSumFinEquiv
@@ -205,6 +210,55 @@ lemma SL2CRep_ρ_basis (M : SL(2, ℂ)) (i : Fin 1 ⊕ Fin 3) :
   funext j
   simp only [LinearMap.map_smulₛₗ, ofRealHom_eq_coe, coe_smul]
   rw [complexContrBasis_of_real]
+
+/-- The semilinear map including real Lorentz co-vectors into complex covariant
+  Lorentz vectors. -/
+def inclCoRealLorentz : CoMod 3 →ₛₗ[Complex.ofRealHom] CoℂModule where
+  toFun v := { val := ofReal ∘ v.toFin1dℝ }
+  map_add' x y := by
+    ext i
+    rw [CoℂModule.val_add]
+    simp only [Function.comp_apply, Pi.add_apply, map_add]
+    simp only [ofReal_add]
+  map_smul' c x := by
+    ext i
+    rw [CoℂModule.val_smul]
+    simp only [Function.comp_apply, ofRealHom_eq_coe, Pi.smul_apply, _root_.map_smul]
+    simp only [smul_eq_mul, ofReal_mul]
+
+lemma inclCoRealLorentz_val (v : CoMod 3) :
+    (inclCoRealLorentz v).val = ofRealHom ∘ v.toFin1dℝ := rfl
+
+lemma complexCoBasis_of_real (i : Fin 1 ⊕ Fin 3) :
+    (complexCoBasis i) = inclCoRealLorentz (CoMod.stdBasis i) := by
+  apply CoℂModule.ext
+  simp only [complexCoBasis, Basis.coe_ofEquivFun, inclCoRealLorentz,
+    LinearMap.coe_mk, AddHom.coe_mk]
+  ext j
+  simp only [Function.comp_apply]
+  change (Pi.single i 1) j = _
+  by_cases h : i = j
+  · subst h
+    rw [CoMod.toFin1dℝ, CoMod.stdBasis_toFin1dℝEquiv_apply_same]
+    simp
+  · rw [CoMod.toFin1dℝ, CoMod.stdBasis_toFin1dℝEquiv_apply_ne h]
+    simp [h]
+
+lemma inclCoRealLorentz_ρ (M : SL(2, ℂ)) (v : CoMod 3) :
+    (CoℂModule.SL2CRep M) (inclCoRealLorentz v) =
+    inclCoRealLorentz ((Co 3).ρ (SL2C.toLorentzGroup M) v) := by
+  ext i
+  rw [complexCoBasis_ρ_val, inclCoRealLorentz_val, inclCoRealLorentz_val]
+  change ((LorentzGroup.toComplex (SL2C.toLorentzGroup M))⁻¹ᵀ *ᵥ
+      (ofRealHom ∘ v.toFin1dℝ)) i =
+    (ofRealHom ∘ ((LorentzGroup.transpose (SL2C.toLorentzGroup M)⁻¹).1 *ᵥ
+      v.toFin1dℝ)) i
+  rw [LorentzGroup.toComplex_inv]
+  change (LorentzGroup.toComplex (LorentzGroup.transpose (SL2C.toLorentzGroup M)⁻¹) *ᵥ
+      (ofRealHom ∘ v.toFin1dℝ)) i =
+    (ofRealHom ∘ ((LorentzGroup.transpose (SL2C.toLorentzGroup M)⁻¹).1 *ᵥ
+      v.toFin1dℝ)) i
+  rw [LorentzGroup.toComplex_mulVec_ofReal]
 
 end Lorentz
 end

--- a/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Modules.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Modules.lean
@@ -123,6 +123,19 @@ instance : AddCommGroup CoℂModule := Equiv.addCommGroup toFin13ℂFun
   with `Fin 1 ⊕ Fin 3 → ℂ`. -/
 instance : Module ℂ CoℂModule := Equiv.module ℂ toFin13ℂFun
 
+@[ext]
+lemma ext (ψ ψ' : CoℂModule) (h : ψ.val = ψ'.val) : ψ = ψ' := by
+  cases ψ
+  cases ψ'
+  subst h
+  rfl
+
+@[simp]
+lemma val_add (ψ ψ' : CoℂModule) : (ψ + ψ').val = ψ.val + ψ'.val := rfl
+
+@[simp]
+lemma val_smul (r : ℂ) (ψ : CoℂModule) : (r • ψ).val = r • ψ.val := rfl
+
 /-- The linear equivalence between `CoℂModule` and `(Fin 1 ⊕ Fin 3 → ℂ)`. -/
 @[simps!]
 def toFin13ℂEquiv : CoℂModule ≃ₗ[ℂ] (Fin 1 ⊕ Fin 3 → ℂ) :=

--- a/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Modules.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Vector/Pre/Modules.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith
+Authors: Nikolai Kashcheev, Joseph Tooby-Smith
 -/
 module
 

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Tooby-Smith, Nikolai Kashcheev
+Authors: Nikolai Kashcheev, Joseph Tooby-Smith
 -/
 module
 

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -341,6 +341,41 @@ noncomputable def toComplexVector (c : realLorentzTensor.Color) :
       rw [← smul_smul]
       rfl
 
+lemma toComplexVector_up_eq_inclCongrRealLorentz (v : Lorentz.ContrMod 3) :
+    toComplexVector Color.up v = Lorentz.inclCongrRealLorentz v := by
+  calc
+    toComplexVector Color.up v
+        = ∑ i, v.toFin1dℝ i • Lorentz.complexContrBasis i := by
+          simp [toComplexVector, Lorentz.contrBasis_repr_apply,
+            Lorentz.complexContrBasisFin4, Lorentz.ContrMod.toFin1dℝ_eq_val]
+          rfl
+    _ = ∑ i, v.toFin1dℝ i • Lorentz.inclCongrRealLorentz
+        (Lorentz.ContrMod.stdBasis i) := by
+          simp only [Lorentz.complexContrBasis_of_real]
+    _ = Lorentz.inclCongrRealLorentz
+        (∑ i, v.toFin1dℝ i • Lorentz.ContrMod.stdBasis i) := by
+          rw [map_sum]
+          simp only [LinearMap.map_smulₛₗ, Complex.ofRealHom_eq_coe, Complex.coe_smul]
+    _ = Lorentz.inclCongrRealLorentz v := by
+          rw [← Lorentz.ContrMod.stdBasis_decomp v]
+
+lemma toComplexVector_down_eq_inclCoRealLorentz (v : Lorentz.CoMod 3) :
+    toComplexVector Color.down v = Lorentz.inclCoRealLorentz v := by
+  calc
+    toComplexVector Color.down v
+        = ∑ i, v.toFin1dℝ i • Lorentz.complexCoBasis i := by
+          simp [toComplexVector, Lorentz.coBasis_repr_apply, Lorentz.complexCoBasisFin4]
+          rfl
+    _ = ∑ i, v.toFin1dℝ i • Lorentz.inclCoRealLorentz
+        (Lorentz.CoMod.stdBasis i) := by
+          simp only [Lorentz.complexCoBasis_of_real]
+    _ = Lorentz.inclCoRealLorentz
+        (∑ i, v.toFin1dℝ i • Lorentz.CoMod.stdBasis i) := by
+          rw [map_sum]
+          simp only [LinearMap.map_smulₛₗ, Complex.ofRealHom_eq_coe, Complex.coe_smul]
+    _ = Lorentz.inclCoRealLorentz v := by
+          rw [← Lorentz.CoMod.stdBasis_decomp v]
+
 /-- The function which turns a real pure tensor into a complex one. -/
 noncomputable def toComplexPure {c : Fin n → Color} (p : Pure realLorentzTensor c) :
     Pure complexLorentzTensor (colorToComplex ∘ c) := fun i =>
@@ -409,8 +444,7 @@ lemma toComplexPure_component {c : Fin n → Color} (p : Pure realLorentzTensor 
       rfl
     simp [- Fintype.sum_sum_type, Finsupp.single_apply]
 
-@[sorryful]
-lemma actionP_toComplexPure {n : ℕ } (c : Fin n → Color) (p : Pure realLorentzTensor c)
+lemma actionP_toComplexPure {n : ℕ} (c : Fin n → Color) (p : Pure realLorentzTensor c)
     (Λ : SL(2, ℂ)) :
     Λ • toComplexPure p = toComplexPure (toLorentzGroup Λ • p) := by
   ext i
@@ -434,22 +468,27 @@ lemma actionP_toComplexPure {n : ℕ } (c : Fin n → Color) (p : Pure realLoren
   generalize c i = c at *
   fin_cases c
   · simp_all [P, b, b', colorToComplex]
-    calc _ = (Lorentz.ContrℂModule.SL2CRep Λ) (∑ i, ((Lorentz.contrBasis 3).repr p i) •
-      Lorentz.complexContrBasisFin4 (finSumFinEquiv i)) := by rfl
-        _ = (∑ i, (Lorentz.ContrℂModule.SL2CRep Λ) (((Lorentz.contrBasis 3).repr p i) •
-          (Lorentz.complexContrBasisFin4 (finSumFinEquiv i)))) := by
-          simp only [Nat.reduceAdd, map_sum]
-        _ = (∑ i, (Lorentz.ContrℂModule.SL2CRep Λ) (((Lorentz.contrBasis 3).repr p i : ℂ) •
-          (Lorentz.complexContrBasisFin4 (finSumFinEquiv i)))) := by rfl
-        _ = (∑ i, (((Lorentz.contrBasis 3).repr p i : ℂ) •
-            (Lorentz.ContrℂModule.SL2CRep Λ)
-            (Lorentz.complexContrBasisFin4 (finSumFinEquiv i)))) := by
-          congr
-          funext x
-          rw [map_smul]
-    sorry
+    calc
+      (Lorentz.ContrℂModule.SL2CRep Λ) ((toComplexVector Color.up) p)
+          = (Lorentz.ContrℂModule.SL2CRep Λ) (Lorentz.inclCongrRealLorentz p) := by
+            exact congrArg (Lorentz.ContrℂModule.SL2CRep Λ)
+              (toComplexVector_up_eq_inclCongrRealLorentz p)
+      _ = Lorentz.inclCongrRealLorentz ((Lorentz.Contr 3).ρ (toLorentzGroup Λ) p) := by
+        rw [Lorentz.inclCongrRealLorentz_ρ]
+      _ = (toComplexVector Color.up) ((Lorentz.ContrMod.rep (toLorentzGroup Λ)) p) := by
+        exact (toComplexVector_up_eq_inclCongrRealLorentz
+          ((Lorentz.ContrMod.rep (toLorentzGroup Λ)) p)).symm
   · simp_all [P, b, b', colorToComplex]
-    sorry
+    calc
+      (Lorentz.CoℂModule.SL2CRep Λ) ((toComplexVector Color.down) p)
+          = (Lorentz.CoℂModule.SL2CRep Λ) (Lorentz.inclCoRealLorentz p) := by
+            exact congrArg (Lorentz.CoℂModule.SL2CRep Λ)
+              (toComplexVector_down_eq_inclCoRealLorentz p)
+      _ = Lorentz.inclCoRealLorentz ((Lorentz.Co 3).ρ (toLorentzGroup Λ) p) := by
+        rw [Lorentz.inclCoRealLorentz_ρ]
+      _ = (toComplexVector Color.down) ((Lorentz.CoMod.rep (toLorentzGroup Λ)) p) := by
+        exact (toComplexVector_down_eq_inclCoRealLorentz
+          ((Lorentz.CoMod.rep (toLorentzGroup Λ)) p)).symm
 
 lemma toComplex_pure {n : ℕ} (c : Fin n → Color) (p : Pure realLorentzTensor c) :
     toComplex p.toTensor = (toComplexPure p).toTensor := by

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -6,7 +6,6 @@ Authors: Nikolai Kashcheev, Joseph Tooby-Smith
 module
 
 public import Physlib.Relativity.Tensors.ComplexTensor.Basic
-public import Physlib.Meta.Sorry
 /-!
 
 # Complex Lorentz tensors from real Lorentz tensors
@@ -509,7 +508,6 @@ Finally we record that `toComplex` is equivariant for the natural action of
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The map `toComplex` is equivariant. -/
-@[sorryful]
 lemma toComplex_equivariant {n} {c : Fin n → realLorentzTensor.Color}
     (v : ℝT(3, c)) (Λ : SL(2, ℂ)) :
     Λ • (toComplex v) = toComplex (Lorentz.SL2C.toLorentzGroup Λ • v) := by


### PR DESCRIPTION
Removed sorry realLorentzTensor.actionP_toComplexPure.

Added real-to-complex helper API for covariant Lorentz vectors, parallel to the existing contravariant API.