### PR TITLE
Removed the informal definition StandardModel.GaugeGroup

### DIFF
--- a/Physlib/Particles/StandardModel/Basic.lean
+++ b/Physlib/Particles/StandardModel/Basic.lean
@@ -604,10 +604,14 @@ quotient.
 
 See https://math.ucr.edu/home/baez/guts.pdf
 -/
-informal_definition GaugeGroup where
-  deps := [``GaugeGroupI, ``gaugeGroupℤ₂SubGroup, ``gaugeGroupℤ₃SubGroup,
-    ``GaugeGroupQuot]
-  tag := "6V2HF"
+def GaugeGroup : GaugeGroupQuot → Type
+  | .ℤ₆ => GaugeGroupℤ₆
+  | .ℤ₂ => GaugeGroupℤ₂
+  | .ℤ₃ => GaugeGroupℤ₃
+  | .I => GaugeGroupI
+
+noncomputable instance (q : GaugeGroupQuot) : Group (GaugeGroup q) := by
+  cases q <;> dsimp [GaugeGroup] <;> infer_instance
 
 /-!
 


### PR DESCRIPTION
- StandardModel.GaugeGroup: the Standard Model gauge group associated to a choice of GaugeGroupQuot, returning GaugeGroupℤ₆, GaugeGroupℤ₂, GaugeGroupℤ₃, or GaugeGroupI
- added StandardModel.instGroupGaugeGroup: the group instance on GaugeGroup q.