### PR TITLE
feat(Electromagnetism): gauge transformations of the electromagnetic potential

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -50,6 +50,7 @@ public import Physlib.Electromagnetism.Kinematics.Boosts
 public import Physlib.Electromagnetism.Kinematics.EMPotential
 public import Physlib.Electromagnetism.Kinematics.ElectricField
 public import Physlib.Electromagnetism.Kinematics.FieldStrength
+public import Physlib.Electromagnetism.Kinematics.GaugeTransformation
 public import Physlib.Electromagnetism.Kinematics.MagneticField
 public import Physlib.Electromagnetism.Kinematics.ScalarPotential
 public import Physlib.Electromagnetism.Kinematics.VectorPotential

--- a/Physlib/Electromagnetism/Kinematics/GaugeTransformation.lean
+++ b/Physlib/Electromagnetism/Kinematics/GaugeTransformation.lean
@@ -44,6 +44,8 @@ the field strength of a bare-gradient potential. The invariance theorem
 - A. The pure-gauge potential
   - A.1. Definition and basic lemmas
   - A.2. Differentiability of the pure-gauge potential
+  - A.3. Vanishing field strength of the pure-gauge potential
+  - A.4. Lorentz equivariance of the pure-gauge potential
 - B. Gauge transformations
   - B.1. Definition and basic lemmas
   - B.2. Invariance of the field strength
