### PR TITLE
Add local CFT first-variation stack to PhyslibAlpha

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -1,5 +1,6 @@
 module
 
 public import PhyslibAlpha.Basic
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Ring
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/Action.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/Action.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.Lagrangian
+public import PhyslibAlpha.ClassicalFieldTheory.Local.Variation
+/-!
+# Local action functionals
+
+## i. Overview
+
+This module defines the local action functional associated with a local Lagrangian, together with
+the first notions needed to talk about variational criticality.
+
+For the first implementation pass, the action is defined directly as the integral of a local
+Lagrangian evaluated along jets of a field. The integrability conditions needed for this action and
+for its variations are kept explicit in the API.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.actionDensity` : the density associated with a field.
+- `ClassicalFieldTheory.Local.action` : the action of a field.
+- `ClassicalFieldTheory.Local.HasFiniteAction` : finiteness of the action integral.
+- `ClassicalFieldTheory.Local.IsAdmissibleForAction` : symmetric admissibility of a lagrangian and
+  field pair for the action functional.
+- `ClassicalFieldTheory.Local.actionVariation` : the action under an admissible variation.
+- `ClassicalFieldTheory.Local.IsCritical` : vanishing first derivative of the varied action.
+
+## iii. Table of contents
+
+- A. Action densities and action
+- B. Action under variation
+- C. Critical fields
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+open scoped ContDiff Topology
+
+/-!
+## A. Action densities and action
+
+-/
+
+/-- The action density determined by a local Lagrangian and a field. -/
+noncomputable def actionDensity (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  L.alongField f
+
+/-- The integrability condition for the action density of a field. -/
+def HasFiniteAction (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  Integrable (actionDensity L f)
+
+/-- Symmetric admissibility predicate for the action functional: the pair `(L, f)` is admissible
+when the field is smooth and the corresponding action density is integrable. -/
+def IsAdmissibleForAction (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ContDiff ℝ ∞ f ∧ HasFiniteAction L f
+
+/-- The action associated with a local Lagrangian. -/
+noncomputable def action (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : ℝ :=
+  ∫ x, actionDensity L f x
+
+@[simp]
+lemma actionDensity_apply (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    actionDensity L f x = L (jetAt k f x) := rfl
+
+@[simp]
+lemma action_eq_integral (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    action L f = ∫ x, actionDensity L f x := rfl
+
+/-!
+## B. Action under variation
+
+-/
+
+/-- The field obtained by varying `f` in the direction `η` with parameter `s`. -/
+noncomputable def variedField (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (s : ℝ) :
+    Space d → EuclideanSpace ℝ (Fin m) :=
+  fun x => f x + s • η x
+
+/-- Smoothness of the varied field for smooth `f` and admissible `η`. -/
+lemma variedField_contDiff (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (s : ℝ)
+    (hf : ContDiff ℝ ∞ f) :
+    ContDiff ℝ ∞ (variedField f η s) := by
+  simpa [variedField] using hf.add (η.isTestFunction.contDiff.const_smul s)
+
+/-- The action of a field under an admissible variation. -/
+noncomputable def actionVariation (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : ℝ → ℝ :=
+  fun s => action L (variedField f η s)
+
+/-- Explicit integrability condition for the family of varied action densities. -/
+def HasFiniteActionVariation (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : Prop :=
+  ∀ s : ℝ, Integrable (actionDensity L (variedField f η s))
+
+/-- Locality package for the action density under compactly supported variations: for every
+variation parameter `s`, the change in the action density is a continuous compactly supported
+function. Combined with finiteness of the base action, this implies finiteness of the varied
+action. -/
+def HasCompactlySupportedActionVariationDifference (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : Prop :=
+  ∀ s : ℝ,
+    Continuous (fun x => actionDensity L (variedField f η s) x - actionDensity L f x) ∧
+      HasCompactSupport (fun x => actionDensity L (variedField f η s) x - actionDensity L f x)
+
+/-- If the base action is finite and every varied action density differs from the base density by
+a continuous compactly supported function, then the whole varied family has finite action. -/
+lemma hasFiniteActionVariation_of_hasFiniteAction_of_compactlySupportedDifference
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hbase : HasFiniteAction L f)
+    (hdiff : HasCompactlySupportedActionVariationDifference L f η) :
+    HasFiniteActionVariation L f η := by
+  intro s
+  rcases hdiff s with ⟨hcont, hsupp⟩
+  have hsub :
+      Integrable (fun x => actionDensity L (variedField f η s) x - actionDensity L f x) := by
+    exact hcont.integrable_of_hasCompactSupport hsupp
+  have hadd :
+      Integrable
+        (fun x =>
+          (actionDensity L (variedField f η s) x - actionDensity L f x)
+            + actionDensity L f x) := by
+    exact hsub.add hbase
+  simpa [sub_eq_add_neg, add_assoc, add_left_comm] using hadd
+
+@[simp]
+lemma variedField_apply (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (s : ℝ)
+    (x : Space d) :
+    variedField f η s x = f x + s • η x := rfl
+
+@[simp]
+lemma actionVariation_apply (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (s : ℝ) :
+    actionVariation L f η s = action L (variedField f η s) := rfl
+
+lemma jetAt_variedField_eq_of_notMem_tsupport
+    (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (s : ℝ)
+    {x : Space d}
+    (hf : ContDiff ℝ ∞ f) (hx : x ∉ tsupport η.toFun) :
+    jetAt k (variedField f η s) x = jetAt k f x := by
+  have hcoords :
+      jetCoordinatesAt k (variedField f η s) x = jetCoordinatesAt k f x := by
+    simpa [variedField, jetCoordinatesAt_eq_zero_of_notMem_tsupport k η.toFun hx] using
+      jetCoordinatesAt_add_smul k f η.toFun x s hf η.isTestFunction.contDiff
+  rw [jetAt_eq_ofBaseCoordinates, jetAt_eq_ofBaseCoordinates]
+  exact congrArg (JetPoint.ofBaseCoordinates x) hcoords
+
+lemma actionDensity_variedField_eq_of_notMem_tsupport
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (s : ℝ)
+    {x : Space d} (hf : ContDiff ℝ ∞ f) (hx : x ∉ tsupport η.toFun) :
+    actionDensity L (variedField f η s) x = actionDensity L f x := by
+  simp [actionDensity_apply, jetAt_variedField_eq_of_notMem_tsupport k f η s hf hx]
+
+lemma hasCompactlySupportedActionVariationDifference_of_continuousInCoordinates
+    (L : Lagrangian d m k) (hcontL : Lagrangian.ContinuousInCoordinates L)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) :
+    HasCompactlySupportedActionVariationDifference L f η := by
+  intro s
+  have hbaseCont : Continuous (actionDensity L f) := by
+    simpa [actionDensity] using Lagrangian.continuousAlongField_of_inCoordinates L hcontL f hf
+  have hvarCont : Continuous (actionDensity L (variedField f η s)) := by
+    simpa [actionDensity] using
+      Lagrangian.continuousAlongField_of_inCoordinates L hcontL (variedField f η s)
+        (variedField_contDiff f η s hf)
+  refine ⟨hvarCont.sub hbaseCont, ?_⟩
+  refine η.hasCompactSupport.of_isClosed_subset (isClosed_tsupport _) ?_
+  have hsupp :
+      Function.support (fun x => actionDensity L (variedField f η s) x - actionDensity L f x)
+        ⊆ tsupport η.toFun := by
+    intro x hx
+    by_contra hxt
+    rw [Function.mem_support] at hx
+    have heq := actionDensity_variedField_eq_of_notMem_tsupport L f η s hf hxt
+    rw [heq] at hx
+    exact hx (sub_self _)
+  simpa [tsupport] using closure_minimal hsupp (isClosed_tsupport _)
+
+/-!
+## C. Critical fields
+
+-/
+
+/-- A field is critical for a local action if every admissible compactly supported variation has
+vanishing first derivative at `s = 0`, under the explicit finite-action hypothesis for the varied
+family. -/
+def IsCritical (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), HasFiniteActionVariation L f η →
+    HasDerivAt (actionVariation L f η) 0 0
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/EulerLagrange.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/EulerLagrange.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.Action
+/-!
+# Local Euler-Lagrange operators
+
+## i. Overview
+
+This module defines the local Euler-Lagrange operator associated with a local Lagrangian.
+
+In the first implementation pass, the derivatives of the Lagrangian with respect to the jet
+coordinates are packaged explicitly as part of the local Lagrangian data. This keeps the formula
+close to the one in the book while avoiding a premature smooth structure on `JetPoint`.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.eulerLagrangeTerm` : a single summand in the local
+  Euler-Lagrange formula.
+- `ClassicalFieldTheory.Local.eulerLagrangeComponent` : one component `E_a(L)` of the operator.
+- `ClassicalFieldTheory.Local.eulerLagrangeOp` : the full local Euler-Lagrange operator.
+
+## iii. Table of contents
+
+- A. Euler-Lagrange summands
+- B. Components of the Euler-Lagrange operator
+- C. The full operator
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5.
+
+-/
+
+@[expose] public section
+
+open scoped BigOperators
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Euler-Lagrange summands
+
+-/
+
+/-- The summand `(-1)^|I| D_I (∂L/∂u^a_I)` in the local Euler-Lagrange formula. -/
+noncomputable def eulerLagrangeTerm (L : Lagrangian d m k) (I : DerivativeIndex d k) (a : Fin m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  fun x =>
+    (-1 : ℝ) ^ I.1.order * iteratedTotalDerivative k I.1 (L.coordDeriv I a) f x
+
+@[simp]
+lemma eulerLagrangeTerm_apply (L : Lagrangian d m k) (I : DerivativeIndex d k) (a : Fin m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    eulerLagrangeTerm L I a f x =
+      (-1 : ℝ) ^ I.1.order * iteratedTotalDerivative k I.1 (L.coordDeriv I a) f x := rfl
+
+/-!
+## B. Components of the Euler-Lagrange operator
+
+-/
+
+/-- The `a`-th component of the local Euler-Lagrange operator. -/
+noncomputable def eulerLagrangeComponent (L : Lagrangian d m k) (a : Fin m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  fun x => ∑ I : DerivativeIndex d k, eulerLagrangeTerm L I a f x
+
+@[simp]
+lemma eulerLagrangeComponent_apply (L : Lagrangian d m k) (a : Fin m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    eulerLagrangeComponent L a f x = ∑ I : DerivativeIndex d k, eulerLagrangeTerm L I a f x := rfl
+
+/-!
+## C. The full operator
+
+-/
+
+/-- The local Euler-Lagrange operator attached to a local Lagrangian. -/
+noncomputable def eulerLagrangeOp (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    Space d → EuclideanSpace ℝ (Fin m) :=
+  fun x => WithLp.toLp 2 fun a => eulerLagrangeComponent L a f x
+
+lemma eulerLagrangeOp_apply (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (a : Fin m) :
+    eulerLagrangeOp L f x a = eulerLagrangeComponent L a f x := by
+  simp [eulerLagrangeOp]
+
+@[simp]
+lemma eulerLagrangeOp_eq (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    eulerLagrangeOp L f = fun x => WithLp.toLp 2 fun a => eulerLagrangeComponent L a f x := by
+  rfl
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Criterion
+/-!
+# First variation and the Euler-Lagrange criterion
+
+## i. Overview
+
+This module is the public entry point for the local first-variation theory. The core linearized
+density objects live in `FirstVariation.Basic`, the analytic derivation tools and packaged
+hypotheses live in `FirstVariation.Density`, `FirstVariation.IntegrationByParts`,
+`FirstVariation.Regularity`, and `FirstVariation.Criterion`, and this file exposes the cleanest
+surface-level statements of the local Euler-Lagrange criterion.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.hasSmoothEulerLagrangeRegularity_of_smoothInCoordinates`
+- `ClassicalFieldTheory.Local.isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothInCoordinates`
+- `ClassicalFieldTheory.Local.
+  isCritical_iff_eulerLagrange_zero_of_admissibleForAction_and_smoothInCoordinates`
+
+## iii. Table of contents
+
+- A. Smooth-coordinate regularity
+- B. Final Euler-Lagrange criteria
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open scoped ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Smooth-coordinate regularity
+
+-/
+
+theorem hasSmoothEulerLagrangeRegularity_of_smoothInCoordinates
+    (L : Lagrangian d m k) (hL : Lagrangian.SmoothInCoordinates L) :
+    HasSmoothEulerLagrangeRegularity L := by
+  exact hasSmoothEulerLagrangeRegularity_of_contDiffCoordDerivInCoordinates L hL.2
+
+/-!
+## B. Final Euler-Lagrange criteria
+
+-/
+
+theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothInCoordinates
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hL : Lagrangian.SmoothInCoordinates L)
+    (hbase : HasFiniteAction L f) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact
+    isCritical_iff_eulerLagrange_zero_of_hasFiniteAction_and_continuousInCoordinates
+      L f hf hL.2 hL.1 hbase
+
+theorem isCritical_iff_eulerLagrange_zero_of_admissibleForAction_and_smoothInCoordinates
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hLf : IsAdmissibleForAction L f)
+    (hL : Lagrangian.SmoothInCoordinates L) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  rcases hLf with ⟨hf, hbase⟩
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothInCoordinates L f hf hL hbase
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Basic.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Basic.lean
@@ -90,10 +90,10 @@ lemma firstVariationValue_eq_integral (L : Lagrangian d m k)
 
 lemma firstVariationValue_eq_zero_of_eulerLagrange_zero
     (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
-    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (hel : eulerLagrangeOp L f = 0) :
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (hEuler : eulerLagrangeOp L f = 0) :
     firstVariationValue L f η = 0 := by
   unfold firstVariationValue
-  rw [hel]
+  rw [hEuler]
   simp
 
 end Local

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Basic.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Basic.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.EulerLagrange
+public import Physlib.Mathematics.VariationalCalculus.Basic
+/-!
+# First variation core objects
+
+## i. Overview
+
+This module contains the basic objects used throughout the local first-variation theory:
+the linearized density before integration by parts and its Euler-Lagrange pairing.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.firstVariationDensityTerm`
+- `ClassicalFieldTheory.Local.firstVariationDensity`
+- `ClassicalFieldTheory.Local.firstVariationValue`
+
+## iii. Table of contents
+
+- A. First-variation values
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. First-variation values
+
+-/
+
+/-- A single term in the linearized first-variation density before integration by parts. -/
+noncomputable def firstVariationDensityTerm (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (I : DerivativeIndex d k)
+    (a : Fin m) :
+    Space d → ℝ :=
+  fun x => L.coordDeriv I a (jetAt k f x) * ∂^[I.1] (fun y => (η y) a) x
+
+/-- The pointwise linearized first-variation density before integration by parts. -/
+noncomputable def firstVariationDensity (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : Space d → ℝ :=
+  fun x => ∑ I : DerivativeIndex d k, ∑ a : Fin m, firstVariationDensityTerm L f η I a x
+
+/-- The value predicted by the first-variation formula for an admissible variation. -/
+noncomputable def firstVariationValue (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : ℝ :=
+  ∫ x, ⟪eulerLagrangeOp L f x, η x⟫_ℝ
+
+@[simp]
+lemma firstVariationDensityTerm_apply (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (I : DerivativeIndex d k)
+    (a : Fin m) (x : Space d) :
+    firstVariationDensityTerm L f η I a x =
+      L.coordDeriv I a (jetAt k f x) * ∂^[I.1] (fun y => (η y) a) x := rfl
+
+@[simp]
+lemma firstVariationDensity_apply (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (x : Space d) :
+    firstVariationDensity L f η x =
+      ∑ I : DerivativeIndex d k, ∑ a : Fin m, firstVariationDensityTerm L f η I a x := rfl
+
+@[simp]
+lemma firstVariationValue_eq_integral (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) :
+    firstVariationValue L f η = ∫ x, ⟪eulerLagrangeOp L f x, η x⟫_ℝ := rfl
+
+lemma firstVariationValue_eq_zero_of_eulerLagrange_zero
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (hel : eulerLagrangeOp L f = 0) :
+    firstVariationValue L f η = 0 := by
+  unfold firstVariationValue
+  rw [hel]
+  simp
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Criterion.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Criterion.lean
@@ -62,12 +62,12 @@ def HasFirstVariationFormula (L : Lagrangian d m k)
 
 lemma isCritical_of_eulerLagrange_zero (L : Lagrangian d m k)
     (f : Space d → EuclideanSpace ℝ (Fin m))
-    (hfirst : HasFirstVariationFormula L f) (hel : eulerLagrangeOp L f = 0) :
+    (hfirst : HasFirstVariationFormula L f) (hEuler : eulerLagrangeOp L f = 0) :
     IsCritical L f := by
   intro η hη
   have hderiv := hfirst η hη
   have hzero : firstVariationValue L f η = 0 :=
-    firstVariationValue_eq_zero_of_eulerLagrange_zero L f η hel
+    firstVariationValue_eq_zero_of_eulerLagrange_zero L f η hEuler
   rw [hzero] at hderiv
   exact hderiv
 

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Criterion.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Criterion.lean
@@ -1,0 +1,299 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Density
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.IntegrationByParts
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Regularity
+/-!
+# First variation criteria
+
+## i. Overview
+
+This module assembles the analytic ingredients of the local first-variation proof into the
+packaged first-variation formula and the internal Euler-Lagrange criteria used by the public
+facade.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.
+  isCritical_iff_eulerLagrange_zero_of_hasFiniteAction_and_continuousInCoordinates`
+
+## iii. Table of contents
+
+- A. First-variation assembly
+- B. Final Euler-Lagrange criterion
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. First-variation assembly
+
+-/
+
+/-- Explicit global finiteness hypothesis for all admissible variations. -/
+def AllVariationsHaveFiniteAction (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), HasFiniteActionVariation L f η
+
+/-- The first-variation formula for the local action, packaged as a reusable hypothesis. -/
+def HasFirstVariationFormula (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), HasFiniteActionVariation L f η →
+    HasDerivAt (actionVariation L f η) (firstVariationValue L f η) 0
+
+lemma isCritical_of_eulerLagrange_zero (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hfirst : HasFirstVariationFormula L f) (hel : eulerLagrangeOp L f = 0) :
+    IsCritical L f := by
+  intro η hη
+  have hderiv := hfirst η hη
+  have hzero : firstVariationValue L f η = 0 :=
+    firstVariationValue_eq_zero_of_eulerLagrange_zero L f η hel
+  rw [hzero] at hderiv
+  exact hderiv
+
+lemma eulerLagrange_zero_of_isCritical (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hfirst : HasFirstVariationFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f))
+    (hcrit : IsCritical L f) :
+    eulerLagrangeOp L f = 0 := by
+  apply fundamental_theorem_of_variational_calculus' (@volume (Space d) _)
+  · exact hcont
+  · intro g hg
+    let η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)) := ⟨g, hg⟩
+    have hηfin : HasFiniteActionVariation L f η := hfin η
+    have hfirstη : HasDerivAt (actionVariation L f η) (firstVariationValue L f η) 0 :=
+      hfirst η hηfin
+    have hcritη : HasDerivAt (actionVariation L f η) 0 0 := hcrit η hηfin
+    have hzero : firstVariationValue L f η = 0 := HasDerivAt.unique hfirstη hcritη
+    simpa [firstVariationValue, η] using hzero
+
+theorem isCritical_iff_eulerLagrange_zero (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hfirst : HasFirstVariationFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  constructor
+  · exact eulerLagrange_zero_of_isCritical L f hfirst hfin hcont
+  · exact isCritical_of_eulerLagrange_zero L f hfirst
+
+private lemma hasFirstVariationFormula_of_underIntegral_linearized_and_parts
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hpoint : HasPointwiseLinearizedDensityFormula L f)
+    (hibp : HasIntegratedByPartsFormula L f) :
+    HasFirstVariationFormula L f := by
+  intro η hη
+  have hderiv := hint η hη
+  have hlinearized :
+      (∫ x, deriv (fun s : ℝ => actionDensity L (variedField f η s) x) 0)
+        = ∫ x, firstVariationDensity L f η x := by
+    apply integral_congr_ae
+    filter_upwards with x
+    simpa using hpoint η x
+  have hvalue :
+      (∫ x, deriv (fun s : ℝ => actionDensity L (variedField f η s) x) 0)
+        = firstVariationValue L f η := by
+    rw [hlinearized, hibp η]
+  rw [hvalue] at hderiv
+  exact hderiv
+
+private lemma hasFirstVariationFormula_of_contDiff_underIntegral_and_parts
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hibp : HasIntegratedByPartsFormula L f) :
+    HasFirstVariationFormula L f := by
+  exact hasFirstVariationFormula_of_underIntegral_linearized_and_parts L f hint
+    (hasPointwiseLinearizedDensityFormula_of_contDiff L f hf) hibp
+
+private lemma hasFirstVariationFormula_of_underIntegral_linearized_and_termwise
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hpoint : HasPointwiseLinearizedDensityFormula L f)
+    (hterm : HasTermwiseIntegratedByPartsFormula L f) :
+    HasFirstVariationFormula L f := by
+  exact hasFirstVariationFormula_of_underIntegral_linearized_and_parts L f hint hpoint
+    (hasIntegratedByPartsFormula_of_termwise L f hterm)
+
+private lemma hasFirstVariationFormula_of_contDiff_underIntegral_and_termwise
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hterm : HasTermwiseIntegratedByPartsFormula L f) :
+    HasFirstVariationFormula L f := by
+  exact hasFirstVariationFormula_of_contDiff_underIntegral_and_parts L f hf hint
+    (hasIntegratedByPartsFormula_of_termwise L f hterm)
+
+/-!
+## B. Intermediate Euler-Lagrange criteria
+
+-/
+
+/-- The local Euler-Lagrange criterion obtained from the packaged analytic ingredients of the
+first-variation formula. This is the current formalized form of Theorem 5.2. -/
+private theorem isCritical_iff_eulerLagrange_zero_of_underIntegral_linearized_and_parts
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hpoint : HasPointwiseLinearizedDensityFormula L f)
+    (hibp : HasIntegratedByPartsFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero L f
+    (hasFirstVariationFormula_of_underIntegral_linearized_and_parts L f hint hpoint hibp)
+    hfin hcont
+
+/-- Variant of the local Euler-Lagrange criterion where the integration-by-parts input is reduced
+to a termwise hypothesis. -/
+private theorem isCritical_iff_eulerLagrange_zero_of_underIntegral_linearized_and_termwise
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hpoint : HasPointwiseLinearizedDensityFormula L f)
+    (hterm : HasTermwiseIntegratedByPartsFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_underIntegral_linearized_and_parts L f
+    hint hpoint (hasIntegratedByPartsFormula_of_termwise L f hterm) hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_underIntegral_and_termwise
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hint : HasActionVariationDerivativeUnderIntegral L f)
+    (hterm : HasTermwiseIntegratedByPartsFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero L f
+    (hasFirstVariationFormula_of_contDiff_underIntegral_and_termwise L f hf hint hterm)
+    hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_continuous_coordDeriv_and_termwise
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcontVar : ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      Continuous (fun p : ℝ × Space d =>
+        L.coordDeriv I a (jetAt k (variedField f η p.1) p.2)))
+    (hterm : HasTermwiseIntegratedByPartsFormula L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_underIntegral_and_termwise L f hf
+    (hasActionVariationDerivativeUnderIntegral_of_contDiff_of_continuous_coordDeriv L f hf
+      hcontVar)
+    hterm hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcontVar : ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      Lagrangian.ContinuousCoordDerivAlongFamily L (fun s : ℝ => variedField f η s))
+    (hcoeff : Lagrangian.ContDiffCoordDerivAlongField L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_underIntegral_and_termwise L f hf
+    (hasActionVariationDerivativeUnderIntegral_of_contDiff_of_regular L f hf hcontVar)
+    (hasTermwiseIntegratedByPartsFormula_of_regular L f hcoeff)
+    hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_regularityAt
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hreg : HasEulerLagrangeRegularityAt L f)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  rcases hreg with ⟨hcoeff, hcontVar⟩
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_regular L f hf hcontVar hcoeff
+    hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothRegularity
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hreg : HasSmoothEulerLagrangeRegularity L)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_regularityAt L f hf (hreg f hf)
+    hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_coordinateRegularity
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcoord : Lagrangian.ContDiffCoordDerivInCoordinates L)
+    (hfin : AllVariationsHaveFiniteAction L f)
+    (hcont : Continuous (eulerLagrangeOp L f)) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothRegularity L f hf
+    (hasSmoothEulerLagrangeRegularity_of_contDiffCoordDerivInCoordinates L hcoord) hfin hcont
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_regularityAt'
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hreg : HasEulerLagrangeRegularityAt L f)
+    (hfin : AllVariationsHaveFiniteAction L f) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  rcases hreg with ⟨hcoeff, hcontVar⟩
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_regular L f hf hcontVar hcoeff hfin
+    (continuous_eulerLagrangeOp_of_regular L f hcoeff)
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothRegularity'
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hreg : HasSmoothEulerLagrangeRegularity L)
+    (hfin : AllVariationsHaveFiniteAction L f) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_regularityAt' L f hf (hreg f hf) hfin
+
+private theorem isCritical_iff_eulerLagrange_zero_of_contDiff_and_coordinateRegularity'
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcoord : Lagrangian.ContDiffCoordDerivInCoordinates L)
+    (hfin : AllVariationsHaveFiniteAction L f) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothRegularity' L f hf
+    (hasSmoothEulerLagrangeRegularity_of_contDiffCoordDerivInCoordinates L hcoord) hfin
+
+private theorem
+    isCritical_iff_eulerLagrange_zero_of_contDiff_and_coordinateRegularity_of_hasFiniteAction
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcoord : Lagrangian.ContDiffCoordDerivInCoordinates L)
+    (hbase : HasFiniteAction L f)
+    (hlocal :
+      ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+        HasCompactlySupportedActionVariationDifference L f η) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  have hfin : AllVariationsHaveFiniteAction L f := by
+    intro η
+    exact hasFiniteActionVariation_of_hasFiniteAction_of_compactlySupportedDifference
+      L f η hbase (hlocal η)
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_coordinateRegularity' L f hf hcoord hfin
+
+theorem isCritical_iff_eulerLagrange_zero_of_hasFiniteAction_and_continuousInCoordinates
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcoord : Lagrangian.ContDiffCoordDerivInCoordinates L)
+    (hcontL : Lagrangian.ContinuousInCoordinates L)
+    (hbase : HasFiniteAction L f) :
+    IsCritical L f ↔ eulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_coordinateRegularity_of_hasFiniteAction
+    L f hf hcoord hbase
+    (fun η =>
+      hasCompactlySupportedActionVariationDifference_of_continuousInCoordinates
+        L hcontL f hf η)
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Density.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Density.lean
@@ -1,0 +1,361 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Support
+public import Mathlib.Analysis.Calculus.ParametricIntegral
+/-!
+# First variation density formulas
+
+## i. Overview
+
+This module contains the pointwise and integral first-variation formulas before integration by
+parts: differentiation of the varied action density, dominated differentiation under the integral,
+and the corresponding packaged hypotheses.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.hasPointwiseLinearizedDensityFormula_of_contDiff`
+- `ClassicalFieldTheory.Local.hasActionVariationDerivativeUnderIntegral_of_contDiff_of_regular`
+
+## iii. Table of contents
+
+- A. Differentiation under the integral sign
+- B. Pointwise linearization
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Differentiation under the integral sign
+
+-/
+
+/-- Differentiation of the varied action under the integral sign, packaged as a hypothesis. -/
+def HasActionVariationDerivativeUnderIntegral (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), HasFiniteActionVariation L f η →
+    HasDerivAt (actionVariation L f η)
+      (∫ x, deriv (fun s : ℝ => actionDensity L (variedField f η s) x) 0) 0
+
+/-- Pointwise linearization of the action density before integration by parts. -/
+def HasPointwiseLinearizedDensityFormula (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), ∀ x : Space d,
+    deriv (fun s : ℝ => actionDensity L (variedField f η s) x) 0 =
+      firstVariationDensity L f η x
+
+/-- A direct bridge from Mathlib's dominated differentiation-under-the-integral theorem to the
+local action variation. This isolates the measure-theoretic input needed to prove
+`HasActionVariationDerivativeUnderIntegral`. -/
+lemma actionVariation_hasDerivAt_of_dominated_loc_of_deriv_le
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    {F' : ℝ → Space d → ℝ} {bound : Space d → ℝ} {ε : ℝ} (hε : 0 < ε)
+    (hmeas :
+      ∀ᶠ s in nhds (0 : ℝ),
+        AEStronglyMeasurable (actionDensity L (variedField f η s)) volume)
+    (hfinite0 : Integrable (actionDensity L (variedField f η 0)))
+    (hF'_meas : AEStronglyMeasurable (F' 0) volume)
+    (hbound :
+      ∀ᵐ x ∂volume, ∀ s ∈ Metric.ball (0 : ℝ) ε, ‖F' s x‖ ≤ bound x)
+    (hbound_int : Integrable bound volume)
+    (hderiv :
+      ∀ᵐ x ∂volume, ∀ s ∈ Metric.ball (0 : ℝ) ε,
+        HasDerivAt (fun r : ℝ => actionDensity L (variedField f η r) x) (F' s x) s) :
+    HasDerivAt (actionVariation L f η) (∫ x, F' 0 x) 0 := by
+  have hs : Metric.ball (0 : ℝ) ε ∈ nhds (0 : ℝ) := Metric.ball_mem_nhds _ hε
+  simpa [actionVariation, action, actionDensity] using
+    (hasDerivAt_integral_of_dominated_loc_of_deriv_le
+      (μ := volume) (F := fun s x => actionDensity L (variedField f η s) x)
+      (x₀ := (0 : ℝ)) (s := Metric.ball (0 : ℝ) ε) hs
+      hmeas hfinite0 hF'_meas hbound hbound_int hderiv).2
+
+/-- A dominated bound for the pointwise first variation along the varied-field family near
+`s = 0`. This packages the analytic domination needed to differentiate the action under the
+integral sign. -/
+def HasDominatedVariationDerivativeNear (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) : Prop :=
+  ∃ ε > 0, ∃ bound : Space d → ℝ,
+    AEStronglyMeasurable (firstVariationDensity L f η) volume ∧
+    Integrable bound volume ∧
+    ∀ᵐ x ∂volume, ∀ s ∈ Metric.ball (0 : ℝ) ε,
+      ‖firstVariationDensity L (variedField f η s) η x‖ ≤ bound x
+
+private lemma continuous_coordDeriv_at_zero
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hcont : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      Continuous (fun p : ℝ × Space d =>
+        L.coordDeriv I a (jetAt k (variedField f η p.1) p.2)))
+    (I : DerivativeIndex d k) (a : Fin m) :
+    Continuous (fun x : Space d => L.coordDeriv I a (jetAt k f x)) := by
+  have hpair : Continuous (fun x : Space d => ((0 : ℝ), x)) := by
+    fun_prop
+  have hcoeff0 :
+      Continuous (fun x : Space d => L.coordDeriv I a (jetAt k (variedField f η 0) x)) := by
+    exact (hcont I a).comp hpair
+  simpa [variedField_zero] using hcoeff0
+
+private lemma firstVariationDensityTerm_norm_le_of_coeff_bound
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (ψ : DerivativeIndex d k → Fin m → Space d → ℝ)
+    (hψ : ∀ I : DerivativeIndex d k, ∀ a : Fin m, ∀ x : Space d,
+      ψ I a x = ∂^[I.1] (fun y => (η y) a) x)
+    (C : DerivativeIndex d k → Fin m → ℝ)
+    (K : DerivativeIndex d k → Fin m → Set (Space d))
+    (hKzero : ∀ I : DerivativeIndex d k, ∀ a : Fin m, ∀ x, x ∉ K I a → ψ I a x = 0)
+    (hC : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      ∀ p ∈ Metric.closedBall (0 : ℝ) 1 ×ˢ K I a,
+        ‖L.coordDeriv I a (jetAt k (variedField f η p.1) p.2)‖ ≤ C I a)
+    {x : Space d} {s : ℝ} (hs : s ∈ Metric.ball (0 : ℝ) 1)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    ‖firstVariationDensityTerm L (variedField f η s) η I a x‖ ≤ C I a * ‖ψ I a x‖ := by
+  by_cases hx : x ∈ K I a
+  · have hs' : s ∈ Metric.closedBall (0 : ℝ) 1 := Metric.ball_subset_closedBall hs
+    have hcoeff := hC I a (s, x) ⟨hs', hx⟩
+    calc
+      ‖firstVariationDensityTerm L (variedField f η s) η I a x‖
+        = ‖L.coordDeriv I a (jetAt k (variedField f η s) x) * ψ I a x‖ := by
+            rw [hψ I a x]
+            simp [firstVariationDensityTerm]
+      _ = ‖L.coordDeriv I a (jetAt k (variedField f η s) x)‖ * ‖ψ I a x‖ := by
+            rw [norm_mul]
+      _ ≤ C I a * ‖ψ I a x‖ := by
+            exact mul_le_mul_of_nonneg_right hcoeff (norm_nonneg _)
+  · have hψzero : ψ I a x = 0 := hKzero I a x hx
+    rw [hψ I a x] at hψzero
+    rw [hψ I a x]
+    simp [firstVariationDensityTerm, hψzero]
+
+private lemma norm_firstVariationDensity_le_bound
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (ψ : DerivativeIndex d k → Fin m → Space d → ℝ)
+    (hψ : ∀ I : DerivativeIndex d k, ∀ a : Fin m, ∀ x : Space d,
+      ψ I a x = ∂^[I.1] (fun y => (η y) a) x)
+    (C : DerivativeIndex d k → Fin m → ℝ)
+    (K : DerivativeIndex d k → Fin m → Set (Space d))
+    (hKzero : ∀ I : DerivativeIndex d k, ∀ a : Fin m, ∀ x, x ∉ K I a → ψ I a x = 0)
+    (hC : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      ∀ p ∈ Metric.closedBall (0 : ℝ) 1 ×ˢ K I a,
+        ‖L.coordDeriv I a (jetAt k (variedField f η p.1) p.2)‖ ≤ C I a)
+    {x : Space d} {s : ℝ} (hs : s ∈ Metric.ball (0 : ℝ) 1) :
+    ‖firstVariationDensity L (variedField f η s) η x‖
+      ≤ ∑ I : DerivativeIndex d k, ∑ a : Fin m, C I a * ‖ψ I a x‖ := by
+  have houter :
+      ‖∑ I : DerivativeIndex d k, ∑ a : Fin m,
+          firstVariationDensityTerm L (variedField f η s) η I a x‖
+        ≤ ∑ I : DerivativeIndex d k, ‖∑ a : Fin m,
+            firstVariationDensityTerm L (variedField f η s) η I a x‖ := by
+    exact norm_sum_le _ _
+  calc
+    ‖firstVariationDensity L (variedField f η s) η x‖
+      = ‖∑ I : DerivativeIndex d k, ∑ a : Fin m,
+          firstVariationDensityTerm L (variedField f η s) η I a x‖ := by
+            simp [firstVariationDensity]
+    _ ≤ ∑ I : DerivativeIndex d k, ‖∑ a : Fin m,
+          firstVariationDensityTerm L (variedField f η s) η I a x‖ := houter
+    _ ≤ ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+          ‖firstVariationDensityTerm L (variedField f η s) η I a x‖ := by
+            refine Finset.sum_le_sum ?_
+            intro I _
+            exact norm_sum_le _ _
+    _ ≤ ∑ I : DerivativeIndex d k, ∑ a : Fin m, C I a * ‖ψ I a x‖ := by
+            refine Finset.sum_le_sum ?_
+            intro I _
+            refine Finset.sum_le_sum ?_
+            intro a _
+            exact firstVariationDensityTerm_norm_le_of_coeff_bound
+              L f η ψ hψ C K hKzero hC hs I a
+
+/-- A concrete dominated bound for the varied first-variation density, obtained from continuity of
+the jet-coordinate coefficient family in `(s, x)`. The compact support of the iterated derivatives
+of the admissible variation supplies the integrable majorant. -/
+lemma hasDominatedVariationDerivativeNear_of_continuous_coordDeriv
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hcont : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      Continuous (fun p : ℝ × Space d =>
+        L.coordDeriv I a (jetAt k (variedField f η p.1) p.2))) :
+    HasDominatedVariationDerivativeNear L f η := by
+  classical
+  let ψ : DerivativeIndex d k → Fin m → Space d → ℝ :=
+    fun I a x => ∂^[I.1] (fun y => (η y) a) x
+  have hψ : ∀ I : DerivativeIndex d k, ∀ a : Fin m, IsTestFunction (ψ I a) := by
+    intro I a
+    simpa [ψ] using iteratedDeriv_coord_isTestFunction η I a
+  have hψ_eval : ∀ I : DerivativeIndex d k, ∀ a : Fin m, ∀ x : Space d,
+      ψ I a x = ∂^[I.1] (fun y => (η y) a) x := by
+    intro I a x
+    rfl
+  choose K hKcompact hKzero using fun I : DerivativeIndex d k => fun a : Fin m =>
+    exists_compact_iff_hasCompactSupport.mpr (hψ I a).supp
+  let C : DerivativeIndex d k → Fin m → ℝ := fun I a =>
+    Classical.choose <|
+      ((isCompact_closedBall (0 : ℝ) 1).prod (hKcompact I a)).exists_bound_of_continuousOn
+        ((hcont I a).continuousOn)
+  have hC : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      ∀ p ∈ Metric.closedBall (0 : ℝ) 1 ×ˢ K I a,
+        ‖L.coordDeriv I a (jetAt k (variedField f η p.1) p.2)‖ ≤ C I a := by
+    intro I a
+    simpa [C] using Classical.choose_spec
+      (((isCompact_closedBall (0 : ℝ) 1).prod (hKcompact I a)).exists_bound_of_continuousOn
+        ((hcont I a).continuousOn))
+  let bound : Space d → ℝ :=
+    fun x => ∑ I : DerivativeIndex d k, ∑ a : Fin m, C I a * ‖ψ I a x‖
+  have hbound_int : Integrable bound volume := by
+    refine integrable_finsetSum Finset.univ ?_
+    intro I _
+    refine integrable_finsetSum Finset.univ ?_
+    intro a _
+    exact ((hψ I a).integrable (μ := volume)).norm.const_mul (C I a)
+  have hfirst_int :
+      Integrable (firstVariationDensity L f η) volume := by
+    refine integrable_finsetSum Finset.univ ?_
+    intro I _
+    refine integrable_finsetSum Finset.univ ?_
+    intro a _
+    have hcoeff0 :
+        Continuous (fun x : Space d => L.coordDeriv I a (jetAt k f x)) :=
+      continuous_coordDeriv_at_zero L f η hcont I a
+    exact firstVariationDensityTerm_integrable_of_continuous_coordDeriv L f η I a hcoeff0
+  have hbound :
+      ∀ x : Space d, ∀ s ∈ Metric.ball (0 : ℝ) 1,
+        ‖firstVariationDensity L (variedField f η s) η x‖ ≤ bound x := by
+    intro x s hs
+    simpa [bound] using norm_firstVariationDensity_le_bound
+      L f η ψ hψ_eval C K hKzero hC hs
+  refine ⟨1, zero_lt_one, bound, hfirst_int.aestronglyMeasurable, hbound_int, ?_⟩
+  exact Filter.Eventually.of_forall hbound
+
+/-!
+## B. Pointwise linearization
+
+-/
+
+lemma hasDerivAt_actionDensity_variedField_zero_of_contDiff
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f) :
+    ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)), ∀ x : Space d,
+      HasDerivAt (fun s : ℝ => actionDensity L (variedField f η s) x)
+        (firstVariationDensity L f η x) 0 := by
+  intro η x
+  have hjet :
+      ∀ s : ℝ, jetAt k (variedField f η s) x =
+        (jetAt k f x).lineMap (jetDirectionAt k η x) s := by
+    intro s
+    simpa [variedField] using jetAt_add_smul k f η x s hf η.isTestFunction.contDiff
+  have hfun :
+      (fun s : ℝ => actionDensity L (variedField f η s) x) =
+        fun s : ℝ => L ((jetAt k f x).lineMap (jetDirectionAt k η x) s) := by
+    funext s
+    rw [actionDensity_apply]
+    simp [hjet s]
+  rw [hfun]
+  simpa [Lagrangian.fiberDerivative, firstVariationDensity, firstVariationDensityTerm,
+    jetDirectionAt_coord] using
+    (L.hasDerivAt_lineMap (jetAt k f x) (jetDirectionAt k η x))
+
+lemma hasDerivAt_actionDensity_variedField_of_contDiff
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (x : Space d) (s : ℝ) :
+    HasDerivAt (fun r : ℝ => actionDensity L (variedField f η r) x)
+      (firstVariationDensity L (variedField f η s) η x) s := by
+  have hzero :
+      HasDerivAt (fun t : ℝ => actionDensity L (variedField (variedField f η s) η t) x)
+        (firstVariationDensity L (variedField f η s) η x) 0 := by
+    exact hasDerivAt_actionDensity_variedField_zero_of_contDiff L (variedField f η s)
+      (variedField_contDiff f η s hf) η x
+  have hshift :
+      HasDerivAt (fun t : ℝ => actionDensity L (variedField f η (t + s)) x)
+        (firstVariationDensity L (variedField f η s) η x) 0 := by
+    simpa [variedField_variedField, add_comm] using hzero
+  let k : ℝ → ℝ := fun t => actionDensity L (variedField f η (t + s)) x
+  have hk : HasDerivAt k (firstVariationDensity L (variedField f η s) η x) (s - s) := by
+    simpa [k] using hshift
+  simpa [k, sub_eq_add_neg, add_assoc] using
+    (HasDerivAt.comp_sub_const (f := k) (x := s) (a := s) hk)
+
+lemma hasPointwiseLinearizedDensityFormula_of_contDiff
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f) :
+    HasPointwiseLinearizedDensityFormula L f := by
+  intro η x
+  exact (hasDerivAt_actionDensity_variedField_zero_of_contDiff L f hf η x).deriv
+
+lemma hasActionVariationDerivativeUnderIntegral_of_contDiff_of_dominatedVariation
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hdom : ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      HasFiniteActionVariation L f η →
+      HasDominatedVariationDerivativeNear L f η) :
+    HasActionVariationDerivativeUnderIntegral L f := by
+  intro η hη
+  rcases hdom η hη with ⟨ε, hε, bound, hF'_meas, hbound_int, hbound⟩
+  let F' : ℝ → Space d → ℝ := fun s => firstVariationDensity L (variedField f η s) η
+  have hmeas :
+      ∀ᶠ s in nhds (0 : ℝ),
+        AEStronglyMeasurable (actionDensity L (variedField f η s)) volume := by
+    exact Filter.Eventually.of_forall fun s => (hη s).aestronglyMeasurable
+  have hderiv :
+      ∀ᵐ x ∂volume, ∀ s ∈ Metric.ball (0 : ℝ) ε,
+        HasDerivAt (fun r : ℝ => actionDensity L (variedField f η r) x) (F' s x) s := by
+    filter_upwards with x
+    intro s hs
+    simpa [F'] using hasDerivAt_actionDensity_variedField_of_contDiff L f hf η x s
+  have hfinite0 : Integrable (actionDensity L (variedField f η 0)) := hη 0
+  have hF0_meas : AEStronglyMeasurable (F' 0) volume := by
+    simpa [F', firstVariationDensity, firstVariationDensityTerm, variedField] using hF'_meas
+  have hresult :=
+    actionVariation_hasDerivAt_of_dominated_loc_of_deriv_le L f η hε hmeas hfinite0
+      hF0_meas hbound hbound_int hderiv
+  have hvalue :
+      (∫ x, F' 0 x)
+        = ∫ x, deriv (fun s : ℝ => actionDensity L (variedField f η s) x) 0 := by
+    apply integral_congr_ae
+    filter_upwards with x
+    simpa [F', firstVariationDensity, firstVariationDensityTerm, variedField] using
+      (hasPointwiseLinearizedDensityFormula_of_contDiff L f hf η x).symm
+  rw [hvalue] at hresult
+  exact hresult
+
+lemma hasActionVariationDerivativeUnderIntegral_of_contDiff_of_continuous_coordDeriv
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcontVar : ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      Continuous (fun p : ℝ × Space d =>
+        L.coordDeriv I a (jetAt k (variedField f η p.1) p.2))) :
+    HasActionVariationDerivativeUnderIntegral L f := by
+  refine hasActionVariationDerivativeUnderIntegral_of_contDiff_of_dominatedVariation L f hf ?_
+  intro η _hη
+  exact hasDominatedVariationDerivativeNear_of_continuous_coordDeriv L f η (hcontVar η)
+
+lemma hasActionVariationDerivativeUnderIntegral_of_contDiff_of_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hcontVar : ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      Lagrangian.ContinuousCoordDerivAlongFamily L (fun s : ℝ => variedField f η s)) :
+    HasActionVariationDerivativeUnderIntegral L f := by
+  apply hasActionVariationDerivativeUnderIntegral_of_contDiff_of_continuous_coordDeriv L f hf
+  intro η I a
+  exact hcontVar η I a
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/IntegrationByParts.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/IntegrationByParts.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Support
+/-!
+# First variation integration by parts
+
+## i. Overview
+
+This module contains the repeated integration-by-parts step needed for the local first-variation
+formula, together with the termwise and summed packaged versions used later in the
+Euler-Lagrange criterion.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.integral_mul_iteratedDeriv_eq_sign`
+- `ClassicalFieldTheory.Local.hasTermwiseIntegratedByPartsFormula_of_regular`
+- `ClassicalFieldTheory.Local.hasIntegratedByPartsFormula_of_termwise`
+
+## iii. Table of contents
+
+- A. Repeated integration by parts
+- B. Termwise formulas
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Repeated integration by parts
+
+-/
+
+/-- The integration-by-parts step sending the linearized density to the Euler-Lagrange pairing. -/
+def HasIntegratedByPartsFormula (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+    ∫ x, firstVariationDensity L f η x = firstVariationValue L f η
+
+/-- Termwise integration-by-parts data for the linearized first-variation density. -/
+def HasTermwiseIntegratedByPartsFormula (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+    ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+    Integrable (firstVariationDensityTerm L f η I a) ∧
+    Integrable (fun x => eulerLagrangeTerm L I a f x * (η x) a) ∧
+    (∫ x, firstVariationDensityTerm L f η I a x)
+      = ∫ x, eulerLagrangeTerm L I a f x * (η x) a
+
+private lemma integral_mul_space_deriv_eq_neg_deriv_mul (i : Fin d) {g h : Space d → ℝ}
+    (hg : ContDiff ℝ ∞ g) (hh : IsTestFunction h) :
+    ∫ x, g x * ∂[i] h x = ∫ x, (-∂[i] g x) * h x := by
+  rw [Space.deriv_eq_fderiv_fun, Space.deriv_eq_fderiv_fun]
+  calc
+    ∫ x, g x * fderiv ℝ h x (Space.basis i)
+      = -∫ x, fderiv ℝ g x (Space.basis i) * h x := by
+          rw [integral_mul_fderiv_eq_neg_fderiv_mul_of_integrable]
+          · simpa [Space.deriv_eq_fderiv_basis] using
+              (IsTestFunction.integrable (μ := volume) <|
+                IsTestFunction.mul_left (contDiff_space_deriv hg i) hh)
+          · simpa [Space.deriv_eq_fderiv_basis] using
+              (IsTestFunction.integrable (μ := volume) <|
+                IsTestFunction.mul_left hg (isTestFunction_space_deriv hh i))
+          · exact IsTestFunction.integrable (μ := volume) <| IsTestFunction.mul_left hg hh
+          · intro x hx
+            exact Differentiable.differentiableAt (hg.differentiable (by simp))
+          · intro x hx
+            exact Differentiable.differentiableAt hh.differentiable
+    _ = ∫ x, (-fderiv ℝ g x (Space.basis i)) * h x := by
+          rw [← integral_neg]
+          congr with x
+          ring
+
+private lemma integral_mul_iteratedDerivList_eq_sign (L : List (Fin d)) {g h : Space d → ℝ}
+    (hg : ContDiff ℝ ∞ g) (hh : IsTestFunction h) :
+    ∫ x, g x * L.foldr (fun i f => ∂[i] f) h x =
+      ∫ x, (((-1 : ℝ) ^ L.length) * L.foldr (fun i f => ∂[i] f) g x) * h x := by
+  induction L generalizing g h with
+  | nil =>
+      simp
+  | cons i L ih =>
+      have hdg : ContDiff ℝ ∞ (∂[i] g) := by
+        exact contDiff_space_deriv hg i
+      have hhL : IsTestFunction (L.foldr (fun j f => ∂[j] f) h) := by
+        exact iteratedDerivList_isTestFunction L hh
+      calc
+        ∫ x, g x * ∂[i] (L.foldr (fun j f => ∂[j] f) h) x
+          = ∫ x, (-∂[i] g x) * L.foldr (fun j f => ∂[j] f) h x := by
+              exact integral_mul_space_deriv_eq_neg_deriv_mul i hg hhL
+        _ = -∫ x, ∂[i] g x * L.foldr (fun j f => ∂[j] f) h x := by
+              rw [← integral_neg]
+              congr with x
+              ring
+        _ = -∫ x, (((-1 : ℝ) ^ L.length) *
+            L.foldr (fun j f => ∂[j] f) (∂[i] g) x) * h x := by
+              rw [ih hdg hh]
+        _ = ∫ x, (((-1 : ℝ) ^ (L.length + 1)) *
+            ∂[i] (L.foldr (fun j f => ∂[j] f) g) x) * h x := by
+              rw [← integral_neg]
+              congr with x
+              rw [iteratedDerivList_commute_deriv L i hg, pow_succ, mul_assoc]
+              ring
+
+/-- Repeated integration by parts for iterated coordinate derivatives against a test function. -/
+lemma integral_mul_iteratedDeriv_eq_sign {g h : Space d → ℝ} (I : MultiIndex d)
+    (hg : ContDiff ℝ ∞ g) (hh : IsTestFunction h) :
+    ∫ x, g x * ∂^[I] h x =
+      ∫ x, (((-1 : ℝ) ^ I.order) * ∂^[I] g x) * h x := by
+  simpa [Space.iteratedDeriv, Physlib.MultiIndex.length_toList] using
+    integral_mul_iteratedDerivList_eq_sign I.toList hg hh
+
+/-!
+## B. Termwise formulas
+
+-/
+
+/-- Concrete termwise integration by parts for the first-variation density, assuming the jet
+coordinate coefficient functions are smooth along the field. -/
+lemma hasTermwiseIntegratedByPartsFormula_of_contDiff_coordDeriv
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hcoeff : ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+      ContDiff ℝ ∞ (fun x => L.coordDeriv I a (jetAt k f x))) :
+    HasTermwiseIntegratedByPartsFormula L f := by
+  intro η I a
+  let g : Space d → ℝ := fun x => L.coordDeriv I a (jetAt k f x)
+  let h : Space d → ℝ := fun x => (η.toFun x) a
+  have hg : ContDiff ℝ ∞ g := hcoeff I a
+  have hh : IsTestFunction h := by
+    simpa [h] using η.coord_euclidean a
+  constructor
+  · simpa [g, h, firstVariationDensityTerm, Space.iteratedDeriv] using
+      firstVariationDensityTerm_integrable_of_continuous_coordDeriv L f η I a hg.continuous
+  constructor
+  · have htd : ContDiff ℝ ∞ (∂^[I.1] g) :=
+      Space.iteratedDeriv_contDiff I.1 hg
+    have htdSign : ContDiff ℝ ∞
+        (fun x => ((-1 : ℝ) ^ I.1.order) * ∂^[I.1] g x) := by
+      apply ContDiff.mul
+      · fun_prop
+      · exact htd
+    simpa [g, h, eulerLagrangeTerm, ClassicalFieldTheory.Local.iteratedTotalDerivative,
+      ClassicalFieldTheory.Local.evalOnJet] using
+      (IsTestFunction.integrable (μ := volume) <|
+        IsTestFunction.mul_left htdSign hh)
+  · simpa [g, h, firstVariationDensityTerm, eulerLagrangeTerm,
+      ClassicalFieldTheory.Local.iteratedTotalDerivative,
+      ClassicalFieldTheory.Local.evalOnJet] using
+      integral_mul_iteratedDeriv_eq_sign I.1 hg hh
+
+lemma hasTermwiseIntegratedByPartsFormula_of_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hcoeff : Lagrangian.ContDiffCoordDerivAlongField L f) :
+    HasTermwiseIntegratedByPartsFormula L f := by
+  exact hasTermwiseIntegratedByPartsFormula_of_contDiff_coordDeriv L f hcoeff
+
+private lemma integral_firstVariationDensity_eq_termwise_sum
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hterm : HasTermwiseIntegratedByPartsFormula L f) :
+    ∫ x, firstVariationDensity L f η x =
+      ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        ∫ x, firstVariationDensityTerm L f η I a x := by
+  calc
+    ∫ x, firstVariationDensity L f η x
+      = ∫ x, ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        firstVariationDensityTerm L f η I a x := by
+          rfl
+    _ = ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        ∫ x, firstVariationDensityTerm L f η I a x := by
+          rw [MeasureTheory.integral_finsetSum Finset.univ
+            (fun I _ => integrable_finsetSum Finset.univ (fun a _ => (hterm η I a).1))]
+          apply Finset.sum_congr rfl
+          intro I _
+          rw [MeasureTheory.integral_finsetSum Finset.univ (fun a _ => (hterm η I a).1)]
+
+private lemma integral_eulerLagrange_termwise_sum_eq_pairing
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hterm : HasTermwiseIntegratedByPartsFormula L f) :
+    ∑ I : DerivativeIndex d k, ∑ a : Fin m, ∫ x, eulerLagrangeTerm L I a f x * (η x) a
+      = firstVariationValue L f η := by
+  calc
+    ∑ I : DerivativeIndex d k, ∑ a : Fin m, ∫ x, eulerLagrangeTerm L I a f x * (η x) a
+      = ∫ x, ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        eulerLagrangeTerm L I a f x * (η x) a := by
+          calc
+            ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+                ∫ x, eulerLagrangeTerm L I a f x * (η x) a
+              =
+                ∑ I : DerivativeIndex d k,
+                  ∫ x, ∑ a : Fin m, eulerLagrangeTerm L I a f x * (η x) a := by
+                  apply Finset.sum_congr rfl
+                  intro I _
+                  rw [← MeasureTheory.integral_finsetSum Finset.univ
+                    (fun a _ => (hterm η I a).2.1)]
+            _ =
+                ∫ x, ∑ I : DerivativeIndex d k,
+                  ∑ a : Fin m, eulerLagrangeTerm L I a f x * (η x) a := by
+                  rw [← MeasureTheory.integral_finsetSum Finset.univ
+                    (fun I _ => integrable_finsetSum Finset.univ (fun a _ => (hterm η I a).2.1))]
+    _ = ∫ x, ⟪eulerLagrangeOp L f x, η x⟫_ℝ := by
+          apply integral_congr_ae
+          filter_upwards with x
+          rw [PiLp.inner_apply]
+          simp_rw [eulerLagrangeOp_apply, eulerLagrangeComponent_apply]
+          rw [Finset.sum_comm]
+          apply Finset.sum_congr rfl
+          intro a _
+          rw [show ⟪∑ I : DerivativeIndex d k, eulerLagrangeTerm L I a f x,
+              (η.toFun x).ofLp a⟫_ℝ =
+              (∑ I : DerivativeIndex d k, eulerLagrangeTerm L I a f x) *
+                (η.toFun x).ofLp a by
+            norm_num [inner, Inner.inner]
+            ring]
+          rw [← Finset.sum_mul]
+    _ = firstVariationValue L f η := by
+          rfl
+
+lemma hasIntegratedByPartsFormula_of_termwise (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hterm : HasTermwiseIntegratedByPartsFormula L f) :
+    HasIntegratedByPartsFormula L f := by
+  intro η
+  calc
+    ∫ x, firstVariationDensity L f η x
+      = ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        ∫ x, firstVariationDensityTerm L f η I a x := by
+          exact integral_firstVariationDensity_eq_termwise_sum L f η hterm
+    _ = ∑ I : DerivativeIndex d k, ∑ a : Fin m,
+        ∫ x, eulerLagrangeTerm L I a f x * (η x) a := by
+          apply Finset.sum_congr rfl
+          intro I _
+          apply Finset.sum_congr rfl
+          intro a _
+          exact (hterm η I a).2.2
+    _ = firstVariationValue L f η := by
+          exact integral_eulerLagrange_termwise_sum_eq_pairing L f η hterm
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Regularity.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Regularity.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Support
+/-!
+# First variation regularity
+
+## i. Overview
+
+This module contains regularity consequences used in the local Euler-Lagrange criterion: continuity
+of the Euler-Lagrange operator from coefficient regularity, and the bridge from coordinate
+regularity of the local Lagrangian to the packaged smooth-regularity statement.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.continuous_eulerLagrangeOp_of_regular`
+- `ClassicalFieldTheory.Local.hasSmoothEulerLagrangeRegularity_of_contDiffCoordDerivInCoordinates`
+
+## iii. Table of contents
+
+- A. Continuity of the Euler-Lagrange operator
+- B. Smooth regularity in coordinates
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Continuity of the Euler-Lagrange operator
+
+-/
+
+/-- The combined regularity package currently needed to derive the local Euler-Lagrange
+criterion for a field `f`: smooth coefficient functions along `f`, and continuity of the
+corresponding coefficient families along every admissible varied-field family based at `f`. -/
+def HasEulerLagrangeRegularityAt (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  Lagrangian.ContDiffCoordDerivAlongField L f ∧
+    ∀ η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)),
+      Lagrangian.ContinuousCoordDerivAlongFamily L (fun s : ℝ => variedField f η s)
+
+/-- A local Lagrangian has smooth Euler-Lagrange regularity if every smooth field satisfies the
+regularity package currently needed by the local first-variation proof. -/
+def HasSmoothEulerLagrangeRegularity (L : Lagrangian d m k) : Prop :=
+  ∀ f : Space d → EuclideanSpace ℝ (Fin m),
+    ContDiff ℝ ∞ f → HasEulerLagrangeRegularityAt L f
+
+lemma continuous_eulerLagrangeTerm_of_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hcoeff : Lagrangian.ContDiffCoordDerivAlongField L f)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    Continuous (eulerLagrangeTerm L I a f) := by
+  have htd : ContDiff ℝ ∞
+      (iteratedTotalDerivative k I.1 (L.coordDeriv I a) f) := by
+    simpa [iteratedTotalDerivative, evalOnJet] using
+      Space.iteratedDeriv_contDiff I.1 (hcoeff I a)
+  have hsign : ContDiff ℝ ∞
+      (fun _ : Space d => (-1 : ℝ) ^ I.1.order) := by
+    fun_prop
+  simpa [eulerLagrangeTerm] using (hsign.mul htd).continuous
+
+lemma continuous_eulerLagrangeComponent_of_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hcoeff : Lagrangian.ContDiffCoordDerivAlongField L f)
+    (a : Fin m) :
+    Continuous (eulerLagrangeComponent L a f) := by
+  refine continuous_finsetSum Finset.univ ?_
+  intro I _
+  exact continuous_eulerLagrangeTerm_of_regular L f hcoeff I a
+
+lemma continuous_eulerLagrangeOp_of_regular
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hcoeff : Lagrangian.ContDiffCoordDerivAlongField L f) :
+    Continuous (eulerLagrangeOp L f) := by
+  let g : Space d → Fin m → ℝ := fun x a => eulerLagrangeComponent L a f x
+  have hg : Continuous g := continuous_pi fun a =>
+    continuous_eulerLagrangeComponent_of_regular L f hcoeff a
+  change Continuous (fun x : Space d => (WithLp.toLp 2 (g x) : EuclideanSpace ℝ (Fin m)))
+  fun_prop
+
+/-!
+## B. Smooth regularity in coordinates
+
+-/
+
+theorem hasSmoothEulerLagrangeRegularity_of_contDiffCoordDerivInCoordinates
+    (L : Lagrangian d m k) (hcoord : Lagrangian.ContDiffCoordDerivInCoordinates L) :
+    HasSmoothEulerLagrangeRegularity L := by
+  intro f hf
+  refine ⟨Lagrangian.contDiffCoordDerivAlongField_of_inCoordinates L hcoord f hf, ?_⟩
+  intro η
+  exact Lagrangian.continuousCoordDerivAlongFamily_of_inCoordinates L hcoord
+    (fun s : ℝ => variedField f η s)
+    (continuous_jetBaseCoordinates_variedField k f η hf)
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Support.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstVariation/Support.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Basic
+/-!
+# First variation support lemmas
+
+## i. Overview
+
+This module collects the reusable support lemmas used by the analytic part of the local
+first-variation proof: basic identities for varied fields, iterated derivative regularity for
+test functions, and continuity of the varied local-jet coordinate map.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.variedField_zero`
+- `ClassicalFieldTheory.Local.variedField_variedField`
+
+## iii. Table of contents
+
+- A. Varied fields
+- B. Iterated derivative support lemmas
+- C. Varied local-jet coordinates
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open InnerProductSpace
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Varied fields
+
+-/
+
+@[simp]
+lemma variedField_zero (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) :
+    variedField f η 0 = f := by
+  funext x
+  simp [variedField]
+
+@[simp]
+lemma variedField_variedField (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (s t : ℝ) :
+    variedField (variedField f η s) η t = variedField f η (s + t) := by
+  funext x
+  simp [variedField, add_assoc, add_smul]
+
+/-!
+## B. Iterated derivative support lemmas
+
+-/
+
+lemma contDiff_space_deriv {g : Space d → ℝ} (hg : ContDiff ℝ ∞ g)
+    (i : Fin d) : ContDiff ℝ ∞ (∂[i] g) := by
+  have hfamily : ContDiff ℝ ∞ (fun x : Space d => fun j : Fin d => ∂[j] g x) := by
+    simpa using (Space.deriv_contDiff (n := ∞) hg)
+  simpa using (contDiff_apply ℝ ℝ i).comp hfamily
+
+lemma isTestFunction_space_deriv {g : Space d → ℝ} (hg : IsTestFunction g) (i : Fin d) :
+    IsTestFunction (∂[i] g) := by
+  simpa [Space.deriv_eq_fderiv_fun] using IsTestFunction.fderiv_apply hg (Space.basis i)
+
+lemma iteratedDerivList_contDiff (L : List (Fin d)) {g : Space d → ℝ}
+    (hg : ContDiff ℝ ∞ g) :
+    ContDiff ℝ ∞ (L.foldr (fun i h => ∂[i] h) g) := by
+  induction L generalizing g with
+  | nil =>
+      simpa using hg
+  | cons i L ih =>
+      have htail : ContDiff ℝ ∞ (L.foldr (fun j h => ∂[j] h) g) := ih hg
+      exact contDiff_space_deriv htail i
+
+lemma iteratedDerivList_isTestFunction (L : List (Fin d)) {g : Space d → ℝ}
+    (hg : IsTestFunction g) :
+    IsTestFunction (L.foldr (fun i h => ∂[i] h) g) := by
+  induction L generalizing g with
+  | nil =>
+      simpa using hg
+  | cons i L ih =>
+      simp only [List.foldr]
+      exact isTestFunction_space_deriv (ih hg) i
+
+lemma iteratedDerivList_commute_deriv (L : List (Fin d)) (i : Fin d)
+    {g : Space d → ℝ} (hg : ContDiff ℝ ∞ g) :
+    L.foldr (fun j h => ∂[j] h) (∂[i] g) = ∂[i] (L.foldr (fun j h => ∂[j] h) g) := by
+  induction L generalizing g with
+  | nil =>
+      rfl
+  | cons j L ih =>
+      simp only [List.foldr]
+      rw [ih hg]
+      rw [Space.deriv_commute (u := j) (v := i)]
+      have h2 : ContDiff ℝ (2 : ℕ∞) (L.foldr (fun j h => ∂[j] h) g) := by
+        exact (iteratedDerivList_contDiff L hg).of_le (by
+          exact WithTop.coe_le_coe.mpr le_top)
+      exact h2
+
+lemma iteratedDeriv_coord_isTestFunction (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (I : DerivativeIndex d k) (a : Fin m) :
+    IsTestFunction (fun x => ∂^[I.1] (fun y => (η y) a) x) := by
+  simpa [Space.iteratedDeriv, Space.coord] using
+    iteratedDerivList_isTestFunction I.1.toList (η.coord_euclidean a)
+
+lemma firstVariationDensityTerm_integrable_of_continuous_coordDeriv
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (I : DerivativeIndex d k) (a : Fin m)
+    (hcont : Continuous (fun x : Space d =>
+      L.coordDeriv I a (jetAt k f x))) :
+    Integrable (firstVariationDensityTerm L f η I a) := by
+  let ψ : Space d → ℝ := fun x => ∂^[I.1] (fun y => (η y) a) x
+  have hψ : IsTestFunction ψ := iteratedDeriv_coord_isTestFunction η I a
+  have hψcont : Continuous ψ := hψ.contDiff.continuous
+  have htermCont : Continuous (fun x => L.coordDeriv I a (jetAt k f x) * ψ x) :=
+    hcont.mul hψcont
+  have hsupp : HasCompactSupport (fun x => L.coordDeriv I a (jetAt k f x) * ψ x) :=
+    HasCompactSupport.mul_left hψ.supp
+  simpa [firstVariationDensityTerm, ψ] using
+    htermCont.integrable_of_hasCompactSupport hsupp
+
+/-!
+## C. Varied local-jet coordinates
+
+-/
+
+lemma continuous_jetBaseCoordinates_variedField
+    (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m)))
+    (hf : ContDiff ℝ ∞ f) :
+    Continuous
+      (fun p : ℝ × Space d => (p.2, jetCoordinatesAt k (variedField f η p.1) p.2)) := by
+  have hfjet : Continuous (jetCoordinatesAt k f) :=
+    (jetCoordinatesAt_contDiff k f hf).continuous
+  have hηjet : Continuous (jetCoordinatesAt k η) :=
+    (jetCoordinatesAt_contDiff k η η.isTestFunction.contDiff).continuous
+  have hcoord :
+      Continuous
+        (fun p : ℝ × Space d =>
+          jetCoordinatesAt k f p.2 + p.1 • jetCoordinatesAt k η p.2) := by
+    exact (hfjet.comp continuous_snd).add (continuous_fst.smul (hηjet.comp continuous_snd))
+  have hpair :
+      Continuous
+        (fun p : ℝ × Space d =>
+          (p.2, jetCoordinatesAt k f p.2 + p.1 • jetCoordinatesAt k η p.2)) := by
+    exact Continuous.prodMk continuous_snd hcoord
+  have heq :
+      (fun p : ℝ × Space d => (p.2, jetCoordinatesAt k (variedField f η p.1) p.2)) =
+      (fun p : ℝ × Space d =>
+        (p.2, jetCoordinatesAt k f p.2 + p.1 • jetCoordinatesAt k η p.2)) := by
+    funext p
+    congr 1
+    simpa [variedField] using
+      (jetCoordinatesAt_add_smul k f η p.2 p.1 hf η.isTestFunction.contDiff)
+  rw [heq]
+  exact hpair
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/JetPoint.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/JetPoint.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import Physlib.SpaceAndTime.Space.Derivatives.DerivativeIndex
+public import Physlib.SpaceAndTime.Space.Derivatives.Iterated
+/-!
+# Coordinate-level jet points
+
+## i. Overview
+
+This module introduces the coordinate-level point of the locally trivialized `k`-jet bundle for
+fields on `Space d` with values in `EuclideanSpace ℝ (Fin m)`.
+
+This module only formalizes the local coordinate model `Jet^k(Ω, ℝ^m) ≃ Ω × V`; it does not
+attempt to define global jet bundles.
+
+At this core stage, a jet point is represented by:
+
+- its base point in `Space d`,
+- and its jet coordinates indexed by derivative indices of order at most `k`.
+
+In particular, the zero-th order field value is not stored separately: it is the zero derivative
+coordinate.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.JetCoordinates`
+- `ClassicalFieldTheory.Local.JetPoint`
+- `ClassicalFieldTheory.Local.jetCoordinatesAt`
+- `ClassicalFieldTheory.Local.jetAt`
+
+## iii. Table of contents
+
+- A. Jet coordinates
+- B. Jet points
+- C. Jet points of fields
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  arXiv:1612.03100v2, Chapter 5, Section 5.1.
+
+-/
+
+@[expose] public section
+
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Jet coordinates
+
+-/
+
+/-- Coordinate data `u^a_I` for `k`-th order jet points.
+
+For each derivative index `I`, these are the scalar components of the corresponding
+`EuclideanSpace ℝ (Fin m)` fiber coordinate. We keep this componentwise form because the
+local Euler-Lagrange formulas are indexed by both `I` and `a`. -/
+abbrev JetCoordinates (d m k : ℕ) := DerivativeIndex d k → Fin m → ℝ
+
+/-!
+## B. Jet points
+
+-/
+
+/-- The coordinate-level points of the locally trivialized `k`-jet bundle for fields
+`Space d → EuclideanSpace ℝ (Fin m)`. -/
+structure JetPoint (d m k : ℕ) where
+  /-- The base point of the jet point. -/
+  base : Space d
+  /-- The jet coordinates indexed by all derivative indices of order at most `k`. -/
+  fiber : JetCoordinates d m k
+
+namespace JetPoint
+
+variable {d m k : ℕ}
+
+/-- The coordinate `u^a_I` of a jet point. -/
+def coord (J : JetPoint d m k) (I : DerivativeIndex d k) (a : Fin m) : ℝ := J.fiber I a
+
+/-- The zero-th order value encoded by a jet point. -/
+def value (J : JetPoint d m k) : EuclideanSpace ℝ (Fin m) :=
+  WithLp.toLp 2 fun a => J.coord 0 a
+
+@[simp]
+lemma value_apply (J : JetPoint d m k) (a : Fin m) :
+    J.value a = J.coord 0 a := by
+  simp [value]
+
+@[ext]
+lemma ext (J K : JetPoint d m k) (hbase : J.base = K.base)
+    (hcoord : ∀ I a, J.coord I a = K.coord I a) :
+    J = K := by
+  cases J with
+  | mk x u =>
+    cases K with
+    | mk y v =>
+      dsimp [coord] at hbase hcoord
+      subst y
+      congr
+      funext I a
+      exact hcoord I a
+
+/-- Build a jet point from a base point and its jet coordinates. -/
+def ofBaseCoordinates (x : Space d) (u : JetCoordinates d m k) : JetPoint d m k where
+  base := x
+  fiber := u
+
+/-- The base point and jet coordinates of a jet point. -/
+def toBaseCoordinates (J : JetPoint d m k) : Space d × JetCoordinates d m k := (J.base, J.fiber)
+
+@[simp]
+lemma ofBaseCoordinates_base (x : Space d) (u : JetCoordinates d m k) :
+    (ofBaseCoordinates x u).base = x := rfl
+
+@[simp]
+lemma ofBaseCoordinates_fiber (x : Space d) (u : JetCoordinates d m k) :
+    (ofBaseCoordinates x u).fiber = u := rfl
+
+@[simp]
+lemma ofBaseCoordinates_coord (x : Space d) (u : JetCoordinates d m k)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    (ofBaseCoordinates x u).coord I a = u I a := rfl
+
+@[simp]
+lemma ofBaseCoordinates_base_fiber (J : JetPoint d m k) :
+    ofBaseCoordinates J.base J.fiber = J := by
+  apply JetPoint.ext
+  · rfl
+  · intro I a
+    rfl
+
+@[simp]
+lemma toBaseCoordinates_ofBaseCoordinates (x : Space d) (u : JetCoordinates d m k) :
+    (ofBaseCoordinates x u).toBaseCoordinates = (x, u) := rfl
+
+end JetPoint
+
+/-!
+## C. Jet points of fields
+
+-/
+
+/-- The jet-coordinate function determined by a field `g`. -/
+noncomputable def jetCoordinatesAt (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) :
+    JetCoordinates d m k :=
+  fun I a => ∂^[I.1] (fun y => (g y) a) x
+
+/-- The coordinate-level `k`-jet point of a field `f` at the point `x`. -/
+noncomputable def jetAt (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    JetPoint d m k where
+  base := x
+  fiber := jetCoordinatesAt k f x
+
+@[simp]
+lemma jetAt_base (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    (jetAt k f x).base = x := rfl
+
+@[simp]
+lemma jetAt_value (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    (jetAt k f x).value = f x := by
+  ext a
+  simp [JetPoint.value, JetPoint.coord, jetAt, jetCoordinatesAt, Space.iteratedDeriv_zero]
+
+@[simp]
+lemma jetAt_coord (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    (jetAt k f x).coord I a = ∂^[I.1] (fun y => (f y) a) x := rfl
+
+lemma jetAt_coord_zero (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d)
+    (a : Fin m) :
+    (jetAt k f x).coord 0 a = (f x) a := by
+  simp [jetAt_coord]
+
+@[simp]
+lemma jetCoordinatesAt_eq (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    jetCoordinatesAt k g x I a = ∂^[I.1] (fun y => (g y) a) x := rfl
+
+lemma jetCoordinatesAt_zero (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (a : Fin m) :
+    jetCoordinatesAt k g x 0 a = (g x) a := by
+  simp [jetCoordinatesAt]
+
+lemma jetAt_eq_ofBaseCoordinates (k : ℕ) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) :
+    jetAt k f x = JetPoint.ofBaseCoordinates x (jetCoordinatesAt k f x) := by
+  apply JetPoint.ext
+  · rfl
+  · intro I a
+    rfl
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/JetPointFiber.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/JetPointFiber.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.JetPoint
+/-!
+# Fiber directions on jet points
+
+## i. Overview
+
+This module adds the affine fiber-direction structure on coordinate-level jet points.
+
+At this stage, it introduces:
+
+- fiber-coordinate data on jet points,
+- affine translation and line maps in the jet fiber,
+- and the jet-fiber direction determined by a field.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.JetFiberData`
+- `ClassicalFieldTheory.Local.JetPoint.addFiber`
+- `ClassicalFieldTheory.Local.JetPoint.lineMap`
+- `ClassicalFieldTheory.Local.jetDirectionAt`
+
+## iii. Table of contents
+
+- A. Fiber-coordinate data
+- B. Affine fiber structure on jet points
+- C. Fiber directions determined by fields
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+open Physlib
+open scoped ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Fiber-coordinate data
+
+-/
+
+/-- Fiber-coordinate data for jet points of order `k`. This records only the coordinates `u^a_I`,
+not the base point in `Space d`. -/
+structure JetFiberData (d m k : ℕ) where
+  /-- The fiber coordinates indexed by all derivative indices of order at most `k`. -/
+  coord : JetCoordinates d m k
+
+namespace JetFiberData
+
+variable {d m k : ℕ}
+
+instance : CoeFun (JetFiberData d m k) (fun _ => DerivativeIndex d k → Fin m → ℝ) where
+  coe V := V.coord
+
+@[ext]
+lemma ext (V W : JetFiberData d m k) (hcoord : ∀ I a, V.coord I a = W.coord I a) : V = W := by
+  cases V with
+  | mk coordV =>
+  cases W with
+  | mk coordW =>
+  have h : coordV = coordW := by
+    funext I
+    funext a
+    exact hcoord I a
+  cases h
+  rfl
+
+/-- The zero-th order component of a jet-fiber direction, corresponding to the field value. -/
+def value (V : JetFiberData d m k) : EuclideanSpace ℝ (Fin m) :=
+  WithLp.toLp 2 fun a => V.coord 0 a
+
+@[simp]
+lemma value_apply (V : JetFiberData d m k) (a : Fin m) :
+    V.value a = V.coord 0 a := by
+  simp [value]
+
+instance : Zero (JetFiberData d m k) where
+  zero := { coord := fun _ _ => 0 }
+
+instance : Add (JetFiberData d m k) where
+  add V W := { coord := fun I a => V.coord I a + W.coord I a }
+
+instance : SMul ℝ (JetFiberData d m k) where
+  smul c V := { coord := fun I a => c * V.coord I a }
+
+@[simp]
+lemma zero_coord (I : DerivativeIndex d k) (a : Fin m) :
+    (0 : JetFiberData d m k).coord I a = 0 := rfl
+
+@[simp]
+lemma add_coord (V W : JetFiberData d m k) (I : DerivativeIndex d k) (a : Fin m) :
+    (V + W).coord I a = V.coord I a + W.coord I a := rfl
+
+@[simp]
+lemma smul_coord (c : ℝ) (V : JetFiberData d m k) (I : DerivativeIndex d k) (a : Fin m) :
+    (c • V).coord I a = c * V.coord I a := rfl
+
+end JetFiberData
+
+/-!
+## B. Affine fiber structure on jet points
+
+-/
+
+namespace JetPoint
+
+variable {d m k : ℕ}
+
+/-- Translate a jet point by a fiber-direction increment. -/
+def addFiber (J : JetPoint d m k) (V : JetFiberData d m k) : JetPoint d m k where
+  base := J.base
+  fiber := fun I a => J.fiber I a + V.coord I a
+
+/-- The affine line in jet space through `J` in the fiber direction `V`. -/
+def lineMap (J : JetPoint d m k) (V : JetFiberData d m k) (s : ℝ) : JetPoint d m k :=
+  J.addFiber (s • V)
+
+@[simp]
+lemma addFiber_base (J : JetPoint d m k) (V : JetFiberData d m k) :
+    (J.addFiber V).base = J.base := rfl
+
+@[simp]
+lemma addFiber_value (J : JetPoint d m k) (V : JetFiberData d m k) :
+    (J.addFiber V).value = J.value + V.value := by
+  ext a
+  rfl
+
+@[simp]
+lemma addFiber_coord (J : JetPoint d m k) (V : JetFiberData d m k)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    (J.addFiber V).coord I a = J.coord I a + V.coord I a := rfl
+
+@[simp]
+lemma lineMap_base (J : JetPoint d m k) (V : JetFiberData d m k) (s : ℝ) :
+    (J.lineMap V s).base = J.base := rfl
+
+@[simp]
+lemma lineMap_coord (J : JetPoint d m k) (V : JetFiberData d m k) (s : ℝ)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    (J.lineMap V s).coord I a = J.coord I a + s * V.coord I a := rfl
+
+end JetPoint
+
+/-!
+## C. Fiber directions determined by fields
+
+-/
+
+/-- The jet-fiber direction determined by a field `g` at a point `x`. -/
+noncomputable def jetDirectionAt (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) :
+    JetFiberData d m k where
+  coord := jetCoordinatesAt k g x
+
+@[simp]
+lemma jetDirectionAt_coord (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d)
+    (I : DerivativeIndex d k) (a : Fin m) :
+    (jetDirectionAt k g x).coord I a = ∂^[I.1] (fun y => (g y) a) x := rfl
+
+lemma jetDirectionAt_coord_zero (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (a : Fin m) :
+    (jetDirectionAt k g x).coord 0 a = (g x) a := by
+  simp [jetDirectionAt_coord]
+
+lemma jetCoordinatesAt_add_smul (k : ℕ) (f g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (s : ℝ)
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) :
+    jetCoordinatesAt k (fun y => f y + s • g y) x =
+      jetCoordinatesAt k f x + s • jetCoordinatesAt k g x := by
+  funext I
+  funext a
+  have hfa : ContDiff ℝ ∞ (fun y => (f y) a) := by
+    simpa using (contDiff_piLp_apply (𝕜 := ℝ) (n := ∞) (p := 2)
+      (E := fun _ : Fin m => ℝ) (i := a)).comp hf
+  have hga : ContDiff ℝ ∞ (fun y => (g y) a) := by
+    simpa using (contDiff_piLp_apply (𝕜 := ℝ) (n := ∞) (p := 2)
+      (E := fun _ : Fin m => ℝ) (i := a)).comp hg
+  have hadd :
+      (fun y => (f y + s • g y) a) = (fun y => (f y) a) + s • fun y => (g y) a := by
+    funext y
+    simp [smul_eq_mul]
+  have hsg : ContDiff ℝ ∞ (s • fun y => (g y) a) := by
+    simpa using hga.const_smul s
+  simp [jetCoordinatesAt]
+  have hsum := congrFun (Space.iteratedDeriv_add I.1 hfa hsg) x
+  have hsmul := congrFun (Space.iteratedDeriv_const_smul I.1 s hga) x
+  calc
+    ∂^[I.1] ((fun y => (f y) a) + s • fun y => (g y) a) x
+      = (∂^[I.1] (fun y => (f y) a) + ∂^[I.1] (s • fun y => (g y) a)) x := by
+          simpa using hsum
+    _ = ∂^[I.1] (fun y => (f y) a) x + s * ∂^[I.1] (fun y => (g y) a) x := by
+          simp [Pi.add_apply, Pi.smul_apply, smul_eq_mul, hsmul]
+
+lemma jetAt_add_smul (k : ℕ) (f g : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (s : ℝ)
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) :
+    jetAt k (fun y => f y + s • g y) x = (jetAt k f x).lineMap (jetDirectionAt k g x) s := by
+  apply JetPoint.ext
+  · simp [JetPoint.lineMap]
+  · intro I a
+    have hfa : ContDiff ℝ ∞ (fun y => (f y) a) := by
+      simpa using (contDiff_piLp_apply (𝕜 := ℝ) (n := ∞) (p := 2)
+        (E := fun _ : Fin m => ℝ) (i := a)).comp hf
+    have hga : ContDiff ℝ ∞ (fun y => (g y) a) := by
+      simpa using (contDiff_piLp_apply (𝕜 := ℝ) (n := ∞) (p := 2)
+        (E := fun _ : Fin m => ℝ) (i := a)).comp hg
+    have hadd :
+        (fun y => (f y + s • g y) a) = (fun y => (f y) a) + s • fun y => (g y) a := by
+      funext y
+      simp [smul_eq_mul]
+    change ∂^[I.1] (fun y => (f y + s • g y) a) x =
+      ((jetAt k f x).lineMap (jetDirectionAt k g x) s).coord I a
+    rw [JetPoint.lineMap_coord, jetAt_coord, jetDirectionAt_coord]
+    rw [hadd]
+    have hsg : ContDiff ℝ ∞ (s • fun y => (g y) a) := by
+      simpa using hga.const_smul s
+    have hsum := congrFun (Space.iteratedDeriv_add I.1 hfa hsg) x
+    have hsmul := congrFun (Space.iteratedDeriv_const_smul I.1 s hga) x
+    calc
+      ∂^[I.1] ((fun y => (f y) a) + s • fun y => (g y) a) x
+        = (∂^[I.1] (fun y => (f y) a) + ∂^[I.1] (s • fun y => (g y) a)) x := hsum
+      _ = ∂^[I.1] (fun y => (f y) a) x + s * ∂^[I.1] (fun y => (g y) a) x := by
+          simp [Pi.add_apply, Pi.smul_apply, smul_eq_mul, hsmul]
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/JetPointRegularity.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/JetPointRegularity.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.JetPointFiber
+/-!
+# Regularity and support for jet-coordinate maps
+
+## i. Overview
+
+This module collects the analytic facts about coordinate-level jet maps that are needed later in
+the local variational argument.
+
+At this stage, it provides:
+
+- smoothness of jet-coordinate maps of smooth fields,
+- smoothness of the base-plus-coordinate jet map,
+- and vanishing of jet coordinates outside topological support.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.jetCoordinatesAt_contDiff`
+- `ClassicalFieldTheory.Local.jetBaseCoordinates_contDiff`
+- `ClassicalFieldTheory.Local.jetCoordinatesAt_eq_zero_of_notMem_tsupport`
+- `ClassicalFieldTheory.Local.jetDirectionAt_eq_zero_of_notMem_tsupport`
+
+## iii. Table of contents
+
+- A. Smoothness of jet-coordinate maps
+- B. Support and vanishing lemmas
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+open Physlib
+open scoped ContDiff Topology
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Smoothness of jet-coordinate maps
+
+-/
+
+/-- Smoothness of the jet-coordinate map of a smooth field. -/
+lemma jetCoordinatesAt_contDiff (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (hg : ContDiff ℝ ∞ g) :
+    ContDiff ℝ ∞ (jetCoordinatesAt k g) := by
+  refine contDiff_pi.2 ?_
+  intro I
+  refine contDiff_pi.2 ?_
+  intro a
+  have hga : ContDiff ℝ ∞ (fun y => (g y) a) := by
+    simpa using (contDiff_piLp_apply (𝕜 := ℝ) (n := ∞) (p := 2)
+      (E := fun _ : Fin m => ℝ) (i := a)).comp hg
+  simpa [jetCoordinatesAt] using Space.iteratedDeriv_contDiff I.1 hga
+
+/-- Smoothness of the base-plus-coordinate jet map of a smooth field. -/
+lemma jetBaseCoordinates_contDiff (k : ℕ) (g : Space d → EuclideanSpace ℝ (Fin m))
+    (hg : ContDiff ℝ ∞ g) :
+    ContDiff ℝ ∞ (fun x : Space d => (x, jetCoordinatesAt k g x)) := by
+  exact contDiff_id.prodMk (jetCoordinatesAt_contDiff k g hg)
+
+/-!
+## B. Support and vanishing lemmas
+
+-/
+
+private lemma notMem_tsupport_coord {g : Space d → EuclideanSpace ℝ (Fin m)} {x : Space d}
+    (hx : x ∉ tsupport g) (a : Fin m) :
+    x ∉ tsupport (fun y => (g y) a) := by
+  rw [notMem_tsupport_iff_eventuallyEq] at hx ⊢
+  filter_upwards [hx] with y hy
+  simp [hy]
+
+/-- Outside the topological support of a field, all of its jet coordinates vanish. -/
+lemma jetCoordinatesAt_eq_zero_of_notMem_tsupport (k : ℕ)
+    (g : Space d → EuclideanSpace ℝ (Fin m)) {x : Space d}
+    (hx : x ∉ tsupport g) :
+    jetCoordinatesAt k g x = 0 := by
+  funext I
+  funext a
+  exact Space.iteratedDeriv_eq_zero_of_notMem_tsupport I.1 (notMem_tsupport_coord hx a)
+
+/-- Outside the topological support of a field, the corresponding jet-fiber direction vanishes. -/
+lemma jetDirectionAt_eq_zero_of_notMem_tsupport (k : ℕ)
+    (g : Space d → EuclideanSpace ℝ (Fin m)) {x : Space d}
+    (hx : x ∉ tsupport g) :
+    jetDirectionAt k g x = 0 := by
+  ext I a
+  exact Space.iteratedDeriv_eq_zero_of_notMem_tsupport I.1 (notMem_tsupport_coord hx a)
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/Lagrangian.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/Lagrangian.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.JetPointRegularity
+public import PhyslibAlpha.ClassicalFieldTheory.Local.TotalDerivative
+/-!
+# Local Lagrangians
+
+## i. Overview
+
+This module defines local Lagrangians of finite order for fields on `Space d` with values in
+`EuclideanSpace ℝ (Fin m)`.
+
+In the first local stage of the Classical Field Theory development, a local `k`-th order
+Lagrangian is treated as a function on `JetPoint d m k`. This matches the local book-level picture
+`L : Jet^k(Ω, R^m) → R` while postponing any stronger smoothness packaging until the ambient
+structure on local jet-point data has been made explicit enough to support it naturally.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.Lagrangian` : local `k`-th order Lagrangians.
+- `ClassicalFieldTheory.Local.Lagrangian.coordDeriv` : coordinate derivatives with respect to the
+  jet coordinates `u^a_I`.
+- `ClassicalFieldTheory.Local.Lagrangian.SmoothInCoordinates` : the combined public regularity
+  package for smooth local lagrangians in explicit jet coordinates.
+- `ClassicalFieldTheory.Local.Lagrangian.alongField` : evaluate a local Lagrangian along the jets
+  of a field.
+
+## iii. Table of contents
+
+- A. Local Lagrangians
+- B. Regularity packages
+- C. Evaluation along a field
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  Chapter 5.
+
+-/
+
+@[expose] public section
+
+open Physlib
+open scoped BigOperators ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Local Lagrangians
+
+-/
+
+/-- A local `k`-th order Lagrangian for fields `Space d → EuclideanSpace ℝ (Fin m)`. -/
+structure Lagrangian (d m k : ℕ) where
+  /-- The underlying jet-dependent function. -/
+  toFun : JetPoint d m k → ℝ
+  /-- The derivatives of the Lagrangian with respect to the jet coordinates `u^a_I`. -/
+  coordDeriv : DerivativeIndex d k → Fin m → JetPoint d m k → ℝ
+  /-- The first derivative of the Lagrangian along affine lines in the jet-fiber coordinates is
+  given by the pairing with the coordinate derivatives. -/
+  hasDerivAlongFiber :
+    ∀ J : JetPoint d m k, ∀ V : JetFiberData d m k,
+      HasDerivAt (fun s : ℝ => toFun (J.lineMap V s))
+        (∑ I : DerivativeIndex d k, ∑ a : Fin m, coordDeriv I a J * V.coord I a) 0
+
+namespace Lagrangian
+
+variable {d m k : ℕ}
+
+instance : CoeFun (Lagrangian d m k) (fun _ => JetPoint d m k → ℝ) where
+  coe L := L.toFun
+
+/-- The derivative of `L` along the fiber-jet direction `V` based at `J`. -/
+noncomputable def fiberDerivative (L : Lagrangian d m k) (J : JetPoint d m k)
+    (V : JetFiberData d m k) : ℝ :=
+  ∑ I : DerivativeIndex d k, ∑ a : Fin m, L.coordDeriv I a J * V.coord I a
+
+lemma hasDerivAt_lineMap (L : Lagrangian d m k) (J : JetPoint d m k) (V : JetFiberData d m k) :
+    HasDerivAt (fun s : ℝ => L (J.lineMap V s)) (L.fiberDerivative J V) 0 := by
+  simpa [fiberDerivative] using L.hasDerivAlongFiber J V
+
+/-!
+## B. Regularity packages
+
+-/
+
+/-- Continuity of a local lagrangian in the explicit local jet coordinates `(x, u^a_I)`. -/
+def ContinuousInCoordinates (L : Lagrangian d m k) : Prop :=
+  Continuous (fun p : Space d × JetCoordinates d m k =>
+    L (JetPoint.ofBaseCoordinates p.1 p.2))
+
+/-- Intrinsic smoothness of the jet-coordinate derivatives of a local Lagrangian in the explicit
+local jet coordinates `(x, u^a_I)`. -/
+def ContDiffCoordDerivInCoordinates (L : Lagrangian d m k) : Prop :=
+  ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+    ContDiff ℝ ∞
+      (fun p : Space d × JetCoordinates d m k =>
+        L.coordDeriv I a (JetPoint.ofBaseCoordinates p.1 p.2))
+
+/-- Public regularity package for a smooth local lagrangian in explicit local jet coordinates:
+continuity of the lagrangian itself together with smoothness of all jet-coordinate derivatives. -/
+def SmoothInCoordinates (L : Lagrangian d m k) : Prop :=
+  L.ContinuousInCoordinates ∧ L.ContDiffCoordDerivInCoordinates
+
+/-- Smoothness of all coefficient functions `x ↦ ∂L/∂u_I^a (j^k f(x))` along a field `f`. -/
+def ContDiffCoordDerivAlongField (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+    ContDiff ℝ ∞ (fun x => L.coordDeriv I a (jetAt k f x))
+
+/-- Continuity of the coefficient family `(s, x) ↦ ∂L/∂u_I^a (j^k(F s)(x))` along a
+one-parameter family of fields `F : ℝ → Space d → EuclideanSpace ℝ (Fin m)`. -/
+def ContinuousCoordDerivAlongFamily (L : Lagrangian d m k)
+    (F : ℝ → Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  ∀ I : DerivativeIndex d k, ∀ a : Fin m,
+    Continuous (fun p : ℝ × Space d => L.coordDeriv I a (jetAt k (F p.1) p.2))
+
+lemma continuousAlongField_of_inCoordinates (L : Lagrangian d m k)
+    (hcont : ContinuousInCoordinates L) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hf : ContDiff ℝ ∞ f) :
+    Continuous (fun x : Space d => L (jetAt k f x)) := by
+  simpa only [Function.comp, jetAt_eq_ofBaseCoordinates] using
+    hcont.comp (jetBaseCoordinates_contDiff k f hf).continuous
+
+lemma contDiffCoordDerivAlongField_of_inCoordinates (L : Lagrangian d m k)
+    (hcoord : ContDiffCoordDerivInCoordinates L) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hf : ContDiff ℝ ∞ f) :
+    ContDiffCoordDerivAlongField L f := by
+  intro I a
+  have hjet : ContDiff ℝ ∞ (fun x : Space d => (x, jetCoordinatesAt k f x)) :=
+    jetBaseCoordinates_contDiff k f hf
+  have hcomp :=
+    (hcoord I a).comp hjet
+  simpa only [Function.comp, jetAt_eq_ofBaseCoordinates] using hcomp
+
+lemma continuousCoordDerivAlongFamily_of_inCoordinates (L : Lagrangian d m k)
+    (hcoord : ContDiffCoordDerivInCoordinates L)
+    (F : ℝ → Space d → EuclideanSpace ℝ (Fin m))
+    (hjet : Continuous (fun p : ℝ × Space d => (p.2, jetCoordinatesAt k (F p.1) p.2))) :
+    ContinuousCoordDerivAlongFamily L F := by
+  intro I a
+  have hbase :
+      Continuous
+        (fun p : ℝ × Space d =>
+          L.coordDeriv I a (JetPoint.ofBaseCoordinates p.2 (jetCoordinatesAt k (F p.1) p.2))) := by
+    exact (hcoord I a).continuous.comp hjet
+  simpa only [jetAt_eq_ofBaseCoordinates] using hbase
+
+/-!
+## C. Evaluation along a field
+
+-/
+
+/-- Evaluate a local Lagrangian along the `k`-jets of a field. -/
+noncomputable def alongField (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  evalOnJet k L f
+
+@[simp]
+lemma alongField_apply (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    L.alongField f x = L (jetAt k f x) := rfl
+
+end Lagrangian
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/TotalDerivative.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/TotalDerivative.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.JetPoint
+/-!
+# Total derivatives on local jet-dependent functions
+
+## i. Overview
+
+This module defines total derivatives of local jet-dependent functions by differentiating their
+evaluation along jets of fields.
+
+For the first local stage, this keeps the operator close to the use made in the Euler-Lagrange
+formula, without yet introducing a separate coordinate-level derivative calculus on `JetPoint`.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.evalOnJet` : evaluate a jet-dependent function along a field.
+- `ClassicalFieldTheory.Local.totalDerivative` : total derivative in one coordinate direction.
+- `ClassicalFieldTheory.Local.iteratedTotalDerivative` : iterated total derivative indexed by a
+  multi-index.
+
+## iii. Table of contents
+
+- A. Evaluation on jets
+- B. Total derivatives
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Evaluation on jets
+
+-/
+
+/-- Evaluate a local jet-dependent function along the `k`-jet of a field. -/
+noncomputable def evalOnJet (k : ℕ) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    Space d → ℝ :=
+  fun x => F (jetAt k f x)
+
+/-!
+## B. Total derivatives
+
+-/
+
+/-- The total derivative of a jet-dependent function in the coordinate direction `i`. -/
+noncomputable def totalDerivative (k : ℕ) (i : Fin d) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  ∂[i] (evalOnJet k F f)
+
+/-- The iterated total derivative indexed by a multi-index. -/
+noncomputable def iteratedTotalDerivative (k : ℕ) (I : MultiIndex d) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  ∂^[I] (evalOnJet k F f)
+
+@[simp]
+lemma evalOnJet_apply (k : ℕ) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    evalOnJet k F f x = F (jetAt k f x) := rfl
+
+@[simp]
+lemma totalDerivative_eq (k : ℕ) (i : Fin d) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    totalDerivative k i F f = ∂[i] (fun x => F (jetAt k f x)) := rfl
+
+@[simp]
+lemma iteratedTotalDerivative_eq (k : ℕ) (I : MultiIndex d) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    iteratedTotalDerivative k I F f = ∂^[I] (fun x => F (jetAt k f x)) := rfl
+
+lemma iteratedTotalDerivative_zero (k : ℕ) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    iteratedTotalDerivative k (0 : MultiIndex d) F f = evalOnJet k F f := by
+  simp [iteratedTotalDerivative]
+
+lemma iteratedTotalDerivative_single (k : ℕ) (i : Fin d) (F : JetPoint d m k → ℝ)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    iteratedTotalDerivative k (Physlib.MultiIndex.increment 0 i) F f =
+      totalDerivative k i F f := by
+  simp [iteratedTotalDerivative, totalDerivative]
+
+end Local
+end ClassicalFieldTheory

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/Variation.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/Variation.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import Physlib.ClassicalFieldTheory.Local.Variation
+/-!
+# Alpha extensions for admissible local variations
+
+## i. Overview
+
+This module adds the Euclidean component API needed by the coordinate-readout CFT stack in
+`PhyslibAlpha`.
+
+The underlying `AdmissibleVariation` structure remains the maintained one from `Physlib`; this file
+only adds helper lemmas used by the Alpha development.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.AdmissibleVariation.coord_euclidean`
+
+-/
+
+@[expose] public section
+
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+namespace AdmissibleVariation
+
+variable {d m : ℕ}
+
+/-- A Euclidean component of an admissible variation is again a test function. -/
+@[fun_prop]
+lemma coord_euclidean (η : AdmissibleVariation d (EuclideanSpace ℝ (Fin m))) (a : Fin m) :
+    IsTestFunction (fun x => (η.toFun x) a) := by
+  exact η.isTestFunction.comp_left (g := fun v : EuclideanSpace ℝ (Fin m) => v a)
+    (by simp) (by fun_prop)
+
+end AdmissibleVariation
+
+end Local
+end ClassicalFieldTheory


### PR DESCRIPTION
This PR moves the local classical field theory stack into `PhyslibAlpha`, following the discussion on the previous core `Physlib` PR about developing this coordinate-first material in the Alpha area first.

The development is based on the coordinate local setup used in Cortes--Haupt, [arXiv:1612.03100v2](https://arxiv.org/abs/1612.03100v2): fields `Space d -> EuclideanSpace ℝ (Fin m)`, coordinate-level jet points, local Lagrangians, total derivatives, and the first-variation / Euler--Lagrange pipeline.

The stack added here includes:

- coordinate-level jet points and jet fiber directions;
- regularity/support lemmas for jet-coordinate maps;
- total derivatives of jet-dependent functions;
- local Lagrangians and their coordinate derivatives;
- local action/criticality definitions;
- Euler--Lagrange operators;
- first-variation density, integration-by-parts, regularity, support, and criterion modules.

The underlying maintained `AdmissibleVariation` structure remains imported from `Physlib`; Alpha only adds the Euclidean component helper needed by this coordinate stack.

Validation run locally:

- `lake build PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation`
- `lake build PhyslibAlpha`
- `lake exe runPhyslibAlphaLinters`
- `./scripts/PhyslibAlpha/alphaFileImports.py`
- `./scripts/PhyslibAlpha/noAlphaImports.py`
- `./scripts/PhyslibAlpha/alphaPythonLinters.sh`
