### PR TITLE
chore: update contributing links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
 See:
-- https://physlib.io/GettingStarted to learn how to get started
-- https://physlib.io/GetInvolved.html to see how to get involved.
+- https://physlib.io/getting-started to learn how to get started
+- https://physlib.io/get-involved to see how to get involved.


### PR DESCRIPTION
This could be fixed in multiple ways:
- This pull request is offered as an easy way to just fix the current state especially if these links are unlikely to change again
- physlib.io could dynamically reroute old paths (probably not the best option)
- Docs update dev/CI tooling that works out link graph implications and maintains correctness (in addition to other linters).