### PR TITLE
feat: generalized Kronecker delta definition

### DIFF
--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -144,7 +144,7 @@ open Matrix
 local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
 
 /-- Generalized Kronecker delta:
-`δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`. 
+`δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`.
 
 This is defined for any finite type `α` with decidable equality. -/
 def generalizedKroneckerDelta {α : Type} [DecidableEq α] [Fintype α] (n : ℕ)

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 public import Mathlib.Algebra.CharZero.Defs
 public import Mathlib.Algebra.Field.Defs
 public import Mathlib.Algebra.Module.Defs
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 /-!
 
 # Kronecker delta

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -144,9 +144,11 @@ open Matrix
 local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
 
 /-- Generalized Kronecker delta:
-`δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`. -/
-def generalizedKroneckerDelta (n : ℕ) (d : ℕ := 3)
-    (μ : Fin n → Fin (d + 1)) (ν : Fin n → Fin (d + 1)) : ℤ :=
+`δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`. 
+
+This is defined for any finite type `α` with decidable equality. -/
+def generalizedKroneckerDelta {α : Type} [DecidableEq α] [Fintype α] (n : ℕ)
+    (μ : Fin n → α) (ν : Fin n → α) : ℤ :=
   Matrix.det (fun i j => δℤ (μ i) (ν j))
 
 end Generalized

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -147,8 +147,8 @@ local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
 `δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`.
 
 This is defined for any finite type `α` with decidable equality. -/