@@ -109,6 +111,24 @@ lemma ofGradient_apply {d} (χ : SpaceTime d → ℝ) (x : SpaceTime d) (μ : Fi
     simp
   · simp
 
+/-- The pure-gauge potential built from the zero gauge function has all components zero.
+  (Stated pointwise: `ElectromagneticPotential` carries no `Zero` instance, so the bundled
+  form `ofGradient 0 = 0` is not expressible.) -/
+lemma ofGradient_zero {d} (x : SpaceTime d) (μ : Fin 1 ⊕ Fin d) :
+    ofGradient (0 : SpaceTime d → ℝ) x μ = 0 := by
+  rw [ofGradient_apply]
+  simp [SpaceTime.deriv_eq]
+
+/-- `ofGradient` is additive in the gauge function (when both summands are differentiable). -/
+lemma ofGradient_add {d} {χ₁ χ₂ : SpaceTime d → ℝ}
+    (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
+    ofGradient (χ₁ + χ₂) = ofGradient χ₁ + ofGradient χ₂ := by
+  apply eq_of_val_eq; funext x μ
+  show ofGradient (χ₁ + χ₂) x μ = ofGradient χ₁ x μ + ofGradient χ₂ x μ
+  simp only [ofGradient_apply, SpaceTime.deriv_eq,
+    fderiv_add hχ₁.differentiableAt hχ₂.differentiableAt, ContinuousLinearMap.add_apply,
+    mul_add]
+
 /-!
 
 ### A.2. Differentiability of the pure-gauge potential
@@ -136,28 +156,7 @@ lemma contDiff_ofGradient {n} {d} {χ : SpaceTime d → ℝ} (hχ : ContDiff ℝ
 
 /-!
 
-## B. Gauge transformations
-
--/
-
-/-!
-
-### B.1. Definition and basic lemmas
-
--/
-
-/-- The gauge transformation `A^μ ↦ A^μ + ∂^μ χ` of an electromagnetic potential. -/
-noncomputable def gaugeTransform {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d) :
-    ElectromagneticPotential d := A + ofGradient χ
-
-/-- Evaluation of `gaugeTransform`. -/
-lemma gaugeTransform_apply {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d)
-    (x : SpaceTime d) : gaugeTransform χ A x = A x + ofGradient χ x := by
-  simp [gaugeTransform, add_apply]
-
-/-!
-
-### B.2. Invariance of the field strength
+### A.3. Vanishing field strength of the pure-gauge potential
 
 -/
 
@@ -186,73 +185,14 @@ lemma toFieldStrength_ofGradient {d} {χ : SpaceTime d → ℝ} (hχ : ContDiff 
   rw [heq]
   ring
 
-/-- The field strength tensor is invariant under gauge transformations. -/
-lemma toFieldStrength_gaugeTransform {d} (A : ElectromagneticPotential d)
-    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
-    (gaugeTransform χ A).toFieldStrength x = A.toFieldStrength x := by
-  rw [gaugeTransform, toFieldStrength_add A (ofGradient χ) x hA (differentiable_ofGradient hχ),
-    toFieldStrength_ofGradient hχ, add_zero]
-
-/-- The field strength matrix is invariant under gauge transformations. -/
-lemma fieldStrengthMatrix_gaugeTransform {d} (A : ElectromagneticPotential d)
-    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
-    (gaugeTransform χ A).fieldStrengthMatrix x = A.fieldStrengthMatrix x := by
-  rw [fieldStrengthMatrix, toFieldStrength_gaugeTransform A χ hA hχ]
-
 /-!
 
-### B.3. Group structure of gauge shifts
+### A.4. Lorentz equivariance of the pure-gauge potential
 
-Composing two gauge shifts by χ₁ and χ₂ is the same as shifting by χ₁ + χ₂. Together with
-`gaugeTransform_zero` this shows that the map `χ ↦ (A ↦ gaugeTransform χ A)` is a group action
-of the additive group of smooth functions. (We do not build the formal `MulAction` here —
-the composition lemma is the agreeable core, and the rest is straightforward from it.)
-
--/
-
-/-- The pure-gauge potential built from the zero gauge function has all components zero.
-  (Stated pointwise: `ElectromagneticPotential` carries no `Zero` instance, so the bundled
-  form `ofGradient 0 = 0` is not expressible.) -/
-lemma ofGradient_zero {d} (x : SpaceTime d) (μ : Fin 1 ⊕ Fin d) :
-    ofGradient (0 : SpaceTime d → ℝ) x μ = 0 := by
-  rw [ofGradient_apply]
-  simp [SpaceTime.deriv_eq]
-
-/-- `ofGradient` is additive in the gauge function (when both summands are differentiable). -/
-lemma ofGradient_add {d} {χ₁ χ₂ : SpaceTime d → ℝ}
-    (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
-    ofGradient (χ₁ + χ₂) = ofGradient χ₁ + ofGradient χ₂ := by
-  apply eq_of_val_eq; funext x μ
-  show ofGradient (χ₁ + χ₂) x μ = ofGradient χ₁ x μ + ofGradient χ₂ x μ
-  simp only [ofGradient_apply, SpaceTime.deriv_eq,
-    fderiv_add hχ₁.differentiableAt hχ₂.differentiableAt, ContinuousLinearMap.add_apply,
-    mul_add]
-
-/-- Shifting by the zero gauge function is the identity. -/
-lemma gaugeTransform_zero {d} (A : ElectromagneticPotential d) :
-    gaugeTransform (0 : SpaceTime d → ℝ) A = A := by
-  apply eq_of_val_eq; funext x μ
-  show gaugeTransform (0 : SpaceTime d → ℝ) A x μ = A x μ
-  simp [gaugeTransform, add_apply, ofGradient_zero]
-
-/-- Two successive gauge shifts compose: shifting by χ₂ then χ₁ equals shifting by χ₁ + χ₂.
-  This upgrades one-step F-invariance to invariance along any finite chain of gauge shifts. -/
-lemma gaugeTransform_gaugeTransform {d} (A : ElectromagneticPotential d)
-    (χ₁ χ₂ : SpaceTime d → ℝ) (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
-    gaugeTransform χ₁ (gaugeTransform χ₂ A) = gaugeTransform (χ₁ + χ₂) A := by
-  apply eq_of_val_eq; funext x μ
-  simp only [gaugeTransform, add_apply]
-  rw [ofGradient_add hχ₁ hχ₂]
-  simp [add_apply, add_comm, add_left_comm]
-
-/-!
-
-### B.4. Equivariance under Lorentz transformations
-
-The gauge-transformation map commutes with the Lorentz group action: applying Λ to a potential
-and then gauge-transforming by χ is the same as gauge-transforming by `χ ∘ (Λ⁻¹ • ·)` and then
-applying Λ. The proof reduces to the metric-commutativity identity `Λ * η = η * (Λ⁻¹)ᵀ`, which
-is the defining property of the Lorentz group (`LorentzGroup.comm_minkowskiMatrix`).
+`ofGradient` intertwines the Lorentz action on potentials with composition by Λ⁻¹ on the gauge
+function: `Λ • ofGradient χ = ofGradient (χ ∘ (Λ⁻¹ • ·))`. The proof reduces to the
+metric-commutativity identity `Λ * η = η * (Λ⁻¹)ᵀ`, which is the defining property of the
+Lorentz group (`LorentzGroup.comm_minkowskiMatrix`).
 
 -/
 
@@ -294,6 +234,89 @@ lemma ofGradient_equivariant {d} (χ : SpaceTime d → ℝ) (hχ : Differentiabl
     simp_rw [← mul_assoc]
     rw [← Finset.sum_mul, ← hmetric]
   rw [hlhs, hrhs]
+
+/-!
+
+## B. Gauge transformations
+
+-/
+
+/-!
+
+### B.1. Definition and basic lemmas
+
+-/
+
+/-- The gauge transformation `A^μ ↦ A^μ + ∂^μ χ` of an electromagnetic potential. -/
+noncomputable def gaugeTransform {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d) :
+    ElectromagneticPotential d := A + ofGradient χ
+
+/-- Evaluation of `gaugeTransform`. -/
+lemma gaugeTransform_apply {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d)
+    (x : SpaceTime d) : gaugeTransform χ A x = A x + ofGradient χ x := by
+  simp [gaugeTransform, add_apply]
+
+/-!
+
+### B.2. Invariance of the field strength
+
+The key ingredient — that a pure-gauge potential has vanishing field strength — is proved in §A.3
+(`toFieldStrength_ofGradient`).
+
+-/
+
+/-- The field strength tensor is invariant under gauge transformations. -/
+lemma toFieldStrength_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
+    (gaugeTransform χ A).toFieldStrength x = A.toFieldStrength x := by
+  rw [gaugeTransform, toFieldStrength_add A (ofGradient χ) x hA (differentiable_ofGradient hχ),
+    toFieldStrength_ofGradient hχ, add_zero]
+
+/-- The field strength matrix is invariant under gauge transformations. -/
+lemma fieldStrengthMatrix_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
+    (gaugeTransform χ A).fieldStrengthMatrix x = A.fieldStrengthMatrix x := by
+  rw [fieldStrengthMatrix, toFieldStrength_gaugeTransform A χ hA hχ]
+
+/-!
+
+### B.3. Group structure of gauge shifts
+
+Composing two gauge shifts by χ₁ and χ₂ is the same as shifting by χ₁ + χ₂. Together with
+`gaugeTransform_zero` this shows that the map `χ ↦ (A ↦ gaugeTransform χ A)` is a group action
+of the additive group of smooth functions. (We do not build the formal `MulAction` here —
+the composition lemma is the agreeable core, and the rest is straightforward from it.)
+
+The `ofGradient` lemmas used here — `ofGradient_zero` and `ofGradient_add` — are proved in §A.1.
+
+-/
+
+/-- Shifting by the zero gauge function is the identity. -/
+lemma gaugeTransform_zero {d} (A : ElectromagneticPotential d) :
+    gaugeTransform (0 : SpaceTime d → ℝ) A = A := by
+  apply eq_of_val_eq; funext x μ
+  show gaugeTransform (0 : SpaceTime d → ℝ) A x μ = A x μ
+  simp [gaugeTransform, add_apply, ofGradient_zero]
+
+/-- Two successive gauge shifts compose: shifting by χ₂ then χ₁ equals shifting by χ₁ + χ₂.
+  This upgrades one-step F-invariance to invariance along any finite chain of gauge shifts. -/
+lemma gaugeTransform_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ₁ χ₂ : SpaceTime d → ℝ) (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
+    gaugeTransform χ₁ (gaugeTransform χ₂ A) = gaugeTransform (χ₁ + χ₂) A := by
+  apply eq_of_val_eq; funext x μ
+  simp only [gaugeTransform, add_apply]
+  rw [ofGradient_add hχ₁ hχ₂]
+  simp [add_apply, add_comm, add_left_comm]
+
+/-!
+
+### B.4. Equivariance under Lorentz transformations
+
+The gauge-transformation map commutes with the Lorentz group action: applying Λ to a potential
+and then gauge-transforming by χ is the same as gauge-transforming by `χ ∘ (Λ⁻¹ • ·)` and then
+applying Λ. The proof delegates to `ofGradient_equivariant` (§A.4).
+
+-/
 
 /-- Gauge transformations commute with Lorentz transformations: applying Λ and then performing
   a gauge transformation by `χ` equals performing a gauge transformation by `χ ∘ (Λ⁻¹ • ·)`

--- a/Physlib/Electromagnetism/Kinematics/GaugeTransformation.lean
+++ b/Physlib/Electromagnetism/Kinematics/GaugeTransformation.lean
@@ -1,0 +1,390 @@
+/-
+Copyright (c) 2026 Justin Findlay. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Justin Findlay
+-/
+module
+
+public import Physlib.Electromagnetism.Kinematics.FieldStrength
+/-!
+
+# Gauge Transformations of the Electromagnetic Potential
+
+## i. Overview
+
+In this module we define gauge transformations of the electromagnetic potential
+`A^μ ↦ A^μ + ∂^μ χ` where `χ : SpaceTime d → ℝ` is a smooth gauge function, and prove
+that the field strength tensor is invariant under such transformations.
+
+The raised-index gradient `∂^μ χ := η^{μν} ∂_ν χ` is necessary because the bare covariant gradient
+`∂_μ χ` does not make `F^{μν}` invariant. The formal witness is
+`fieldStrengthMatrix_bareGradient_inl_inr` (§B.5), which computes a specific nonzero component of
+the field strength of a bare-gradient potential. The invariance theorem
+`toFieldStrength_gaugeTransform` doubles as a correctness test of `ofGradient`.
+
+## ii. Key results
+
+- `ofGradient` : The pure-gauge potential `A^μ = η^{μν} ∂_ν χ` built from a gauge function `χ`.
+- `gaugeTransform` : The gauge transformation `A^μ ↦ A^μ + ∂^μ χ`.
+- `toFieldStrength_ofGradient` : A pure-gauge potential has vanishing field strength.
+- `toFieldStrength_gaugeTransform` : The field strength tensor is invariant under gauge
+  transformations.
+- `fieldStrengthMatrix_gaugeTransform` : The field strength matrix is invariant under gauge
+  transformations.
+- `gaugeTransform_gaugeTransform` : Composing two gauge shifts equals shifting by the sum;
+  upgrades one-step F-invariance to invariance along any finite chain.
+- `ofGradient_equivariant` : `ofGradient` intertwines the Lorentz action with function composition.
+- `gaugeTransform_equivariant` : Gauge transformations commute with Lorentz transformations.
+- `fieldStrengthMatrix_bareGradient_inl_inr` : The `(inl 0, inr i)` field-strength component of
+  the bare-gradient potential `χ(x) = x⁰·xⁱ` equals `2`; in particular the bare gradient does
+  not give a gauge-invariant field strength (necessity of the metric contraction in `ofGradient`).
+
+## iii. Table of contents
+
+- A. The pure-gauge potential
+  - A.1. Definition and basic lemmas
+  - A.2. Differentiability of the pure-gauge potential
+- B. Gauge transformations
+  - B.1. Definition and basic lemmas
+  - B.2. Invariance of the field strength
+  - B.3. Group structure of gauge shifts
+  - B.4. Equivariance under Lorentz transformations
+  - B.5. Necessity: bare gradient does not give gauge invariance
+
+## iv. References
+
+- https://en.wikipedia.org/wiki/Mathematical_descriptions_of_the_electromagnetic_field#Gauge_freedom
+
+-/
+
+@[expose] public section
+namespace Electromagnetism
+open Module realLorentzTensor
+open TensorSpecies
+open Tensor
+
+namespace ElectromagneticPotential
+
+open TensorSpecies
+open Tensor
+open SpaceTime
+open TensorProduct
+open minkowskiMatrix Tensorial
+open Lorentz
+
+attribute [-simp] Fintype.sum_sum_type
+attribute [-simp] Nat.succ_eq_add_one
+
+/-!
+
+## A. The pure-gauge potential
+
+-/
+
+/-!
+
+### A.1. Definition and basic lemmas
+
+-/
+
+/-- The pure-gauge electromagnetic potential `A^μ = ∂^μ χ = η^{μν} ∂_ν χ` built from a
+  gauge function `χ`. The metric-contracted form `∑ κ, η μ κ * ∂_ κ χ` is the definition;
+  the diagonal form (which equals `η μ μ * ∂_ μ χ` since `η` is diagonal) is derived in
+  `ofGradient_apply`. -/
+noncomputable def ofGradient {d} (χ : SpaceTime d → ℝ) : ElectromagneticPotential d where
+  val x μ := ∑ κ, η μ κ * ∂_ κ χ x
+
+/-- Unfolding of the summed definition of `ofGradient`. -/
+lemma ofGradient_apply_sum {d} (χ : SpaceTime d → ℝ) (x : SpaceTime d) (μ : Fin 1 ⊕ Fin d) :
+    ofGradient χ x μ = ∑ κ, η μ κ * ∂_ κ χ x := rfl
+
+/-- Evaluation of `ofGradient` in the diagonal form; the off-diagonal entries of `η` vanish so
+  only the `κ = μ` term survives. -/
+lemma ofGradient_apply {d} (χ : SpaceTime d → ℝ) (x : SpaceTime d) (μ : Fin 1 ⊕ Fin d) :
+    ofGradient χ x μ = η μ μ * ∂_ μ χ x := by
+  rw [ofGradient_apply_sum]
+  rw [Finset.sum_eq_single μ]
+  · intro κ _ hκ
+    rw [minkowskiMatrix.off_diag_zero (Ne.symm hκ)]
+    simp
+  · simp
+
+/-!
+
+### A.2. Differentiability of the pure-gauge potential
+
+-/
+
+/-- The pure-gauge potential is differentiable when `χ` is `C^2`. -/
+lemma differentiable_ofGradient {d} {χ : SpaceTime d → ℝ} (hχ : ContDiff ℝ 2 χ) :
+    Differentiable ℝ (ofGradient χ) := by
+  show Differentiable ℝ (ofGradient χ).val
+  rw [← SpaceTime.differentiable_vector]
+  intro μ
+  simp_rw [ofGradient_apply]
+  exact (SpaceTime.differentiable_deriv μ χ hχ).const_mul _
+
+/-- The pure-gauge potential is `C^n` when `χ` is `C^{n+1}`. -/
+lemma contDiff_ofGradient {n} {d} {χ : SpaceTime d → ℝ} (hχ : ContDiff ℝ (n + 1) χ) :
+    ContDiff ℝ n (ofGradient χ) := by
+  show ContDiff ℝ n (ofGradient χ).val
+  rw [← SpaceTime.contDiff_vector]
+  intro μ
+  simp_rw [ofGradient_apply]
+  have h := SpaceTime.contDiff_deriv μ χ hχ
+  fun_prop
+
+/-!
+
+## B. Gauge transformations
+
+-/
+
+/-!
+
+### B.1. Definition and basic lemmas
+
+-/
+
+/-- The gauge transformation `A^μ ↦ A^μ + ∂^μ χ` of an electromagnetic potential. -/
+noncomputable def gaugeTransform {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d) :
+    ElectromagneticPotential d := A + ofGradient χ
+
+/-- Evaluation of `gaugeTransform`. -/
+lemma gaugeTransform_apply {d} (χ : SpaceTime d → ℝ) (A : ElectromagneticPotential d)
+    (x : SpaceTime d) : gaugeTransform χ A x = A x + ofGradient χ x := by
+  simp [gaugeTransform, add_apply]
+
+/-!
+
+### B.2. Invariance of the field strength
+
+-/
+
+/-- A pure-gauge potential has vanishing field strength. -/
+lemma toFieldStrength_ofGradient {d} {χ : SpaceTime d → ℝ} (hχ : ContDiff ℝ 2 χ)
+    (x : SpaceTime d) : (ofGradient χ).toFieldStrength x = 0 := by
+  apply (Lorentz.CoVector.basis.tensorProduct Lorentz.Vector.basis).repr.injective
+  apply Finsupp.ext
+  intro μν
+  simp only [toFieldStrength_basis_repr_apply_eq_single]
+  rw [SpaceTime.deriv_apply_eq μν.1 μν.2 (ofGradient χ) (differentiable_ofGradient hχ),
+    SpaceTime.deriv_apply_eq μν.2 μν.1 (ofGradient χ) (differentiable_ofGradient hχ)]
+  simp only [ofGradient_apply]
+  rw [fderiv_const_mul (SpaceTime.differentiable_deriv μν.1 χ hχ).differentiableAt,
+    fderiv_const_mul (SpaceTime.differentiable_deriv μν.2 χ hχ).differentiableAt]
+  simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul]
+  -- simplify repr 0 to 0
+  conv_rhs => rw [show (Lorentz.CoVector.basis.tensorProduct Lorentz.Vector.basis).repr
+      (0 : Lorentz.Vector d ⊗[ℝ] Lorentz.Vector d) = 0 from map_zero _]
+  simp only [Finsupp.zero_apply]
+  -- use Clairaut: ∂_ μ (∂_ ν χ) x = ∂_ ν (∂_ μ χ) x, so the two terms cancel
+  have heq : fderiv ℝ (∂_ μν.2 χ) x (Lorentz.Vector.basis μν.1) =
+      fderiv ℝ (∂_ μν.1 χ) x (Lorentz.Vector.basis μν.2) := by
+    change ∂_ μν.1 (∂_ μν.2 χ) x = ∂_ μν.2 (∂_ μν.1 χ) x
+    rw [← SpaceTime.deriv_commute μν.2 μν.1 χ hχ]
+  rw [heq]
+  ring
+
+/-- The field strength tensor is invariant under gauge transformations. -/
+lemma toFieldStrength_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
+    (gaugeTransform χ A).toFieldStrength x = A.toFieldStrength x := by
+  rw [gaugeTransform, toFieldStrength_add A (ofGradient χ) x hA (differentiable_ofGradient hχ),
+    toFieldStrength_ofGradient hχ, add_zero]
+
+/-- The field strength matrix is invariant under gauge transformations. -/
+lemma fieldStrengthMatrix_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ : SpaceTime d → ℝ) (hA : Differentiable ℝ A) (hχ : ContDiff ℝ 2 χ) (x : SpaceTime d) :
+    (gaugeTransform χ A).fieldStrengthMatrix x = A.fieldStrengthMatrix x := by
+  rw [fieldStrengthMatrix, toFieldStrength_gaugeTransform A χ hA hχ]
+
+/-!
+
+### B.3. Group structure of gauge shifts
+
+Composing two gauge shifts by χ₁ and χ₂ is the same as shifting by χ₁ + χ₂. Together with
+`gaugeTransform_zero` this shows that the map `χ ↦ (A ↦ gaugeTransform χ A)` is a group action
+of the additive group of smooth functions. (We do not build the formal `MulAction` here —
+the composition lemma is the agreeable core, and the rest is straightforward from it.)
+
+-/
+
+/-- The pure-gauge potential built from the zero gauge function has all components zero.
+  (Stated pointwise: `ElectromagneticPotential` carries no `Zero` instance, so the bundled
+  form `ofGradient 0 = 0` is not expressible.) -/
+lemma ofGradient_zero {d} (x : SpaceTime d) (μ : Fin 1 ⊕ Fin d) :
+    ofGradient (0 : SpaceTime d → ℝ) x μ = 0 := by
+  rw [ofGradient_apply]
+  simp [SpaceTime.deriv_eq]
+
+/-- `ofGradient` is additive in the gauge function (when both summands are differentiable). -/
+lemma ofGradient_add {d} {χ₁ χ₂ : SpaceTime d → ℝ}
+    (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
+    ofGradient (χ₁ + χ₂) = ofGradient χ₁ + ofGradient χ₂ := by
+  apply eq_of_val_eq; funext x μ
+  show ofGradient (χ₁ + χ₂) x μ = ofGradient χ₁ x μ + ofGradient χ₂ x μ
+  simp only [ofGradient_apply, SpaceTime.deriv_eq,
+    fderiv_add hχ₁.differentiableAt hχ₂.differentiableAt, ContinuousLinearMap.add_apply,
+    mul_add]
+
+/-- Shifting by the zero gauge function is the identity. -/
+lemma gaugeTransform_zero {d} (A : ElectromagneticPotential d) :
+    gaugeTransform (0 : SpaceTime d → ℝ) A = A := by
+  apply eq_of_val_eq; funext x μ
+  show gaugeTransform (0 : SpaceTime d → ℝ) A x μ = A x μ
+  simp [gaugeTransform, add_apply, ofGradient_zero]
+
+/-- Two successive gauge shifts compose: shifting by χ₂ then χ₁ equals shifting by χ₁ + χ₂.
+  This upgrades one-step F-invariance to invariance along any finite chain of gauge shifts. -/
+lemma gaugeTransform_gaugeTransform {d} (A : ElectromagneticPotential d)
+    (χ₁ χ₂ : SpaceTime d → ℝ) (hχ₁ : Differentiable ℝ χ₁) (hχ₂ : Differentiable ℝ χ₂) :
+    gaugeTransform χ₁ (gaugeTransform χ₂ A) = gaugeTransform (χ₁ + χ₂) A := by
+  apply eq_of_val_eq; funext x μ
+  simp only [gaugeTransform, add_apply]
+  rw [ofGradient_add hχ₁ hχ₂]
+  simp [add_apply, add_comm, add_left_comm]
+
+/-!
+
+### B.4. Equivariance under Lorentz transformations
+
+The gauge-transformation map commutes with the Lorentz group action: applying Λ to a potential
+and then gauge-transforming by χ is the same as gauge-transforming by `χ ∘ (Λ⁻¹ • ·)` and then
+applying Λ. The proof reduces to the metric-commutativity identity `Λ * η = η * (Λ⁻¹)ᵀ`, which
+is the defining property of the Lorentz group (`LorentzGroup.comm_minkowskiMatrix`).
+
+-/
+
+/-- `ofGradient` intertwines the Lorentz action on potentials with composition by Λ⁻¹ on the
+  gauge function: `Λ • ofGradient χ = ofGradient (χ ∘ (Λ⁻¹ • ·))`. -/
+lemma ofGradient_equivariant {d} (χ : SpaceTime d → ℝ) (hχ : Differentiable ℝ χ)
+    (Λ : LorentzGroup d) :
+    Λ • ofGradient χ = ofGradient (χ ∘ (Λ⁻¹ • ·)) := by
+  -- The metric-commutativity row identity, extracted from `comm_minkowskiMatrix`:
+  -- ∑ ν, Λ.1 μ ν * η ν κ = ∑ ν, η μ ν * (Λ⁻¹).1 κ ν
+  have hmetric : ∀ (μ κ : Fin 1 ⊕ Fin d),
+      ∑ ν, Λ.1 μ ν * η ν κ = ∑ ν, η μ ν * (Λ⁻¹).1 κ ν := by
+    intro μ κ
+    -- comm_minkowskiMatrix: Λ.1 * η = η * (Λ⁻¹)ᵀ, applied at (μ, κ)
+    have h := congr_fun₂ (LorentzGroup.comm_minkowskiMatrix (Λ := Λ)) μ κ
+    simp only [Matrix.mul_apply, LorentzGroup.transpose_val, Matrix.transpose_apply] at h
+    exact h
+  apply eq_of_val_eq; funext x μ
+  -- Let a κ = ∂_ κ χ (Λ⁻¹ • x). Both sides equal ∑ κ, (∑ ν, Λ.1 μ ν * η ν κ) * a κ.
+  set a : Fin 1 ⊕ Fin d → ℝ := fun κ => ∂_ κ χ (Λ⁻¹ • x)
+  -- Expand LHS: action_val → smul_eq_sum → ofGradient_apply_sum → reassociate + factor
+  have hlhs : (Λ • ofGradient χ).val x μ = ∑ κ, (∑ ν, Λ.1 μ ν * η ν κ) * a κ := by
+    simp only [ElectromagneticPotential.action_val, Lorentz.Vector.smul_eq_sum, a,
+      ofGradient_apply_sum, Finset.mul_sum]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl; intro κ _
+    simp_rw [← mul_assoc]
+    rw [← Finset.sum_mul]
+  -- Expand RHS: ofGradient_apply_sum → deriv_comp_lorentz_action → sum_comm + factor + hmetric
+  have hrhs : (ofGradient (χ ∘ (Λ⁻¹ • ·))).val x μ = ∑ κ, (∑ ν, Λ.1 μ ν * η ν κ) * a κ := by
+    simp only [ofGradient_apply_sum, a]
+    conv_lhs =>
+      enter [2, ν]
+      rw [show ∂_ ν (χ ∘ (Λ⁻¹ • ·)) x = ∂_ ν (fun y => χ (Λ⁻¹ • y)) x from rfl,
+        SpaceTime.deriv_comp_lorentz_action ν χ hχ Λ⁻¹ x]
+    simp only [smul_eq_mul, Finset.mul_sum]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl; intro κ _
+    simp_rw [← mul_assoc]
+    rw [← Finset.sum_mul, ← hmetric]
+  rw [hlhs, hrhs]
+
+/-- Gauge transformations commute with Lorentz transformations: applying Λ and then performing
+  a gauge transformation by `χ` equals performing a gauge transformation by `χ ∘ (Λ⁻¹ • ·)`
+  and then applying Λ. -/
+lemma gaugeTransform_equivariant {d} (A : ElectromagneticPotential d)
+    (χ : SpaceTime d → ℝ) (hχ : Differentiable ℝ χ) (Λ : LorentzGroup d) :
+    Λ • gaugeTransform χ A = gaugeTransform (χ ∘ (Λ⁻¹ • ·)) (Λ • A) := by
+  -- Unfold both sides to Λ • A + ofGradient (χ ∘ (Λ⁻¹ • ·))
+  simp only [gaugeTransform]
+  rw [← ofGradient_equivariant χ hχ Λ]
+  -- Goal: Λ • (A + ofGradient χ) = Λ • A + Λ • ofGradient χ
+  apply eq_of_val_eq; funext x μ
+  simp only [ElectromagneticPotential.action_val, add_val, Pi.add_apply,
+    Lorentz.Vector.smul_add]
+
+/-!
+
+### B.5. Necessity: bare gradient does not give gauge invariance
+
+We exhibit a concrete gauge function `χ(x) = x⁰·xⁱ` whose **bare** covariant gradient
+`B^μ := ∂_μ χ` has a nonzero field-strength component (equal to `2`), certifying that the metric
+contraction in `ofGradient` is required for gauge invariance.
+
+-/
+
+/-- The `(inl 0, inr i)` component of the field strength matrix of the bare-gradient potential
+  `B^μ := ∂_μ χ` for `χ(x) = x⁰·xⁱ` equals `2`. This witnesses that the bare covariant gradient
+  does not produce a gauge-invariant field strength, so the raised-index contraction
+  `η^{μν} ∂_ν χ` in `ofGradient` is necessary (see the module overview). -/
+lemma fieldStrengthMatrix_bareGradient_inl_inr {d : ℕ} (i : Fin d)
+    (x : SpaceTime d) :
+    let χ : SpaceTime d → ℝ := fun y => y (Sum.inl 0) * y (Sum.inr i)
+    let B : ElectromagneticPotential d := ⟨fun y μ => ∂_ μ χ y⟩
+    B.fieldStrengthMatrix x (Sum.inl 0, Sum.inr i) = 2 := by
+  intro χ B
+  have hχ : ContDiff ℝ 2 χ := by
+    show ContDiff ℝ 2 (fun y : SpaceTime d => y (Sum.inl 0) * y (Sum.inr i))
+    fun_prop
+  have hB : Differentiable ℝ B := by
+    rw [← SpaceTime.differentiable_vector]; intro μ
+    exact SpaceTime.differentiable_deriv μ χ hχ
+  -- fieldStrengthMatrix (μ, ν) = η μ μ * ∂_ μ B x ν − η ν ν * ∂_ ν B x μ
+  rw [toFieldStrength_basis_repr_apply_eq_single]
+  -- Expand ∂_ μ B x ν as ∂_ μ (fun y => ∂_ ν χ y) x = ∂_ μ (∂_ ν χ) x
+  rw [SpaceTime.deriv_apply_eq (Sum.inl 0) (Sum.inr i) B hB,
+      SpaceTime.deriv_apply_eq (Sum.inr i) (Sum.inl 0) B hB]
+  -- Now compute the mixed partials of χ = t·xⁱ using fderiv_fun_mul + deriv_coord
+  -- ∂_t χ = xⁱ, ∂_{xⁱ} χ = t; so ∂_{xⁱ}(∂_t χ) = 1 and ∂_t(∂_{xⁱ} χ) = 1
+  have hfderiv : ∀ (y : SpaceTime d),
+      fderiv ℝ χ y = (y (Sum.inr i)) • Lorentz.Vector.coordCLM (Sum.inl 0) +
+                      (y (Sum.inl 0)) • Lorentz.Vector.coordCLM (Sum.inr i) := fun y => by
+    have h : fderiv ℝ (fun z : SpaceTime d => z (Sum.inl 0) * z (Sum.inr i)) y =
+        (y (Sum.inr i)) • Lorentz.Vector.coordCLM (Sum.inl 0) +
+        (y (Sum.inl 0)) • Lorentz.Vector.coordCLM (Sum.inr i) := by
+      have hmul := fderiv_fun_mul (𝕜 := ℝ)
+        (hc := (Lorentz.Vector.coordCLM (Sum.inl 0)).differentiableAt)
+        (hd := (Lorentz.Vector.coordCLM (Sum.inr i)).differentiableAt) (x := y)
+      simp only [ContinuousLinearMap.fderiv, Lorentz.Vector.coordCLM_apply] at hmul
+      -- hmul: fderiv ... y = y (Sum.inl 0) • coordCLM (Sum.inr i)
+      --                         + y (Sum.inr i) • coordCLM (Sum.inl 0)
+      -- goal: ... = y (Sum.inr i) • coordCLM (Sum.inl 0)
+      --               + y (Sum.inl 0) • coordCLM (Sum.inr i)
+      rw [hmul, add_comm]
+    exact h
+  simp only [SpaceTime.deriv_eq, B]
+  simp_rw [hfderiv]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.coe_smul',
+    Pi.smul_apply, Lorentz.Vector.coordCLM_apply, smul_eq_mul, Lorentz.Vector.basis_apply]
+  simp only [mul_ite, mul_one, mul_zero, ite_add, zero_add, if_true]
+  simp only [minkowskiMatrix.inl_0_inl_0, minkowskiMatrix.inr_i_inr_i]
+  simp only [reduceCtorEq, ↓reduceIte, add_zero]
+  simp only [Lorentz.Vector.fderiv_coord, Lorentz.Vector.coordCLM_apply,
+    Lorentz.Vector.basis_apply, ↓reduceIte]
+  norm_num
+
+/-- The field strength of the bare-gradient potential `B^μ := ∂_μ χ` for
+  `χ(x) = x⁰·xⁱ` is nonzero (follows from `fieldStrengthMatrix_bareGradient_inl_inr`). -/
+lemma toFieldStrength_bareGradient_ne_zero {d : ℕ} (i : Fin d)
+    (x : SpaceTime d) :
+    let χ : SpaceTime d → ℝ := fun y => y (Sum.inl 0) * y (Sum.inr i)
+    let B : ElectromagneticPotential d := ⟨fun y μ => ∂_ μ χ y⟩
+    B.toFieldStrength x ≠ 0 := by
+  intro χ B h
+  have h2 := fieldStrengthMatrix_bareGradient_inl_inr i x
+  dsimp only at h2
+  rw [fieldStrengthMatrix_eq, h] at h2
+  have h3 : ((Lorentz.CoVector.basis.tensorProduct Lorentz.Vector.basis).repr
+      (0 : Lorentz.CoVector d ⊗[ℝ] Lorentz.Vector d)) = 0 := map_zero _
+  erw [h3, Finsupp.zero_apply] at h2
+  norm_num at h2
+
+end ElectromagneticPotential
+
+end Electromagnetism

--- a/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Derivatives.lean
@@ -22,6 +22,9 @@ distributions on `SpaceTime d`.
 ## ii. Key results
 
 - `deriv` : The derivative of a function `SpaceTime d → M` along the `μ` coordinate.
+- `contDiff_deriv` : If `f` is `C^{n+1}` then `∂_ μ f` is `C^n`.
+- `differentiable_deriv` : If `f` is `C^2` then `∂_ μ f` is differentiable.
+- `deriv_commute` : Derivatives on `SpaceTime d` commute (Clairaut's theorem).
 - `deriv_sum_inr` : The derivative along a spatial coordinate in terms of the
   derivative on `Space d`.
 - `deriv_sum_inl` : The derivative along the temporal coordinate in terms of the
@@ -35,8 +38,10 @@ distributions on `SpaceTime d`.
   - A.1. The definition of the derivative
   - A.2. Basic equality lemmas
   - A.3. Derivative of the zero function
-  - A.4. The derivative of a function composed with a Lorentz transformation
-  - A.5. Spacetime derivatives in terms of time and space derivatives
+  - A.4. Smoothness and differentiability of the derivative
+  - A.5. Derivatives commute
+  - A.6. The derivative of a function composed with a Lorentz transformation
+  - A.7. Spacetime derivatives in terms of time and space derivatives
 - B. Derivatives of distributions
   - B.1. Commutation of derivatives of distributions
   - B.2. Lorentz group action on derivatives of distributions
@@ -162,7 +167,55 @@ attribute [-simp] Fintype.sum_sum_type
 
 /-!
 
-### A.4. The derivative of a function composed with a Lorentz transformation
+### A.4. Smoothness and differentiability of the derivative
+
+-/
+
+/-- If `f` is `C^{n+1}` then `∂_ μ f` is `C^n`. -/
+@[fun_prop]
+lemma contDiff_deriv {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] {d : ℕ}
+    {n : WithTop ℕ∞} (μ : Fin 1 ⊕ Fin d) (f : SpaceTime d → M) (hf : ContDiff ℝ (n + 1) f) :
+    ContDiff ℝ n (∂_ μ f) := by
+  -- `∂_ μ f = fun x => fderiv ℝ f x (Lorentz.Vector.basis μ)`; use
+  -- `ContDiff.clm_apply` with `ContDiff.fderiv_right`.
+  show ContDiff ℝ n (fun x => fderiv ℝ f x (Lorentz.Vector.basis μ))
+  exact (ContDiff.fderiv_right (m := n) hf (by rfl)).clm_apply contDiff_const
+
+/-- If `f` is `C^2` then `∂_ μ f` is differentiable. -/
+@[fun_prop]
+lemma differentiable_deriv {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] {d : ℕ}
+    (μ : Fin 1 ⊕ Fin d) (f : SpaceTime d → M) (hf : ContDiff ℝ 2 f) :
+    Differentiable ℝ (∂_ μ f) :=
+  (contDiff_deriv μ f (n := 1) (by norm_cast)).differentiable one_ne_zero
+
+/-!
+
+### A.5. Derivatives commute
+
+-/
+
+/-- Derivatives on spacetime commute with one another (Clairaut's theorem). -/
+lemma deriv_commute {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M] {d : ℕ}
+    (μ ν : Fin 1 ⊕ Fin d) (f : SpaceTime d → M) (hf : ContDiff ℝ 2 f) :
+    ∂_ μ (∂_ ν f) = ∂_ ν (∂_ μ f) := by
+  ext x
+  show fderiv ℝ (fun y => fderiv ℝ f y (Lorentz.Vector.basis ν)) x (Lorentz.Vector.basis μ) =
+    fderiv ℝ (fun y => fderiv ℝ f y (Lorentz.Vector.basis μ)) x (Lorentz.Vector.basis ν)
+  rw [fderiv_clm_apply, fderiv_clm_apply]
+  simp only [fderiv_fun_const, Pi.ofNat_apply, ContinuousLinearMap.comp_zero, zero_add,
+    ContinuousLinearMap.flip_apply]
+  rw [IsSymmSndFDerivAt.eq]
+  · apply ContDiffAt.isSymmSndFDerivAt
+    exact hf.contDiffAt
+    simp only [minSmoothness_of_isRCLikeNormedField, le_refl]
+  · have h1 := hf.differentiable (by norm_cast); fun_prop
+  · fun_prop
+  · have h1 := hf.differentiable (by norm_cast); fun_prop
+  · fun_prop
+
+/-!
+
+### A.6. The derivative of a function composed with a Lorentz transformation
 
 -/
 
@@ -208,7 +261,7 @@ lemma deriv_equivariant (f : SpaceTime d → M) (Λ : LorentzGroup d) (x : Space
 
 /-!
 
-### A.5. Spacetime derivatives in terms of time and space derivatives
+### A.7. Spacetime derivatives in terms of time and space derivatives
 
 -/
 


### PR DESCRIPTION
Defines gauge transformations of the electromagnetic potential `A^μ ↦ A^μ + ∂^μ χ`, where `χ : SpaceTime d → ℝ` is a smooth gauge function, and proves that the field strength tensor is invariant under them.

## Key results

- `ofGradient` : the pure-gauge potential `A^μ = η^{μν} ∂_ν χ`, with `fieldStrengthMatrix_bareGradient_inl_inr` as a necessity witness — the **bare** covariant gradient `∂_μ χ` does *not* leave `F^{μν}` invariant, so the raised-index
  contraction is forced.
- `toFieldStrength_gaugeTransform` / `fieldStrengthMatrix_gaugeTransform` : invariance of the field strength under gauge transformations.
- `gaugeTransform_gaugeTransform`, `gaugeTransform_zero` : gauge shifts compose additively, upgrading one-step invariance to invariance along any finite chain of gauge shifts.
- `ofGradient_equivariant` / `gaugeTransform_equivariant` : gauge transformations commute with the Lorentz group action (via `Λη = η(Λ⁻¹)ᵀ`).

## Supporting infrastructure (`SpaceTime/Derivatives.lean`)

- `deriv_commute` : spacetime coordinate derivatives commute (Clairaut) for `C²` functions — the engine of the invariance proof.
- `contDiff_deriv`, `differentiable_deriv` : smoothness of `∂_ μ f` from smoothness of `f`, both `@[fun_prop]`.