### PR TITLE
feat(QuantumMechanics): Begin spectral theory of symmetric operators

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -265,6 +265,7 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.Momentum
 public import Physlib.QuantumMechanics.DDimensions.Operators.Multiplication
 public import Physlib.QuantumMechanics.DDimensions.Operators.Position
 public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basic
+public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Symmetric
 public import Physlib.QuantumMechanics.DDimensions.Operators.StateObservables.ExpectedValue
 public import Physlib.QuantumMechanics.DDimensions.Operators.StateObservables.IsEigenvector
 public import Physlib.QuantumMechanics.DDimensions.Operators.StateObservables.Variance

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -440,15 +440,25 @@ scoped notation "Θ" => numericalRange
 
 lemma numericalRange_eq (T : H →ₗ.[ℂ] H) : Θ T = (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x | ‖x‖ = 1} := rfl
 
-lemma numericalRange_nonempty {T : H →ₗ.[ℂ] H} (hT : T.domain ≠ ⊥) : T.numericalRange.Nonempty := by
-  obtain ⟨x, hx, hx'⟩ := exists_mem_ne_zero_of_ne_bot hT
-  refine ⟨(‖x‖ ^ 2)⁻¹ * ⟪x, T ⟨x, hx⟩⟫_ℂ, ofReal ‖x‖⁻¹ • ⟨x, hx⟩, ?_, ?_⟩
-  · simp [norm_smul, inv_mul_cancel₀ (norm_ne_zero_iff.mpr hx')]
+lemma mem_numericalRange {T : H →ₗ.[ℂ] H} {x : T.domain} (hx : x ≠ 0) :
+    (‖x‖ ^ 2)⁻¹ * ⟪↑x, T x⟫_ℂ ∈ Θ T := by
+  refine ⟨ofReal ‖x‖⁻¹ • x, ?_, ?_⟩
+  · simp [norm_smul, inv_mul_cancel₀, hx]
   · simp_rw [map_smul]
     simp [inner_smul_left, inner_smul_right, ← mul_assoc, pow_two]
 
-lemma numericalRange_smul (T : H →ₗ.[ℂ] H) (c : ℂ) :
-    (c • T).numericalRange = c • T.numericalRange := by
+lemma numericalRange_nonempty {T : H →ₗ.[ℂ] H} (hT : T.domain ≠ ⊥) : (Θ T).Nonempty := by
+  obtain ⟨x, hx, hx'⟩ := exists_mem_ne_zero_of_ne_bot hT
+  use (‖x‖ ^ 2)⁻¹ * ⟪x, T ⟨x, hx⟩⟫_ℂ
+  exact mem_numericalRange (x := ⟨x, hx⟩) (Subtype.coe_ne_coe.mp hx')
+
+@[simp]
+lemma numericalRange_neg (T : H →ₗ.[ℂ] H) : Θ (-T) = -Θ T := by
+  ext
+  simp [numericalRange_eq, neg_eq_iff_eq_neg]
+
+@[simp]
+lemma numericalRange_smul (T : H →ₗ.[ℂ] H) (c : ℂ) : Θ (c • T) = c • Θ T := by
   ext
   simp [numericalRange_eq, inner_smul_right, mem_smul_set]
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -38,7 +38,7 @@ Definitions (corresponding to an operator `T : H →ₗ.[ℂ] H`)
     is orthogonal to the range of `T - z • 1`.
 - `LinearPMap.defectNumber` : Given a complex number `z`, the rank of the corresponding
     deficiency subspace as a (possibly infinite) cardinal.
-- `LinearPMap.numericalRange` : The set of complex numbers `⟪x, T x⟫_ℂ` as `x` ranges over
+- `LinearPMap.numericalRange` (`Θ`) : The set of complex numbers `⟪x, T x⟫_ℂ` as `x` ranges over
     the unit sphere in `T.domain`.
 - `LinearPMap.resolventSet` (`ρ`) : The set of complex numbers `z` for which `T - z • 1`
     has a continuous (equivalently, bounded) inverse with domain all of `H`.
@@ -435,8 +435,10 @@ lemma IsClosable.defectNumber_const [CompleteSpace H]
 /-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1} ⊆ ℂ`. -/
 def numericalRange (T : H →ₗ.[ℂ] H) : Set ℂ := (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x : T.domain | ‖x‖ = 1}
 
-lemma numericalRange_eq (T : H →ₗ.[ℂ] H) :
-    T.numericalRange = (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x | ‖x‖ = 1} := rfl
+@[inherit_doc numericalRange]
+scoped notation "Θ" => numericalRange
+
+lemma numericalRange_eq (T : H →ₗ.[ℂ] H) : Θ T = (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x | ‖x‖ = 1} := rfl
 
 lemma numericalRange_nonempty {T : H →ₗ.[ℂ] H} (hT : T.domain ≠ ⊥) : T.numericalRange.Nonempty := by
   obtain ⟨x, hx, hx'⟩ := exists_mem_ne_zero_of_ne_bot hT
@@ -450,8 +452,7 @@ lemma numericalRange_smul (T : H →ₗ.[ℂ] H) (c : ℂ) :
   ext
   simp [numericalRange_eq, inner_smul_right, mem_smul_set]
 
-lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) :
-    (T - c • 1).numericalRange = T.numericalRange - {c} := by
+lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) : Θ (T - c • 1) = Θ T - {c} := by
   ext z
   constructor
   · intro ⟨x, hx, hxz⟩
@@ -464,13 +465,13 @@ lemma numericalRange_sub_const (T : H →ₗ.[ℂ] H) (c : ℂ) :
 
 /-- The regularity domain contains the exterior of the numerical range. -/
 lemma compl_closure_numericalRange_subset_regularityDomain (T : H →ₗ.[ℂ] H) :
-    (_root_.closure T.numericalRange)ᶜ ⊆ T.regularityDomain := by
+    (_root_.closure (Θ T))ᶜ ⊆ T.regularityDomain := by
   intro z hz
   by_cases hT : T.domain = ⊥
   · refine ⟨1, zero_lt_one, fun ⟨x, hx⟩ ↦ ?_⟩
     rw [hT] at hx
     simp_all
-  · use infDist z T.numericalRange
+  · use infDist z (Θ T)
     constructor
     · exact (infDist_pos_iff_notMem_closure <| numericalRange_nonempty hT).mp hz
     · intro x
@@ -513,7 +514,7 @@ private lemma exists_phase_add_im_eq_zero (z₁ z₂ : ℂ) :
     exact (mem_image _ _ _).mp (hIVT ⟨by linarith, by linarith⟩)
 
 /-- The Toeplitz-Hausdorff theorem. -/
-theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRange := by
+theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ (Θ T) := by
   intro z₀ hz₀ z₁ hz₁ a b ha hb hab
   rcases eq_or_ne z₁ z₀ with rfl | hz
   · simp [← add_mul, eq_sub_iff_add_eq.mpr hab, hz₁]
@@ -528,7 +529,7 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
     have hy₁ : ‖y₁‖ = 1 := hx₁
     have h₀ : ⟪↑y₀, S y₀⟫_ℂ = 0 := by simp_all [S, y₀, sub_apply, inner_smul_right, inner_sub_right]
     have h₁ : ⟪↑y₁, S y₁⟫_ℂ = 1 := by simp_all [S, y₁, sub_apply, inner_smul_right, inner_sub_right]
-    suffices ofReal '' unitInterval ⊆ S.numericalRange by
+    suffices ofReal '' unitInterval ⊆ Θ S by
       have hba : a = 1 - b := by linarith
       rw [numericalRange_smul, numericalRange_sub_const] at this
       obtain ⟨c, hc, hca⟩ := (image_subset_iff.mp this) ⟨hb, by linarith⟩
@@ -564,8 +565,8 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
             simp [map_smul, inner_smul_left, inner_smul_right, ← mul_assoc, pow_two]
           _ = ⟪↑(-(r • y₂)), S (-(r • y₂))⟫_ℂ := by simp [eq_neg_iff_add_eq_zero.mpr hr]
         simp [map_neg, ← Complex.coe_smul, map_smul, inner_smul_left, inner_smul_right, pow_two, h₂]
-    -- `g r = ⟪f r, S (f r)⟫_ℂ / ‖f r‖²` is real (by def of `θ`) and clearly in `S.numericalRange`.
-    -- `g 0 = 0`, `g 1 = 1` and continuity ensure that all of `[0,1]` is also in `S.numericalRange`.
+    -- `g r = ⟪f r, S (f r)⟫_ℂ / ‖f r‖²` is real (by def of `θ`) and clearly in `Θ S`.
+    -- `g 0 = 0`, `g 1 = 1` and continuity ensure that all of `[0,1]` is also in `Θ S`.
     let g : ℝ → ℝ := fun t ↦ (t ^ 2 + (1 - t) * t * (⟪↑y₀, S y₂⟫_ℂ + ⟪↑y₂, S y₀⟫_ℂ).re) / ‖f t‖ ^ 2
     have hg₀ : g 0 = 0 := by simp [g]
     have hg₁ : g 1 = 1 := by simp [g, f, coe_norm y₂ ▸ hy₂]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -98,6 +98,7 @@ open Metric
 open InnerProductSpace
 open Complex
 open Set
+open Pointwise
 
 /-- The resolvent, `(T - z • 1)⁻¹`. -/
 abbrev resolvent (T : H →ₗ.[ℂ] H) (z : ℂ) : H →ₗ.[ℂ] H := (T - z • 1).inverse
@@ -111,6 +112,11 @@ local notation "𝑅" => resolvent
 
 /-- `IsLowerBound T z c` is the property that `c * ‖x‖ ≤ ‖T x - z • x‖` for all `x : T.domain`. -/
 def IsLowerBound (T : H →ₗ.[ℂ] H) (z : ℂ) (c : ℝ) : Prop := ∀ x : T.domain, c * ‖x‖ ≤ ‖T x - z • x‖
+
+lemma isLowerBound_neg {T : H →ₗ.[ℂ] H} {z : ℂ} {c : ℝ} (h : IsLowerBound T z c) :
+    IsLowerBound (-T) (-z) c := by
+  intro x
+  simp only [neg_apply, neg_smul, sub_neg_eq_add, norm_neg_add, h x]
 
 lemma isLowerBound_of_right_le
     {T : H →ₗ.[ℂ] H} {z : ℂ} {c₁ c₂ : ℝ} (hle : c₁ ≤ c₂) (h : IsLowerBound T z c₂) :
@@ -141,6 +147,33 @@ lemma isLowerBound_closure
   `z : ℂ` is a regular point for `T` iff there exists a constant `c > 0` such that
   `c * ‖x‖ ≤ ‖(T - z • 1) x‖` for all `x ∈ T.domain`. -/
 def regularityDomain (T : H →ₗ.[ℂ] H) : Set ℂ := {z : ℂ | ∃ c > 0, IsLowerBound T z c}
+
+@[simp]
+lemma regularityDomain_neg (T : H →ₗ.[ℂ] H) : (-T).regularityDomain = -T.regularityDomain := by
+  ext z
+  constructor
+  · exact fun ⟨c, hc, h_bound⟩ ↦ ⟨c, hc, neg_neg T ▸ isLowerBound_neg h_bound⟩
+  · exact fun ⟨c, hc, h_bound⟩ ↦ ⟨c, hc, neg_neg z ▸ isLowerBound_neg h_bound⟩
+
+@[simp]
+lemma regularityDomain_smul (T : H →ₗ.[ℂ] H) {w : ℂ} (hw : w ≠ 0) :
+    (w • T).regularityDomain = w • T.regularityDomain := by
+  ext z
+  constructor
+  · intro ⟨c, hc, h_bound⟩
+    refine ⟨w⁻¹ * z, ?_, ?_⟩
+    · refine ⟨‖w‖⁻¹ * c, by positivity, fun x ↦ ?_⟩
+      rw [mul_assoc]
+      apply (inv_mul_le_iff₀ <| norm_pos_iff.mpr hw).mpr
+      rw [← norm_smul, smul_sub, smul_smul, mul_inv_cancel_left₀ hw]
+      exact h_bound x
+    · simp [hw]
+  · intro ⟨u, ⟨c, hc, h_bound⟩, huz⟩
+    refine ⟨‖w‖ * c, by positivity, fun x ↦ ?_⟩
+    rw [mul_assoc]
+    apply (le_inv_mul_iff₀ <| norm_pos_iff.mpr hw).mp
+    refine le_of_le_of_eq (h_bound x) ?_
+    simp [← norm_inv, ← norm_smul, smul_sub, smul_smul, ← huz, hw]
 
 /-- `T ≤ T'` implies `T'.regularityDomain ⊆ T.regularityDomain`. -/
 lemma regularityDomain_antitone : Antitone (regularityDomain (H := H)) :=
@@ -399,10 +432,6 @@ lemma IsClosable.defectNumber_const [CompleteSpace H]
 ## C. Numerical range
 -/
 
-section
-
-open Pointwise
-
 /-- The set `{⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1} ⊆ ℂ`. -/
 def numericalRange (T : H →ₗ.[ℂ] H) : Set ℂ := (fun x ↦ ⟪↑x, T x⟫_ℂ) '' {x : T.domain | ‖x‖ = 1}
 
@@ -560,8 +589,6 @@ theorem numericalRange_convex (T : H →ₗ.[ℂ] H) : Convex ℝ T.numericalRan
         zero_add, ofReal_neg, neg_mul, mul_neg, mul_one, add_re, ofReal_add, ofReal_mul,
         ofReal_sub, ofReal_one, ofReal_pow]
       ring
-
-end
 
 /-!
 ## D. Spectrum of a closed operator

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -130,5 +130,72 @@ lemma Ioi_subset_regularityDomain {m : ℝ} (h : m ∈ upperBounds (Θᵣₑ T))
   · exact fun _ _ ↦ by simp_all [neg_le.mp, upperBounds]
   · exact ⟨-r, by simp [mem_Ioi.mp hr], by simp [hrz]⟩
 
+/-- The regularity domain of a symmetric operator is connected iff it contains a real number. -/
+lemma regularityDomain_isConnected_iff :
+    IsConnected T.regularityDomain ↔ (ofReal ⁻¹' T.regularityDomain).Nonempty := by
+  rw [T.regularityDomain_isOpen.isConnected_iff_isPathConnected]
+  constructor
+  · intro h
+    obtain ⟨f, hf⟩ : JoinedIn T.regularityDomain (-I) I := by
+      refine h.joinedIn (-I) ?_ I ?_
+      · exact hT.mem_regularityDomain_of_im_ne_zero (by simp)
+      · exact hT.mem_regularityDomain_of_im_ne_zero (by simp)
+    obtain ⟨t, ht⟩ : ∃ t, (f t).im = 0 := by
+      have hIVT := intermediate_value_Icc (f := fun t ↦ (f t).im) zero_le_one (by fun_prop)
+      simp only [Path.source, neg_im, I_im, Path.target] at hIVT
+      have h₀ : (0 : ℝ) ∈ Icc (-1) 1 := by simp
+      exact ⟨(hIVT h₀).choose, (hIVT h₀).choose_spec.2⟩
+    specialize hf t
+    rw [← re_add_im (f t), ht] at hf
+    exact ⟨(f t).re, by simp_all⟩
+  · intro ⟨r, hr⟩
+    apply mem_preimage.mp at hr
+    refine isPathConnected_iff.mpr ⟨?_, fun z₁ hz₁ z₂ hz₂ ↦ ?_⟩
+    · exact ⟨I, hT.mem_regularityDomain_of_im_ne_zero (by simp)⟩
+    · have h : ∀ z ∈ T.regularityDomain, JoinedIn T.regularityDomain z r := by
+        intro z hz
+        by_cases hz_im : z.im = 0
+        · rcases eq_or_ne z r with rfl | hzr
+          · exact JoinedIn.refl hr
+          · let path : Path z r := {
+              toFun t := ((z + r) + (z - r) * cexp (Real.pi * t * I)) / 2
+              source' := by simp
+              target' := by simp [add_comm z r, add_add_sub_cancel]
+            }
+            refine ⟨path, fun t ↦ ?_⟩
+            by_cases! ht : ∃ n : ℤ, n = (t : ℝ)
+            · obtain ⟨n, htn⟩ := ht
+              obtain ⟨k, hk⟩ := Int.even_or_odd' n
+              rcases hk with heven | hodd
+              · suffices cexp (Real.pi * t * I) = 1 by simp [path, this, hz]
+                exact exp_eq_one_iff.mpr ⟨k, by simp [← htn, heven, mul_comm, ← mul_assoc]⟩
+              · suffices cexp (Real.pi * (t - 1) * I) = 1 by
+                  rw [mul_sub, sub_mul, mul_one, exp_sub_pi_mul_I, neg_eq_iff_eq_neg] at this
+                  simp [path, this, add_comm z r, hr]
+                exact exp_eq_one_iff.mpr ⟨k, by simp [← htn, hodd, mul_comm, ← mul_assoc]⟩
+            · have hzr' : z.re - r ≠ 0 :=
+                  fun h ↦ hzr <| Complex.ext (sub_eq_zero.mp h) (by simp [hz_im])
+              refine hT.mem_regularityDomain_of_im_ne_zero ?_
+              simp [path, hz_im, exp_im, Real.sin_eq_zero_iff, mul_comm, hzr', ht]
+        · refine JoinedIn.of_segment_subset fun w ⟨a, b, _, _, _, hw⟩ ↦ ?_
+          rcases eq_zero_or_neZero a with rfl | _
+          · simp_all
+          · exact hT.mem_regularityDomain_of_im_ne_zero fun _ ↦ hz_im (by simp_all [← hw])
+      exact (h z₁ hz₁).trans (h z₂ hz₂).symm
+
+/-- The regularity domain of a lower semibounded symmetric operator is connected. -/
+lemma regularityDomain_isConnected_of_bddBelow (h : BddBelow (Θᵣₑ T)) :
+    IsConnected T.regularityDomain := by
+  obtain ⟨m, hm⟩ := h
+  apply hT.regularityDomain_isConnected_iff.mpr
+  exact ⟨m - 1, hT.Iio_subset_regularityDomain hm ⟨m - 1, by simp⟩⟩
+
+/-- The regularity domain of an upper semibounded symmetric operator is connected. -/
+lemma regularityDomain_isConnected_of_bddAbove (h : BddAbove (Θᵣₑ T)) :
+    IsConnected T.regularityDomain := by
+  obtain ⟨m, hm⟩ := h
+  apply hT.regularityDomain_isConnected_iff.mpr
+  exact ⟨m + 1, hT.Ioi_subset_regularityDomain hm ⟨m + 1, by simp⟩⟩
+
 end IsSymmetric
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -75,9 +75,9 @@ lemma im_eq_zero_of_mem_numericalRange {z : ℂ} (hz : z ∈ Θ T) : z.im = 0 :=
   exact conj_eq_iff_im.mp (hxz ▸ isSymmetric_iff_inner_map_self_real.mp hT x)
 
 /-- The numerical range of a symmetric operator is contained in the real axis. -/
-lemma numericalRange_subset : Θ T ⊆ ofReal '' univ := by
+lemma numericalRange_subset : Θ T ⊆ range ofReal := by
   intro z hz
-  refine ⟨z.re, mem_univ _, ?_⟩
+  use z.re
   rw [← re_add_im z]
   simp [hT.im_eq_zero_of_mem_numericalRange hz]
 
@@ -92,6 +92,13 @@ lemma numericalRange_eq : Θ T = ofReal '' Θᵣₑ T := by
     obtain ⟨s, _, rfl⟩ := hT.numericalRange_subset hw
     exact hrz ▸ (ofReal_re s ▸ hwr) ▸ hw
 
+lemma closure_numericalRange_subset : _root_.closure (Θ T) ⊆ range ofReal := by
+  refine (closure_mono hT.numericalRange_subset).trans ?_
+  have h : range ofReal = im ⁻¹' {0} := by
+    ext z
+    exact ⟨fun ⟨r, hr⟩ ↦ hr ▸ ofReal_im r, fun hz ↦ ⟨z.re, Eq.symm (Complex.ext rfl hz)⟩⟩
+  exact (h ▸ IsClosed.preimage (by fun_prop) (by simp)).closure_subset
+
 /-!
 ## B. Regularity domain
 -/
@@ -99,21 +106,15 @@ lemma numericalRange_eq : Θ T = ofReal '' Θᵣₑ T := by
 /-- The regularity domain of a symmetric operator contains all complex numbers with non-zero
   imaginary part. -/
 lemma mem_regularityDomain_of_im_ne_zero {z : ℂ} (hz : z.im ≠ 0) : z ∈ T.regularityDomain := by
-  refine ⟨|z.im|, abs_pos.mpr hz, fun x ↦ ?_⟩
-  refine le_of_sq_le_sq ?_ (norm_nonneg _)
-  have h : ‖z‖ ^ 2 = z.re ^ 2 + z.im ^ 2 := norm_eq_sqrt_sq_add_sq z ▸ Real.sq_sqrt (by nlinarith)
-  have h' : (⟪T x, x⟫_ℂ).im = 0 := conj_eq_iff_im.mp (isSymmetric_iff_inner_map_self_real.mp hT x)
-  refine le_of_le_of_eq (b := ‖T x - z.re • x‖ ^ 2 + z.im ^ 2 * ‖x‖ ^ 2) ?_ ?_
-  · simp [mul_pow]
-  · simp [norm_sub_sq (𝕜 := ℂ), ← Complex.coe_smul, inner_smul_right, norm_smul, mul_pow,
-      add_assoc, add_mul, h, h']
+  apply T.compl_closure_numericalRange_subset_regularityDomain
+  refine (mem_compl_iff _ _).mpr fun h ↦ hz ?_
+  obtain ⟨r, _, rfl⟩ := hT.closure_numericalRange_subset h
+  exact ofReal_im r
 
 /-- The regularity domain of a symmetric operator contains all complex numbers with non-zero
   imaginary part. -/
-lemma compl_ofReal_subset_regularityDomain : (ofReal '' univ)ᶜ ⊆ T.regularityDomain := by
-  intro z hz
-  refine hT.mem_regularityDomain_of_im_ne_zero ?_
-  exact fun h ↦ hz ⟨z.re, mem_univ _, Eq.symm (Complex.ext rfl h)⟩
+lemma compl_ofReal_subset_regularityDomain : (range ofReal)ᶜ ⊆ T.regularityDomain :=
+  fun z hz ↦ hT.mem_regularityDomain_of_im_ne_zero fun h ↦ hz ⟨z.re, Eq.symm (Complex.ext rfl h)⟩
 
 /-- If `m` is a lower bound on the numerical range then the regularity domain contains `(-∞,m)`. -/
 lemma Iio_subset_regularityDomain {m : ℝ} (h : m ∈ lowerBounds (Θᵣₑ T)) :

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basic
+/-!
+
+# Spectral theory for symmetric operators
+
+## i. Overview
+
+## ii. Key results
+
+## iii. Table of contents
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace LinearPMap
+namespace IsSymmetric
+
+open Complex
+open Set
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+
+/-- The projection of the numerical range onto the real axis. -/
+def realNumericalRange (T : H →ₗ.[ℂ] H) : Set ℝ := re '' (Θ T)
+
+@[inherit_doc realNumericalRange]
+local notation "Θᵣₑ" => realNumericalRange
+
+lemma realNumericalRange_eq (T : H →ₗ.[ℂ] H) : Θᵣₑ T = re '' Θ T := rfl
+
+@[simp]
+lemma realNumericalRange_neg (T : H →ₗ.[ℂ] H) : Θᵣₑ (-T) = -Θᵣₑ T := by
+  ext
+  simp [realNumericalRange_eq, neg_eq_iff_eq_neg]
+
+variable {T : H →ₗ.[ℂ] H} (hT : T.IsSymmetric)
+include hT
+
+/-- The numerical range of a symmetric operator is contained in the real axis. -/
+lemma im_eq_zero_of_mem_numericalRange {z : ℂ} (hz : z ∈ Θ T) : z.im = 0 := by
+  obtain ⟨x, hx, hxz⟩ := hz
+  simp only [← hT x x] at hxz
+  exact conj_eq_iff_im.mp (hxz ▸ isSymmetric_iff_inner_map_self_real.mp hT x)
+
+/-- The numerical range of a symmetric operator is contained in the real axis. -/
+lemma numericalRange_subset : Θ T ⊆ ofReal '' univ := by
+  intro z hz
+  refine ⟨z.re, mem_univ _, ?_⟩
+  rw [← re_add_im z]
+  simp [hT.im_eq_zero_of_mem_numericalRange hz]
+
+/-- The numerical range of a symmetric operator is equal to its projection onto the real axis. -/
+lemma numericalRange_eq : Θ T = ofReal '' Θᵣₑ T := by
+  ext z
+  constructor
+  · intro h
+    obtain ⟨r, _, rfl⟩ := hT.numericalRange_subset h
+    exact ⟨r, ⟨r, h, rfl⟩, rfl⟩
+  · intro ⟨r, ⟨w, hw, hwr⟩, hrz⟩
+    obtain ⟨s, _, rfl⟩ := hT.numericalRange_subset hw
+    exact hrz ▸ (ofReal_re s ▸ hwr) ▸ hw
+
+end IsSymmetric
+end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -16,6 +16,9 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basi
 
 ## iii. Table of contents
 
+- A. Numerical range
+- B. Regularity domain
+
 ## iv. References
 
 -/
@@ -25,10 +28,15 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basi
 namespace LinearPMap
 namespace IsSymmetric
 
+open InnerProductSpace
 open Complex
 open Set
 
 variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+
+/-!
+## A. Numerical range
+-/
 
 /-- The projection of the numerical range onto the real axis. -/
 def realNumericalRange (T : H →ₗ.[ℂ] H) : Set ℝ := re '' (Θ T)
@@ -69,6 +77,29 @@ lemma numericalRange_eq : Θ T = ofReal '' Θᵣₑ T := by
   · intro ⟨r, ⟨w, hw, hwr⟩, hrz⟩
     obtain ⟨s, _, rfl⟩ := hT.numericalRange_subset hw
     exact hrz ▸ (ofReal_re s ▸ hwr) ▸ hw
+
+/-!
+## B. Regularity domain
+-/
+
+/-- The regularity domain of a symmetric operator contains all complex numbers with non-zero
+  imaginary part. -/
+lemma mem_regularityDomain_of_im_ne_zero {z : ℂ} (hz : z.im ≠ 0) : z ∈ T.regularityDomain := by
+  refine ⟨|z.im|, abs_pos.mpr hz, fun x ↦ ?_⟩
+  refine le_of_sq_le_sq ?_ (norm_nonneg _)
+  have h : ‖z‖ ^ 2 = z.re ^ 2 + z.im ^ 2 := norm_eq_sqrt_sq_add_sq z ▸ Real.sq_sqrt (by nlinarith)
+  have h' : (⟪T x, x⟫_ℂ).im = 0 := conj_eq_iff_im.mp (isSymmetric_iff_inner_map_self_real.mp hT x)
+  refine le_of_le_of_eq (b := ‖T x - z.re • x‖ ^ 2 + z.im ^ 2 * ‖x‖ ^ 2) ?_ ?_
+  · simp [mul_pow]
+  · simp [norm_sub_sq (𝕜 := ℂ), ← Complex.coe_smul, inner_smul_right, norm_smul, mul_pow,
+      add_assoc, add_mul, h, h']
+
+/-- The regularity domain of a symmetric operator contains all complex numbers with non-zero
+  imaginary part. -/
+lemma compl_ofReal_subset_regularityDomain : (ofReal '' univ)ᶜ ⊆ T.regularityDomain := by
+  intro z hz
+  refine hT.mem_regularityDomain_of_im_ne_zero ?_
+  exact fun h ↦ hz ⟨z.re, mem_univ _, Eq.symm (Complex.ext rfl h)⟩
 
 end IsSymmetric
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -12,7 +12,21 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basi
 
 ## i. Overview
 
+In this module we develop the spectral theory for symmetric operators.
+
+The numerical range of an operator, `Θ T = {⟪x, T x⟫_ℂ | x ∈ T.domain ∧ ‖x‖ = 1}`, is a subset of ℂ.
+For symmetric operators the numerical range consists only of real numbers and it is meaningful
+to discuss its upper/lower bounds. To facilitate this, we define `LinearPMap.realNumericalRange`
+as the projection of `LinearPMap.numericalRange` onto the real axis. For symmetric operators this
+simply reinterprets the numerical range as a subset of ℝ.
+
 ## ii. Key results
+
+- `realNumericalRange` (`Θᵣₑ`) : The projection of the numerical range onto the real axis.
+- `compl_ofReal_subset_regularityDomain` : The regularity domain of a symmetric operator contains
+    all complex numbers with non-zero imaginary part.
+- `regularityDomain_isConnected_iff` : The regularity domain of a symmetric operator is connected
+    if and only if it contains a real number.
 
 ## iii. Table of contents
 

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -101,5 +101,34 @@ lemma compl_ofReal_subset_regularityDomain : (ofReal '' univ)ᶜ ⊆ T.regularit
   refine hT.mem_regularityDomain_of_im_ne_zero ?_
   exact fun h ↦ hz ⟨z.re, mem_univ _, Eq.symm (Complex.ext rfl h)⟩
 
+/-- If `m` is a lower bound on the numerical range then the regularity domain contains `(-∞,m)`. -/
+lemma Iio_subset_regularityDomain {m : ℝ} (h : m ∈ lowerBounds (Θᵣₑ T)) :
+    ofReal '' Iio m ⊆ T.regularityDomain := by
+  intro z ⟨r, hr, hrz⟩
+  refine ⟨m - r, sub_pos.mpr hr, fun x ↦ ?_⟩
+  rcases eq_zero_or_neZero x with rfl | hx
+  · simp
+  · obtain ⟨s, hs, hs'⟩ := hT.numericalRange_eq ▸ mem_numericalRange hx.ne
+    apply h at hs
+    have hsr : r < s := lt_of_lt_of_le hr hs
+    refine le_of_mul_le_mul_right ?_ (norm_pos_iff.mpr hx.ne)
+    calc
+      _ = (m - r) * ‖x‖ ^ 2 := by rw [mul_assoc, pow_two]
+      _ ≤ (s - r) * ‖x‖ ^ 2 := by nlinarith
+      _ = ‖s * ‖x‖ ^ 2 - r * ‖x‖ ^ 2‖ := by simp [← sub_mul, abs_of_pos, sub_pos, hsr]
+      _ = ‖(s : ℂ) * ‖x‖ ^ 2 - r * ‖x‖ ^ 2‖ := by simp [← ofReal_pow, ← ofReal_mul, ← ofReal_sub]
+      _ = ‖⟪↑x, T x⟫_ℂ - r * ‖x‖ ^ 2‖ := by simp [hs', mul_comm, hx.ne]
+      _ = ‖⟪↑x, T x - z • x⟫_ℂ‖ := by simp [inner_sub_right, inner_smul_right, hrz]
+      _ ≤ ‖T x - z • x‖ * ‖x‖ := mul_comm _ ‖x‖ ▸ norm_inner_le_norm _ _
+
+/-- If `m` is an upper bound on the numerical range then the regularity domain contains `(m,∞)`. -/
+lemma Ioi_subset_regularityDomain {m : ℝ} (h : m ∈ upperBounds (Θᵣₑ T)) :
+    ofReal '' Ioi m ⊆ T.regularityDomain := by
+  intro z ⟨r, hr, hrz⟩
+  rw [← neg_mem_neg, ← regularityDomain_neg]
+  refine hT.neg.Iio_subset_regularityDomain (m := -m) ?_ ?_
+  · exact fun _ _ ↦ by simp_all [neg_le.mp, upperBounds]
+  · exact ⟨-r, by simp [mem_Ioi.mp hr], by simp [hrz]⟩
+
 end IsSymmetric
 end LinearPMap


### PR DESCRIPTION
Begins the spectral theory for symmetric operators with some results on the regularity domain and numerical range.
- Adds some general results for behavior under negation / scalar multiplication.
- Defines `realNumericalRange` which is the numerical range of a symmetric operator as a subset of ℝ rather than of ℂ, allowing for the notion of upper/lower bounds.
- Proves that the regularity domain contains all complex numbers with nonzero imaginary part as well as `(-∞,m)` or `(m,∞)` when `m` is a lower/upper bound on the numerical range.
- Adds a characterization of when the regularity domain is connected.