-def generalizedKroneckerDelta {α ι : Type} [DecidableEq α] [Fintype α] 
-    [DecidableEq ι] [Fintype ι] 
+def generalizedKroneckerDelta {α ι : Type} [DecidableEq α] [Fintype α]
+    [DecidableEq ι] [Fintype ι]
     (μ : ι → α) (ν : ι → α) : ℤ :=
   Matrix.det (fun i j => δℤ (μ i) (ν j))
 

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -131,4 +131,24 @@ lemma finset_sum_sum_smul_eq_zero {s s' : Finset α} {f : α → α → M}
 
 end Sums
 
+/-!
+
+# Generalized Kronecker delta
+
+-/
+
+section Generalized
+open Matrix
+
+/-- Integer-valued Kronecker entry via the existing `kroneckerDelta`. -/
+local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
+
+/-- Generalized Kronecker delta:
+`δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`. -/
+def generalizedKroneckerDelta (n : ℕ) (d : ℕ := 3)
+    (μ : Fin n → Fin (d + 1)) (ν : Fin n → Fin (d + 1)) : ℤ :=
+  Matrix.det (fun i j => δℤ (μ i) (ν j))
+
+end Generalized
+
 end KroneckerDelta

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -148,7 +148,7 @@ local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
 `δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`.
 
 This is defined for any finite type `α` with decidable equality. -/
-def generalizedKroneckerDelta {α ι : Type} [DecidableEq α] [Fintype α]
+def generalizedKroneckerDelta {α ι : Type} [DecidableEq α]
     [DecidableEq ι] [Fintype ι]
     (μ : ι → α) (ν : ι → α) : ℤ :=
   Matrix.det (fun i j => δℤ (μ i) (ν j))

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -147,8 +147,9 @@ local notation "δℤ" => (fun ρ σ => ((kroneckerDelta ρ σ : ℕ) : ℤ))
 `δ^{μ₁...μₙ}_{ν₁...νₙ} = det (δ[μᵢ, νⱼ])`.
 
 This is defined for any finite type `α` with decidable equality. -/
-def generalizedKroneckerDelta {α : Type} [DecidableEq α] [Fintype α] (n : ℕ)
-    (μ : Fin n → α) (ν : Fin n → α) : ℤ :=
+def generalizedKroneckerDelta {α ι : Type} [DecidableEq α] [Fintype α] 
+    [DecidableEq ι] [Fintype ι] 
+    (μ : ι → α) (ν : ι → α) : ℤ :=
   Matrix.det (fun i j => δℤ (μ i) (ν j))
 
 end Generalized

--- a/Physlib/Mathematics/KroneckerDelta.lean
+++ b/Physlib/Mathematics/KroneckerDelta.lean
@@ -57,7 +57,7 @@ lemma smul_of_eq_zero [AddMonoid M] (i j : α) {f : α → α → M} (hf : f i i
 lemma smul_eq_zero_iff [AddMonoid M] (i j : α) (f : α → α → M) :
     δ[i,j] • f i j = 0 ↔ i ≠ j ∨ f i i = 0 := by
   rcases eq_or_ne i j with (rfl | hne)
-  · simp [one_nsmul]
+  · simp
   · simp [eq_zero_of_ne, hne]
 
 lemma smul_eq_zero_iff' [AddMonoid M] (i : α) (f : α → α → M) :
@@ -83,7 +83,7 @@ lemma smul_symm [AddMonoid M] (i j : α) (f : α → α → M) : δ[i,j] • f j
 lemma symmetrize [AddMonoid M] (i j : α) (f : α → α → M) :
     δ[i,j] • (f i j + f j i) = (2 * δ[i,j]) • f i j := by
   rcases eq_or_ne i j with (rfl | hne)
-  · simp [one_nsmul, two_nsmul]
+  · simp [two_nsmul]
   · simp [eq_zero_of_ne hne]
 
 lemma symmetrize' [AddCommMonoid M] {K : Type*} [Semifield K] [CharZero K] [Module K M]
@@ -114,7 +114,7 @@ lemma sum_mul [Fintype α] (i j : α) : ∑ k : α, δ[i,k] * δ[k,j] = δ[i,j] 
 
 @[simp]
 lemma sum_smul [Fintype α] (i : α) (f : α → M) : ∑ j : α, δ[i,j] • f j = f i := by
-  simp [kroneckerDelta, one_nsmul]
+  simp [kroneckerDelta]
 
 lemma sum_sum_smul_eq_zero [Fintype α] {f : α → α → M} (hf : ∀ i : α, f i i = 0) :
     ∑ i : α, ∑ j : α, δ[i,j] • f i j = 0 := by
@@ -122,7 +122,7 @@ lemma sum_sum_smul_eq_zero [Fintype α] {f : α → α → M} (hf : ∀ i : α, 
 
 lemma finset_sum_smul (s : Finset α) (i : α) (f : α → M) :
     ∑ j ∈ s, δ[i,j] • f j = if i ∈ s then f i else 0 := by
-  simp [kroneckerDelta, one_nsmul]
+  simp [kroneckerDelta]
 
 lemma finset_sum_sum_smul_eq_zero {s s' : Finset α} {f : α → α → M}
     (hf : ∀ i ∈ s ∩ s', f i i = 0) : ∑ i ∈ s, ∑ j ∈ s', δ[i,j] • f i j = 0 := by


### PR DESCRIPTION
This is my first small definitional PR on the way to proving the gamma matrix trace identities in QFT, part assisted by AI and as part of a general Lean learning trajectory:
1. the generalized Kronecker delta (https://en.wikipedia.org/wiki/Kronecker_delta#Definitions_of_the_generalized_Kronecker_delta) is the Levi-Civita symbol ε^{μνρσ} that comes about in trace identities,
2. contractions over the generalized Kronecker delta, in particular δ^{μ₁...μₖ λₖ₊₁...λₙ}\_{μ₁...μₖ ωₖ₊₁...ωₙ} = k! δ^{λₖ₊₁...λₙ}\_{ωₖ₊₁...ωₙ}, are at the basis of proving (naturally) Levi-Civita contractions like ε^{μνρσ} ε_{μνρτ} = -6 g^σ_τ,
3. this then leads to proofs of e.g. Tr[ γ5 /a /b /c /d ] = 4i ε^{μνρσ} a_μ b_ν c_ρ d_σ, (with /a the slash notation for a_μ γ^μ).

## Review map:
This PR only changes Physlib/Mathematics/KroneckerDelta.lean (where the 1D Kronecker delta is already), and adds the definition of the generalized Kronecker delta. Due to the sign, this must be over ℤ, not just ℕ. ~~Due to this being inside Physlib, I'm using a d = 3 default spatial dimensions.~~ *Indices can be any finite type with decidable equality.*

## Future work:
I'm hoping to extend this gradually (potentially putting some things in PhyslibAlpha) with additional proofs.
- Physlib/Mathematics/KroneckerDelta.lean for the contraction property proof and lemmas (~350 lines),
- Physlib/Relativity/Tensors/RealTensor/Metrics/LeviCivita.lean for the definition of the Levi-Civita symbol as
```
abbrev leviCivita4Int (μ ν ρ σ : Fin 4) : ℤ :=
  generalizedKroneckerDelta 4 ![μ, ν, ρ, σ] id
```
and the associated contraction identities (based on `generalizedKroneckerDelta_contraction`)
- Physlib/Relativity/CliffordAlgebra.lean with the definition of the slash as
```
def slash (k : Lorentz.Vector 3) : Matrix (Fin 4) (Fin 4) ℂ :=
  ∑ μ, coord k μ • γ μ
```
and the associated identities.

The heavy lift is the generalized Kronecker delta contraction identity which relies on Laplace expansion (cofactor expansion) and I couldn't find a lot of pre-existing functionality in mathlib. I'm not happy with that and hope to figure out a more compact proof.

## AI disclosure

This particular definition is minor enough and has been modified a few times by me (e.g. to prefer ℤ over ℝ, and to reuse the existing definition), but it originates in an AI session. The pitfalls addressed in the AI instructions in #1187 are relevant (i.e. AI reinventing stuff that's already in mathlib).
