### PR TITLE
refactor: QuantumInfo line lengths <100characters

### DIFF
--- a/QuantumInfo/Capacity/Capacity.lean
+++ b/QuantumInfo/Capacity/Capacity.lean
@@ -22,33 +22,47 @@ public import Physlib.Meta.Sorry
 
 /-! # Quantum Capacity
 
-This focuses on defining and proving theorems about the quantum capacity, the maximum asymptotic rate at which quantum information can be coherently transmitted. The precise definition is not consistent in the literature, see [Capacity_doc](./QuantumInfo/Finite/Capacity_doc.html) for a note on what has been used and how that was used to arrive at the following definition:
+This focuses on defining and proving theorems about the quantum capacity, the maximum asymptotic
+rate at which quantum information can be coherently transmitted. The precise definition is not
+consistent in the literature, see [Capacity_doc](./QuantumInfo/Finite/Capacity_doc.html) for a note
+on what has been used and how that was used to arrive at the following definition:
 
  1. A channel A `Emulates` another channel B if there are D and E such that D∘A∘E = B.
- 2. A channel A `εApproximates` channel B (of the same dimensions) if the for every state ρ, the fidelity F(A(ρ), B(ρ)) is at least 1-ε.
- 3. A channel A `AchievesRate` R:ℝ if for every ε>0, n copies of A emulates some channel B such that log2(dimout(B))/n ≥ R, and that B is εApproximately the identity.
- 4. The `quantumCapacity` of the channel A is the supremum of the achievable rates, i.e. `sSup { R : ℝ | AchievesRate A R }`.
+ 2. A channel A `εApproximates` channel B (of the same dimensions) if the for every state ρ, the
+    fidelity F(A(ρ), B(ρ)) is at least 1-ε.
+ 3. A channel A `AchievesRate` R:ℝ if for every ε>0, n copies of A emulates some channel B such
+    that log2(dimout(B))/n ≥ R, and that B is εApproximately the identity.
+ 4. The `quantumCapacity` of the channel A is the supremum of the achievable rates, i.e.
+    `sSup { R : ℝ | AchievesRate A R }`.
 
 The most basic facts:
  * `emulates_self`: Every channel emulates itself.
- * `emulates_trans`: If A emulates B and B emulates C, then A emulates C. (That is, emulation is an ordering.)
- * `εApproximates A B ε` is equivalent to the existence of some δ (depending ε and dims(A)) so that |A-B| has diamond norm at most δ, and δ→0 as ε→0.
+ * `emulates_trans`: If A emulates B and B emulates C, then A emulates C. (That is, emulation is an
+   ordering.)
+ * `εApproximates A B ε` is equivalent to the existence of some δ (depending ε and dims(A)) so that
+   |A-B| has diamond norm at most δ, and δ→0 as ε→0.
  * `achievesRate_0`: Every channel out of a nonempty space achievesRate 0. So, in that case,
    the set of achievable rates is Nonempty.
- * If a channel achievesRate R₁, it also every achievesRate R₂ every R₂ ≤ R₁, i.e. it is an interval extending left towards -∞. Achievable rates are `¬BddBelow`.
- * `bddAbove_achievesRate`: A channel C : dimX → dimY cannot achievesRate R with `R > log2(min(dimX, dimY))`. Thus, the interval is `BddAbove`.
+ * If a channel achievesRate R₁, it also every achievesRate R₂ every R₂ ≤ R₁, i.e. it is an interval
+   extending left towards -∞. Achievable rates are `¬BddBelow`.
+ * `bddAbove_achievesRate`: A channel C : dimX → dimY cannot achievesRate R with
+   `R > log2(min(dimX, dimY))`. Thus, the interval is `BddAbove`.
 
 The nice lemmas we would want:
  * Capacity of a replacement channel is zero.
  * Capacity of an identity channel is `log2(D)`.
- * Capacity is superadditive under tensor products. (That is, at least additive. Showing that it isn't _exactly_ additive, unlike classical capacity which is additive, is a much harder task.)
+ * Capacity is superadditive under tensor products. (That is, at least additive. Showing that it
+   isn't _exactly_ additive, unlike classical capacity which is additive, is a much harder task.)
  * Capacity of a kth tensor power is exactly k times the capacity of the original channel.
  * Capacity does not decrease under tensor sums.
  * Capacity does not increase under composition.
 
-Then, we should show that our definition is equivalent to some above. Most, except (3), should be not too hard to prove.
+Then, we should show that our definition is equivalent to some above. Most, except (3), should be
+not too hard to prove.
 
-Then the LSD theorem establishes that the single-copy coherent information is a lower bound. This is stated in `coherentInfo_le_quantumCapacity`. The corollary, that the n-copy coherent information converges to the capacity, is `quantumCapacity_eq_piProd_coherentInfo`.
+Then the LSD theorem establishes that the single-copy coherent information is a lower bound. This is
+stated in `coherentInfo_le_quantumCapacity`. The corollary, that the n-copy coherent information
+converges to the capacity, is `quantumCapacity_eq_piProd_coherentInfo`.
 
 # TODO
 
@@ -70,7 +84,8 @@ And other important theorems like superdense coding, nonadditivity, superactivat
 namespace CPTPMap
 
 variable {d₁ d₂ d₃ d₄ d₅ d₆ : Type*}
-variable [Fintype d₁] [Fintype d₂] [Fintype d₃] [Fintype d₄] [Fintype d₅] [Fintype d₆] [DecidableEq d₁] [DecidableEq d₂]
+variable [Fintype d₁] [Fintype d₂] [Fintype d₃] [Fintype d₄] [Fintype d₅] [Fintype d₆]
+variable [DecidableEq d₁] [DecidableEq d₂]
 
 variable [DecidableEq d₃] [DecidableEq d₄] in
 /--
@@ -80,13 +95,15 @@ def Emulates (Λ₁ : CPTPMap d₁ d₂) (Λ₂ : CPTPMap d₃ d₄) : Prop :=
   ∃ (E : CPTPMap d₃ d₁) (D : CPTPMap d₂ d₄), D.compose (Λ₁.compose E) = Λ₂
 
 /--
-A channel A `εApproximates` channel B of the same dimensions if the for every state ρ, the fidelity F(A(ρ), B(ρ)) is at least 1-ε.
+A channel A `εApproximates` channel B of the same dimensions if the for every state ρ, the fidelity
+F(A(ρ), B(ρ)) is at least 1-ε.
 -/
 def εApproximates (A B : CPTPMap d₁ d₂) (ε : ℝ) : Prop :=
   ∀ (ρ : MState d₁), (A ρ).fidelity (B ρ) ≥ 1-ε
 
 /--
-A channel A `AchievesRate` R:ℝ if for every ε>0, some n copies of A emulates a channel B such that log2(dimout(B))/n ≥ R, and that B εApproximates the identity channel.
+A channel A `AchievesRate` R:ℝ if for every ε>0, some n copies of A emulates a channel B such that
+log2(dimout(B))/n ≥ R, and that B εApproximates the identity channel.
 -/
 def AchievesRate (A : CPTPMap d₁ d₂) (R : ℝ) : Prop :=
   ∀ ε : ℝ, ε > 0 →
@@ -139,13 +156,15 @@ theorem achievesRate_0 (Λ : CPTPMap d₁ d₂) [Nonempty d₁] : Λ.AchievesRat
     εApproximates_monotone (εApproximates_self (id (dIn := Fin 1))) hε.le
 
 /-- The identity channel on D dimensional space achieves a rate of log2(D). -/
-theorem id_achievesRate_log_dim : (id (dIn := d₁)).AchievesRate (Real.logb 2 (Fintype.card d₁)) := by
+theorem id_achievesRate_log_dim :
+    (id (dIn := d₁)).AchievesRate (Real.logb 2 (Fintype.card d₁)) := by
   intro ε hε
   use 1, zero_lt_one, Fintype.card d₁, id
   constructor
   · --piProd of id's is id, then use emulates_self up to equivalence
     rw [show (fun (_ : Fin 1) ↦ id (dIn := d₁)) = (fun _ ↦ id) from rfl, piProd_id]
-    exact let σ := Fintype.equivFinOfCardEq (by simp +decide : Fintype.card (Fin 1 → d₁) = Fintype.card d₁)
+    exact let σ := Fintype.equivFinOfCardEq
+        (by simp +decide : Fintype.card (Fin 1 → d₁) = Fintype.card d₁)
       ⟨ofEquiv σ.symm, ofEquiv σ, by ext1; simp⟩
   constructor
   · norm_num
@@ -153,7 +172,8 @@ theorem id_achievesRate_log_dim : (id (dIn := d₁)).AchievesRate (Real.logb 2 (
 
 /-- A channel cannot achieve a rate greater than log2(D), where D is the input dimension. -/
 @[sorryful]
-theorem not_achievesRate_gt_log_dim_in (Λ : CPTPMap d₁ d₂) {R : ℝ} (hR : Real.logb 2 (Fintype.card d₁) < R) :
+theorem not_achievesRate_gt_log_dim_in (Λ : CPTPMap d₁ d₂) {R : ℝ}
+    (hR : Real.logb 2 (Fintype.card d₁) < R) :
     ¬Λ.AchievesRate R := by
   sorry
 
@@ -163,16 +183,21 @@ end AristotleLemmas
 
 /-- A channel cannot achieve a rate greater than log2(D), where D is the output dimension. -/
 @[sorryful]
-theorem not_achievesRate_gt_log_dim_out (Λ : CPTPMap d₁ d₂) {R : ℝ} (hR : Real.logb 2 (Fintype.card d₂) < R): ¬Λ.AchievesRate R := by
+theorem not_achievesRate_gt_log_dim_out (Λ : CPTPMap d₁ d₂) {R : ℝ}
+    (hR : Real.logb 2 (Fintype.card d₂) < R): ¬Λ.AchievesRate R := by
   intro h;
-  -- We show that the identity channel on the output space `d₂` emulates `Λ`. Since capacity is monotonic under emulation, `Q(Λ) ≤ Q(id_{d₂})`.
+  -- We show that the identity channel on the output space `d₂` emulates `Λ`. Since capacity is
+  -- monotonic under emulation, `Q(Λ) ≤ Q(id_{d₂})`.
   have h_emulate : (CPTPMap.id (dIn := d₂)).Emulates Λ := by
     exact ⟨Λ, CPTPMap.id, by simp⟩
-  -- If `Λ` achieves rate `R`, then `id_{d₂}` achieves rate `R`. This follows because if `Λ^{\otimes n}` emulates `B`, and `id^{\otimes n}` emulates `Λ^{\otimes n}` (by functoriality of tensor product), then `id^{\otimes n}` emulates `B`.
+  -- If `Λ` achieves rate `R`, then `id_{d₂}` achieves rate `R`. This follows because if
+  -- `Λ^{\otimes n}` emulates `B`, and `id^{\otimes n}` emulates `Λ^{\otimes n}` (by functoriality
+  -- of tensor product), then `id^{\otimes n}` emulates `B`.
   have h_id_achieves : (CPTPMap.id (dIn := d₂)).AchievesRate R := by
     intro ε hε_pos
     obtain ⟨n, hn, dimB, B, hB_emulate, hB_rate, hB_approx⟩ := h ε hε_pos
-    have h_id_emulate : (CPTPMap.piProd (fun (_ : Fin n) => CPTPMap.id (dIn := d₂))).Emulates B := by
+    have h_id_emulate :
+        (CPTPMap.piProd (fun (_ : Fin n) => CPTPMap.id (dIn := d₂))).Emulates B := by
       rw [piProd_id]
       obtain ⟨E, D, hD⟩ := h_emulate
       exact emulates_trans _ _ _ ⟨piProd fun _ => E, piProd fun _ => D,
@@ -201,7 +226,8 @@ theorem zero_le_quantumCapacity (Λ : CPTPMap d₁ d₂) [Nonempty d₁] :
 
 /-- Quantum channel capacity is at most log2(D), where D is the input dimension. -/
 @[sorryful]
-theorem quantumCapacity_ge_log_dim_in (Λ : CPTPMap d₁ d₂) : Λ.quantumCapacity ≤ Real.logb 2 (Fintype.card d₁) :=
+theorem quantumCapacity_ge_log_dim_in (Λ : CPTPMap d₁ d₂) :
+    Λ.quantumCapacity ≤ Real.logb 2 (Fintype.card d₁) :=
   Real.sSup_le (by
     intro R h
     contrapose h
@@ -211,12 +237,14 @@ theorem quantumCapacity_ge_log_dim_in (Λ : CPTPMap d₁ d₂) : Λ.quantumCapac
     · apply Real.logb_nonneg one_lt_two (Nat.one_le_cast.mpr Fintype.card_pos)
     · simp [not_nonempty_iff.mp h])
 
-/-- The LSD (Lloyd-Shor-Devetak) theorem: the quantum capacity is at least as large the single-copy coherent
-information. The "coherent information" is used in literature to refer to both a function of state and
-a channel (`coherentInfo`), or a function of just a channel. In the latter case, the state is implicitly
-maximized over. Here we use the former definition and state that the lower bound is true for all states. -/
+/-- The LSD (Lloyd-Shor-Devetak) theorem: the quantum capacity is at least as large the single-copy
+coherent information. The "coherent information" is used in literature to refer to both a function
+of state and a channel (`coherentInfo`), or a function of just a channel. In the latter case, the
+state is implicitly maximized over. Here we use the former definition and state that the lower bound
+is true for all states. -/
 @[sorryful]
-theorem coherentInfo_le_quantumCapacity (Λ : CPTPMap d₁ d₂) (ρ : MState d₁) : coherentInfo ρ Λ ≤ Λ.quantumCapacity := by
+theorem coherentInfo_le_quantumCapacity (Λ : CPTPMap d₁ d₂) (ρ : MState d₁) :
+    coherentInfo ρ Λ ≤ Λ.quantumCapacity := by
   sorry
 
 /-- The quantum capacity is the limit of the coherent information of n-copy uses of the channel. -/

--- a/QuantumInfo/Capacity/Capacity.lean
+++ b/QuantumInfo/Capacity/Capacity.lean
@@ -163,8 +163,8 @@ theorem id_achievesRate_log_dim :
   constructor
   · --piProd of id's is id, then use emulates_self up to equivalence
     rw [show (fun (_ : Fin 1) ↦ id (dIn := d₁)) = (fun _ ↦ id) from rfl, piProd_id]
-    exact let σ := Fintype.equivFinOfCardEq
-        (by simp +decide : Fintype.card (Fin 1 → d₁) = Fintype.card d₁)
+    exact let σ := Fintype.equivFinOfCardEq (by simp +decide :
+        Fintype.card (Fin 1 → d₁) = Fintype.card d₁)
       ⟨ofEquiv σ.symm, ofEquiv σ, by ext1; simp⟩
   constructor
   · norm_num

--- a/QuantumInfo/Capacity/Capacity_doc.lean
+++ b/QuantumInfo/Capacity/Capacity_doc.lean
@@ -8,31 +8,62 @@ module
 /-!
 # Defining Quantum Capacity
 
-Quantum capacity is defined in different reference works in at least seven meaningfully different ways:
+Quantum capacity is defined in different reference works in at least seven meaningfully different
+ways:
 
 (1) https://www.uio.no/studier/emner/matnat/math/MAT4430/v23/timeplan/lectureblup.pdf, Defn 20.3.
 
-Defines the notion of "(n, m, δ)-coding scheme", a code for m qubits in n copies of the channel, with diamond-norm distance of δ from the identity channel. Then a rate R is "achievable" if there is a sequence of coding schemes that converge m/n -> R and δ -> 0. The set of achieveable rates is a closed interval, and the capacity is the maximum of this interval.
+Defines the notion of "(n, m, δ)-coding scheme", a code for m qubits in n copies of the channel,
+with diamond-norm distance of δ from the identity channel. Then a rate R is "achievable" if there
+is a sequence of coding schemes that converge m/n -> R and δ -> 0. The set of achieveable rates is
+a closed interval, and the capacity is the maximum of this interval.
 
 (2) https://cs.uwaterloo.ca/~watrous/TQI/TQI.8.pdf, Defn 8.42.
 
-Watrous doesn't use the word "coding scheme", but rather define "emulating" (8.1) an "ε-approximation" (8.2) of the identity. This is equivalent to the coding scheme and diamond norm part. Then a rate R is "achievable" if, for every δ>0, there is a k:ℕ such that k < n implies the existence of a (n, floor(R*n), δ)-coding scheme. Now the set of achievable rates may be an open or closed interval, and the capacity is the supremum of this interval (not the maximum, since an open interval has no maximum).
+Watrous doesn't use the word "coding scheme", but rather define "emulating" (8.1) an
+"ε-approximation" (8.2) of the identity. This is equivalent to the coding scheme and diamond norm
+part. Then a rate R is "achievable" if, for every δ>0, there is a k:ℕ such that k < n implies the
+existence of a (n, floor(R*n), δ)-coding scheme. Now the set of achievable rates may be an open or
+closed interval, and the capacity is the supremum of this interval (not the maximum, since an open
+interval has no maximum).
 
 (3) Works like https://arxiv.org/pdf/1007.2855 (equation 3) and https://arxiv.org/pdf/1801.02019 (equation 186) define the quantum capacity of C as $Q(C) = lim_n 1/n * Q^{(1)}(C ^ {⊗n})$, where $Q^{(1)}$ is the quantum coherent information (or "one-shot channel capacity"), and so it is the average coherent information achieved across n copies of the channel, in the large-n limit. This definition makes the LSD theorem (which stats that $Q ≥ Q^{(1)}$) actually entirely trivial, as it requires only the fact that $Q^{(1)}$ is superadditive.
 
 (4) https://arxiv.org/pdf/quant-ph/0304127 (Section 5) and https://arxiv.org/pdf/quant-ph/9809010 specifically distinguish between "subspace transmission", "entanglement transmission", and "entanglement generation" capabilities of the channel. The fact that all three are equal is then a theorem. Option (4), subspace transsmission capacity, is like option (1) above, but instead of the channel having diamond norm at most δ from the identity channel, we require that the channel has fidelity at least 1-δ on all inputs. Converging in fidelity is surely equivalent to converging in diamond norm, but the precise bounds are not obvious. (4) also differs from (1) and (2) in that it has an arbitrary dimension input space, instead of specifically a 2^n-dimensional space of qubits. arxiv:9809010 specifically requires a sequence of codes whose limiting fidelity is 1 and rate is R; arxiv:0304127 doesn't actually precisely say.
 
-(5) "Entanglement transmission" asks for a high-entropy state (thus, a large subspace dimension) that can be transmitted through the channel with a high "entanglement fidelity". See equation (52) in arxiv:0304127. The rate achieved is the von Neumann entropy of the state, the set of achievable rates are closed, and the rate of the channel is the maximum.
+(5) "Entanglement transmission" asks for a high-entropy state (thus, a large subspace dimension)
+that can be transmitted through the channel with a high "entanglement fidelity". See equation (52)
+in arxiv:0304127. The rate achieved is the von Neumann entropy of the state, the set of achievable
+rates are closed, and the rate of the channel is the maximum.
 
-(6) "Entanglement generation" changes the task from coding. Instead we need a bipartite state ρ_AB on a Hilbert space of dimension κ, of which the left half goes through the encoder, channel, and decoder. The fidelity between the result C(ρ) and the maximally entangled state must be at least 1-ε. The rates are (1/n)*(log κ), achievable if for all δ and sufficiently large n (etc. - like option (2)), and we take the supremum.
+(6) "Entanglement generation" changes the task from coding. Instead we need a bipartite state ρ_AB
+on a Hilbert space of dimension κ, of which the left half goes through the encoder, channel, and
+decoder. The fidelity between the result C(ρ) and the maximally entangled state must be at least
+1-ε. The rates are (1/n)*(log κ), achievable if for all δ and sufficiently large n (etc. - like
+option (2)), and we take the supremum.
 
-Note: Option (6) is what Devetak, in arxiv:0304127, actually proves the LSD theorem for. Theorem 5 in that reference. (4), (5), and (6) are proven equal.
+Note: Option (6) is what Devetak, in arxiv:0304127, actually proves the LSD theorem for. Theorem 5
+in that reference. (4), (5), and (6) are proven equal.
 
-(7) Wilde's book also of "coding scheme", but defines it in terms of entanglement generation and the logarithm of the dimension of the space. Instead of fidelity preserved in the entanglement, it's the trace norm. He effectively defines it by supremum, although he doesn't need to use the word, giving an equivalent δ/ε definition for coding schemes. He then takes supremum (even though maximum would work as well -- the capacity is itself an achievable rate by his definition). In this way, it combines aspects of definitions (1), (2), and (4). He gives as an exercise showing that small trace norm error of transmitted states implies a small diamond norm error from the identity.
+(7) Wilde's book also of "coding scheme", but defines it in terms of entanglement generation and
+the logarithm of the dimension of the space. Instead of fidelity preserved in the entanglement,
+it's the trace norm. He effectively defines it by supremum, although he doesn't need to use the
+word, giving an equivalent δ/ε definition for coding schemes. He then takes supremum (even though
+maximum would work as well -- the capacity is itself an achievable rate by his definition). In this
+way, it combines aspects of definitions (1), (2), and (4). He gives as an exercise showing that
+small trace norm error of transmitted states implies a small diamond norm error from the identity.
 
 ----
 
-To capture the idea of "quantum capacity", and some other idea that turns out to be equivalent, (1), (2), or (5) seems best. The definitions (1) and (2) seem to be the more recently popular ones. Between those two, choosing "supremum" or "maximum", the supremum seems shorter to state in a definition (as it doesn't require proving closure); indeed Mathlib has no notion of "max real" as a function, only a supremum which can also be shown to be in the set. But the definition in (2) of "For every δ>0, there is a k:ℕ such that k < n implies the existence of a (...)-coding scheme" is cleaner work with as a way to directly construct or extract codes, as opposed to limits of sequences of codes. And finally, the notions of "emulate" and "approximate" seem useful for defining it more elegantly.
+To capture the idea of "quantum capacity", and some other idea that turns out to be equivalent,
+(1), (2), or (5) seems best. The definitions (1) and (2) seem to be the more recently popular ones.
+Between those two, choosing "supremum" or "maximum", the supremum seems shorter to state in a
+definition (as it doesn't require proving closure); indeed Mathlib has no notion of "max real" as a
+function, only a supremum which can also be shown to be in the set. But the definition in (2) of
+"For every δ>0, there is a k:ℕ such that k < n implies the existence of a (...)-coding scheme" is
+cleaner work with as a way to directly construct or extract codes, as opposed to limits of
+sequences of codes. And finally, the notions of "emulate" and "approximate" seem useful for
+defining it more elegantly.
 
 This leads to the final definition in [Capacity.lean](./QuantumInfo/Finite/Capacity.html).
 -/@[expose] public section

--- a/QuantumInfo/Channels/Bundled.lean
+++ b/QuantumInfo/Channels/Bundled.lean
@@ -111,7 +111,8 @@ theorem funext_hermitian (h : ∀ M : HermitianMat dIn ℂ, CΛ₁.map M = CΛ�
   <;> rfl
 
 /-- Two maps are equal if they agree on all positive inputs. -/
-theorem funext_pos [Fintype dIn] (h : ∀ M : HermitianMat dIn ℂ, 0 ≤ M → CΛ₁.map M = CΛ₂.map M) :
+theorem funext_pos [Fintype dIn]
+    (h : ∀ M : HermitianMat dIn ℂ, 0 ≤ M → CΛ₁.map M = CΛ₂.map M) :
     CΛ₁ = CΛ₂ := by
   classical
   open scoped HermitianMat in
@@ -148,7 +149,8 @@ theorem funext_mstate [Fintype dIn] [DecidableEq dIn] {Λ₁ Λ₂ : HPMap dIn d
   funext_pos_trace fun M hM_pos hM_tr ↦ h ⟨M, hM_pos, hM_tr⟩
 
 /-- Hermitian-preserving maps are functions from `HermitianMat`s to `HermitianMat`s. -/
-noncomputable instance instFunLike : FunLike (HPMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+noncomputable instance instFunLike :
+    FunLike (HPMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   coe Λ ρ := ⟨Λ.map ρ.1, Λ.HP ρ.2⟩
   coe_injective' x y h := funext_hermitian fun M ↦
     by simpa using congrFun h M
@@ -184,7 +186,8 @@ theorem injective_toHPMap : (PMap.toHPMap (dIn := dIn) (dOut := dOut) (𝕜 := �
   fun _ _ ↦ (mk.injEq _ _ _ _).mpr
 
 /-- Positive maps are functions from `HermitianMat`s to `HermitianMat`s. -/
-noncomputable instance instFunLike : FunLike (PMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+noncomputable instance instFunLike :
+    FunLike (PMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   coe := DFunLike.coe ∘ toHPMap
   coe_injective' := DFunLike.coe_injective'.comp injective_toHPMap
 
@@ -192,7 +195,8 @@ lemma apply_hermitianMat_eq (Λ : PMap dIn dOut ℂ) (ρ : HermitianMat dIn ℂ)
     Λ ρ = ⟨Λ.map ρ.1, Λ.HP ρ.2⟩ := rfl
 
 set_option synthInstance.maxHeartbeats 40000 in
-instance instLinearMapClass : LinearMapClass (PMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+instance instLinearMapClass :
+    LinearMapClass (PMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   map_add f x y := HermitianMat.ext <| LinearMap.map_add f.toLinearMap x y
   map_smulₛₗ f c x := HermitianMat.ext <| by simp [apply_hermitianMat_eq]
 
@@ -204,14 +208,16 @@ instance instContinuousOrderHomClass : ContinuousOrderHomClass (PMap dIn dOut �
 
 /-- Positive-presering maps also preserve positivity on, specifically, Hermitian matrices. -/
 @[simp]
-theorem pos_Hermitian (M : PMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) : 0 ≤ M x := by
+theorem pos_Hermitian (M : PMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) :
+    0 ≤ M x := by
   simpa only [map_zero] using ContinuousOrderHomClass.map_monotone M h
 
 end PMap
 
 namespace CPMap
 
-def of_kraus_CPMap {κ : Type*} [Fintype κ] [DecidableEq dIn] (M : κ → Matrix dOut dIn 𝕜) : CPMap dIn dOut 𝕜 where
+def of_kraus_CPMap {κ : Type*} [Fintype κ] [DecidableEq dIn] (M : κ → Matrix dOut dIn 𝕜) :
+    CPMap dIn dOut 𝕜 where
   toLinearMap := MatrixMap.of_kraus M M
   cp := MatrixMap.of_kraus_isCompletelyPositive M
 
@@ -236,14 +242,16 @@ theorem injective_toPMap : (PTPMap.toPMap (dIn := dIn) (dOut := dOut) (𝕜 := �
   fun _ _ ↦ (mk.injEq _ _ _ _).mpr
 
 /-- Positive trace-preserving maps are functions from `HermitianMat`s to `HermitianMat`s. -/
-noncomputable instance instFunLike : FunLike (PTPMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+noncomputable instance instFunLike :
+    FunLike (PTPMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   coe := DFunLike.coe ∘ toPMap
   coe_injective' := DFunLike.coe_injective'.comp injective_toPMap
 
 lemma apply_hermitianMat_eq_toPMap (Λ : PTPMap dIn dOut ℂ) (ρ : HermitianMat dIn ℂ) :
     Λ ρ = Λ.toPMap ρ := rfl
 
-instance instLinearMapClass : LinearMapClass (PTPMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+instance instLinearMapClass :
+    LinearMapClass (PTPMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   map_add f x y := by simp [apply_hermitianMat_eq_toPMap]
   map_smulₛₗ f c x := by simp [apply_hermitianMat_eq_toPMap]
 
@@ -255,7 +263,8 @@ instance instHContinuousOrderHomClass : ContinuousOrderHomClass (PTPMap dIn dOut
 
 /-- PTP maps also preserve positivity on Hermitian matrices. -/
 @[simp]
-theorem pos_Hermitian (M : PTPMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) : 0 ≤ M x := by
+theorem pos_Hermitian (M : PTPMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) :
+    0 ≤ M x := by
   simpa only [map_zero] using ContinuousOrderHomClass.map_monotone M h
 
 /-- `PTPMap`s are functions from `MState`s to `MState`s. -/
@@ -270,7 +279,8 @@ noncomputable instance instMFunLike [DecidableEq dIn] [DecidableEq dOut] :
       have := congr($h ρ);
       rwa [MState.ext_iff, HermitianMat.ext_iff] at this
 
-lemma apply_mstate_eq [DecidableEq dIn] [DecidableEq dOut] (Λ : PTPMap dIn dOut ℂ) (ρ : MState dIn) :
+lemma apply_mstate_eq [DecidableEq dIn] [DecidableEq dOut] (Λ : PTPMap dIn dOut ℂ)
+    (ρ : MState dIn) :
     Λ ρ = MState.mk
       (Λ.toHPMap ρ.M) (HermitianMat.zero_le_iff.mpr (Λ.pos ρ.psd)) (by
         rw [HermitianMat.trace_eq_one_iff, ← ρ.tr']
@@ -290,7 +300,8 @@ theorem val_apply_MState [DecidableEq dIn] (M : PTPMap dIn dOut) (ρ : MState dI
 --If we have a PTPMap, the input and output dimensions are always both nonempty (otherwise
 --we can't preserve trace) - or they're both empty. So `[Nonempty dIn]` will always suffice.
 -- This would be nice as an `instance` but that would leave `dIn` as a metavariable.
-theorem nonemptyOut (Λ : PTPMap dIn dOut) [hIn : Nonempty dIn] [DecidableEq dIn] : Nonempty dOut := by
+theorem nonemptyOut (Λ : PTPMap dIn dOut) [hIn : Nonempty dIn] [DecidableEq dIn] :
+    Nonempty dOut := by
   by_contra h
   simp only [not_nonempty_iff] at h
   let M := (1 : Matrix dIn dIn ℂ)
@@ -317,16 +328,19 @@ theorem ext {Λ₁ Λ₂ : CPTPMap dIn dOut 𝕜} (h : Λ₁.map = Λ₂.map) : 
   rw [CPTPMap.mk.injEq]
   exact PTPMap.ext h
 
-theorem injective_toPTPMap : (CPTPMap.toPTPMap (dIn := dIn) (dOut := dOut) (𝕜 := 𝕜)).Injective :=
+theorem injective_toPTPMap :
+    (CPTPMap.toPTPMap (dIn := dIn) (dOut := dOut) (𝕜 := 𝕜)).Injective :=
   fun _ _ ↦ (mk.injEq _ _ _ _).mpr
 
 -- /-- Positive trace-preserving maps are functions from `HermitianMat`s to `HermitianMat`s. -/
--- instance instFunLike : FunLike (CPTPMap dIn dOut 𝕜) (HermitianMat dIn 𝕜) (HermitianMat dOut 𝕜) where
+-- instance instFunLike : FunLike (CPTPMap dIn dOut 𝕜) (HermitianMat dIn 𝕜)
+-- (HermitianMat dOut 𝕜) where
 --   coe :=  DFunLike.coe ∘ toPTPMap
 --   coe_injective' := DFunLike.coe_injective'.comp injective_toPTPMap
 
 -- set_option synthInstance.maxHeartbeats 40000 in
--- instance instLinearMapClass : LinearMapClass (CPTPMap dIn dOut 𝕜) ℝ (HermitianMat dIn 𝕜) (HermitianMat dOut 𝕜) where
+-- instance instLinearMapClass : LinearMapClass (CPTPMap dIn dOut 𝕜) ℝ (HermitianMat dIn 𝕜)
+-- (HermitianMat dOut 𝕜) where
 --   map_add f x y := by simp [instFunLike]
 --   map_smulₛₗ f c x := by simp [instFunLike]
 
@@ -338,11 +352,13 @@ theorem injective_toPTPMap : (CPTPMap.toPTPMap (dIn := dIn) (dOut := dOut) (𝕜
 
 -- /-- PTP maps also preserve positivity on Hermitian matrices. -/
 -- @[simp]
--- theorem pos_Hermitian (M : CPTPMap dIn dOut 𝕜) {x : HermitianMat dIn 𝕜} (h : 0 ≤ x) : 0 ≤ M x := by
+-- theorem pos_Hermitian (M : CPTPMap dIn dOut 𝕜) {x : HermitianMat dIn 𝕜} (h : 0 ≤ x) :
+-- 0 ≤ M x := by
 --   simpa only [map_zero] using ContinuousOrderHomClass.map_monotone M h
 
 /-- `CPTPMap`s are functions from `MState`s to `MState`s. -/
-noncomputable instance instMFunLike [DecidableEq dOut] : FunLike (CPTPMap dIn dOut) (MState dIn) (MState dOut) where
+noncomputable instance instMFunLike [DecidableEq dOut] :
+    FunLike (CPTPMap dIn dOut) (MState dIn) (MState dOut) where
   coe := DFunLike.coe ∘ toPTPMap
   coe_injective' := DFunLike.coe_injective'.comp injective_toPTPMap
 
@@ -380,14 +396,16 @@ theorem injective_toPMap : (PUMap.toPMap (dIn := dIn) (dOut := dOut) (𝕜 := �
   rwa [PUMap.mk.injEq]
 
 /-- `PUMap`s are functions from `HermitianMat`s to `HermitianMat`s. -/
-noncomputable instance instFunLike : FunLike (PUMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+noncomputable instance instFunLike :
+    FunLike (PUMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   coe Λ := Λ.toPMap
   coe_injective' := (DFunLike.coe_injective' (F := PMap dIn dOut ℂ)).comp injective_toPMap
 
 lemma apply_hermitianMat_eq_toPMap (Λ : PUMap dIn dOut ℂ) (ρ : HermitianMat dIn ℂ) :
     Λ ρ = Λ.toPMap ρ := rfl
 
-instance instLinearMapClass : LinearMapClass (PUMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+instance instLinearMapClass :
+    LinearMapClass (PUMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   map_add f x y := HermitianMat.ext <| LinearMap.map_add f.toLinearMap x y
   map_smulₛₗ f c x := HermitianMat.ext <| by simp [apply_hermitianMat_eq_toPMap]
 
@@ -403,7 +421,8 @@ instance instOneHomClass : OneHomClass (PUMap dIn dOut ℂ)
 
 /-- CPTP maps also preserve positivity on Hermitian matrices. -/
 @[simp]
-theorem pos_Hermitian (M : PUMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) : 0 ≤ M x := by
+theorem pos_Hermitian (M : PUMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) :
+    0 ≤ M x := by
   simpa only [map_zero] using ContinuousOrderHomClass.map_monotone M h
 
 end PUMap
@@ -416,19 +435,22 @@ theorem ext {Λ₁ Λ₂ : CPUMap dIn dOut 𝕜} (h : Λ₁.map = Λ₂.map) : �
   rw [CPUMap.mk.injEq, CPMap.mk.injEq]
   exact PMap.ext h
 
-theorem injective_toPMap : (CPMap.toPMap ∘ CPUMap.toCPMap (dIn := dIn) (dOut := dOut) (𝕜 := 𝕜)).Injective := by
+theorem injective_toPMap :
+    (CPMap.toPMap ∘ CPUMap.toCPMap (dIn := dIn) (dOut := dOut) (𝕜 := 𝕜)).Injective := by
   intro _ _ _
   rwa [CPUMap.mk.injEq, CPMap.mk.injEq]
 
 /-- `CPUMap`s are functions from `HermitianMat`s to `HermitianMat`s. -/
-noncomputable instance instFunLike : FunLike (CPUMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+noncomputable instance instFunLike :
+    FunLike (CPUMap dIn dOut ℂ) (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   coe Λ := Λ.toPMap
   coe_injective' := (DFunLike.coe_injective' (F := PMap dIn dOut ℂ)).comp injective_toPMap
 
 lemma apply_hermitianMat_eq_toPMap (Λ : CPUMap dIn dOut ℂ) (ρ : HermitianMat dIn ℂ) :
     Λ ρ = Λ.toPMap ρ := rfl
 
-instance instLinearMapClass : LinearMapClass (CPUMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
+instance instLinearMapClass :
+    LinearMapClass (CPUMap dIn dOut ℂ) ℝ (HermitianMat dIn ℂ) (HermitianMat dOut ℂ) where
   map_add f x y := HermitianMat.ext <| LinearMap.map_add f.toLinearMap x y
   map_smulₛₗ f c x := HermitianMat.ext <| by simp [apply_hermitianMat_eq_toPMap]
 
@@ -444,7 +466,8 @@ instance instOneHomClass : OneHomClass (CPUMap dIn dOut ℂ)
 
 /-- CPTP maps also preserve positivity on Hermitian matrices. -/
 @[simp]
-theorem pos_Hermitian (M : CPUMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) : 0 ≤ M x := by
+theorem pos_Hermitian (M : CPUMap dIn dOut ℂ) {x : HermitianMat dIn ℂ} (h : 0 ≤ x) :
+    0 ≤ M x := by
   simpa only [map_zero] using ContinuousOrderHomClass.map_monotone M h
 
 end CPUMap
@@ -461,9 +484,11 @@ example (M : HPMap dIn dOut ℂ) : (M (Real.pi • 1)) = Real.pi • M 1 := by s
 example (M : PTPMap dIn dOut ℂ) : (M.toHPMap (Real.pi • 1)) = Real.pi • M.toHPMap 1 := by simp
 
 #guard_msgs in
-example (M : CPTPMap dIn dOut 𝕜) (ρ : Matrix dIn dIn 𝕜) : (M.map ρ).trace = ρ.trace := by simp
+example (M : CPTPMap dIn dOut 𝕜) (ρ : Matrix dIn dIn 𝕜) : (M.map ρ).trace = ρ.trace := by
+  simp
 
 #guard_msgs in
-example (M : CPUMap dIn dOut ℂ) (T : HermitianMat dIn ℂ) : M (1 + 2 • T) = 1 + 2 • M T := by simp
+example (M : CPUMap dIn dOut ℂ) (T : HermitianMat dIn ℂ) : M (1 + 2 • T) = 1 + 2 • M T := by
+  simp
 
 end test

--- a/QuantumInfo/Channels/CPTP.lean
+++ b/QuantumInfo/Channels/CPTP.lean
@@ -56,7 +56,8 @@ variable (Λ : CPTPMap dIn dOut)
 def choi := Λ.map.choi_matrix
 
 /-- Two CPTPMaps are equal if their Choi matrices are equal. -/
-theorem choi_ext {Λ₁ Λ₂ : CPTPMap dIn dOut} (h : Λ₁.choi = Λ₂.choi) : Λ₁ = Λ₂ := by
+theorem choi_ext {Λ₁ Λ₂ : CPTPMap dIn dOut} (h : Λ₁.choi = Λ₂.choi) :
+    Λ₁ = Λ₂ := by
   ext1
   exact MatrixMap.choi_equiv.injective h
 
@@ -89,7 +90,9 @@ theorem mat_coe_eq_apply_mat [DecidableEq dOut] (ρ : MState dIn) : (Λ ρ).m = 
   rfl
 
 @[ext]
-theorem funext [DecidableEq dOut] {Λ₁ Λ₂ : CPTPMap dIn dOut} (h : ∀ ρ, Λ₁ ρ = Λ₂ ρ) : Λ₁ = Λ₂ :=
+theorem funext [DecidableEq dOut] {Λ₁ Λ₂ : CPTPMap dIn dOut}
+    (h : ∀ ρ, Λ₁ ρ = Λ₂ ρ) :
+    Λ₁ = Λ₂ :=
   DFunLike.ext _ _ h
 
 /-- The composition of CPTPMaps, as a CPTPMap. -/
@@ -102,12 +105,14 @@ infixl:75 "∘ₘ" => CPTPMap.compose
 
 /-- Composition of CPTPMaps by `CPTPMap.compose` is compatible with the `instFunLike` action. -/
 @[simp]
-theorem compose_eq [DecidableEq dOut] {Λ₁ : CPTPMap dIn dM} {Λ₂ : CPTPMap dM dOut} : ∀ρ, (Λ₂ ∘ₘ Λ₁) ρ = Λ₂ (Λ₁ ρ) :=
+theorem compose_eq [DecidableEq dOut] {Λ₁ : CPTPMap dIn dM} {Λ₂ : CPTPMap dM dOut} :
+    ∀ρ, (Λ₂ ∘ₘ Λ₁) ρ = Λ₂ (Λ₁ ρ) :=
   fun _ ↦ rfl
 
 /-- Composition of CPTPMaps is associative. -/
 theorem compose_assoc [DecidableEq dOut] (Λ₃ : CPTPMap dM₂ dOut) (Λ₂ : CPTPMap dM dM₂)
-    (Λ₁ : CPTPMap dIn dM) : (Λ₃ ∘ₘ Λ₂) ∘ₘ Λ₁ = Λ₃ ∘ₘ (Λ₂ ∘ₘ Λ₁) := by
+    (Λ₁ : CPTPMap dIn dM) :
+    (Λ₃ ∘ₘ Λ₂) ∘ₘ Λ₁ = Λ₃ ∘ₘ (Λ₂ ∘ₘ Λ₁) := by
   ext1 ρ
   simp
 
@@ -122,13 +127,18 @@ instance instMixable : Mixable (Matrix (dOut × dIn) (dOut × dIn) ℂ) (CPTPMap
       exact t.TP)),
     by apply choi_of_CPTP_of_choi⟩
   convex := by
-    have h_convex : ∀ (M₁ M₂ : Matrix (dOut × dIn) (dOut × dIn) ℂ), M₁.PosSemidef → M₂.PosSemidef → ∀ (t : ℝ), 0 ≤ t → t ≤ 1 → (t • M₁ + (1 - t) • M₂).PosSemidef := by
+    have h_convex : ∀ (M₁ M₂ : Matrix (dOut × dIn) (dOut × dIn) ℂ),
+        M₁.PosSemidef → M₂.PosSemidef → ∀ (t : ℝ), 0 ≤ t → t ≤ 1 →
+        (t • M₁ + (1 - t) • M₂).PosSemidef := by
       intro M₁ M₂ h₁ h₂ t ht₁ ht₂;
-      convert Matrix.PosSemidef.add ( h₁.smul ht₁ ) ( h₂.smul ( sub_nonneg.mpr ht₂ ) ) using 1;
+      convert Matrix.PosSemidef.add ( h₁.smul ht₁ )
+        ( h₂.smul ( sub_nonneg.mpr ht₂ ) ) using 1;
     intro M hM N hN a b ha hb hab;
     obtain ⟨Λ₁, hΛ₁⟩ := hM
     obtain ⟨Λ₂, hΛ₂⟩ := hN;
-    obtain ⟨Λ, hΛ⟩ : ∃ Λ : MatrixMap dIn dOut ℂ, (a • M + b • N).traceLeft = 1 ∧ (a • M + b • N).PosSemidef ∧ Λ = MatrixMap.of_choi_matrix (a • M + b • N) := by
+    obtain ⟨Λ, hΛ⟩ : ∃ Λ : MatrixMap dIn dOut ℂ, (a • M + b • N).traceLeft = 1 ∧
+        (a • M + b • N).PosSemidef ∧
+        Λ = MatrixMap.of_choi_matrix (a • M + b • N) := by
       refine ⟨_, ?_, ?_, rfl⟩
       · have h_trace_M : M.traceLeft = 1 := by
           convert Λ₁.TP using 1;
@@ -136,12 +146,15 @@ instance instMixable : Mixable (Matrix (dOut × dIn) (dOut × dIn) ℂ) (CPTPMap
         have h_trace_N : N.traceLeft = 1 := by
           convert Λ₂.map.IsTracePreserving_iff_trace_choi.1 Λ₂.TP;
           exact hΛ₂.symm;
-        convert congr_arg₂ ( fun x y : Matrix dIn dIn ℂ => a • x + b • y ) h_trace_M h_trace_N using 1;
+        convert congr_arg₂ ( fun x y : Matrix dIn dIn ℂ => a • x + b • y )
+          h_trace_M h_trace_N using 1;
         · ext i j
           simp [ Matrix.traceLeft ]
           simp only [Finset.sum_add_distrib, Finset.mul_sum _ _ _];
         · rw [ ← add_smul, hab, one_smul ];
-      · convert h_convex M N ( by simpa [ ← hΛ₁ ] using Λ₁.choi_PSD_of_CPTP ) ( by simpa [ ← hΛ₂ ] using Λ₂.choi_PSD_of_CPTP ) a ha ( by linarith ) using 1 ; rw [ ← hab ]
+      · convert h_convex M N ( by simpa [ ← hΛ₁ ] using Λ₁.choi_PSD_of_CPTP )
+          ( by simpa [ ← hΛ₂ ] using Λ₂.choi_PSD_of_CPTP ) a ha ( by linarith ) using 1
+        rw [ ← hab ]
         ring_nf
     use CPTP_of_choi_PSD_Tr hΛ.2.1 hΛ.1;
     exact MatrixMap.map_choi_inv (a • M + b • N)
@@ -194,7 +207,8 @@ theorem ofEquiv_apply (σ : dIn ≃ dOut) (ρ : MState dIn) :
   rfl
 
 @[simp]
-theorem equiv_inverse (σ : dIn ≃ dOut)  : (ofEquiv σ) ∘ (ofEquiv σ.symm) = id (dIn := dOut) := by
+theorem equiv_inverse (σ : dIn ≃ dOut)  :
+    (ofEquiv σ) ∘ (ofEquiv σ.symm) = id (dIn := dOut) := by
   ext1; simp
 
 variable {d₁ d₂ d₃ : Type*} [Fintype d₁] [Fintype d₂] [Fintype d₃]
@@ -216,15 +230,18 @@ def assoc' : CPTPMap (d₁ × d₂ × d₃) ((d₁ × d₂) × d₃) :=
   ofEquiv (Equiv.prodAssoc d₁ d₂ d₃).symm
 
 @[simp]
-theorem SWAP_eq_MState_SWAP (ρ : MState (d₁ × d₂)) : SWAP (d₁ := d₁) (d₂ := d₂) ρ = ρ.SWAP :=
+theorem SWAP_eq_MState_SWAP (ρ : MState (d₁ × d₂)) :
+    SWAP (d₁ := d₁) (d₂ := d₂) ρ = ρ.SWAP :=
   rfl
 
 @[simp]
-theorem assoc_eq_MState_assoc (ρ : MState ((d₁ × d₂) × d₃)) : assoc (d₁ := d₁) (d₂ := d₂) (d₃ := d₃) ρ = ρ.assoc :=
+theorem assoc_eq_MState_assoc (ρ : MState ((d₁ × d₂) × d₃)) :
+    assoc (d₁ := d₁) (d₂ := d₂) (d₃ := d₃) ρ = ρ.assoc :=
   rfl
 
 @[simp]
-theorem assoc'_eq_MState_assoc' (ρ : MState (d₁ × d₂ × d₃)) : assoc' (d₁ := d₁) (d₂ := d₂) (d₃ := d₃) ρ = ρ.assoc' :=
+theorem assoc'_eq_MState_assoc' (ρ : MState (d₁ × d₂ × d₃)) :
+    assoc' (d₁ := d₁) (d₂ := d₂) (d₃ := d₃) ρ = ρ.assoc' :=
   rfl
 
 @[simp]
@@ -241,7 +258,8 @@ variable {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [D
 @[simps]
 def traceLeft : CPTPMap (d₁ × d₂) d₂ :=
     --TODO: make Matrix.traceLeft a linear map, a `MatrixMap`.
-  letI f (d) [Fintype d] [DecidableEq d]: Matrix (d₁ × d) (d₁ × d) ℂ →ₗ[ℂ] Matrix d d ℂ := {
+  letI f (d) [Fintype d] [DecidableEq d]:
+      Matrix (d₁ × d) (d₁ × d) ℂ →ₗ[ℂ] Matrix d d ℂ := {
     toFun x := Matrix.traceLeft x
     map_add' := by
       intros; ext
@@ -260,7 +278,8 @@ def traceLeft : CPTPMap (d₁ × d₂) d₂ :=
       intro n
       classical
       suffices MatrixMap.IsPositive
-          (f (d₂ × Fin n) ∘ₗ (MatrixMap.submatrix ℂ (Equiv.prodAssoc d₁ d₂ (Fin n)).symm)) by
+          (f (d₂ × Fin n) ∘ₗ
+            (MatrixMap.submatrix ℂ (Equiv.prodAssoc d₁ d₂ (Fin n)).symm)) by
         convert this
         ext
         rw [MatrixMap.kron_def]
@@ -299,7 +318,8 @@ def replacement [Nonempty dIn] [DecidableEq dOut] (ρ : MState dOut) : CPTPMap d
 
 /-- The output of `replacement ρ` is always that `ρ`. -/
 @[simp]
-theorem replacement_apply [Nonempty dIn] [DecidableEq dOut] (ρ : MState dOut) (ρ₀ : MState dIn) :
+theorem replacement_apply [Nonempty dIn] [DecidableEq dOut] (ρ : MState dOut)
+    (ρ₀ : MState dIn) :
     replacement ρ ρ₀ = ρ := by
   simp only [replacement, compose_eq, traceLeft_eq_MState_traceLeft]
   simp only [apply_mState_eq_toPTPMap, PTPMap.apply_mstate_eq, HPMap.apply_hermitianMat_eq,
@@ -336,7 +356,8 @@ instance instUnique [Nonempty dIn] [Unique dOut] : Unique (CPTPMap dIn dOut) whe
   uniq := fun _ ↦ eq_if_output_unique _ _
 
 @[simp]
-theorem destroy_comp {dOut₂ : Type*} [Unique dOut₂] [DecidableEq dOut] [Nonempty dIn] [Nonempty dOut]
+theorem destroy_comp {dOut₂ : Type*} [Unique dOut₂] [DecidableEq dOut] [Nonempty dIn]
+    [Nonempty dOut]
   (Λ : CPTPMap dIn dOut) :
     destroy (dOut := dOut₂) ∘ₘ Λ = destroy :=
   Unique.eq_default _
@@ -344,12 +365,14 @@ theorem destroy_comp {dOut₂ : Type*} [Unique dOut₂] [DecidableEq dOut] [None
 section prod
 open Kronecker
 
-variable {dI₁ dI₂ dO₁ dO₂ : Type*} [Fintype dI₁] [Fintype dI₂] [Fintype dO₁] [Fintype dO₂]
+variable {dI₁ dI₂ dO₁ dO₂ : Type*} [Fintype dI₁] [Fintype dI₂] [Fintype dO₁]
+    [Fintype dO₂]
 variable [DecidableEq dI₁] [DecidableEq dI₂] [DecidableEq dO₁] [DecidableEq dO₂]
 
 set_option maxRecDepth 1000 in -- ??? what the heck is recursing
 /-- The tensor product of two CPTPMaps. -/
-def prod (Λ₁ : CPTPMap dI₁ dO₁) (Λ₂ : CPTPMap dI₂ dO₂) : CPTPMap (dI₁ × dI₂) (dO₁ × dO₂) where
+def prod (Λ₁ : CPTPMap dI₁ dO₁) (Λ₂ : CPTPMap dI₂ dO₂) :
+    CPTPMap (dI₁ × dI₂) (dO₁ × dO₂) where
   toLinearMap := Λ₁.map.kron Λ₂.map
   cp := Λ₁.cp.kron Λ₂.cp
   TP := Λ₁.TP.kron Λ₂.TP
@@ -376,7 +399,8 @@ variable {dO : ι → Type w} [∀(i :ι), Fintype (dO i)] [∀(i :ι), Decidabl
 
 set_option maxRecDepth 1000 in
 /-- Finitely-indexed tensor products of CPTPMaps.  -/
-def piProd (Λi : (i:ι) → CPTPMap (dI i) (dO i)) : CPTPMap ((i:ι) → dI i) ((i:ι) → dO i) where
+def piProd (Λi : (i:ι) → CPTPMap (dI i) (dO i)) :
+    CPTPMap ((i:ι) → dI i) ((i:ι) → dO i) where
   toLinearMap := MatrixMap.piProd (fun i ↦ (Λi i).map)
   cp := MatrixMap.IsCompletelyPositive.piProd (fun i ↦ (Λi i).cp)
   TP := MatrixMap.IsTracePreserving.piProd (fun i ↦ (Λi i).TP)
@@ -444,11 +468,15 @@ def IsUnitary (Λ : CPTPMap dIn dIn) : Prop :=
   ∃ U, Λ = ofUnitary U
 
 /-- A channel is unitary iff it can be written as conjugation by a unitary. -/
-theorem IsUnitary_iff_U_conj (Λ : CPTPMap dIn dIn) : IsUnitary Λ ↔ ∃ U, ∀ ρ, Λ ρ = ρ.U_conj U := by
+theorem IsUnitary_iff_U_conj (Λ : CPTPMap dIn dIn) :
+    IsUnitary Λ ↔ ∃ U, ∀ ρ, Λ ρ = ρ.U_conj U := by
   simp_rw [IsUnitary, ← ofUnitary_eq_conj, CPTPMap.funext_iff]
 
 theorem IsUnitary_equiv (σ : dIn ≃ dIn) : IsUnitary (ofEquiv σ) := by
-  have h_unitary : ∃ U : Matrix dIn dIn ℂ, U * U.conjTranspose = 1 ∧ U.conjTranspose * U = 1 ∧ ∀ x : dIn, (∀ y : dIn, (U y x = 1) ↔ (y = σ x)) ∧ ∀ y : dIn, (U y x = 0) ↔ (y ≠ σ x) := by
+  have h_unitary : ∃ U : Matrix dIn dIn ℂ, U * U.conjTranspose = 1 ∧
+      U.conjTranspose * U = 1 ∧
+      ∀ x : dIn, (∀ y : dIn, (U y x = 1) ↔ (y = σ x)) ∧
+        ∀ y : dIn, (U y x = 0) ↔ (y ≠ σ x) := by
     simp only [Matrix.conjTranspose, RCLike.star_def];
     refine' ⟨ fun y x => if y = σ x then 1 else 0, ?_, ?_, by simp⟩
     · ext y x
@@ -459,7 +487,8 @@ theorem IsUnitary_equiv (σ : dIn ≃ dIn) : IsUnitary (ofEquiv σ) := by
       simp [Matrix.one_apply, eq_comm]
   obtain ⟨U, hU_unitary, hU_eq⟩ := h_unitary;
   use ⟨U, Matrix.mem_unitaryGroup_iff.mpr hU_unitary⟩
-  have h_mul : ∀ ρ : Matrix dIn dIn ℂ, U * ρ * Uᴴ = Matrix.submatrix ρ σ.symm σ.symm := by
+  have h_mul : ∀ ρ : Matrix dIn dIn ℂ,
+      U * ρ * Uᴴ = Matrix.submatrix ρ σ.symm σ.symm := by
     intro ρ
     ext i j
     have hU_i_x : ∀ x : dIn, U i x = if x = σ.symm i then 1 else 0 := by grind
@@ -491,11 +520,12 @@ omit [DecidableEq dOut] [Inhabited dOut] in
 PROBLEM If a MatrixMap of_kraus K K is trace-preserving, then Σ_k K_k† K_k = 1.
 
 PROVIDED SOLUTION The TP condition says for all X, trace((of_kraus K K) X) = trace(X). Unfolding
-of_kraus: trace(Σ_k K_k X K_k†) = Σ_k trace(K_k† K_k X) (by cycle) = trace((Σ_k K_k† K_k) X). So
+of_kraus: trace(Σ_k K_k X K_k†) = Σ_k trace(K_k† K_k X) (by cycle) =
+trace((Σ_k K_k† K_k) X). So
 trace(A X) = trace(X) for all X where A = Σ_k K_k† K_k, which means A = 1. Use
 `Matrix.eq_of_trace_mul_eq` or the fact that trace is a faithful pairing on matrices to conclude A =
-1. The TP condition `Λ.TP` gives us `∀ x, (Λ.map x).trace = x.trace`, and since `Λ.map = of_kraus K
-K`, we substitute and simplify.
+1. The TP condition `Λ.TP` gives us `∀ x, (Λ.map x).trace = x.trace`, and since
+`Λ.map = of_kraus K K`, we substitute and simplify.
 -/
 private lemma kraus_sum_eq_one_of_TP
     {κ : Type*} [Fintype κ]
@@ -544,16 +574,19 @@ private lemma exists_unitary_extending_isometry
   -- Let $u_i$ be the $i$-th column of $V$.
   set u : n → EuclideanSpace ℂ m := fun j => WithLp.toLp 2 (fun i => V i j)
   -- Since $u$ is an orthonormal set, we can extend it to an orthonormal basis of $\mathbb{C}^m$.
-  obtain ⟨b, hb⟩ : ∃ b : OrthonormalBasis m ℂ (EuclideanSpace ℂ m), ∀ j, b (emb j) = u j := by
+  obtain ⟨b, hb⟩ : ∃ b : OrthonormalBasis m ℂ (EuclideanSpace ℂ m),
+      ∀ j, b (emb j) = u j := by
     have h_orthonormal : Orthonormal ℂ (fun j => u j) := by
       rw [ orthonormal_iff_ite ];
       intro i j
       replace hV := congr_fun (congr_fun hV i) j
       simpa only [ mul_comm, Matrix.mul_apply ] using hV
-    have := Orthonormal.exists_orthonormalBasis_extension_of_card_eq (𝕜 := ℂ) (E := EuclideanSpace ℂ m) (ι := m)
+    have := Orthonormal.exists_orthonormalBasis_extension_of_card_eq (𝕜 := ℂ)
+      (E := EuclideanSpace ℂ m) (ι := m)
     simp only [finrank_euclideanSpace, forall_const] at this
     contrapose! this
-    · refine ⟨fun i => if hi : i ∈ Set.range emb then u (Classical.choose hi) else 0, Set.range emb, ?_, ?_ ⟩
+    · refine ⟨fun i => if hi : i ∈ Set.range emb then u (Classical.choose hi) else 0,
+        Set.range emb, ?_, ?_ ⟩
       · simp +contextual only [Orthonormal, h_orthonormal.1, implies_true, true_and,
           Set.mem_range, Set.restrict_apply, Subtype.forall, ↓reduceDIte]
         intro i j hij
@@ -566,11 +599,13 @@ private lemma exists_unitary_extending_isometry
         · simp
         · simp
       · simp_all only [Orthonormal, ne_eq, Set.mem_range, exists_exists_eq_and,
-          EmbeddingLike.apply_eq_iff_eq, exists_eq, ↓reduceDIte, Classical.choose_eq, implies_true];
+          EmbeddingLike.apply_eq_iff_eq, exists_eq, ↓reduceDIte, Classical.choose_eq,
+          implies_true];
   refine ⟨⟨Matrix.of (fun i j ↦ b j i), ?_⟩, ?_⟩
   · simp only [Matrix.mem_unitaryGroup_iff]
     ext1 i j
-    simpa [inner] using b.sum_inner_mul_inner (EuclideanSpace.single i 1) (EuclideanSpace.single j 1)
+    simpa [inner] using
+      b.sum_inner_mul_inner (EuclideanSpace.single i 1) (EuclideanSpace.single j 1)
   · simp [hb, u]
 
 omit [DecidableEq dOut] [Inhabited dOut] in
@@ -600,7 +635,8 @@ private lemma purify_MState_pure_basis_default_entry (i j : dOut × dOut) :
   split_ifs <;> simp_all [eq_comm]
 
 omit [Inhabited dOut] in
-private lemma purify_replacement_single_eq (ρ₀ : MState (dOut × dOut)) (b₁ b₂ : dOut × dOut) :
+private lemma purify_replacement_single_eq (ρ₀ : MState (dOut × dOut))
+    (b₁ b₂ : dOut × dOut) :
     ((replacement ρ₀).map (Matrix.single () () 1)) b₁ b₂ = ρ₀.m b₁ b₂ := by
   open Kronecker in
   suffices h : (Matrix.single () () 1 ⊗ₖ ρ₀.m).traceLeft = ρ₀.m from
@@ -649,7 +685,8 @@ private lemma purify_conj_entry (X : Matrix dIn dIn ℂ) (U : 𝐔[dIn × dOut �
       let zero_prep : CPTPMap Unit (dOut × dOut) := replacement ρ₀
       let prep := (id ⊗ᶜᵖ zero_prep)
       let append : CPTPMap dIn (dIn × Unit) := CPTPMap.ofEquiv (Equiv.prodPUnit dIn).symm
-      (prep ∘ₘ append).map X = X ⊗ₖ (MState.pure (Ket.basis (default : dOut × dOut))).m := by
+      (prep ∘ₘ append).map X =
+        X ⊗ₖ (MState.pure (Ket.basis (default : dOut × dOut))).m := by
     ext ⟨a₁, b₁c₁⟩ ⟨a₂, b₂c₂⟩
     simp [purify_prep_append_entry]
   have h_conj :
@@ -658,13 +695,19 @@ private lemma purify_conj_entry (X : Matrix dIn dIn ℂ) (U : 𝐔[dIn × dOut �
       let prep := (id ⊗ᶜᵖ zero_prep)
       let append := CPTPMap.ofEquiv (Equiv.prodPUnit dIn).symm
       (ofUnitary U).map ((prep ∘ₘ append).map X) i j =
-      ∑ k, ∑ l, U.val i k * (X ⊗ₖ (MState.pure (Ket.basis (default : dOut × dOut))).m) k l * starRingEnd ℂ (U.val j l) := by
+      ∑ k, ∑ l,
+        U.val i k * (X ⊗ₖ (MState.pure (Ket.basis (default : dOut × dOut))).m) k l *
+        starRingEnd ℂ (U.val j l) := by
     simp [h_conj, Matrix.kroneckerMap]
-    convert congr_arg (fun m : Matrix (dIn × dOut × dOut) (dIn × dOut × dOut) ℂ => m i j) (show (U.val * (Matrix.of fun i j => X i.1 j.1 * ((Ket.basis default) i.2 * (starRingEnd ℂ) ((Ket.basis default) j.2))) * U.val.conjTranspose) = _ from rfl) using 1
+    convert congr_arg (fun m : Matrix (dIn × dOut × dOut) (dIn × dOut × dOut) ℂ => m i j)
+      (show (U.val * (Matrix.of fun i j => X i.1 j.1 *
+        ((Ket.basis default) i.2 * (starRingEnd ℂ) ((Ket.basis default) j.2))) *
+        U.val.conjTranspose) = _ from rfl) using 1
     simp [Matrix.mul_apply, Matrix.conjTranspose_apply]
     ring_nf!
     exact Finset.sum_comm.trans (Finset.sum_congr rfl fun _ _ => by rw [Finset.sum_mul])
-  have h_restrict : ∀ x : dIn × dOut × dOut, (Ket.basis default) x.2 = if x.2 = default then 1 else 0 := by
+  have h_restrict : ∀ x : dIn × dOut × dOut,
+      (Ket.basis default) x.2 = if x.2 = default then 1 else 0 := by
     intro x
     simp [Ket.basis, eq_comm]
     exact rfl
@@ -698,7 +741,8 @@ private lemma purify_rhs_entry (X : Matrix dIn dIn ℂ) (d₁ d₂ : dOut)
     (h (x, y, d₁) (x, y, d₂)).symm
 
 omit [DecidableEq dIn] [DecidableEq dOut] [Inhabited dOut] in
-private lemma purify_of_kraus_entry (K : (dOut × dIn) → Matrix dOut dIn ℂ) (X : Matrix dIn dIn ℂ) (d₁ d₂ : dOut) :
+private lemma purify_of_kraus_entry (K : (dOut × dIn) → Matrix dOut dIn ℂ)
+    (X : Matrix dIn dIn ℂ) (d₁ d₂ : dOut) :
     (MatrixMap.of_kraus K K) X d₁ d₂ =
     ∑ k : dOut × dIn, ∑ α₁ : dIn, ∑ α₂ : dIn,
       (K k) d₁ α₁ * X α₁ α₂ * starRingEnd ℂ ((K k) d₂ α₂) := by
@@ -787,7 +831,8 @@ theorem prep_append_map_entry (X : Matrix dIn dIn ℂ)
     X a₁ a₂ * τ.m b₁c₁ b₂c₂ := by
   simp [purify_prep_append_entry]
 
-/-- The complementary channel comes from tracing out the other half (the right half) of the purified channel `purify`. -/
+/-- The complementary channel comes from tracing out the other half (the right half) of the
+purified channel `purify`. -/
 def complementary (Λ : CPTPMap dIn dOut) : CPTPMap dIn (dIn × dOut) :=
   let zero_prep : CPTPMap Unit (dOut × dOut) := replacement (MState.pure (Ket.basis default))
   let prep := (id ⊗ᶜᵖ zero_prep)

--- a/QuantumInfo/Channels/Dual.lean
+++ b/QuantumInfo/Channels/Dual.lean
@@ -72,7 +72,8 @@ theorem IsHermitianPreserving.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsHermiti
     M.dual.IsHermitianPreserving := by
   have map_conjTranspose (x : Matrix dIn dIn ℂ) :
       M (Matrix.conjTranspose x) = Matrix.conjTranspose (M x) := by
-    have hxstar : (realPart x : Matrix dIn dIn ℂ) - Complex.I • (imaginaryPart x : Matrix dIn dIn ℂ) =
+    have hxstar : (realPart x : Matrix dIn dIn ℂ) -
+        Complex.I • (imaginaryPart x : Matrix dIn dIn ℂ) =
         Matrix.conjTranspose x := by
       rw [← Matrix.star_eq_conjTranspose]
       have hreal_star : (realPart (star x) : Matrix dIn dIn ℂ) = realPart x := by
@@ -102,7 +103,8 @@ theorem IsHermitianPreserving.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsHermiti
   simpa [Matrix.IsHermitian] using show Matrix.conjTranspose (M.dual x) = M.dual x by
     apply Matrix.ext_iff_trace_mul_left.mpr
     intro A
-    have htrace2 := congrArg star (Dual.trace_eq M (Matrix.conjTranspose A) (Matrix.conjTranspose x))
+    have htrace2 :=
+      congrArg star (Dual.trace_eq M (Matrix.conjTranspose A) (Matrix.conjTranspose x))
     rw [← Matrix.trace_conjTranspose, ← Matrix.trace_conjTranspose] at htrace2
     rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
       Matrix.conjTranspose_conjTranspose, Matrix.conjTranspose_conjTranspose,
@@ -146,7 +148,8 @@ theorem IsPositive.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsPositive) : M.dual
   rw [ MatrixMap.Dual.trace_eq ];
   simp [ Matrix.vecMulVec, Matrix.mul_apply, Matrix.trace ];
   simp [ Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _, mul_assoc, mul_comm, mul_left_comm ];
-  exact Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring )
+  exact Finset.sum_comm.trans
+    ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring )
 
 /-- The dual of TracePreserving map is *not* trace-preserving, it's *unital*, that is, M*(I) = I. -/
 theorem dual_Unital (h : M.IsTracePreserving) : M.dual.Unital := by
@@ -170,10 +173,12 @@ lemma dual_unique
     (h : ∀ A B, (M A * B).trace = (A * M' B).trace) : M.dual = M' := by
   -- By definition of dual, we know that for any A and B, the trace of (M A) * B equals the trace of
   -- A * (M.dual B).
-  have h_dual : ∀ A : Matrix dIn dIn 𝕜, ∀ B : Matrix dOut dOut 𝕜, (M A * B).trace = (A * M.dual B).trace := by
+  have h_dual : ∀ A : Matrix dIn dIn 𝕜, ∀ B : Matrix dOut dOut 𝕜,
+      (M A * B).trace = (A * M.dual B).trace := by
     exact fun A B => Dual.trace_eq M A B;
   -- Since these two linear maps agree on all bases, they must be equal.
-  have h_eq : ∀ A : Matrix dIn dIn 𝕜, ∀ B : Matrix dOut dOut 𝕜, (A * M.dual B).trace = (A * M' B).trace := by
+  have h_eq : ∀ A : Matrix dIn dIn 𝕜, ∀ B : Matrix dOut dOut 𝕜,
+      (A * M.dual B).trace = (A * M' B).trace := by
     exact fun A B => h_dual A B ▸ h A B;
   refine' LinearMap.ext fun B => _;
   exact Matrix.ext_iff_trace_mul_left.mpr fun x => h_eq x B
@@ -182,12 +187,15 @@ lemma dual_unique
 The Choi matrix of the dual map is the transpose of the reindexed Choi matrix of the original map.
 -/
 lemma dual_choi_matrix (M : MatrixMap dIn dOut 𝕜) :
-    M.dual.choi_matrix = (M.choi_matrix.transpose).reindex (Equiv.prodComm dOut dIn) (Equiv.prodComm dOut dIn) := by
+    M.dual.choi_matrix =
+      (M.choi_matrix.transpose).reindex (Equiv.prodComm dOut dIn) (Equiv.prodComm dOut dIn) := by
   -- By definition of dual, we know that
   -- $(M.dual (single j₁ j₂ 1)) i₁ i₂ = (M (single i₂ i₁ 1)) j₂ j₁$.
-  have h_dual_def : ∀ (i₁ : dIn) (j₁ : dOut) (i₂ : dIn) (j₂ : dOut), (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ = (M (Matrix.single i₂ i₁ 1)) j₂ j₁ := by
+  have h_dual_def : ∀ (i₁ : dIn) (j₁ : dOut) (i₂ : dIn) (j₂ : dOut),
+      (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ = (M (Matrix.single i₂ i₁ 1)) j₂ j₁ := by
     intro i₁ j₁ i₂ j₂
-    have h_dual_def : (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ = Matrix.trace (Matrix.single i₂ i₁ 1 * M.dual (Matrix.single j₁ j₂ 1)) := by
+    have h_dual_def : (M.dual (Matrix.single j₁ j₂ 1)) i₁ i₂ =
+        Matrix.trace (Matrix.single i₂ i₁ 1 * M.dual (Matrix.single j₁ j₂ 1)) := by
       simp [ Matrix.trace, Matrix.mul_apply ];
       simp [ Matrix.single];
       rw [ Finset.sum_eq_single i₂ ]
@@ -204,7 +212,8 @@ lemma dual_choi_matrix (M : MatrixMap dIn dOut 𝕜) :
 If the Choi matrix of a map is positive semidefinite, then the Choi matrix of its dual is also
 positive semidefinite.
 -/
-lemma dual_choi_matrix_posSemidef_of_posSemidef (M : MatrixMap dIn dOut 𝕜) (h : M.choi_matrix.PosSemidef) :
+lemma dual_choi_matrix_posSemidef_of_posSemidef (M : MatrixMap dIn dOut 𝕜)
+    (h : M.choi_matrix.PosSemidef) :
     M.dual.choi_matrix.PosSemidef := by
   rw [ dual_choi_matrix ];
   simp +zetaDelta at *;
@@ -265,12 +274,15 @@ lemma dual_kron {A B C D : Type*} [Fintype A] [Fintype B] [Fintype C] [Fintype D
 
 --The dual of a CompletelyPositive map is always CP, more generally it's k-positive
 -- see Lemma 3.1 of https://www.math.uwaterloo.ca/~krdavids/Preprints/CDPRpositivereal.pdf
-theorem IsCompletelyPositive.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsCompletelyPositive) : M.dual.IsCompletelyPositive := by
+theorem IsCompletelyPositive.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsCompletelyPositive) :
+    M.dual.IsCompletelyPositive := by
   intro n
   have h_dual_pos : (MatrixMap.dual (M ⊗ₖₘ MatrixMap.id (Fin n) ℂ)).IsPositive := by
     exact IsPositive.dual (h n);
-  -- By definition of complete positivity, we know that $(M ⊗ₖₘ id) dually map = M.dual ⊗ₖₘ id.dual$.
-  have h_dual_kron : (MatrixMap.dual (M ⊗ₖₘ MatrixMap.id (Fin n) ℂ)) = (MatrixMap.dual M) ⊗ₖₘ (MatrixMap.dual (MatrixMap.id (Fin n) ℂ)) := by
+  -- By definition of complete positivity, we know that
+  -- $(M ⊗ₖₘ id) dually map = M.dual ⊗ₖₘ id.dual$.
+  have h_dual_kron : (MatrixMap.dual (M ⊗ₖₘ MatrixMap.id (Fin n) ℂ)) =
+      (MatrixMap.dual M) ⊗ₖₘ (MatrixMap.dual (MatrixMap.id (Fin n) ℂ)) := by
     convert dual_kron M ( MatrixMap.id ( Fin n ) ℂ ) using 1;
   convert h_dual_pos using 1;
   rw [ h_dual_kron, dual_id ]
@@ -279,10 +291,14 @@ theorem IsCompletelyPositive.dual {M : MatrixMap dIn dOut ℂ} (h : M.IsComplete
 The composition of the dual of the inverse of the dual basis isomorphism with the dual basis
 isomorphism is the evaluation map.
 -/
-lemma Module.Basis.dualMap_toDualEquiv_symm_comp_toDualEquiv {ι R M : Type*} [Fintype ι] [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M] (b : Module.Basis ι R M) :
-    b.toDualEquiv.symm.toLinearMap.dualMap ∘ₗ b.toDualEquiv.toLinearMap = (Module.evalEquiv R M).toLinearMap := by
+lemma Module.Basis.dualMap_toDualEquiv_symm_comp_toDualEquiv {ι R M : Type*} [Fintype ι]
+    [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M]
+    (b : Module.Basis ι R M) :
+    b.toDualEquiv.symm.toLinearMap.dualMap ∘ₗ b.toDualEquiv.toLinearMap =
+      (Module.evalEquiv R M).toLinearMap := by
   ext x f;
-  -- Since $b.toDual$ and $b.toDualEquiv.symm$ are inverses, we have $b.toDual (b.toDualEquiv.symm f) = f$.
+  -- Since $b.toDual$ and $b.toDualEquiv.symm$ are inverses, we have
+  -- $b.toDual (b.toDualEquiv.symm f) = f$.
   have h_inv : b.toDual (b.toDualEquiv.symm f) = f := by
     convert LinearEquiv.apply_symm_apply b.toDualEquiv f;
   convert congr_arg ( fun g => g x ) h_inv using 1;
@@ -294,8 +310,11 @@ lemma Module.Basis.dualMap_toDualEquiv_symm_comp_toDualEquiv {ι R M : Type*} [F
 The composition of the inverse of the dual basis isomorphism with the dual of the dual basis
 isomorphism is the inverse of the evaluation map.
 -/
-lemma Module.Basis.toDualEquiv_symm_comp_dualMap_toDualEquiv {ι R M : Type*} [Fintype ι] [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M] (b : Module.Basis ι R M) :
-    b.toDualEquiv.symm.toLinearMap ∘ₗ b.toDualEquiv.toLinearMap.dualMap = (Module.evalEquiv R M).symm.toLinearMap := by
+lemma Module.Basis.toDualEquiv_symm_comp_dualMap_toDualEquiv {ι R M : Type*} [Fintype ι]
+    [DecidableEq ι] [CommRing R] [AddCommGroup M] [Module R M] [Module.IsReflexive R M]
+    (b : Module.Basis ι R M) :
+    b.toDualEquiv.symm.toLinearMap ∘ₗ b.toDualEquiv.toLinearMap.dualMap =
+      (Module.evalEquiv R M).symm.toLinearMap := by
   simp [ LinearMap.ext_iff ];
   intro x
   obtain ⟨y, hy⟩ : ∃ y, x = (Module.evalEquiv R M).toLinearMap y := by
@@ -332,7 +351,8 @@ theorem dual_pos (M : CPTPMap dIn dOut) {T : HermitianMat dOut ℂ} (hT : 0 ≤ 
 
 /-- The dual of a CPTP map preserves POVMs. Stated here just for two-element POVMs, that is, an
 operator `T` between 0 and 1. -/
-theorem dual.PTP_POVM (M : CPTPMap dIn dOut) {T : HermitianMat dOut ℂ} (hT : 0 ≤ T ∧ T ≤ 1) :
+theorem dual.PTP_POVM (M : CPTPMap dIn dOut) {T : HermitianMat dOut ℂ}
+    (hT : 0 ≤ T ∧ T ≤ 1) :
     (0 ≤ M.dual T ∧ M.dual T ≤ 1) := by
   rcases hT with ⟨hT₁, hT₂⟩
   have hT_psd := HermitianMat.zero_le_iff.mp hT₁
@@ -352,7 +372,8 @@ section hermDual
 
 set_option backward.isDefEq.respectTransparency false in
 --PULLOUT to Bundled.lean. Also use this to improve the definitions in POVM.lean.
-def HPMap.ofHermitianMat {dOut : Type*} (f : HermitianMat dIn ℂ →ₗ[ℝ] HermitianMat dOut ℂ) : HPMap dIn dOut where
+def HPMap.ofHermitianMat {dOut : Type*} (f : HermitianMat dIn ℂ →ₗ[ℝ] HermitianMat dOut ℂ) :
+    HPMap dIn dOut where
   toFun x := f (realPart x) + Complex.I • f (imaginaryPart x)
   map_add' x y := by
     simp only [map_add, HermitianMat.mat_add, smul_add]
@@ -361,7 +382,8 @@ def HPMap.ofHermitianMat {dOut : Type*} (f : HermitianMat dIn ℂ →ₗ[ℝ] He
     have h_expand : realPart (c • m) = c.re • realPart m - c.im • imaginaryPart m ∧
       imaginaryPart (c • m) = c.re • imaginaryPart m + c.im • realPart m := by
       simp only [Subtype.ext_iff, AddSubgroupClass.coe_sub, selfAdjoint.val_smul,
-        AddSubgroup.coe_add, realPart, selfAdjointPart_apply_coe, invOf_eq_inv, star_smul, RCLike.star_def,
+        AddSubgroup.coe_add, realPart, selfAdjointPart_apply_coe, invOf_eq_inv, star_smul,
+        RCLike.star_def,
         smul_add, imaginaryPart, LinearMap.coe_comp, Function.comp_apply,
         skewAdjoint.negISMul_apply_coe, skewAdjointPart_apply_coe,
         ← Matrix.ext_iff, Matrix.add_apply, Matrix.smul_apply, smul_eq_mul, Complex.real_smul,
@@ -445,7 +467,8 @@ theorem HPMap.inner_hermDual' (B : HermitianMat dOut ℂ) :
   HPMap.inner_hermDual f A B
 
 /-- The dual of a `IsPositive` map also `IsPositive`. -/
-theorem MatrixMap.IsPositive.hermDual (h : MatrixMap.IsPositive f.map) : f.hermDual.map.IsPositive := by
+theorem MatrixMap.IsPositive.hermDual (h : MatrixMap.IsPositive f.map) :
+    f.hermDual.map.IsPositive := by
   unfold IsPositive at h ⊢
   intro x hx
   set xH : HermitianMat dOut ℂ := ⟨x, hx.left⟩ with hxH
@@ -463,7 +486,8 @@ theorem MatrixMap.IsPositive.hermDual (h : MatrixMap.IsPositive f.map) : f.hermD
   apply HermitianMat.inner_ge_zero hx h
 
 /-- The dual of TracePreserving map is *not* trace-preserving, it's *unital*, that is, M*(I) = I. -/
-theorem HPMap.hermDual_Unital [DecidableEq dIn] [DecidableEq dOut] (h : MatrixMap.IsTracePreserving f.map) :
+theorem HPMap.hermDual_Unital [DecidableEq dIn] [DecidableEq dOut]
+    (h : MatrixMap.IsTracePreserving f.map) :
     f.hermDual.map.Unital := by
   suffices f.hermDual 1 = 1 by --todo: make this is an accessible 'constructor' for Unital
     rw [HermitianMat.ext_iff] at this
@@ -473,7 +497,8 @@ theorem HPMap.hermDual_Unital [DecidableEq dIn] [DecidableEq dOut] (h : MatrixMa
   intro v
   rw [← HPMap.inner_hermDual]
   rw [HermitianMat.inner_one, HermitianMat.inner_one] --TODO change to Inner.inner
-  exact congr(Complex.re $(h v)) --TODO: HPMap with IsTracePreserving give the HermitianMat.trace version
+  --TODO: HPMap with IsTracePreserving give the HermitianMat.trace version
+  exact congr(Complex.re $(h v))
 
 alias MatrixMap.IsTracePreserving.hermDual := HPMap.hermDual_Unital
 

--- a/QuantumInfo/Channels/MatrixMap.lean
+++ b/QuantumInfo/Channels/MatrixMap.lean
@@ -67,7 +67,8 @@ def choi_matrix (M : MatrixMap A B R) : Matrix (B × A) (B × A) R :=
 /-- Given the Choi matrix, generate the corresponding R-linear map between matrices as a
 MatrixMap. This is the inverse of `MatrixMap.choi_matrix`. -/
 def of_choi_matrix (M : Matrix (B × A) (B × A) R) : MatrixMap A B R where
-  toFun X := fun b₁ b₂ ↦ ∑ (a₁ : A), ∑ (a₂ : A), X a₁ a₂ * M (b₁, a₁) (b₂, a₂)
+  toFun X := fun b₁ b₂ ↦
+    ∑ (a₁ : A), ∑ (a₂ : A), X a₁ a₂ * M (b₁, a₁) (b₂, a₂)
   map_add' x y := by funext b₁ b₂; simp [add_mul, Finset.sum_add_distrib]
   map_smul' r x := by
     funext b₁ b₂
@@ -119,8 +120,10 @@ Compare with `MatrixMap.choi_matrix`, which gives the Choi matrix instead of the
 noncomputable def toMatrix [Fintype B] : MatrixMap A B R ≃ₗ[R] Matrix (B × B) (A × A) R :=
   LinearMap.toMatrix (Matrix.stdBasis R A A) (Matrix.stdBasis R B B)
 
-/-- Multiplication of transfer matrices, `MatrixMap.toMatrix`, is equivalent to composition of maps. -/
-theorem toMatrix_comp [Fintype B] [Fintype C] [DecidableEq B] (M₁ : MatrixMap A B R) (M₂ : MatrixMap B C R) : toMatrix (M₂ ∘ₗ M₁) = (toMatrix M₂) * (toMatrix M₁) :=
+/-- Multiplication of transfer matrices, `MatrixMap.toMatrix`, is equivalent to composition of
+maps. -/
+theorem toMatrix_comp [Fintype B] [Fintype C] [DecidableEq B] (M₁ : MatrixMap A B R)
+    (M₂ : MatrixMap B C R) : toMatrix (M₂ ∘ₗ M₁) = (toMatrix M₂) * (toMatrix M₁) :=
   LinearMap.toMatrix_comp _ _ _ M₂ M₁
 
 end matrix
@@ -160,7 +163,8 @@ theorem exists_kraus (Φ : MatrixMap A B R) :
     Finset.sum_apply]
   have hsum_reindex :
       (∑ x : Fin (Fintype.card K),
-          (M₀ ∘ e) x * Matrix.single i₁ i₂ (1 : R) * ((N₀ ∘ e) x).conjTranspose) j₁ j₂
+          (M₀ ∘ e) x * Matrix.single i₁ i₂ (1 : R) *
+            ((N₀ ∘ e) x).conjTranspose) j₁ j₂
         =
       ∑ y : K, (M₀ y * Matrix.single i₁ i₂ (1 : R) * (N₀ y).conjTranspose) j₁ j₂ := by
     rw [Matrix.sum_apply]
@@ -209,9 +213,12 @@ variable {A B C D R : Type*} [Fintype A] [Fintype B] [Fintype C] [Fintype D]
 variable [DecidableEq A] [DecidableEq C]
 
 /-- The Kronecker product of MatrixMaps. Defined here using `TensorProduct.map M₁ M₂`, with
-  appropriate reindexing operations and `LinearMap.toMatrix`/`Matrix.toLin`. Notation `⊗ₖₘ`. -/
-noncomputable def kron [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) : MatrixMap (A × C) (B × D) R :=
-  let h₁ := (LinearMap.toMatrix (Module.Basis.tensorProduct  (Matrix.stdBasis R A A) (Matrix.stdBasis R C C))
+  appropriate reindexing operations and `LinearMap.toMatrix`/`Matrix.toLin`. Notation
+  `⊗ₖₘ`. -/
+noncomputable def kron [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) :
+    MatrixMap (A × C) (B × D) R :=
+  let h₁ := (LinearMap.toMatrix
+      (Module.Basis.tensorProduct  (Matrix.stdBasis R A A) (Matrix.stdBasis R C C))
       (Module.Basis.tensorProduct  (Matrix.stdBasis R B B) (Matrix.stdBasis R D D)))
     (TensorProduct.map M₁ M₂);
   let r₁ := Equiv.prodProdProdComm B B D D;
@@ -225,15 +232,31 @@ set_option maxHeartbeats 800000 in
 set_option synthInstance.maxHeartbeats 60000 in
 /-- The extensional definition of the Kronecker product `MatrixMap.kron`, in terms of the entries of
   its image. -/
-theorem kron_def [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) (M : Matrix (A × C) (A × C) R) :
+theorem kron_def [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R)
+    (M : Matrix (A × C) (A × C) R) :
     (M₁ ⊗ₖₘ M₂) M (b₁, d₁) (b₂, d₂) = ∑ a₁, ∑ a₂, ∑ c₁, ∑ c₂,
-      (M₁ (Matrix.single a₁ a₂ 1) b₁ b₂) * (M₂ (Matrix.single c₁ c₂ 1) d₁ d₂) * (M (a₁, c₁) (a₂, c₂)) := by
+      (M₁ (Matrix.single a₁ a₂ 1) b₁ b₂) * (M₂ (Matrix.single c₁ c₂ 1) d₁ d₂) *
+        (M (a₁, c₁) (a₂, c₂)) := by
   rw [kron]
-  have h_expand : (Matrix.toLin (Matrix.stdBasis R (A × C) (A × C)) (Matrix.stdBasis R (B × D) (B × D))) ((Matrix.reindex (Equiv.prodProdProdComm B B D D) (Equiv.prodProdProdComm A A C C)) ((LinearMap.toMatrix ((Matrix.stdBasis R A A).tensorProduct (Matrix.stdBasis R C C)) ((Matrix.stdBasis R B B).tensorProduct (Matrix.stdBasis R D D))) (TensorProduct.map M₁ M₂))) M = ∑ a₁ : A, ∑ a₂ : A, ∑ c₁ : C, ∑ c₂ : C, M (a₁, c₁) (a₂, c₂) • (Matrix.toLin (Matrix.stdBasis R (A × C) (A × C)) (Matrix.stdBasis R (B × D) (B × D))) ((Matrix.reindex (Equiv.prodProdProdComm B B D D) (Equiv.prodProdProdComm A A C C)) ((LinearMap.toMatrix ((Matrix.stdBasis R A A).tensorProduct (Matrix.stdBasis R C C)) ((Matrix.stdBasis R B B).tensorProduct (Matrix.stdBasis R D D))) (TensorProduct.map M₁ M₂))) (Matrix.single (a₁, c₁) (a₂, c₂) 1) := by
-    have h_expand : M = ∑ a₁ : A, ∑ a₂ : A, ∑ c₁ : C, ∑ c₂ : C, M (a₁, c₁) (a₂, c₂) • Matrix.single (a₁, c₁) (a₂, c₂) 1 := by
+  have h_expand : (Matrix.toLin (Matrix.stdBasis R (A × C) (A × C))
+        (Matrix.stdBasis R (B × D) (B × D)))
+        ((Matrix.reindex (Equiv.prodProdProdComm B B D D) (Equiv.prodProdProdComm A A C C))
+          ((LinearMap.toMatrix ((Matrix.stdBasis R A A).tensorProduct (Matrix.stdBasis R C C))
+            ((Matrix.stdBasis R B B).tensorProduct (Matrix.stdBasis R D D)))
+            (TensorProduct.map M₁ M₂))) M =
+      ∑ a₁ : A, ∑ a₂ : A, ∑ c₁ : C, ∑ c₂ : C, M (a₁, c₁) (a₂, c₂) •
+        (Matrix.toLin (Matrix.stdBasis R (A × C) (A × C))
+          (Matrix.stdBasis R (B × D) (B × D)))
+          ((Matrix.reindex (Equiv.prodProdProdComm B B D D) (Equiv.prodProdProdComm A A C C))
+            ((LinearMap.toMatrix ((Matrix.stdBasis R A A).tensorProduct (Matrix.stdBasis R C C))
+              ((Matrix.stdBasis R B B).tensorProduct (Matrix.stdBasis R D D)))
+              (TensorProduct.map M₁ M₂))) (Matrix.single (a₁, c₁) (a₂, c₂) 1) := by
+    have h_expand : M = ∑ a₁ : A, ∑ a₂ : A, ∑ c₁ : C, ∑ c₂ : C, M (a₁, c₁) (a₂, c₂) •
+        Matrix.single (a₁, c₁) (a₂, c₂) 1 := by
       ext ⟨a₁, c₁⟩ ⟨a₂, c₂⟩
       simp only [Matrix.single, Matrix.sum_apply]
-      rw [Finset.sum_eq_single a₁, Finset.sum_eq_single a₂, Finset.sum_eq_single c₁, Finset.sum_eq_single c₂]
+      rw [Finset.sum_eq_single a₁, Finset.sum_eq_single a₂, Finset.sum_eq_single c₁,
+        Finset.sum_eq_single c₂]
       <;> simp +contextual
     nth_rw 1 [h_expand]
     simp only [map_sum, LinearMap.map_smulₛₗ]
@@ -247,12 +270,18 @@ theorem kron_def [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D
   classical
   simp only [Matrix.stdBasis,
     Matrix.reindex_apply, Equiv.prodProdProdComm_symm, Matrix.toLin_apply,
-    Matrix.mulVec, dotProduct, Matrix.submatrix_apply, Equiv.prodProdProdComm_apply, LinearMap.toMatrix_apply,
-    Module.Basis.tensorProduct_apply, Module.Basis.map_apply, Module.Basis.coe_reindex, Function.comp_apply,
-    Equiv.sigmaEquivProd_symm_apply, Pi.basis_apply, Pi.basisFun_apply, Matrix.coe_ofLinearEquiv, TensorProduct.map_tmul,
-    Module.Basis.tensorProduct_repr_tmul_apply, Module.Basis.map_repr, LinearEquiv.trans_apply, Matrix.coe_ofLinearEquiv_symm,
-    Module.Basis.repr_reindex, Finsupp.mapDomain_equiv_apply, Pi.basis_repr, Pi.basisFun_repr, Matrix.of_symm_apply, smul_eq_mul,
-    Matrix.of_symm_single, Pi.single_apply, Matrix.smul_of, Matrix.sum_apply, Matrix.of_apply, Pi.smul_apply]
+    Matrix.mulVec, dotProduct, Matrix.submatrix_apply, Equiv.prodProdProdComm_apply,
+    LinearMap.toMatrix_apply,
+    Module.Basis.tensorProduct_apply, Module.Basis.map_apply, Module.Basis.coe_reindex,
+    Function.comp_apply,
+    Equiv.sigmaEquivProd_symm_apply, Pi.basis_apply, Pi.basisFun_apply, Matrix.coe_ofLinearEquiv,
+    TensorProduct.map_tmul,
+    Module.Basis.tensorProduct_repr_tmul_apply, Module.Basis.map_repr, LinearEquiv.trans_apply,
+    Matrix.coe_ofLinearEquiv_symm,
+    Module.Basis.repr_reindex, Finsupp.mapDomain_equiv_apply, Pi.basis_repr, Pi.basisFun_repr,
+    Matrix.of_symm_apply, smul_eq_mul,
+    Matrix.of_symm_single, Pi.single_apply, Matrix.smul_of, Matrix.sum_apply, Matrix.of_apply,
+    Pi.smul_apply]
   rw [ Finset.sum_eq_single ( ( b₁, d₁ ), ( b₂, d₂ ) ) ]
   · rw [ Finset.sum_eq_single ( ( a₁, c₁ ), ( a₂, c₂ ) ) ]
     · simp only [↓reduceIte, Pi.single_eq_same, mul_one]
@@ -285,16 +314,20 @@ theorem kron_def [CommSemiring R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D
 section kron_lemmas
 variable [CommSemiring R]
 
-theorem add_kron (ML₁ ML₂ : MatrixMap A B R) (MR : MatrixMap C D R) : (ML₁ + ML₂) ⊗ₖₘ MR = ML₁ ⊗ₖₘ MR + ML₂ ⊗ₖₘ MR := by
+theorem add_kron (ML₁ ML₂ : MatrixMap A B R) (MR : MatrixMap C D R) :
+    (ML₁ + ML₂) ⊗ₖₘ MR = ML₁ ⊗ₖₘ MR + ML₂ ⊗ₖₘ MR := by
   simp [kron, TensorProduct.map_add_left, Matrix.submatrix_add]
 
-theorem kron_add (ML : MatrixMap A B R) (MR₁ MR₂ : MatrixMap C D R) : ML ⊗ₖₘ (MR₁ + MR₂) = ML ⊗ₖₘ MR₁ + ML ⊗ₖₘ  MR₂ := by
+theorem kron_add (ML : MatrixMap A B R) (MR₁ MR₂ : MatrixMap C D R) :
+    ML ⊗ₖₘ (MR₁ + MR₂) = ML ⊗ₖₘ MR₁ + ML ⊗ₖₘ  MR₂ := by
   simp [kron, TensorProduct.map_add_right, Matrix.submatrix_add]
 
-theorem smul_kron (r : R) (ML : MatrixMap A B R) (MR : MatrixMap C D R) : (r • ML) ⊗ₖₘ MR = r • (ML ⊗ₖₘ MR) := by
+theorem smul_kron (r : R) (ML : MatrixMap A B R) (MR : MatrixMap C D R) :
+    (r • ML) ⊗ₖₘ MR = r • (ML ⊗ₖₘ MR) := by
   simp [kron, TensorProduct.map_smul_left, Matrix.submatrix_smul]
 
-theorem kron_smul (r : R) (ML : MatrixMap A B R) (MR : MatrixMap C D R) : ML ⊗ₖₘ (r • MR) = r • (ML ⊗ₖₘ MR) := by
+theorem kron_smul (r : R) (ML : MatrixMap A B R) (MR : MatrixMap C D R) :
+    ML ⊗ₖₘ (r • MR) = r • (ML ⊗ₖₘ MR) := by
   simp [kron, TensorProduct.map_smul_right, Matrix.submatrix_smul]
 
 @[simp]
@@ -312,10 +345,13 @@ theorem kron_id_id : (id A R ⊗ₖₘ id B R) = id (A × B) R := by
 variable {Dl₁ Dl₂ Dl₃ Dr₁ Dr₂ Dr₃ : Type*}
   [Fintype Dl₁] [Fintype Dl₂] [Fintype Dl₃] [Fintype Dr₁] [Fintype Dr₂] [Fintype Dr₃]
   [DecidableEq Dl₁] [DecidableEq Dl₂] [DecidableEq Dr₁] [DecidableEq Dr₂] in
-/-- For maps L₁, L₂, R₁, and R₂, the product (L₂ ∘ₗ L₁) ⊗ₖₘ (R₂ ∘ₗ R₁) = (L₂ ⊗ₖₘ R₂) ∘ₗ (L₁ ⊗ₖₘ R₁) -/
-theorem kron_comp_distrib (L₁ : MatrixMap Dl₁ Dl₂ R) (L₂ : MatrixMap Dl₂ Dl₃ R) (R₁ : MatrixMap Dr₁ Dr₂ R)
+/-- For maps L₁, L₂, R₁, and R₂, the product
+(L₂ ∘ₗ L₁) ⊗ₖₘ (R₂ ∘ₗ R₁) = (L₂ ⊗ₖₘ R₂) ∘ₗ (L₁ ⊗ₖₘ R₁) -/
+theorem kron_comp_distrib (L₁ : MatrixMap Dl₁ Dl₂ R) (L₂ : MatrixMap Dl₂ Dl₃ R)
+    (R₁ : MatrixMap Dr₁ Dr₂ R)
     (R₂ : MatrixMap Dr₂ Dr₃ R) : (L₂ ∘ₗ L₁) ⊗ₖₘ (R₂ ∘ₗ R₁) = (L₂ ⊗ₖₘ R₂) ∘ₗ (L₁ ⊗ₖₘ R₁) := by
-  simp [kron, TensorProduct.map_comp, ← Matrix.toLin_mul, Matrix.submatrix_mul_equiv, ← LinearMap.toMatrix_comp]
+  simp [kron, TensorProduct.map_comp, ← Matrix.toLin_mul, Matrix.submatrix_mul_equiv,
+    ← LinearMap.toMatrix_comp]
 
 end kron_lemmas
 
@@ -328,7 +364,9 @@ end kron_lemmas
 
 /-- The operational definition of the Kronecker product `MatrixMap.kron`, that it maps a Kronecker
   product of inputs to the Kronecker product of outputs. It is the unique bilinear map doing so. -/
-theorem kron_map_of_kron_state [CommRing R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R) (MA : Matrix A A R) (MC : Matrix C C R) : (M₁ ⊗ₖₘ M₂) (MA ⊗ₖ MC) = (M₁ MA) ⊗ₖ (M₂ MC) := by
+theorem kron_map_of_kron_state [CommRing R] (M₁ : MatrixMap A B R) (M₂ : MatrixMap C D R)
+    (MA : Matrix A A R) (MC : Matrix C C R) :
+    (M₁ ⊗ₖₘ M₂) (MA ⊗ₖ MC) = (M₁ MA) ⊗ₖ (M₂ MC) := by
   ext bd₁ bd₂
   let (b₁, d₁) := bd₁
   let (b₂, d₂) := bd₂
@@ -362,7 +400,8 @@ theorem kron_map_of_kron_state [CommRing R] (M₁ : MatrixMap A B R) (M₂ : Mat
     simp [h_expand, Matrix.sum_apply]
 
 theorem choi_matrix_state_rep {B : Type*} [Fintype B] [Nonempty A] (M : MatrixMap A B ℂ) :
-    M.choi_matrix = (↑(Fintype.card (α := A)) : ℂ) • (M ⊗ₖₘ (LinearMap.id : MatrixMap A A ℂ)) (MState.pure (Ket.MES A)).m := by
+    M.choi_matrix = (↑(Fintype.card (α := A)) : ℂ) •
+      (M ⊗ₖₘ (LinearMap.id : MatrixMap A A ℂ)) (MState.pure (Ket.MES A)).m := by
   ext i j
   simp [choi_matrix, kron_def M, Ket.MES, Ket.apply, Finset.mul_sum]
   conv =>
@@ -411,7 +450,8 @@ variable {dO : ι → Type w} [∀i, Fintype (dO i)] [∀i, DecidableEq (dO i)]
 
 /-- Finite Pi-type tensor product of MatrixMaps. Defined as `PiTensorProduct.tprod` of the
   underlying Linear maps. Notation `⨂ₜₘ[R] i, f i`, eventually. -/
-noncomputable def piProd (Λi : ∀ i, MatrixMap (dI i) (dO i) R) : MatrixMap (∀i, dI i) (∀i, dO i) R :=
+noncomputable def piProd (Λi : ∀ i, MatrixMap (dI i) (dO i) R) :
+    MatrixMap (∀i, dI i) (∀i, dO i) R :=
   Matrix.toLin
     (Matrix.stdBasis R ((i:ι) → dI i) ((i:ι) → dI i))
     (Matrix.stdBasis R ((i:ι) → dO i) ((i:ι) → dO i))

--- a/QuantumInfo/Channels/Pinching.lean
+++ b/QuantumInfo/Channels/Pinching.lean
@@ -21,7 +21,8 @@ public import QuantumInfo.ForMathlib.HermitianMat.CFC
 A pinching channel decoheres in the eigenspaces of a given state.
 More precisely, given a state ρ, the pinching channel with respect to ρ is defined as
   E(σ) = ∑ Pᵢ σ Pᵢ
-where the P_i are the projectors onto the i-th eigenspaces of ρ = ∑ᵢ pᵢ Pᵢ, with i ≠ j → pᵢ ≠ pⱼ.
+where the P_i are the projectors onto the i-th eigenspaces of ρ = ∑ᵢ pᵢ Pᵢ, with
+i ≠ j → pᵢ ≠ pⱼ.
 
 TODO: Generalize to pinching with respect to arbitrary P(O)VM.
 -/
@@ -64,7 +65,8 @@ theorem pinching_kraus_orthogonal (ρ : MState d) {i j : spectrum ℝ ρ.m} (h :
 
 /-- The Kraus operators of the pinching channelare projectors: they square to themselves. -/
 @[simp]
-theorem pinching_sq_eq_self (ρ : MState d) (k) : (pinching_kraus ρ k) ^ 2  = pinching_kraus ρ k := by
+theorem pinching_sq_eq_self (ρ : MState d) (k) :
+    (pinching_kraus ρ k) ^ 2  = pinching_kraus ρ k := by
   ext1
   push_cast
   rw [pow_two, pinching_kraus, ← ρ.M.mat_cfc_mul]
@@ -73,7 +75,8 @@ theorem pinching_sq_eq_self (ρ : MState d) (k) : (pinching_kraus ρ k) ^ 2  = p
 
 /-- The Kraus operators of the pinching channel are orthogonal projectors. -/
 theorem pinching_kraus_ortho (ρ : MState d) (i j : spectrum ℝ ρ.m) :
-    (pinching_kraus ρ i).mat * (pinching_kraus ρ j).mat = if i = j then (pinching_kraus ρ i).mat else 0 := by
+    (pinching_kraus ρ i).mat * (pinching_kraus ρ j).mat =
+      if i = j then (pinching_kraus ρ i).mat else 0 := by
   split_ifs with hij
   · grind [sq, HermitianMat.mat_pow, pinching_sq_eq_self]
   · exact pinching_kraus_orthogonal ρ hij
@@ -81,7 +84,8 @@ theorem pinching_kraus_ortho (ρ : MState d) (i j : spectrum ℝ ρ.m) :
 theorem pinching_sum (ρ : MState d) : ∑ k, pinching_kraus ρ k = 1 := by
   ext i j
   simp only [pinching_kraus, HermitianMat.cfc]
-  have heq : Set.EqOn (fun x => ∑ i : spectrum ℝ ρ.m, if x = ↑i then (1 : ℝ) else 0) 1 (spectrum ℝ ρ.m) := by
+  have heq : Set.EqOn (fun x => ∑ i : spectrum ℝ ρ.m, if x = ↑i then (1 : ℝ) else 0) 1
+      (spectrum ℝ ρ.m) := by
     intro x hx
     dsimp
     rw [Finset.sum_set_coe (f := fun i => if x = i then 1 else 0), Finset.sum_ite_eq_of_mem]
@@ -159,9 +163,11 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 3.10 of Hayashi's book "Quantum Information Theory - Mathematical Foundations".
 Also, Lemma 5 in https://arxiv.org/pdf/quant-ph/0107004.
 -- Used in (S60) -/
-theorem pinching_bound (ρ σ : MState d) : ρ.M ≤ (↑(Fintype.card (spectrum ℝ σ.m)) : ℝ) • (pinching_map σ ρ).M := by
+theorem pinching_bound (ρ σ : MState d) :
+    ρ.M ≤ (↑(Fintype.card (spectrum ℝ σ.m)) : ℝ) • (pinching_map σ ρ).M := by
   rw [pinchingMap_apply_M]
-  suffices ρ.M ≤ (Fintype.card (spectrum ℝ σ.m) : ℝ) • ∑ c, ρ.M.conj (pinching_kraus σ c) by
+  suffices ρ.M ≤ (Fintype.card (spectrum ℝ σ.m) : ℝ) •
+      ∑ c, ρ.M.conj (pinching_kraus σ c) by
     convert this
     ext1
     simp [MatrixMap.of_kraus, HermitianMat.conj]
@@ -193,7 +199,8 @@ theorem pinching_bound (ρ σ : MState d) : ρ.M ≤ (↑(Fintype.card (spectrum
   simp only [MState.pure]
   dsimp [MState.m]
   --This out to be Cauchy-Schwarz.
-  have hschwarz := inner_mul_inner_self_le (𝕜 := ℂ) (E := EuclideanSpace ℂ (↑(spectrum ℝ σ.m)))
+  have hschwarz := inner_mul_inner_self_le (𝕜 := ℂ)
+    (E := EuclideanSpace ℂ (↑(spectrum ℝ σ.m)))
     (x := .toLp 2 fun i ↦ 1) (y := .toLp 2 fun k ↦ (
       star v ⬝ᵥ ((pinching_kraus σ k).mat *ᵥ (ψs i))
     ))
@@ -234,7 +241,8 @@ theorem pinching_bound (ρ σ : MState d) : ρ.M ≤ (↑(Fintype.card (spectrum
     · exact h_mul x x
 
 open ComplexOrder in
-theorem ker_le_ker_pinching_of_PosDef (ρ σ : MState d) (hpos : σ.m.PosDef) : σ.M.ker ≤ (pinching_map σ ρ).M.ker := by
+theorem ker_le_ker_pinching_of_PosDef (ρ σ : MState d) (hpos : σ.m.PosDef) :
+    σ.M.ker ≤ (pinching_map σ ρ).M.ker := by
   have h_ker : σ.M.ker = ⊥ := by
     have := hpos.toLin_ker_eq_bot
     simp [LinearMap.ker_eq_bot', HermitianMat.ker] at this ⊢
@@ -246,14 +254,18 @@ theorem ker_le_ker_pinching_of_PosDef (ρ σ : MState d) (hpos : σ.m.PosDef) : 
 theorem pinching_idempotent (ρ σ : MState d) :
     (pinching_map σ) (pinching_map σ ρ) = (pinching_map σ ρ) := by
   rw [MState.ext_iff]
-  have h_idempotent : (∑ k, (pinching_kraus σ k).mat * (∑ l, (pinching_kraus σ l).mat * ρ.M * (pinching_kraus σ l).mat) * (pinching_kraus σ k).mat) = (∑ k, (pinching_kraus σ k).mat * ρ.M * (pinching_kraus σ k).mat) := by
+  have h_idempotent : (∑ k, (pinching_kraus σ k).mat *
+        (∑ l, (pinching_kraus σ l).mat * ρ.M * (pinching_kraus σ l).mat) *
+        (pinching_kraus σ k).mat) =
+      (∑ k, (pinching_kraus σ k).mat * ρ.M * (pinching_kraus σ k).mat) := by
     simp only [Matrix.mul_sum, Matrix.sum_mul, ← mul_assoc, pinching_kraus_ortho]
     simp [mul_assoc, pinching_kraus_ortho]
   ext1
   grind [pinching_eq_sum_conj]
 
 theorem inner_cfc_pinching (ρ σ : MState d) (f : ℝ → ℝ) :
-    ⟪ρ.M, (pinching_map σ ρ).M.cfc f⟫ = ⟪(pinching_map σ ρ).M, (pinching_map σ ρ).M.cfc f⟫ := by
+    ⟪ρ.M, (pinching_map σ ρ).M.cfc f⟫ =
+      ⟪(pinching_map σ ρ).M, (pinching_map σ ρ).M.cfc f⟫ := by
   nth_rw 2 [pinchingMap_apply_M]
   rw [HermitianMat.inner_eq_re_trace, HermitianMat.inner_eq_re_trace]
   congr 1
@@ -281,26 +293,38 @@ theorem inner_cfc_pinching (ρ σ : MState d) (f : ℝ → ℝ) :
 theorem inner_cfc_pinching_right (ρ σ : MState d) (f : ℝ → ℝ) :
     ⟪(pinching_map σ ρ).M, σ.M.cfc f⟫ = ⟪ρ.M, σ.M.cfc f⟫ := by
   --TODO Cleanup
-  -- By definition of pinching_map, we have pinching_map σ ρ = ∑ k, (pinching_kraus σ k).toMat * ρ.toMat * (pinching_kraus σ k).toMat.
-  have h_pinching_def : (pinching_map σ ρ).M = ∑ k, (pinching_kraus σ k).mat * ρ.M.mat * (pinching_kraus σ k).mat := by
+  -- By definition of pinching_map, we have pinching_map σ ρ = ∑ k, (pinching_kraus σ k).toMat
+  -- * ρ.toMat * (pinching_kraus σ k).toMat.
+  have h_pinching_def : (pinching_map σ ρ).M =
+      ∑ k, (pinching_kraus σ k).mat * ρ.M.mat * (pinching_kraus σ k).mat := by
     exact pinching_eq_sum_conj σ ρ
-  -- By definition of pinching_map, we know that (pinching_kraus σ k).toMat * (σ.M.cfc f).toMat = (σ.M.cfc f).toMat * (pinching_kraus σ k).toMat.
-  have h_comm_cfc : ∀ k, (pinching_kraus σ k).mat * (σ.M.cfc f).mat = (σ.M.cfc f).mat * (pinching_kraus σ k).mat := by
+  -- By definition of pinching_map, we know that (pinching_kraus σ k).toMat * (σ.M.cfc f).toMat =
+  -- (σ.M.cfc f).toMat * (pinching_kraus σ k).toMat.
+  have h_comm_cfc : ∀ k, (pinching_kraus σ k).mat * (σ.M.cfc f).mat =
+      (σ.M.cfc f).mat * (pinching_kraus σ k).mat := by
     intro k
     apply Commute.cfc_left
     exact Commute.cfc_right f rfl
   simp_all [ HermitianMat.inner_def, Matrix.mul_assoc ];
   simp [Finset.sum_mul, Matrix.mul_assoc]
   simp only [h_comm_cfc, ← Matrix.mul_assoc];
-  -- By definition of pinching_map, we know that ∑ k, (pinching_kraus σ k).toMat * (pinching_kraus σ k).toMat = 1.
-  have h_sum_kraus : ∑ k : spectrum ℝ σ.m, (pinching_kraus σ k).mat * (pinching_kraus σ k).mat = 1 := by
+  -- By definition of pinching_map, we know that ∑ k, (pinching_kraus σ k).toMat *
+  -- (pinching_kraus σ k).toMat = 1.
+  have h_sum_kraus :
+      ∑ k : spectrum ℝ σ.m, (pinching_kraus σ k).mat * (pinching_kraus σ k).mat = 1 := by
     convert pinching_sum σ using 1;
     simp [HermitianMat.ext_iff ];
-    -- Since each pinching_kraus is a projection, multiplying it by itself gives the same projection. Therefore, the sum of the squares is the same as the sum of the pinching_kraus themselves.
-    have h_proj : ∀ k : spectrum ℝ σ.m, (pinching_kraus σ k).mat * (pinching_kraus σ k).mat = (pinching_kraus σ k).mat := by
-      exact fun k => by simpa [ sq, -pinching_sq_eq_self ] using congr_arg ( fun x : HermitianMat d ℂ => x.mat ) ( pinching_sq_eq_self σ k ) ;
+    -- Since each pinching_kraus is a projection, multiplying it by itself gives the same
+    -- projection. Therefore, the sum of the squares is the same as the sum of the pinching_kraus
+    -- themselves.
+    have h_proj : ∀ k : spectrum ℝ σ.m, (pinching_kraus σ k).mat * (pinching_kraus σ k).mat =
+        (pinching_kraus σ k).mat := by
+      exact fun k => by
+        simpa [ sq, -pinching_sq_eq_self ] using
+          congr_arg ( fun x : HermitianMat d ℂ => x.mat ) ( pinching_sq_eq_self σ k ) ;
     rw [ Finset.sum_congr rfl fun _ _ => h_proj _ ];
-  convert congr_arg ( fun x : Matrix d d ℂ => x.trace.re ) ( congr_arg ( fun x : Matrix d d ℂ => x * ( ρ.m * cfc f σ.m ) ) h_sum_kraus ) using 1;
+  convert congr_arg ( fun x : Matrix d d ℂ => x.trace.re )
+    ( congr_arg ( fun x : Matrix d d ℂ => x * ( ρ.m * cfc f σ.m ) ) h_sum_kraus ) using 1;
   · simp [Matrix.sum_mul]
     refine' Finset.sum_congr rfl fun x _ => _;
     rw [ ← Matrix.trace_mul_comm ] ; simp [ Matrix.mul_assoc ] ;
@@ -313,7 +337,8 @@ theorem pinching_map_eq_sum_conj_hermitian (σ ρ : MState d) :
   simp [pinching_eq_sum_conj σ ρ]
 
 theorem pinching_map_ker_le (ρ σ : MState d) : (pinching_map σ ρ).M.ker ≤ ρ.M.ker := by
-  have h_ker_sum : (∑ k, ρ.M.conj (pinching_kraus σ k).mat).ker = ⨅ k, (ρ.M.conj (pinching_kraus σ k).mat).ker := by
+  have h_ker_sum : (∑ k, ρ.M.conj (pinching_kraus σ k).mat).ker =
+      ⨅ k, (ρ.M.conj (pinching_kraus σ k).mat).ker := by
     apply HermitianMat.ker_sum
     exact fun i ↦ HermitianMat.conj_nonneg (pinching_kraus σ i).mat ρ.nonneg
   intro v hv
@@ -329,14 +354,18 @@ theorem pinching_map_ker_le (ρ σ : MState d) : (pinching_map σ ρ).M.ker ≤ 
 noncomputable section AristotleLemmas
 
 /-
-If v is in the kernel of σ, then for any non-zero eigenvalue k, the projection of v onto the k-eigenspace is 0.
+If v is in the kernel of σ, then for any non-zero eigenvalue k, the projection of v onto the
+k-eigenspace is 0.
 -/
 theorem pinching_kraus_ker_of_ne_zero {d : Type*} [Fintype d] [DecidableEq d]
     (σ : MState d) (v : d → ℂ) (hv : σ.m.mulVec v = 0)
     (k : spectrum ℝ σ.m) (hk : k.val ≠ 0) :
     (pinching_kraus σ k).mat *ᵥ v = 0 := by
-  -- Applying the equation $(pinching_kraus \sigma k).toMat * \sigma.m = k.val \bullet (pinching_kraus \sigma k).toMat$ to $v$, we get $(pinching_kraus \sigma k).toMat (\sigma.m v) = k.val (pinching_kraus \sigma k).toMat v$.
-  have h_eq_zero : ((pinching_kraus σ k).mat * σ.m) *ᵥ v = k.val • ((pinching_kraus σ k).mat *ᵥ v) := by
+  -- Applying the equation $(pinching_kraus \sigma k).toMat * \sigma.m = k.val \bullet
+  -- (pinching_kraus \sigma k).toMat$ to $v$, we get $(pinching_kraus \sigma k).toMat (\sigma.m v) =
+  -- k.val (pinching_kraus \sigma k).toMat v$.
+  have h_eq_zero : ((pinching_kraus σ k).mat * σ.m) *ᵥ v =
+      k.val • ((pinching_kraus σ k).mat *ᵥ v) := by
     have h_eq_zero : ((pinching_kraus σ k).mat * σ.m) = k.val • (pinching_kraus σ k).mat := by
       convert pinching_kraus_mul_self σ k using 1;
     simp [ h_eq_zero];
@@ -353,16 +382,20 @@ theorem ker_le_ker_pinching_map_ker (ρ σ : MState d) (h : σ.M.ker ≤ ρ.M.ke
     σ.M.ker ≤ (pinching_map σ ρ).M.ker := by
   --TODO Cleanup
   intro v hv;
-  -- Since $v \in \ker \sigma$, we have $P_k v = 0$ for all $k$ where the eigenvalue of $k$ is non-zero.
-  have h_proj_zero : ∀ k : spectrum ℝ σ.m, k.val ≠ 0 → (pinching_kraus σ k).mat *ᵥ v = 0 := by
+  -- Since $v \in \ker \sigma$, we have $P_k v = 0$ for all $k$ where the eigenvalue of $k$ is
+  -- non-zero.
+  have h_proj_zero : ∀ k : spectrum ℝ σ.m, k.val ≠ 0 →
+      (pinching_kraus σ k).mat *ᵥ v = 0 := by
     intro k hk
     exact pinching_kraus_ker_of_ne_zero σ v congr($hv) k hk
   -- Since $v \in \ker \sigma$, we have $P_k v = v$ for all $k$ where the eigenvalue of $k$ is zero.
-  have h_proj_one : ∀ k : spectrum ℝ σ.m, k.val = 0 → (pinching_kraus σ k).mat *ᵥ v = v := by
+  have h_proj_one : ∀ k : spectrum ℝ σ.m, k.val = 0 →
+      (pinching_kraus σ k).mat *ᵥ v = v := by
     intro k hk
     have := pinching_kraus_mul_self σ k
     simp_all only [ne_eq, Subtype.forall, zero_smul]
-    -- Since $v$ is in the kernel of $\sigma$, we have $\sum_{i} P_i v = v$ where $P_i$ are the projectors onto the eigenspaces of $\sigma$.
+    -- Since $v$ is in the kernel of $\sigma$, we have $\sum_{i} P_i v = v$ where $P_i$ are the
+    -- projectors onto the eigenspaces of $\sigma$.
     have h_sum_proj : ∑ i : spectrum ℝ σ.m, (pinching_kraus σ i).mat *ᵥ v = v := by
       have h_sum_proj : ∑ i : spectrum ℝ σ.m, (pinching_kraus σ i).mat = 1 := by
         convert pinching_sum σ;
@@ -375,8 +408,11 @@ theorem ker_le_ker_pinching_map_ker (ρ σ : MState d) (h : σ.M.ker ≤ ρ.M.ke
       · norm_num;
     rw [ Finset.sum_eq_single k ] at h_sum_proj <;> aesop;
   -- Since $v \in \ker \sigma$, we have $\mathcal{E}_\sigma(\rho) v = \sum_k P_k \rho P_k v$.
-  have h_sum : (pinching_map σ ρ).M.mat *ᵥ v = ∑ k : spectrum ℝ σ.m, (pinching_kraus σ k).mat *ᵥ (ρ.M.mat *ᵥ ((pinching_kraus σ k).mat *ᵥ v)) := by
-    convert congr_arg ( fun x : Matrix d d ℂ => x.mulVec v ) ( pinching_eq_sum_conj σ ρ ) using 1;
+  have h_sum : (pinching_map σ ρ).M.mat *ᵥ v =
+      ∑ k : spectrum ℝ σ.m,
+        (pinching_kraus σ k).mat *ᵥ (ρ.M.mat *ᵥ ((pinching_kraus σ k).mat *ᵥ v)) := by
+    convert congr_arg ( fun x : Matrix d d ℂ => x.mulVec v )
+      ( pinching_eq_sum_conj σ ρ ) using 1;
     simp [ Matrix.mul_assoc, Matrix.sum_mulVec ];
   refine' Eq.trans congr(WithLp.toLp 2 $(h_sum)) _;
   simp only [MState.mat_M, Matrix.mulVec_mulVec, WithLp.toLp_sum]
@@ -399,7 +435,8 @@ theorem pinching_pythagoras (ρ σ : MState d) :
     𝐃(ρ‖σ) = 𝐃(ρ‖pinching_map σ ρ) + 𝐃(pinching_map σ ρ‖σ) := by
   by_cases h_ker : σ.M.ker ≤ ρ.M.ker
   · have h_ker₁ : (pinching_map σ ρ).M.ker ≤ ρ.M.ker := pinching_map_ker_le ρ σ
-    have h_ker₂ : σ.M.ker ≤ (pinching_map σ ρ).M.ker := ker_le_ker_pinching_map_ker ρ σ h_ker
+    have h_ker₂ : σ.M.ker ≤ (pinching_map σ ρ).M.ker :=
+      ker_le_ker_pinching_map_ker ρ σ h_ker
     rw [← EReal.coe_ennreal_eq_coe_ennreal_iff, EReal.coe_ennreal_add]
     rw [qRelativeEnt_ker h_ker, qRelativeEnt_ker h_ker₁, qRelativeEnt_ker h_ker₂]
     have h_eq₁ := inner_cfc_pinching_right ρ σ Real.log

--- a/QuantumInfo/Channels/Unbundled.lean
+++ b/QuantumInfo/Channels/Unbundled.lean
@@ -99,17 +99,22 @@ theorem unit_linear {M₁ M₂ : MatrixMap A B R} {x y : R}
 
 variable {R : Type*} [CommSemiring R] [DecidableEq C] [DecidableEq A] in
 /-- The kronecker product of IsTracePreserving maps is also trace preserving. -/
-theorem kron {M₁ : MatrixMap A B R} {M₂ : MatrixMap C D R} (h₁ : M₁.IsTracePreserving) (h₂ : M₂.IsTracePreserving) :
+theorem kron {M₁ : MatrixMap A B R} {M₂ : MatrixMap C D R} (h₁ : M₁.IsTracePreserving)
+    (h₂ : M₂.IsTracePreserving) :
     (M₁ ⊗ₖₘ M₂).IsTracePreserving := by
   intro x
   simp_rw [Matrix.trace, Matrix.diag]
   rw [Fintype.sum_prod_type, Fintype.sum_prod_type]
   simp_rw [kron_def]
   have h_simp : ∑ x_1, ∑ x_2, ∑ a₁, ∑ a₂, ∑ c₁, ∑ c₂,
-    M₁ (Matrix.single a₁ a₂ 1) x_1 x_1 * M₂ (Matrix.single c₁ c₂ 1) x_2 x_2 * x (a₁, c₁) (a₂, c₂) =
-      ∑ a₁, ∑ a₂, ∑ c₁, ∑ c₂, (if a₁ = a₂ then 1 else 0) * (if c₁ = c₂ then 1 else 0) * x (a₁, c₁) (a₂, c₂) := by
+    M₁ (Matrix.single a₁ a₂ 1) x_1 x_1 * M₂ (Matrix.single c₁ c₂ 1) x_2 x_2 *
+        x (a₁, c₁) (a₂, c₂) =
+      ∑ a₁, ∑ a₂, ∑ c₁, ∑ c₂,
+        (if a₁ = a₂ then 1 else 0) * (if c₁ = c₂ then 1 else 0) *
+          x (a₁, c₁) (a₂, c₂) := by
     --Sort the sum into AACCBD order
-    simp only [@Finset.sum_comm A _ D, @Finset.sum_comm A _ B, @Finset.sum_comm C _ B, @Finset.sum_comm C _ D]
+    simp only [@Finset.sum_comm A _ D, @Finset.sum_comm A _ B, @Finset.sum_comm C _ B,
+      @Finset.sum_comm C _ D]
     simp only [← Finset.mul_sum, ← Finset.sum_mul]
     congr! 8 with a₁ _ a₂ _ c₁ _ c₂ _
     · refine (h₁ _).trans ?_
@@ -160,8 +165,8 @@ theorem piProd {Λi : ∀ i, MatrixMap (dI i) (dO i) R} (h₁ : ∀ i, (Λi i).I
 end piProd
 
 variable {S : Type*} [CommSemiring S] [Star S] [DecidableEq A] in
-/-- The channel X ↦ ∑ k : κ, (M k) * X * (N k)ᴴ formed by Kraus operators M, N : κ → Matrix B A R
-is trace-preserving if ∑ k : κ, (N k)ᴴ * (M k) = 1 -/
+/-- The channel X ↦ ∑ k : κ, (M k) * X * (N k)ᴴ formed by Kraus operators
+M, N : κ → Matrix B A R is trace-preserving if ∑ k : κ, (N k)ᴴ * (M k) = 1 -/
 theorem of_kraus_isTracePreserving
   (M N : κ → Matrix B A S)
   (hTP : (∑ k, (N k).conjTranspose * (M k)) = 1) :
@@ -218,7 +223,8 @@ open TensorProduct
 open ComplexOrder
 variable [RCLike R]
 
-/-- A linear matrix map is *Hermitian preserving* if it maps `IsHermitian` matrices to `IsHermitian`.-/
+/-- A linear matrix map is *Hermitian preserving* if it maps `IsHermitian` matrices to
+`IsHermitian`.-/
 def IsHermitianPreserving (M : MatrixMap A B R) : Prop :=
   ∀⦃x⦄, x.IsHermitian → (M x).IsHermitian
 
@@ -240,7 +246,8 @@ theorem id : (id A R).IsPositive :=
 
 /-- The composition of IsHermitianPreserving maps is also Hermitian preserving. -/
 theorem comp {M₁ : MatrixMap A B R} {M₂ : MatrixMap B C R}
-    (h₁ : M₁.IsHermitianPreserving) (h₂ : M₂.IsHermitianPreserving) : IsHermitianPreserving (M₂ ∘ₗ M₁) :=
+    (h₁ : M₁.IsHermitianPreserving) (h₂ : M₂.IsHermitianPreserving) :
+    IsHermitianPreserving (M₂ ∘ₗ M₁) :=
   fun _ h ↦ h₂ (h₁ h)
 
 end IsHermitianPreserving
@@ -294,7 +301,10 @@ theorem of_Fintype  {M : MatrixMap A B R} (h : IsCompletelyPositive M)
   obtain ⟨n, ⟨e⟩⟩ : ∃ n : ℕ, Nonempty (T ≃ Fin n) :=
     Finite.exists_equiv_fin T
   convert h n using 1
-  have h_submatrix : (M ⊗ₖₘ (LinearMap.id : MatrixMap T T R)) = (MatrixMap.submatrix R (fun p : B × T => (p.1, e p.2)) ∘ₗ (M ⊗ₖₘ (LinearMap.id : MatrixMap (Fin n) (Fin n) R)) ∘ₗ MatrixMap.submatrix R (fun p : A × Fin n => (p.1, e.symm p.2))) := by
+  have h_submatrix : (M ⊗ₖₘ (LinearMap.id : MatrixMap T T R)) =
+      (MatrixMap.submatrix R (fun p : B × T => (p.1, e p.2)) ∘ₗ
+        (M ⊗ₖₘ (LinearMap.id : MatrixMap (Fin n) (Fin n) R)) ∘ₗ
+        MatrixMap.submatrix R (fun p : A × Fin n => (p.1, e.symm p.2))) := by
     ext
     simp only [submatrix, LinearMap.coe_comp, LinearMap.coe_mk, AddHom.coe_mk, Function.comp_apply,
       Matrix.submatrix_apply]
@@ -344,9 +354,11 @@ theorem IsPositive {M : MatrixMap A B R}
   · simp +contextual
 
 /-- The composition of IsCompletelyPositive maps is also completely positive. -/
-theorem comp [DecidableEq B] {M₁ : MatrixMap A B R} {M₂ : MatrixMap B C R} (h₁ : M₁.IsCompletelyPositive)
+theorem comp [DecidableEq B] {M₁ : MatrixMap A B R} {M₂ : MatrixMap B C R}
+    (h₁ : M₁.IsCompletelyPositive)
     (h₂ : M₂.IsCompletelyPositive) : IsCompletelyPositive (M₂ ∘ₗ M₁) := by
-  --sketch: (M₂ ∘ₗ M₁) ⊗ₖₘ id[n] = (M₂ ⊗ₖₘ id[n]) ∘ₗ (M₁ ⊗ₖₘ id[n]), which is a composition of positive maps.
+  --sketch: (M₂ ∘ₗ M₁) ⊗ₖₘ id[n] = (M₂ ⊗ₖₘ id[n]) ∘ₗ (M₁ ⊗ₖₘ id[n]), which is a
+  -- composition of positive maps.
   intro n x hx
   specialize h₁ n hx
   specialize h₂ n h₁
@@ -362,7 +374,8 @@ theorem id : (id A R).IsCompletelyPositive := by
   rwa [show LinearMap.id = MatrixMap.id (Fin n) R from rfl, kron_id_id]
 
 /-- Sums of IsCompletelyPositive maps are IsCompletelyPositive. -/
-theorem add {M₁ M₂ : MatrixMap A B R} (h₁ : M₁.IsCompletelyPositive) (h₂ : M₂.IsCompletelyPositive) :
+theorem add {M₁ M₂ : MatrixMap A B R} (h₁ : M₁.IsCompletelyPositive)
+    (h₂ : M₂.IsCompletelyPositive) :
     (M₁ + M₂).IsCompletelyPositive :=
   fun n _ h ↦ by
   simpa only [add_kron] using Matrix.PosSemidef.add (h₁ n h) (h₂ n h)
@@ -380,7 +393,8 @@ theorem zero : (0 : MatrixMap A B R).IsCompletelyPositive :=
   fun _ _ _ ↦ by simpa using Matrix.PosSemidef.zero
 
 /-- A finite sum of completely positive maps is completely positive. -/
-theorem finset_sum {ι : Type*} [Fintype ι] {m : ι → MatrixMap A B R} (hm : ∀ i, (m i).IsCompletelyPositive) :
+theorem finset_sum {ι : Type*} [Fintype ι] {m : ι → MatrixMap A B R}
+    (hm : ∀ i, (m i).IsCompletelyPositive) :
     (∑ i, m i).IsCompletelyPositive :=
   Finset.sum_induction m _ (fun _ _ ↦ add) (.zero A B) (by simpa)
 
@@ -393,7 +407,8 @@ open MatrixOrder
 
 /-- The map that takes M and returns M ⊗ₖ C, where C is positive semidefinite, is a completely
   positive map. -/
-theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : _} : IsCompletelyPositive
+theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : _} :
+    IsCompletelyPositive
     (⟨⟨fun M => M ⊗ₖ C, h₁⟩, h₂⟩ : MatrixMap A (A × d) R) := by
   intros n x hx
   have h_kronecker_pos : (x ⊗ₖ C).PosSemidef := by
@@ -414,17 +429,20 @@ theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : 
     rw [ ← hW_pos ]
     exact Matrix.posSemidef_conjTranspose_mul_self (U ⊗ₖ V)
   --TODO clean up this mess (but, thanks Aristotle)
-  convert h_kronecker_pos.submatrix (fun (⟨ ⟨ a, d' ⟩, n' ⟩ : (A × d) × Fin n) => ⟨ ⟨ a, n' ⟩, d' ⟩) using 1;
+  convert h_kronecker_pos.submatrix
+    (fun (⟨ ⟨ a, d' ⟩, n' ⟩ : (A × d) × Fin n) => ⟨ ⟨ a, n' ⟩, d' ⟩) using 1;
   ext ⟨⟨a, d⟩, n⟩ ⟨⟨a', d'⟩, n'⟩
   simp [Matrix.kroneckerMap_apply, Matrix.submatrix_apply]
   erw [MatrixMap.kron_def]
   simp [Matrix.single, Matrix.kroneckerMap_apply]
   simp [Finset.sum_ite, Finset.filter_eq', Finset.filter_and]
   rw [ Finset.sum_eq_single a ]
-  · simp_all only [RingHom.id_apply, ↓reduceIte, Finset.mem_univ, Finset.inter_singleton_of_mem, Finset.sum_singleton]
+  · simp_all only [RingHom.id_apply, ↓reduceIte, Finset.mem_univ, Finset.inter_singleton_of_mem,
+      Finset.sum_singleton]
     simp_all only
     rw [ Finset.sum_eq_single n ]
-    · simp_all only [↓reduceIte, Finset.mem_univ, Finset.inter_singleton_of_mem, Finset.sum_singleton]
+    · simp_all only [↓reduceIte, Finset.mem_univ, Finset.inter_singleton_of_mem,
+        Finset.sum_singleton]
       ring
     · intro b a_1 a_2
       simp_all only [Finset.mem_univ, ne_eq, ↓reduceIte, Finset.notMem_empty, not_false_eq_true,
@@ -432,21 +450,28 @@ theorem kron_kronecker_const {C : Matrix d d R} (h : C.PosSemidef) {h₁ h₂ : 
     · intro a_1
       simp_all only [Finset.mem_univ, not_true_eq_false]
   · intro b a_1 a_2
-    simp_all only [RingHom.id_apply, Finset.mem_univ, ne_eq, ↓reduceIte, Finset.notMem_empty, not_false_eq_true,
+    simp_all only [RingHom.id_apply, Finset.mem_univ, ne_eq, ↓reduceIte, Finset.notMem_empty,
+      not_false_eq_true,
       Finset.inter_singleton_of_notMem, Finset.sum_empty]
   · intro a_1
     simp_all only [RingHom.id_apply, Finset.mem_univ, not_true_eq_false]
 
 omit [Fintype B] in
 theorem choi_of_kraus (K : κ → Matrix B A 𝕜) :
-    (MatrixMap.of_kraus K K).choi_matrix = ∑ k, Matrix.vecMulVec (fun (x : B × A) => K k x.1 x.2) (fun (x : B × A) => star (K k x.1 x.2)) := by
-  -- By definition of Choi matrix, we can expand the left-hand side using the linearity of the map and the properties of the Choi matrix.
+    (MatrixMap.of_kraus K K).choi_matrix =
+      ∑ k, Matrix.vecMulVec (fun (x : B × A) => K k x.1 x.2)
+        (fun (x : B × A) => star (K k x.1 x.2)) := by
+  -- By definition of Choi matrix, we can expand the left-hand side using the linearity of the map
+  -- and the properties of the Choi matrix.
   ext ⟨b₁, a₁⟩ ⟨b₂, a₂⟩
   simp [MatrixMap.choi_matrix, MatrixMap.of_kraus];
-  -- By definition of the sum, the entry (b₁, b₂) of the sum of the Choi matrices of each Kraus operator is the sum of the entries (b₁, b₂) of each individual Choi matrix.
+  -- By definition of the sum, the entry (b₁, b₂) of the sum of the Choi matrices of each Kraus
+  -- operator is the sum of the entries (b₁, b₂) of each individual Choi matrix.
   simp [Matrix.sum_apply, Matrix.mul_apply, Matrix.single];
-  -- Since the inner sum over `x_2` will only contribute when `x_2 = a₁` and `x_1 = a₂`, we can simplify the expression.
-  have h_inner : ∀ x : κ, ∑ x_1 : A, (∑ x_2 : A, if a₁ = x_2 ∧ a₂ = x_1 then K x b₁ x_2 else 0) * (starRingEnd 𝕜) (K x b₂ x_1) = (K x b₁ a₁) * (starRingEnd 𝕜) (K x b₂ a₂) := by
+  -- Since the inner sum over `x_2` will only contribute when `x_2 = a₁` and `x_1 = a₂`, we can
+  -- simplify the expression.
+  have h_inner : ∀ x : κ, ∑ x_1 : A, (∑ x_2 : A, if a₁ = x_2 ∧ a₂ = x_1 then K x b₁ x_2 else 0) *
+      (starRingEnd 𝕜) (K x b₂ x_1) = (K x b₁ a₁) * (starRingEnd 𝕜) (K x b₂ a₂) := by
     simp [ Finset.sum_ite, Finset.filter_eq, Finset.filter_and ];
     intro x; rw [ Finset.sum_eq_single a₂ ] <;> aesop;
   exact Finset.sum_congr rfl fun _ _ => h_inner _
@@ -463,7 +488,8 @@ theorem conj_isPositive (M : Matrix B A 𝕜) : (conj M).IsPositive := by
   exact fun X hX => hX.mul_mul_conjTranspose_same M
 
 omit [DecidableEq A] in
-theorem IsPositive_sum {ι : Type*} [Fintype ι] (f : ι → MatrixMap A B ℂ) (h : ∀ i, (f i).IsPositive) :
+theorem IsPositive_sum {ι : Type*} [Fintype ι] (f : ι → MatrixMap A B ℂ)
+    (h : ∀ i, (f i).IsPositive) :
     (∑ i, f i).IsPositive := by
   intro X hX;
   replace hX : ∀ i, ((f i) X).PosSemidef := fun i => h i hX;
@@ -476,7 +502,9 @@ theorem IsPositive_sum {ι : Type*} [Fintype ι] (f : ι → MatrixMap A B ℂ) 
   simp_rw [mul_assoc, mul_comm ((f _) X _ _), ← mul_assoc]
   intro x
   rw [Finset.sum_comm_cycle]
-  exact Finset.sum_nonneg fun i _ => by simpa [ mul_assoc, mul_comm, mul_left_comm, Finset.mul_sum _ _ _, Finset.sum_mul ] using hX i |>.2 x;
+  exact Finset.sum_nonneg fun i _ => by
+    simpa [ mul_assoc, mul_comm, mul_left_comm, Finset.mul_sum _ _ _, Finset.sum_mul ] using
+      hX i |>.2 x;
 
 omit [DecidableEq A] in
 theorem of_kraus_isPositive (K : κ → Matrix B A ℂ) :
@@ -490,7 +518,8 @@ theorem conj_kron (M : Matrix B A 𝕜) (N : Matrix D C 𝕜) [DecidableEq C] :
     conj M ⊗ₖₘ conj N = conj (M ⊗ₖ N) := by
   apply LinearMap.ext
   intro x
-  have h_eq : ∀ (X : Matrix A A 𝕜) (Y : Matrix C C 𝕜), (conj M ⊗ₖₘ conj N) (X ⊗ₖ Y) = (conj (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) M N)) (X ⊗ₖ Y) := by
+  have h_eq : ∀ (X : Matrix A A 𝕜) (Y : Matrix C C 𝕜), (conj M ⊗ₖₘ conj N) (X ⊗ₖ Y) =
+      (conj (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) M N)) (X ⊗ₖ Y) := by
     intro X Y;
     convert MatrixMap.kron_map_of_kron_state _ _ X Y using 1;
     ext ⟨ b₁, d₁ ⟩ ⟨ b₂, d₂ ⟩
@@ -502,7 +531,9 @@ theorem conj_kron (M : Matrix B A 𝕜) (N : Matrix D C 𝕜) [DecidableEq C] :
     simp only [← Finset.univ_product_univ, ← Finset.sum_product'];
     apply Finset.sum_bij (fun x _ ↦ (x.1.2, x.2.2, x.1.1, x.2.1)) <;> simp
   -- By linearity, it suffices to show that the maps agree on a basis.
-  have h_basis : ∀ (x : Matrix (A × C) (A × C) 𝕜), x ∈ Submodule.span 𝕜 (Set.range (fun (p : Matrix A A 𝕜 × Matrix C C 𝕜) => p.1 ⊗ₖ p.2)) → (conj M ⊗ₖₘ conj N) x = (conj (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) M N)) x := by
+  have h_basis : ∀ (x : Matrix (A × C) (A × C) 𝕜),
+      x ∈ Submodule.span 𝕜 (Set.range (fun (p : Matrix A A 𝕜 × Matrix C C 𝕜) => p.1 ⊗ₖ p.2)) →
+      (conj M ⊗ₖₘ conj N) x = (conj (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) M N)) x := by
     intro x hx;
     induction hx using Submodule.span_induction;
     · rename_i h
@@ -513,8 +544,12 @@ theorem conj_kron (M : Matrix B A 𝕜) (N : Matrix D C 𝕜) [DecidableEq C] :
     · simp_all only [map_add]
     · simp_all only [map_smul]
   convert h_basis x _;
-  -- By definition of matrix multiplication and the properties of the Kronecker product, we can express any matrix as a sum of Kronecker products of basis matrices.
-  have h_decomp : ∀ (x : Matrix (A × C) (A × C) 𝕜), ∃ (coeffs : A → C → A → C → 𝕜), x = ∑ a₁, ∑ c₁, ∑ a₂, ∑ c₂, coeffs a₁ c₁ a₂ c₂ • Matrix.kroneckerMap (fun x1 x2 => x1 * x2) (Matrix.single a₁ a₂ 1) (Matrix.single c₁ c₂ 1) := by
+  -- By definition of matrix multiplication and the properties of the Kronecker product, we can
+  -- express any matrix as a sum of Kronecker products of basis matrices.
+  have h_decomp : ∀ (x : Matrix (A × C) (A × C) 𝕜), ∃ (coeffs : A → C → A → C → 𝕜),
+      x = ∑ a₁, ∑ c₁, ∑ a₂, ∑ c₂,
+        coeffs a₁ c₁ a₂ c₂ • Matrix.kroneckerMap (fun x1 x2 => x1 * x2)
+          (Matrix.single a₁ a₂ 1) (Matrix.single c₁ c₂ 1) := by
     intro x
     use fun a₁ c₁ a₂ c₂ => x (a₁, c₁) (a₂, c₂);
     ext ⟨ a₁, c₁ ⟩ ⟨ a₂, c₂ ⟩
@@ -525,22 +560,28 @@ theorem conj_kron (M : Matrix B A 𝕜) (N : Matrix D C 𝕜) [DecidableEq C] :
       rw [ Finset.sum_eq_single c₂ ] <;> simp +contextual;
     · simp +contextual [Finset.filter_eq', Finset.filter_and ];
   obtain ⟨ coeffs, rfl ⟩ := h_decomp x;
-  exact Submodule.sum_mem _ fun a₁ _ => Submodule.sum_mem _ fun c₁ _ => Submodule.sum_mem _ fun a₂ _ => Submodule.sum_mem _ fun c₂ _ => Submodule.smul_mem _ _ ( Submodule.subset_span ⟨ ( Matrix.single a₁ a₂ 1, Matrix.single c₁ c₂ 1 ), rfl ⟩ )
+  exact Submodule.sum_mem _ fun a₁ _ => Submodule.sum_mem _ fun c₁ _ =>
+    Submodule.sum_mem _ fun a₂ _ => Submodule.sum_mem _ fun c₂ _ =>
+      Submodule.smul_mem _ _
+        ( Submodule.subset_span ⟨ ( Matrix.single a₁ a₂ 1, Matrix.single c₁ c₂ 1 ), rfl ⟩ )
 
 theorem congruence_one_eq_id : conj (1 : Matrix A A ℂ) = MatrixMap.id A ℂ := by
   ext x
   simp [conj]
 
-theorem congruence_CP {A B : Type*} [Fintype A] [Fintype B] [DecidableEq A] [DecidableEq B] (M : Matrix B A 𝕜) : (conj M).IsCompletelyPositive := by
+theorem congruence_CP {A B : Type*} [Fintype A] [Fintype B] [DecidableEq A] [DecidableEq B]
+    (M : Matrix B A 𝕜) : (conj M).IsCompletelyPositive := by
   intro n;
   -- The tensor product of congruence maps is a congruence map.
-  have h_tensor_congruence : conj M ⊗ₖₘ LinearMap.id = conj (M ⊗ₖ (1 : Matrix (Fin n) (Fin n) 𝕜)) := by
+  have h_tensor_congruence : conj M ⊗ₖₘ LinearMap.id =
+      conj (M ⊗ₖ (1 : Matrix (Fin n) (Fin n) 𝕜)) := by
     convert conj_kron M ( 1 : Matrix ( Fin n ) ( Fin n ) 𝕜 );
     ext M
     simp
   convert conj_isPositive ( M ⊗ₖ ( 1 : Matrix ( Fin n ) ( Fin n ) 𝕜 ) ) using 1
 
-theorem IsCompletelyPositive_sum {ι : Type*} [Fintype ι] (f : ι → MatrixMap A B ℂ) (h : ∀ i, (f i).IsCompletelyPositive) :
+theorem IsCompletelyPositive_sum {ι : Type*} [Fintype ι] (f : ι → MatrixMap A B ℂ)
+    (h : ∀ i, (f i).IsCompletelyPositive) :
     (∑ i, f i).IsCompletelyPositive := by
       convert IsCompletelyPositive.finset_sum h using 1
 
@@ -553,7 +594,8 @@ theorem of_kraus_eq_sum_conj (K : κ → Matrix B A 𝕜) :
 theorem of_kraus_CP (K : κ → Matrix B A 𝕜) : (of_kraus K K).IsCompletelyPositive := by
   -- By definition of `MatrixMap.of_kraus`, we know that it is a sum of congruence maps.
   have h_sum_congruence : MatrixMap.of_kraus K K = ∑ k, conj (K k) := by
-    -- By definition of `MatrixMap.of_kraus`, we know that it is equal to the sum of the congruence maps of each Kraus operator.
+    -- By definition of `MatrixMap.of_kraus`, we know that it is equal to the sum of the congruence
+    -- maps of each Kraus operator.
     apply of_kraus_eq_sum_conj
   have h_congruence_CP : ∀ k, (conj (K k)).IsCompletelyPositive := by
     intro k; exact (by
@@ -566,7 +608,8 @@ theorem exists_kraus_of_choi_PSD
     (C : Matrix (B × A) (B × A) 𝕜) (hC : C.PosSemidef) :
     ∃ (K : (B × A) → Matrix B A 𝕜), C = (MatrixMap.of_kraus K K).choi_matrix := by
   classical
-  use fun k i j => ( hC.1.eigenvectorUnitary.val : Matrix _ _ 𝕜 ) (i, j) k * ( hC.1.eigenvalues k |> RCLike.ofReal |> Real.sqrt)
+  use fun k i j => ( hC.1.eigenvectorUnitary.val : Matrix _ _ 𝕜 ) (i, j) k *
+    ( hC.1.eigenvalues k |> RCLike.ofReal |> Real.sqrt)
   convert Matrix.IsHermitian.spectral_theorem hC.1 using 1;
   ext i j
   simp [choi_of_kraus, Matrix.mul_apply, Matrix.vecMulVec ]
@@ -576,11 +619,17 @@ theorem exists_kraus_of_choi_PSD
   rw [ ← RCLike.ofReal_pow, Real.sq_sqrt ( hC.eigenvalues_nonneg _ ) ]
 
 /-
-The Choi matrix of M is the image of the unnormalized maximally entangled state projector under M ⊗ id.
+The Choi matrix of M is the image of the unnormalized maximally entangled state projector under
+M ⊗ id.
 -/
 theorem choi_matrix_eq_map_proj (M : MatrixMap A B R) :
-    M.choi_matrix = (M ⊗ₖₘ MatrixMap.id A R) (Matrix.vecMulVec (fun (x : A × A) => if x.1 = x.2 then 1 else 0) (fun (x : A × A) => star (if x.1 = x.2 then 1 else 0))) := by
-  have h_choi : ∀ (M : MatrixMap A B R), MatrixMap.kron M (MatrixMap.id A R) (Matrix.vecMulVec (fun (x : A × A) => if x.1 = x.2 then 1 else 0) (fun (x : A × A) => star (if x.1 = x.2 then 1 else 0))) = MatrixMap.choi_matrix M := by
+    M.choi_matrix = (M ⊗ₖₘ MatrixMap.id A R)
+      (Matrix.vecMulVec (fun (x : A × A) => if x.1 = x.2 then 1 else 0)
+        (fun (x : A × A) => star (if x.1 = x.2 then 1 else 0))) := by
+  have h_choi : ∀ (M : MatrixMap A B R),
+      MatrixMap.kron M (MatrixMap.id A R)
+        (Matrix.vecMulVec (fun (x : A × A) => if x.1 = x.2 then 1 else 0)
+          (fun (x : A × A) => star (if x.1 = x.2 then 1 else 0))) = MatrixMap.choi_matrix M := by
     intro M
     ext ⟨b₁, d₁⟩ ⟨b₂, d₂⟩
     simp [MatrixMap.kron_def, MatrixMap.choi_matrix];
@@ -588,7 +637,8 @@ theorem choi_matrix_eq_map_proj (M : MatrixMap A B R) :
     rw [ Finset.sum_eq_single d₁ ] <;> aesop;
   convert h_choi M |> Eq.symm
 
-/-- Choi's theorem on completely positive maps: A map `IsCompletelyPositive` iff its Choi Matrix is PSD. -/
+/-- Choi's theorem on completely positive maps: A map `IsCompletelyPositive` iff its Choi Matrix is
+PSD. -/
 theorem choi_PSD_iff_CP_map (M : MatrixMap A B R) :
     M.IsCompletelyPositive ↔ M.choi_matrix.PosSemidef := by
   constructor
@@ -607,7 +657,8 @@ theorem conj_eq_mulRightLinearMap_comp_mulRightLinearMap (y : Matrix B A R) :
   ext1; simp
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The act of conjugating (not necessarily by a unitary, just by any matrix at all) is completely positive. -/
+/-- The act of conjugating (not necessarily by a unitary, just by any matrix at all) is completely
+positive. -/
 theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPositive := by
   --TODO: This is identical to congruence_CP
   intro n m h
@@ -620,7 +671,15 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
     ext ⟨ b₁, c₁ ⟩ ⟨ b₂, c₂ ⟩
     rw [ MatrixMap.kron_def ];
     simp [Matrix.mul_apply, Matrix.single];
-    have h_split : ∑ x, ∑ x_1, ∑ x_2, ∑ x_3, (if x_2 = c₁ ∧ x_3 = c₂ then (∑ x_4, (∑ x_5, if x = x_5 ∧ x_1 = x_4 then M b₁ x_5 else 0) * (starRingEnd R) (M b₂ x_4)) * m (x, x_2) (x_1, x_3) else 0) = ∑ x, ∑ x_1, (∑ x_4, (∑ x_5, if x = x_5 ∧ x_1 = x_4 then M b₁ x_5 else 0) * (starRingEnd R) (M b₂ x_4)) * m (x, c₁) (x_1, c₂) := by
+    have h_split : ∑ x, ∑ x_1, ∑ x_2, ∑ x_3,
+        (if x_2 = c₁ ∧ x_3 = c₂ then
+          (∑ x_4, (∑ x_5, if x = x_5 ∧ x_1 = x_4 then M b₁ x_5 else 0) *
+            (starRingEnd R) (M b₂ x_4)) *
+            m (x, x_2) (x_1, x_3) else 0) =
+        ∑ x, ∑ x_1,
+          (∑ x_4, (∑ x_5, if x = x_5 ∧ x_1 = x_4 then M b₁ x_5 else 0) *
+            (starRingEnd R) (M b₂ x_4)) *
+            m (x, c₁) (x_1, c₂) := by
       refine Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => ?_
       rw [ Finset.sum_eq_single c₁ ]
       · simp_all only [Finset.mem_univ, true_and, Finset.sum_ite_eq', ↓reduceIte]
@@ -633,8 +692,14 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
     simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.conjTranspose_apply,
       RCLike.star_def, Finset.mul_sum _ _ _, Finset.sum_mul, ite_mul, zero_mul];
     simp [ Matrix.one_apply, Finset.sum_ite, Finset.filter_eq, Finset.filter_and ];
-    have h_reindex : ∑ x ∈ {x | c₁ = x.2}, ∑ x_1 ∈ {x | x.2 = c₂}, M b₁ x.1 * (m x x_1 * (starRingEnd R) (M b₂ x_1.1)) = ∑ x ∈ Finset.univ, ∑ x_1 ∈ Finset.univ, M b₁ x * (m (x, c₁) (x_1, c₂) * (starRingEnd R) (M b₂ x_1)) := by
-      rw [ show ( Finset.univ.filter fun x : A × Fin n => c₁ = x.2 ) = Finset.image ( fun x : A => ( x, c₁ ) ) Finset.univ from ?_, show ( Finset.univ.filter fun x : A × Fin n => x.2 = c₂ ) = Finset.image ( fun x : A => ( x, c₂ ) ) Finset.univ from ?_ ];
+    have h_reindex : ∑ x ∈ {x | c₁ = x.2}, ∑ x_1 ∈ {x | x.2 = c₂},
+        M b₁ x.1 * (m x x_1 * (starRingEnd R) (M b₂ x_1.1)) =
+        ∑ x ∈ Finset.univ, ∑ x_1 ∈ Finset.univ,
+          M b₁ x * (m (x, c₁) (x_1, c₂) * (starRingEnd R) (M b₂ x_1)) := by
+      rw [ show ( Finset.univ.filter fun x : A × Fin n => c₁ = x.2 ) =
+            Finset.image ( fun x : A => ( x, c₁ ) ) Finset.univ from ?_,
+          show ( Finset.univ.filter fun x : A × Fin n => x.2 = c₂ ) =
+            Finset.image ( fun x : A => ( x, c₂ ) ) Finset.univ from ?_ ];
       · simp [Finset.sum_image, Set.InjOn]
       · ext ⟨ x, y ⟩
         simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image, Prod.mk.injEq,
@@ -642,7 +707,9 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
         exact eq_comm;
       · ext ⟨ x, y ⟩
         simp [ eq_comm ];
-    have h_inner : ∀ x x_1, ∑ x_2, ∑ x_3 ∈ {x} ∩ if x_1 = x_2 then Finset.univ else ∅, M b₁ x_3 * (starRingEnd R) (M b₂ x_2) * m (x, c₁) (x_1, c₂) = M b₁ x * (starRingEnd R) (M b₂ x_1) * m (x, c₁) (x_1, c₂) := by
+    have h_inner : ∀ x x_1, ∑ x_2, ∑ x_3 ∈ {x} ∩ if x_1 = x_2 then Finset.univ else ∅,
+        M b₁ x_3 * (starRingEnd R) (M b₂ x_2) * m (x, c₁) (x_1, c₂) =
+        M b₁ x * (starRingEnd R) (M b₂ x_1) * m (x, c₁) (x_1, c₂) := by
       intro x x_1
       rw [ Finset.sum_eq_single x_1 ] <;> simp +contextual;
       simp +contextual [ eq_comm ];
@@ -652,7 +719,8 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
     classical
     apply CStarAlgebra.nonneg_iff_eq_star_mul_self.mp
     exact Matrix.nonneg_iff_posSemidef.mpr h
-  convert Matrix.posSemidef_conjTranspose_mul_self (m' * (M ⊗ₖ 1 : Matrix (B × Fin n) (A × Fin n) R).conjTranspose) using 1
+  convert Matrix.posSemidef_conjTranspose_mul_self
+    (m' * (M ⊗ₖ 1 : Matrix (B × Fin n) (A × Fin n) R).conjTranspose) using 1
   simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
   rw [Matrix.mul_assoc, Matrix.mul_assoc]
   congr
@@ -663,7 +731,8 @@ theorem conj_isCompletelyPositive (M : Matrix B A R) : (conj M).IsCompletelyPosi
   tauto
 
 /-- `MatrixMap.submatrix` is completely positive -/
-theorem IsCompletelyPositive.submatrix (f : B → A) : (MatrixMap.submatrix R f).IsCompletelyPositive := by
+theorem IsCompletelyPositive.submatrix (f : B → A) :
+    (MatrixMap.submatrix R f).IsCompletelyPositive := by
   convert conj_isCompletelyPositive (Matrix.submatrix (α := R) 1 f _root_.id : Matrix B A R)
   ext1 m
   simp [m.submatrix_eq_mul_mul]
@@ -680,7 +749,9 @@ omit [Fintype B] [DecidableEq A] in
 The Choi matrix of a map in symmetric Kraus form is a sum of rank-1 projectors.
 -/
 theorem choi_of_kraus_R [DecidableEq A] (K : κ → Matrix B A 𝕜) :
-    (of_kraus K K).choi_matrix = ∑ k, Matrix.vecMulVec (fun (x : B × A) => K k x.1 x.2) (fun (x : B × A) => star (K k x.1 x.2)) := by
+    (of_kraus K K).choi_matrix =
+      ∑ k, Matrix.vecMulVec (fun (x : B × A) => K k x.1 x.2)
+        (fun (x : B × A) => star (K k x.1 x.2)) := by
   unfold of_kraus choi_matrix
   ext i j : 2
   simp only [LinearMap.coe_sum, LinearMap.coe_mk, AddHom.coe_mk, Finset.sum_apply,
@@ -697,7 +768,8 @@ theorem choi_of_kraus_R [DecidableEq A] (K : κ → Matrix B A 𝕜) :
   · simp
 
 /-
-The Choi matrix of M is the result of applying M \otimes I to the unnormalized maximally entangled state (Choi matrix of identity).
+The Choi matrix of M is the result of applying M \otimes I to the unnormalized maximally entangled
+state (Choi matrix of identity).
 -/
 variable {A B R : Type*} [Fintype A] [Fintype B] [DecidableEq A] [RCLike R]
 
@@ -740,7 +812,8 @@ theorem choi_id_is_PSD {A R : Type*} [Fintype A] [DecidableEq A] [RCLike R] :
   refine' ⟨ _, fun x => _ ⟩;
   · ext i j; aesop;
   · -- By definition of $v$, we know that $star x ⬝ᵥ v v^* x = |star x ⬝ᵥ v|^2$.
-    have h_inner : star x ⬝ᵥ (MatrixMap.id A R).choi_matrix.mulVec x = star (star x ⬝ᵥ v) * (star x ⬝ᵥ v) := by
+    have h_inner : star x ⬝ᵥ (MatrixMap.id A R).choi_matrix.mulVec x =
+        star (star x ⬝ᵥ v) * (star x ⬝ᵥ v) := by
       simp [ hC, Matrix.mulVec, dotProduct ];
       simp [ Finset.mul_sum, mul_comm, v]
       exact Finset.sum_congr rfl fun i hi => by split_ifs <;> simp [ * ] ;
@@ -750,7 +823,8 @@ theorem choi_id_is_PSD {A R : Type*} [Fintype A] [DecidableEq A] [RCLike R] :
 /-
 If a map is completely positive, its Choi matrix is positive semidefinite.
 -/
-theorem is_CP_implies_choi_PSD {A B R : Type*} [Fintype A] [Fintype B] [DecidableEq A] [DecidableEq B] [RCLike R] (M : MatrixMap A B R) (hCP : M.IsCompletelyPositive) :
+theorem is_CP_implies_choi_PSD {A B R : Type*} [Fintype A] [Fintype B] [DecidableEq A]
+    [DecidableEq B] [RCLike R] (M : MatrixMap A B R) (hCP : M.IsCompletelyPositive) :
     M.choi_matrix.PosSemidef := by
   rw [choi_eq_kron_id_apply_choi_id]
   exact MatrixMap.IsCompletelyPositive.of_Fintype hCP A choi_id_is_PSD
@@ -879,7 +953,9 @@ theorem kron_of_kraus {A B C D R : Type*} [Fintype A] [Fintype B] [Fintype C] [F
     Finset.sum_const_zero, add_zero, ne_eq];
   simp only [Finset.sum_sigma', Finset.univ_sigma_univ];
   simp only [mul_comm, Finset.mul_sum, Finset.sum_sigma', mul_left_comm, mul_assoc];
-  refine Finset.sum_bij ( fun x _ => ⟨ ⟨ ⟨ x.snd.snd.fst.fst, x.snd.fst.fst.fst ⟩, x.snd.snd.fst.snd, x.snd.fst.fst.snd ⟩, x.snd.snd.snd, x.snd.fst.snd ⟩ ) ?_ ?_ ?_ ?_
+  refine Finset.sum_bij ( fun x _ =>
+    ⟨ ⟨ ⟨ x.snd.snd.fst.fst, x.snd.fst.fst.fst ⟩, x.snd.snd.fst.snd, x.snd.fst.fst.snd ⟩,
+      x.snd.snd.snd, x.snd.fst.snd ⟩ ) ?_ ?_ ?_ ?_
   · simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_filter, true_and, and_imp]
     grind
   · simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_filter, true_and, Sigma.mk.injEq,
@@ -894,7 +970,8 @@ namespace IsCompletelyPositive
 
 /-- The Kronecker product of IsCompletelyPositive maps is also completely positive. -/
 theorem kron {D : Type*} [DecidableEq C] [Fintype D] {M₁ : MatrixMap A B R} {M₂ : MatrixMap C D R}
-    (h₁ : M₁.IsCompletelyPositive) (h₂ : M₂.IsCompletelyPositive) : IsCompletelyPositive (M₁ ⊗ₖₘ M₂) := by
+    (h₁ : M₁.IsCompletelyPositive) (h₂ : M₂.IsCompletelyPositive) :
+    IsCompletelyPositive (M₁ ⊗ₖₘ M₂) := by
   obtain ⟨K₁, rfl⟩ := exists_kraus M₁ h₁
   obtain ⟨K₂, rfl⟩ := exists_kraus M₂ h₂
   rw [kron_of_kraus K₁ K₂]

--- a/QuantumInfo/ClassicalInfo/Distribution.lean
+++ b/QuantumInfo/ClassicalInfo/Distribution.lean
@@ -127,7 +127,8 @@ def uniform [n : Nonempty α] : ProbDistribution α :=
     bound⟩, by simp⟩
 
 @[simp]
-theorem uniform_def [Nonempty α] (y : α) : ((uniform y) : ℝ) = 1 / (Finset.univ.card (α := α)) :=
+theorem uniform_def [Nonempty α] (y : α) :
+    ((uniform y) : ℝ) = 1 / (Finset.univ.card (α := α)) :=
   rfl
 
 /-- Make a distribution on a product of two Fintypes. -/
@@ -181,7 +182,8 @@ def congr (σ : α ≃ β) : ProbDistribution α ≃ ProbDistribution β := by
     simp only [← fun_eq_val, Equiv.apply_symm_apply, Subtype.coe_eta]
 
 @[simp]
-theorem congr_apply (σ : α ≃ β) (d : ProbDistribution α) (j : β): (congr σ d) j = d (σ.symm j) := by
+theorem congr_apply (σ : α ≃ β) (d : ProbDistribution α) (j : β):
+    (congr σ d) j = d (σ.symm j) := by
   rfl
 
 /-- The inverse and congruence operations for distributions commute -/
@@ -262,7 +264,8 @@ theorem expect_val_eq_mixable_mix (d : ProbDistribution (Fin 2)) (x₁ x₂ : T)
     ∑ i : Fin (Nat.succ 0).succ, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) =
         ∑ i, (d i : ℝ) • Mixable.to_U (![x₁, x₂] i) := by
       simp
-    _ = (d 0 : ℝ) • Mixable.to_U (![x₁, x₂] 0) + (d 1 : ℝ) • Mixable.to_U (![x₁, x₂] 1) := by
+    _ = (d 0 : ℝ) • Mixable.to_U (![x₁, x₂] 0)
+        + (d 1 : ℝ) • Mixable.to_U (![x₁, x₂] 1) := by
       simp
     _ = (d 0 : ℝ) • Mixable.to_U x₁ + (1 - d 0).val • Mixable.to_U x₂ := by
       congr
@@ -288,8 +291,10 @@ theorem zero_le_expect_val (d : ProbDistribution α) (f : α → ℝ) (hpos : 0 
 /-- `T`-valued random variables on `α` and `β` are equivalent if `α ≃ β` -/
 def congrRandVar (σ : α ≃ β) : RandVar α T ≃ RandVar β T := by
   constructor
-  case toFun => exact fun X ↦ { var := X.var ∘ σ.symm, distr := ProbDistribution.congr σ X.distr }
-  case invFun => exact fun X ↦ { var := X.var ∘ σ, distr := ProbDistribution.congr σ.symm X.distr }
+  case toFun =>
+    exact fun X ↦ { var := X.var ∘ σ.symm, distr := ProbDistribution.congr σ X.distr }
+  case invFun =>
+    exact fun X ↦ { var := X.var ∘ σ, distr := ProbDistribution.congr σ.symm X.distr }
   case left_inv =>
     intro e
     dsimp
@@ -305,7 +310,8 @@ def congrRandVar (σ : α ≃ β) : RandVar α T ≃ RandVar β T := by
 
 /-- Given a `T`-valued random variable `X` over `α`, mapping over `T` commutes
   with the equivalence over `α` -/
-def map_congr_eq_congr_map {S : Type _} [Mixable U S] (f : T → S) (σ : α ≃ β) (X : RandVar α T) :
+def map_congr_eq_congr_map {S : Type _} [Mixable U S] (f : T → S) (σ : α ≃ β)
+    (X : RandVar α T) :
   f <$> congrRandVar σ X = congrRandVar σ (f <$> X) := by rfl
 
 /-- The expectation value is invariant under equivalence of random variables -/

--- a/QuantumInfo/ClassicalInfo/Entropy.lean
+++ b/QuantumInfo/ClassicalInfo/Entropy.lean
@@ -58,9 +58,11 @@ theorem H₁_le_1 (p : Prob) : H₁ p < 1 := by
 theorem H₁_le_exp_m1 (p : Prob) : H₁ p ≤ Real.exp (-1) :=
   Real.negMulLog_le_rexp_neg_one p.zero_le_coe
 
-theorem H₁_concave : ∀ (x y : Prob), ∀ (p : Prob), p[H₁ x ↔ H₁ y] ≤ H₁ (p[x ↔ y]) := by
+theorem H₁_concave : ∀ (x y : Prob), ∀ (p : Prob),
+    p[H₁ x ↔ H₁ y] ≤ H₁ (p[x ↔ y]) := by
   intros x y p
-  simp only [H₁, smul_eq_mul, Prob.coe_one_minus, Mixable.mix, Mixable.mix_ab, Mixable.mkT_instUniv,
+  simp only [H₁, smul_eq_mul, Prob.coe_one_minus, Mixable.mix, Mixable.mix_ab,
+    Mixable.mkT_instUniv,
     Prob.mkT_mixable, Prob.to_U_mixable, Mixable.to_U_instUniv, Prob.to_U_mixable]
   by_cases hxy : x = y
   · subst hxy
@@ -99,7 +101,8 @@ theorem Hₛ_le_log_d (d : ProbDistribution α) : Hₛ d ≤ Real.log (Fintype.c
     -- convex function -x log x.
   have h_jensen {p : α → ℝ} (hsum : ∑ i, p i = 1) (hp : ∀ i, 0 ≤ p i ∧ p i ≤ 1) :
       -∑ i, p i * (p i).log ≤ Real.log (Fintype.card α) := by
-    have h_jensen : (∑ i, (Fintype.card α : ℝ)⁻¹ * p i) * (∑ i, (Fintype.card α : ℝ)⁻¹ * p i).log ≤
+    have h_jensen : (∑ i, (Fintype.card α : ℝ)⁻¹ * p i)
+          * (∑ i, (Fintype.card α : ℝ)⁻¹ * p i).log ≤
           (∑ i, (Fintype.card α : ℝ)⁻¹ * (p i * (p i).log)) := by
       have h_convex : ConvexOn ℝ (Set.Icc 0 1) (fun x ↦ x * Real.log x) :=
         Real.convexOn_mul_log.subset Set.Icc_subset_Ici_self (convex_Icc 0 1)

--- a/QuantumInfo/ClassicalInfo/Prob.lean
+++ b/QuantumInfo/ClassicalInfo/Prob.lean
@@ -190,7 +190,8 @@ instance : OrderTopology Prob :=
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp, norm_cast]
-theorem coe_iInf {ι : Type*} [Nonempty ι] (f : ι → Prob) : ↑(⨅ t, f t) = (⨅ t, f t : ℝ) := by
+theorem coe_iInf {ι : Type*} [Nonempty ι] (f : ι → Prob) :
+    ↑(⨅ t, f t) = (⨅ t, f t : ℝ) := by
   apply Monotone.map_ciInf_of_continuousAt
   · fun_prop
   · exact fun _ _ ↦ id
@@ -235,7 +236,8 @@ end Prob
   PSD matrices of trace 1, `U` is the underlying matrix.
 
   Why not just stick with existing notions of `Convex`? `Convex` requires that
-  the type already forms an `AddCommMonoid` and `Module ℝ`. But many types, such as `Distribution`,
+  the type already forms an `AddCommMonoid` and `Module ℝ`. But many types, such as
+  `Distribution`,
   are not: there is no good notion of "multiplying a probability distribution by 0.3" to get another
   distribution. We can coerce the distribution nto, say, a vector or a function, but then we are not
   doing arithmetic with distributions. Accordingly, the expression `0.3 * distA + 0.7 * distB`
@@ -255,7 +257,8 @@ namespace Mixable
 variable {T U : Type*} [AddCommMonoid U] [Module ℝ U]
 
 @[reducible]
-def mix_ab [inst : Mixable U T] {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) (x₁ x₂ : T) : T :=
+def mix_ab [inst : Mixable U T] {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1)
+    (x₁ x₂ : T) : T :=
   inst.mkT <| inst.convex
     (x := to_U x₁) (exists_apply_eq_apply _ _)
     (y := to_U x₂) (exists_apply_eq_apply _ _)
@@ -276,11 +279,13 @@ notation p "[" x₁:80 "↔" x₂ "]" => mix p x₁ x₂
 notation p "[" x₁:80 "↔" x₂ ":" M "]" => mix (inst := M) p x₁ x₂
 
 @[simp]
-theorem mix_zero [inst : Mixable U T] (x₁ x₂ : T) : (0 : Prob) [ x₁ ↔ x₂ : inst] = x₂ := by
+theorem mix_zero [inst : Mixable U T] (x₁ x₂ : T) :
+    (0 : Prob) [ x₁ ↔ x₂ : inst] = x₂ := by
   apply inst.to_U_inj
   simp [mix, mix_ab]
 
-/--When T is the whole space, and T is a suitable vector space over ℝ, we get a Mixable instance.-/
+/--When T is the whole space, and T is a suitable vector space over ℝ, we get a Mixable
+instance.-/
 instance instUniv [AddCommMonoid T] [Module ℝ T] : Mixable T T where
   to_U := id
   to_U_inj := id
@@ -300,7 +305,8 @@ theorem to_U_instUniv [AddCommMonoid T] [Module ℝ T] {t : T} : instUniv.to_U t
 
 section pi
 
-theorem instPi.lem_1 {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)] [∀ i, Module ℝ (U i)]
+theorem instPi.lem_1 {D : Type*} {T U : D → Type*} [∀i, AddCommMonoid (U i)]
+    [∀ i, Module ℝ (U i)]
     [inst : ∀i, Mixable (U i) (T i)]
     {u : (i : D) → U i} (h : ∃ (t : (i : D) → T i), (fun d => to_U (t d)) = u) (d : D) :
     ∃ (t : T d), to_U t = u d := by
@@ -445,7 +451,8 @@ theorem negLog_pos_Real {p : Prob} : (—log p).toReal = -Real.log p := by
   · simp [hp]
   · simp; rfl
 
-theorem le_negLog_of_le_exp {p : Prob} {x : ℝ} (h : p ≤ Real.exp (-x)) : ENNReal.ofReal x ≤ —log p := by
+theorem le_negLog_of_le_exp {p : Prob} {x : ℝ} (h : p ≤ Real.exp (-x)) :
+    ENNReal.ofReal x ≤ —log p := by
   by_cases hx : 0 ≤ x
   · rw [negLog]
     split_ifs with hp

--- a/QuantumInfo/Entropy/Axiomatized/Defs.lean
+++ b/QuantumInfo/Entropy/Axiomatized/Defs.lean
@@ -52,7 +52,8 @@ universe u
 open scoped NNReal
 open scoped ENNReal
 
-variable (f : ∀ {d : Type u} [Fintype d] [DecidableEq d], MState d → HermitianMat d ℂ → ℝ≥0∞)
+variable (f : ∀ {d : Type u} [Fintype d] [DecidableEq d],
+  MState d → HermitianMat d ℂ → ℝ≥0∞)
 
 /-- The axioms to be a well-behaved quantum relative entropy, as given by
 [Tomamichel](https://www.marcotom.info/files/entropy-masterclass2022.pdf).
@@ -65,7 +66,8 @@ class RelEntropy : Prop where
     (ρ σ : MState d₁) (Λ : CPTPMap d₁ d₂) : f (Λ ρ) (Λ σ) ≤ f ρ σ
   /-- Entropy is additive under tensor products -/
   of_kron {d₁ d₂ : Type u} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [DecidableEq d₂] :
-    ∀ (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂), f (ρ₁ ⊗ ρ₂) (σ₁ ⊗ σ₂) = f ρ₁ σ₁ + f ρ₂ σ₂
+    ∀ (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂),
+      f (ρ₁ ⊗ ρ₂) (σ₁ ⊗ σ₂) = f ρ₁ σ₁ + f ρ₂ σ₂
   /-- Normalization of entropy to be `ln N` for a pure state vs. uniform on `N` many states. -/
   normalized {d : Type u} [fin : Fintype d] [DecidableEq d] [Nonempty d] (i : d) :
     f (.ofClassical (.constant i)) MState.uniform.M =
@@ -110,7 +112,8 @@ theorem of_equiv_eq (e : d ≃ d₂) (ρ σ : MState d) :
     f (CPTPMap.of_equiv e ρ) (CPTPMap.of_equiv e σ) = f ρ σ := by
   apply le_antisymm
   · apply DPI
-  · convert DPI (f := f) ((CPTPMap.of_equiv e) ρ) ((CPTPMap.of_equiv e) σ) (CPTPMap.of_equiv e.symm)
+  · convert DPI (f := f) ((CPTPMap.of_equiv e) ρ) ((CPTPMap.of_equiv e) σ)
+      (CPTPMap.of_equiv e.symm)
     · symm
       exact congrFun (CPTPMap.equiv_inverse e.symm) ρ
     · symm
@@ -164,7 +167,8 @@ theorem min_eq_top_iff (ρ : MState d) (σ : HermitianMat d ℂ) :
   open scoped HermitianMat in
   have h₂ : {0 ≤ₚ σ}.ker = σ.ker := by
     sorry --missing simp lemma
-  simp [min, Prob.negLog_eq_top_iff, MState.exp_val_eq_zero_iff, Subtype.ext_iff, proj_le_nonneg, h₂]
+  simp [min, Prob.negLog_eq_top_iff, MState.exp_val_eq_zero_iff, Subtype.ext_iff, proj_le_nonneg,
+    h₂]
 
 open scoped HermitianMat in
 protected theorem toReal_min (ρ : MState d) (σ : HermitianMat d ℂ) :

--- a/QuantumInfo/Entropy/DPI.lean
+++ b/QuantumInfo/Entropy/DPI.lean
@@ -35,7 +35,8 @@ as a consequence, the quantum relative entropy.
 
 Following Leditzky–Rouzé–Datta (arXiv:1306.5920), the proof proceeds as follows:
 
-1. Define the **trace functional** `Q̃_α(ρ‖σ) = Tr[(σ^γ ρ σ^γ)^α]` where `γ = (1 - α) / (2α)`.
+1. Define the **trace functional** `Q̃_α(ρ‖σ) = Tr[(σ^γ ρ σ^γ)^α]` where
+   `γ = (1 - α) / (2α)`.
    The sandwiched Rényi divergence satisfies `D̃_α(ρ‖σ) = log(Q̃_α(ρ‖σ)) / (α - 1)`.
 
 2. The DPI for `D̃_α` reduces to **monotonicity of `Q̃_α` under partial trace**:
@@ -57,7 +58,8 @@ open BigOperators
 
 /-! ## The Sandwiched Trace Functional -/
 
-/-- The sandwiched trace functional `Q̃_α(ρ‖σ) = Tr[(σ^γ ρ σ^γ)^α]` where `γ = (1-α)/(2α)`.
+/-- The sandwiched trace functional `Q̃_α(ρ‖σ) = Tr[(σ^γ ρ σ^γ)^α]` where
+`γ = (1-α)/(2α)`.
 This is the quantity underlying the sandwiched Rényi divergence:
 `D̃_α(ρ‖σ) = log(Q̃_α(ρ‖σ)) / (α - 1)`.
 
@@ -168,7 +170,8 @@ Key facts (each stated as a lemma below):
 5. The supremum of jointly convex functions is jointly convex.
 -/
 
-/-- The variational function `f_α(H, ρ, σ) = α · ⟪ρ, H⟫ − (α−1) · Tr[(σ^{−γ} H σ^{−γ})^{α/(α−1)}]`
+/-- The variational function
+`f_α(H, ρ, σ) = α · ⟪ρ, H⟫ − (α−1) · Tr[(σ^{−γ} H σ^{−γ})^{α/(α−1)}]`
 where `γ = (1−α)/(2α)`. For fixed `H ≥ 0`, this is linear in `ρ` and convex in `σ`.
 Frank–Lieb show that `Q̃_α(ρ‖σ) = sup_{H ≥ 0} f_α(H, ρ, σ)` for `α > 1`. -/
 noncomputable def f_alpha (α : ℝ) (H : HermitianMat d ℂ) (ρ σ : MState d) : ℝ :=
@@ -207,7 +210,8 @@ private lemma conj_supportProj_eq_of_ker_le (A B : HermitianMat d ℂ) (hker : A
 /--
 The kernel of σ is contained in the kernel of (ρ.conj (σ^γ))^{α-1} when γ ≠ 0 and α > 1.
 -/
-private lemma ker_sigma_le_ker_conj_rpow (ρ σ : MState d) {γ : ℝ} (hγ : γ ≠ 0) (hα1 : α - 1 ≠ 0) :
+private lemma ker_sigma_le_ker_conj_rpow (ρ σ : MState d) {γ : ℝ} (hγ : γ ≠ 0)
+    (hα1 : α - 1 ≠ 0) :
     σ.M.ker ≤ ((ρ.M.conj (σ.M ^ γ).mat) ^ (α - 1)).ker := by
   rw [ker_rpow_eq_of_nonneg (by positivity) hα1]
   intro x hx
@@ -215,7 +219,8 @@ private lemma ker_sigma_le_ker_conj_rpow (ρ σ : MState d) {γ : ℝ} (hγ : γ
     rwa [ker_rpow_eq_of_nonneg σ.nonneg hγ]
   simp_all [ker, lin]
 
-/-- Sub-lemma for Step 1b: the conj of H_hat by σ^{−γ} simplifies to (ρ.M.conj (σ^γ).mat)^{α−1}.
+/-- Sub-lemma for Step 1b: the conj of H_hat by σ^{−γ} simplifies to
+(ρ.M.conj (σ^γ).mat)^{α−1}.
 This uses σ^{−γ} · σ^γ = identity (on support) to cancel the outer σ^γ factors. -/
 theorem H_hat_conj_sigma (hα : 1 < α) (ρ σ : MState d) :
     let γ := (1 - α) / (2 * α)
@@ -233,7 +238,8 @@ theorem H_hat_conj_sigma (hα : 1 < α) (ρ σ : MState d) :
 
 /-
 Sub-lemma for Step 1b: the inner product ⟪ρ.M, H_hat⟫ equals Tr[(σ^γ ρ σ^γ)^α].
-By cyclicity of trace: Tr[ρ · σ^γ · (σ^γ ρ σ^γ)^{α−1} · σ^γ] = Tr[(σ^γ ρ σ^γ)^α].
+By cyclicity of trace:
+Tr[ρ · σ^γ · (σ^γ ρ σ^γ)^{α−1} · σ^γ] = Tr[(σ^γ ρ σ^γ)^α].
 -/
 theorem inner_rho_H_hat (hα : 1 < α) (ρ σ : MState d) :
     let γ := (1 - α) / (2 * α)
@@ -263,11 +269,13 @@ theorem inner_rho_H_hat (hα : 1 < α) (ρ σ : MState d) :
 /-
 **Step 1b**: Evaluating `f_α` at the optimizer `H_hat` gives `Q̃_α(ρ‖σ)`.
 This is the key computation that verifies the variational formula at the optimizer.
-Proof: f_α(H_hat, ρ, σ) = α · Tr[(σ^γ ρ σ^γ)^α] - (α-1) · Tr[(σ^γ ρ σ^γ)^α] = Tr[(σ^γ ρ σ^γ)^α] = Q̃.
+Proof: f_α(H_hat, ρ, σ) = α · Tr[(σ^γ ρ σ^γ)^α] - (α-1) · Tr[(σ^γ ρ σ^γ)^α]
+= Tr[(σ^γ ρ σ^γ)^α] = Q̃.
 -/
 theorem f_alpha_at_optimizer (hα : 1 < α) (ρ σ : MState d) :
     f_alpha α (H_hat α ρ σ) ρ σ = Q̃_ α(ρ‖σ) := by
-  have h_inner : ⟪ρ.M, H_hat α ρ σ⟫_ℝ = ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace := by
+  have h_inner : ⟪ρ.M, H_hat α ρ σ⟫_ℝ =
+      ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace := by
     exact inner_rho_H_hat hα ρ σ
   have h_conj : (H_hat α ρ σ).conj (σ.M ^ ((α - 1) / (2 * α))).mat =
       (ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ (α - 1) := by
@@ -310,7 +318,8 @@ lemma supportProj_mul_of_ker_le {A B : HermitianMat d ℂ}
   -- Since $B$ is not in the kernel of $A$, there exists some $x \in \ker(A)$ such that $Bx \neq 0$.
   obtain ⟨x, hx⟩ : ∃ x : EuclideanSpace ℂ d, A.mat *ᵥ x = 0 ∧ B.mat *ᵥ x ≠ 0 := by
     contrapose! hker
-    have h_support : ∀ x : EuclideanSpace ℂ d, B.mat *ᵥ x = B.mat *ᵥ (A.supportProj.mat *ᵥ x) := by
+    have h_support : ∀ x : EuclideanSpace ℂ d,
+        B.mat *ᵥ x = B.mat *ᵥ (A.supportProj.mat *ᵥ x) := by
       intro x
       have h_support : x.ofLp = A.supportProj.mat *ᵥ x.ofLp + A.kerProj.mat *ᵥ x.ofLp := by
         have h_support : A.supportProj.mat + A.kerProj.mat = 1 := by
@@ -419,7 +428,8 @@ theorem f_alpha_le_at_optimizer (hα : 1 < α) (ρ σ : MState d)
         (A ^ α).trace + (α - 1) * (B ^ (α / (α - 1))).trace := by
       field_simp
     linarith
-  -- Goal is definitionally: α * ⟪ρ.M, H⟫ - (α-1) * (B ^ (α/(α-1))).trace ≤ (A ^ α).trace
+  -- Goal is definitionally:
+  -- α * ⟪ρ.M, H⟫ - (α-1) * (B ^ (α/(α-1))).trace ≤ (A ^ α).trace
   -- which follows from h_scaled and h_inner
   change α * ⟪ρ.M, H⟫_ℝ - (α - 1) * (B ^ (α / (α - 1))).trace ≤ (A ^ α).trace
   have h_inner_scaled : α * ⟪ρ.M, H⟫_ℝ = α * ⟪A, B⟫_ℝ := by rw [h_inner]
@@ -431,23 +441,27 @@ supremum of `f_α` over all PSD `H`:
   `Q̃_α(ρ‖σ) = ⨆ (H : HermitianMat d ℂ) (_ : 0 ≤ H), f_alpha α H ρ σ`.
 The optimizer is `H_hat = σ^γ (σ^γ ρ σ^γ)^{α−1} σ^γ`.
 -/
-theorem traceFunctional_eq_iSup_f_alpha (hα : 1 < α) (ρ σ : MState d) (hker : σ.M.ker ≤ ρ.M.ker) :
+theorem traceFunctional_eq_iSup_f_alpha (hα : 1 < α) (ρ σ : MState d)
+    (hker : σ.M.ker ≤ ρ.M.ker) :
     Q̃_ α(ρ‖σ) = ⨆ (H : {H : HermitianMat d ℂ // 0 ≤ H}), f_alpha α H.1 ρ σ := by
   rw [@ciSup_eq_of_forall_le_of_forall_lt_exists_gt]
   · intro i
     rw [← f_alpha_at_optimizer hα ρ σ]
     exact f_alpha_le_at_optimizer hα ρ σ i i.2 hker
   · intro w hw
-    exact ⟨⟨H_hat α ρ σ, H_hat_nonneg ρ σ⟩, hw.trans_le (f_alpha_at_optimizer hα ρ σ ▸ le_rfl)⟩
+    exact ⟨⟨H_hat α ρ σ, H_hat_nonneg ρ σ⟩,
+      hw.trans_le (f_alpha_at_optimizer hα ρ σ ▸ le_rfl)⟩
 
 /-- (Convexity in σ): For fixed `H ≥ 0` and `ρ`, and `α > 1`, the map
 `σ ↦ f_alpha α H ρ σ` is convex. The key is that for `p = α/(α−1) > 1`:
 • `A ↦ Tr[A^p]` is convex on PSD matrices (trace function convexity, Theorem 2.10 of Carlen),
-• `σ ↦ σ^{−γ} H σ^{−γ}` is *concave* in `σ` by Lieb concavity (since `−γ = (α−1)/(2α) ∈ (0,½)`),
+• `σ ↦ σ^{−γ} H σ^{−γ}` is *concave* in `σ` by Lieb concavity
+  (since `−γ = (α−1)/(2α) ∈ (0,½)`),
 • The composition of a convex non-decreasing function with a concave function is convex,
   but we actually need the sign: the second term has a factor `−(α−1) < 0` which
   flips concave → convex.
-More precisely: `σ ↦ Tr[(σ^{−γ} H σ^{−γ})^p]` is concave (by Lieb + trace function convexity),
+More precisely: `σ ↦ Tr[(σ^{−γ} H σ^{−γ})^p]` is concave
+(by Lieb + trace function convexity),
 so `σ ↦ −(α−1) · Tr[(σ^{−γ} H σ^{−γ})^p]` is convex. -/
 theorem f_alpha_convex_in_sigma (hα : 1 < α) (H : HermitianMat d ℂ) (hH : 0 ≤ H)
     (ρ : MState d) {ι : Type*} [Fintype ι]
@@ -462,7 +476,8 @@ theorem f_alpha_convex_in_sigma (hα : 1 < α) (H : HermitianMat d ℂ) (hH : 0 
   let F : HermitianMat d ℂ → ℝ := fun σ => ((H.conj (σ ^ s).mat) ^ p).trace
   -- f_alpha relates to F via: f_alpha α H ρ σ = α * ⟪ρ.M, H⟫ - (α-1) * F(σ.M)
   -- because -γ = -((1-α)/(2α)) = (α-1)/(2α) = s
-  have hf_eq : ∀ σ : MState d, f_alpha α H ρ σ = α * ⟪ρ.M, H⟫_ℝ - (α - 1) * F σ.M := by
+  have hf_eq : ∀ σ : MState d,
+      f_alpha α H ρ σ = α * ⟪ρ.M, H⟫_ℝ - (α - 1) * F σ.M := by
     intro σ
     show _ = α * ⟪ρ.M, H⟫_ℝ - (α - 1) *
       ((H.conj (σ.M ^ ((α - 1) / (2 * α))).mat) ^ (α / (α - 1))).trace
@@ -521,7 +536,8 @@ theorem f_alpha_bddAbove (hα : 1 < α) (ρ σ : MState d) (hker : σ.M.ker ≤ 
 /-
 **Step 5 (Sup preserves convexity)**: The supremum over `H ≥ 0` of the jointly
 convex `f_alpha α H` is jointly convex. This is a standard fact: for each `H`,
-`f_alpha α H (ρ_mix) (σ_mix) ≤ ∑ wᵢ f_alpha α H (ρᵢ) (σᵢ) ≤ ∑ wᵢ sup_H f_alpha ...`,
+`f_alpha α H (ρ_mix) (σ_mix) ≤ ∑ wᵢ f_alpha α H (ρᵢ) (σᵢ)
+  ≤ ∑ wᵢ sup_H f_alpha ...`,
 so taking sup on the left gives the result.
 -/
 theorem iSup_f_alpha_jointly_convex (hα : 1 < α)
@@ -532,11 +548,13 @@ theorem iSup_f_alpha_jointly_convex (hα : 1 < α)
     (hσ_mix : σ_mix.M = ∑ i, w i • (σs i).M)
     (hker : ∀ i, (σs i).M.ker ≤ (ρs i).M.ker) :
     (⨆ (H : {H : HermitianMat d ℂ // 0 ≤ H}), f_alpha α H.1 ρ_mix σ_mix) ≤
-      ∑ i, w i * (⨆ (H : {H : HermitianMat d ℂ // 0 ≤ H}), f_alpha α H.1 (ρs i) (σs i)) := by
+      ∑ i, w i *
+        (⨆ (H : {H : HermitianMat d ℂ // 0 ≤ H}), f_alpha α H.1 (ρs i) (σs i)) := by
   apply ciSup_le
   intro H
   have h_sum : f_alpha α H.1 ρ_mix σ_mix ≤ ∑ i, w i * (f_alpha α H.1 (ρs i) (σs i)) := by
-    apply f_alpha_jointly_convex hα H.1 H.2 w hw_nonneg hw_sum ρs σs ρ_mix σ_mix hρ_mix hσ_mix
+    apply f_alpha_jointly_convex hα H.1 H.2 w hw_nonneg hw_sum ρs σs ρ_mix σ_mix
+      hρ_mix hσ_mix
   exact h_sum.trans (Finset.sum_le_sum fun i _ => mul_le_mul_of_nonneg_left
     (le_ciSup (f_alpha_bddAbove hα (ρs i) (σs i) (hker i)) H) (hw_nonneg i))
 
@@ -574,11 +592,14 @@ theorem sandwichedTraceFunctional_jointly_convex (hα : 1 < α) {ι : Type*} [Fi
     Q̃_ α(ρ_mix‖σ_mix) ≤ ∑ i, w i * Q̃_ α(ρs i‖σs i) := by
   have hker' : σ_mix.M.ker ≤ ρ_mix.M.ker := by
     rw [hρ_mix, hσ_mix]
-    exact ker_weighted_sum_le w hw_nonneg _ _ (fun i => (ρs i).nonneg) (fun i => (σs i).nonneg) hker
+    exact ker_weighted_sum_le w hw_nonneg _ _ (fun i => (ρs i).nonneg)
+      (fun i => (σs i).nonneg) hker
   rw [traceFunctional_eq_iSup_f_alpha hα ρ_mix σ_mix hker']
   calc ⨆ H : {H : HermitianMat d ℂ // 0 ≤ H}, f_alpha α H.1 ρ_mix σ_mix
-      ≤ ∑ i, w i * (⨆ H : {H : HermitianMat d ℂ // 0 ≤ H}, f_alpha α H.1 (ρs i) (σs i)) :=
-        iSup_f_alpha_jointly_convex hα w hw_nonneg hw_sum ρs σs ρ_mix σ_mix hρ_mix hσ_mix hker
+      ≤ ∑ i, w i *
+          (⨆ H : {H : HermitianMat d ℂ // 0 ≤ H}, f_alpha α H.1 (ρs i) (σs i)) :=
+        iSup_f_alpha_jointly_convex hα w hw_nonneg hw_sum ρs σs ρ_mix σ_mix hρ_mix
+          hσ_mix hker
     _ = ∑ i, w i * Q̃_ α(ρs i‖σs i) := by
         congr 1; ext i
         rw [traceFunctional_eq_iSup_f_alpha hα (ρs i) (σs i) (hker i)]
@@ -596,7 +617,8 @@ The averaging property follows from:
 A diagonal matrix with ±1 entries (determined by a Bool function) is unitary.
 -/
 private lemma signDiag_mem_unitaryGroup (f : dB → Bool) :
-    Matrix.diagonal (fun i : dB => (if f i then (-1 : ℂ) else 1)) ∈ Matrix.unitaryGroup dB ℂ := by
+    Matrix.diagonal (fun i : dB => (if f i then (-1 : ℂ) else 1)) ∈
+      Matrix.unitaryGroup dB ℂ := by
   constructor
   · ext i j; by_cases hi : i = j <;> simp [hi]
     · split_ifs <;> simp [*, Matrix.one_apply]
@@ -660,7 +682,8 @@ private lemma sum_sign_prod (p q : dB) :
   -- By pairing each function with its p-flip, we can see that the sum of each pair is zero.
   have h_pair :
       ∑ f : dB → Bool, (if f q then -if f p then -1 else 1 else if f p then -1 else 1 : ℂ) =
-      ∑ f : dB → Bool, - (if f q then -if f p then -1 else 1 else if f p then -1 else 1 : ℂ) := by
+      ∑ f : dB → Bool,
+        - (if f q then -if f p then -1 else 1 else if f p then -1 else 1 : ℂ) := by
     apply Finset.sum_bij (fun f _ => Function.update f p (¬f p)) (by simp)
     · intro a₁ _ a₂ _ h; ext x; by_cases hx : x = p
       · replace h := congr_fun h x
@@ -707,7 +730,8 @@ private lemma sum_perm_diag_entry (X : HermitianMat dB ℂ) (p : dB) :
     rcases n : Fintype.card dB with (_ | _ | n) <;> simp_all [Nat.factorial_succ, Fintype.card_perm]
     exact absurd n (Nat.ne_of_gt (Fintype.card_pos_iff.mpr ⟨p⟩))
   -- By Fubini's theorem, we can interchange the order of summation.
-  have h_fubini : ∑ σ : Equiv.Perm dB, X (σ p) (σ p) = ∑ k : dB, ∑ σ ∈ Finset.univ.filter
+  have h_fubini : ∑ σ : Equiv.Perm dB, X (σ p) (σ p) =
+      ∑ k : dB, ∑ σ ∈ Finset.univ.filter
       (fun σ : Equiv.Perm dB => σ p = k), X k k := by
     simp only [Finset.sum_filter]
     rw [Finset.sum_comm, Finset.sum_congr rfl]
@@ -752,7 +776,8 @@ private lemma twirling_identity [Nonempty dB] (X : HermitianMat dB ℂ) :
   ext p q
   simp [Fintype.card_prod, Fintype.card_perm, Fintype.card_pi]
   ring_nf
-  convert congr_arg ((2⁻¹ ^ Fintype.card dB * (Fintype.card dB |> Nat.factorial : ℂ)⁻¹) * ·)
+  convert congr_arg
+      ((2⁻¹ ^ Fintype.card dB * (Fintype.card dB |> Nat.factorial : ℂ)⁻¹) * ·)
       (twirling_sum_eq X p q) using 1
   · norm_num [Matrix.one_apply]
     convert Or.inl rfl
@@ -826,7 +851,8 @@ The trace functional is multiplicative over tensor products:
 -/
 theorem sandwichedTraceFunctional_mul
     (ρ₁ σ₁ : MState dA) (ρ₂ σ₂ : MState dB) :
-    Q̃_ α(ρ₁ ⊗ᴹ ρ₂‖σ₁ ⊗ᴹ σ₂) = Q̃_ α(ρ₁‖σ₁) * Q̃_ α(ρ₂‖σ₂) := by
+    Q̃_ α(ρ₁ ⊗ᴹ ρ₂‖σ₁ ⊗ᴹ σ₂) =
+      Q̃_ α(ρ₁‖σ₁) * Q̃_ α(ρ₂‖σ₂) := by
   exact sandwiched_term_product ρ₁ σ₁ ρ₂ σ₂ α ((1 - α) / (2 * α))
 
 /-
@@ -899,8 +925,10 @@ omit [DecidableEq dB] in
 lemma conj_kron_one_entry (M : Matrix (dA × dB) (dA × dB) ℂ)
     (V : Matrix dB dB ℂ) (a₁ a₂ : dA) (b₁ b₂ : dB) :
     (Matrix.kroneckerMap (· * ·) (1 : Matrix dA dA ℂ) V * M *
-     (Matrix.kroneckerMap (· * ·) (1 : Matrix dA dA ℂ) V).conjTranspose) (a₁, b₁) (a₂, b₂) =
-    (V * (Matrix.of fun b₁' b₂' => M (a₁, b₁') (a₂, b₂')) * V.conjTranspose) b₁ b₂ := by
+     (Matrix.kroneckerMap (· * ·) (1 : Matrix dA dA ℂ) V).conjTranspose)
+       (a₁, b₁) (a₂, b₂) =
+    (V * (Matrix.of fun b₁' b₂' => M (a₁, b₁') (a₂, b₂')) * V.conjTranspose)
+      b₁ b₂ := by
   norm_num [Matrix.mul_apply, Matrix.adjugate_apply, Matrix.det_apply', Matrix.trace]
   simp [Matrix.one_apply, Finset.sum_ite]
   apply Finset.sum_bij (fun x _ => x.2)
@@ -967,7 +995,8 @@ lemma twirling_general_matrix
     simp +zetaDelta at *
     ext i j; simp [Matrix.conjTranspose_apply]; ring
   have h_tw_a : ∑ i : κ, ((V i).val * X_anti_herm * (V i).val.conjTranspose) b₁ b₂ =
-      (X_anti_herm.trace / (Fintype.card dB)) * (Fintype.card κ) * (if b₁ = b₂ then 1 else 0) := by
+      (X_anti_herm.trace / (Fintype.card dB)) * (Fintype.card κ) *
+        (if b₁ = b₂ then 1 else 0) := by
     convert twirling_hermitian_entry κ V hV ⟨X_anti_herm, ?_⟩ b₁ b₂ using 1
     ext i j; simp [X_anti_herm, Matrix.conjTranspose_apply]; ring
   rw [h_decomp]
@@ -993,7 +1022,8 @@ lemma conjTensorUnitary'_entry (ρ : MState (dA × dB)) (V : Matrix.unitaryGroup
 lemma prod_traceRight_uniform_entry [Nonempty dB] (ρ : MState (dA × dB))
     (a₁ a₂ : dA) (b₁ b₂ : dB) :
     (ρ.traceRight ⊗ᴹ MState.uniform).M.val (a₁, b₁) (a₂, b₂) =
-    ρ.M.val.traceRight a₁ a₂ * ((Fintype.card dB : ℂ)⁻¹ * if b₁ = b₂ then 1 else 0) := by
+    ρ.M.val.traceRight a₁ a₂ *
+      ((Fintype.card dB : ℂ)⁻¹ * if b₁ = b₂ then 1 else 0) := by
   unfold MState.traceRight MState.uniform
   unfold MState.ofClassical
   unfold diagonal
@@ -1014,7 +1044,8 @@ theorem twirling_average_eq [Nonempty dB]
   -- Apply the twirling hypothesis to each term in the sum.
   have h_sum : ∀ a₁ a₂ : dA, ∀ b₁ b₂ : dB, (∑ i, (1 / (Fintype.card κ : ℂ)) •
       (ρ.conjTensorUnitary' (V i)).M.val (a₁, b₁) (a₂, b₂)) =
-      (ρ.M.val.traceRight a₁ a₂) * (1 / (Fintype.card dB : ℂ)) * (if b₁ = b₂ then 1 else 0) := by
+      (ρ.M.val.traceRight a₁ a₂) * (1 / (Fintype.card dB : ℂ)) *
+        (if b₁ = b₂ then 1 else 0) := by
     intro a₁ a₂ b₁ b₂
     have h_sum : ∑ i : κ, ((V i : Matrix dB dB ℂ) * (Matrix.of fun b₁' b₂' =>
         ρ.M.val (a₁, b₁') (a₂, b₂')) * (V i : Matrix dB dB ℂ).conjTranspose) b₁ b₂ =
@@ -1053,9 +1084,11 @@ under partial trace:
 `Q̃_α(ρ_AB ‖ σ_AB) ≥ Q̃_α(ρ_A ‖ σ_A)`.
 
 The proof uses the twirling argument:
-1. By unitary invariance, `Q̃_α(ρ_AB‖σ_AB) = Q̃_α(V_i ρ_AB V_i†‖V_i σ_AB V_i†)` for each `i`.
+1. By unitary invariance, `Q̃_α(ρ_AB‖σ_AB) = Q̃_α(V_i ρ_AB V_i†‖V_i σ_AB V_i†)`
+   for each `i`.
 2. Averaging: `Q̃_α(ρ_AB‖σ_AB) = (1/|κ|) Σ_i Q̃_α(V_i ρ_AB V_i†‖V_i σ_AB V_i†)`.
-3. By joint convexity (α > 1): `≥ Q̃_α((1/|κ|) Σ_i V_i ρ_AB V_i†‖(1/|κ|) Σ_i V_i σ_AB V_i†)`.
+3. By joint convexity (α > 1):
+   `≥ Q̃_α((1/|κ|) Σ_i V_i ρ_AB V_i†‖(1/|κ|) Σ_i V_i σ_AB V_i†)`.
 4. By twirling: `= Q̃_α(ρ_A ⊗ π_B ‖ σ_A ⊗ π_B)`.
 5. By tensor invariance: `= Q̃_α(ρ_A ‖ σ_A)`. -/
 
@@ -1069,7 +1102,8 @@ lemma ker_conj_le_of_ker_le {n : Type*} [Fintype n] [DecidableEq n]
   exact Submodule.comap_mono h
 
 /-- Unitary conjugation preserves the kernel ordering between MStates.
-If `σ.M.ker ≤ ρ.M.ker`, then `(σ.conjTensorUnitary V).M.ker ≤ (ρ.conjTensorUnitary V).M.ker`. -/
+If `σ.M.ker ≤ ρ.M.ker`, then
+`(σ.conjTensorUnitary V).M.ker ≤ (ρ.conjTensorUnitary V).M.ker`. -/
 lemma MState.ker_conjTensorUnitary_le {dA dB : Type*} [Fintype dA] [Fintype dB]
     [DecidableEq dA] [DecidableEq dB]
     (ρ σ : MState (dA × dB)) (V : Matrix.unitaryGroup dB ℂ)
@@ -1088,7 +1122,8 @@ theorem sandwichedTraceFunctional_mono_traceRight [Nonempty dB]
   letI : Fintype κ := hκ_fin
   letI : Nonempty κ := hκ_ne
   -- By unitary invariance, Q̃_α(ρ‖σ) = Q̃_α(V_i ρ V_i†‖V_i σ V_i†) for each i
-  have h_inv (i) : Q̃_ α(ρ.conjTensorUnitary (V i)‖σ.conjTensorUnitary (V i)) = Q̃_ α(ρ‖σ) :=
+  have h_inv (i) :
+      Q̃_ α(ρ.conjTensorUnitary (V i)‖σ.conjTensorUnitary (V i)) = Q̃_ α(ρ‖σ) :=
     sandwichedTraceFunctional_conj_tensorUnitary ρ σ (V i)
   -- Step 2: Q̃_α(ρ‖σ) = Σ_i (1/|κ|) * Q̃_α(V_i ρ V_i†‖V_i σ V_i†)
   have hcard_ne : (Fintype.card κ : ℝ) ≠ 0 :=
@@ -1103,9 +1138,11 @@ theorem sandwichedTraceFunctional_mono_traceRight [Nonempty dB]
     exact mul_inv_cancel₀ hcard_ne
   set ρ_mix := ρ.traceRight ⊗ᴹ MState.uniform (d := dB)
   set σ_mix := σ.traceRight ⊗ᴹ MState.uniform (d := dB)
-  have hρ_mix : ρ_mix.M = ∑ i : κ, (Fintype.card κ : ℝ)⁻¹ • (ρ.conjTensorUnitary (V i)).M :=
+  have hρ_mix : ρ_mix.M =
+      ∑ i : κ, (Fintype.card κ : ℝ)⁻¹ • (ρ.conjTensorUnitary (V i)).M :=
     (twirling_average_eq κ V hV ρ).symm
-  have hσ_mix : σ_mix.M = ∑ i : κ, (Fintype.card κ : ℝ)⁻¹ • (σ.conjTensorUnitary (V i)).M :=
+  have hσ_mix : σ_mix.M =
+      ∑ i : κ, (Fintype.card κ : ℝ)⁻¹ • (σ.conjTensorUnitary (V i)).M :=
     (twirling_average_eq κ V hV σ).symm
   have h_convex := sandwichedTraceFunctional_jointly_convex hα
     (fun (_ : κ) => (Fintype.card κ : ℝ)⁻¹) (by intro; positivity) hw_sum
@@ -1173,7 +1210,8 @@ private lemma traceRight_mulVec_zero_of_vecTensorBasis_zero
 /-- The kernel condition `σ.M.ker ≤ ρ.M.ker` is preserved under partial trace.
 This follows because `supp(ρ) ⊆ supp(σ)` implies `supp(Tr_B ρ) ⊆ supp(Tr_B σ)`:
 if `v ∈ supp(Tr_B ρ)`, then `⟨v, (Tr_B ρ) v⟩ > 0`, so for some basis vector `e_b`
-we have `v ⊗ e_b ∈ supp(ρ) ⊆ supp(σ)`, hence `⟨v, (Tr_B σ) v⟩ ≥ ⟨v ⊗ e_b, σ (v ⊗ e_b)⟩ > 0`. -/
+we have `v ⊗ e_b ∈ supp(ρ) ⊆ supp(σ)`, hence
+`⟨v, (Tr_B σ) v⟩ ≥ ⟨v ⊗ e_b, σ (v ⊗ e_b)⟩ > 0`. -/
 theorem ker_le_traceRight {ρ σ : MState (dA × dB)}
     (hker : σ.M.ker ≤ ρ.M.ker) :
     σ.traceRight.M.ker ≤ ρ.traceRight.M.ker := by
@@ -1197,7 +1235,8 @@ theorem ker_le_traceRight {ρ σ : MState (dA × dB)}
     fun b => (hσ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero b)
   have h_ρ_zero : ∀ b : dB, ρ.M.mat *ᵥ (vecTensorBasis v.ofLp b) = 0 := by
     intro b
-    have hmem_σ : (WithLp.toLp 2 (vecTensorBasis v.ofLp b) : EuclideanSpace ℂ _) ∈ σ.M.ker := by
+    have hmem_σ :
+        (WithLp.toLp 2 (vecTensorBasis v.ofLp b) : EuclideanSpace ℂ _) ∈ σ.M.ker := by
       rw [mem_ker_iff_mulVec_zero]; exact h_σ_zero b
     have hmem_ρ := hker hmem_σ
     rwa [mem_ker_iff_mulVec_zero] at hmem_ρ
@@ -1345,7 +1384,8 @@ every CPTP map can be written as ancilla preparation + unitary conjugation + par
 Since the sandwiched Rényi divergence is invariant under the first two operations
 (by additivity and relabel invariance) and monotone under partial trace
 (by `sandwichedRenyiEntropy_mono_traceRight`), the DPI follows. -/
-theorem sandwichedRenyiEntropy_DPI_gt_one (hα : 1 < α) (ρ σ : MState d₁) (Φ : CPTPMap d₁ d₂) :
+theorem sandwichedRenyiEntropy_DPI_gt_one (hα : 1 < α) (ρ σ : MState d₁)
+    (Φ : CPTPMap d₁ d₂) :
     D̃_ α(Φ ρ‖Φ σ) ≤ D̃_ α(ρ‖σ) := by
   have _ : Nonempty d₁ := ρ.nonempty
   have _ : Nonempty d₂ := (Φ ρ).nonempty
@@ -1385,10 +1425,12 @@ theorem sandwichedRenyiEntropy_DPI_eq_one (ρ σ : MState d₁) (Φ : CPTPMap d�
     D̃_ 1(Φ ρ‖Φ σ) ≤ D̃_ 1(ρ‖σ) := by
   -- Since α → D_α(ρ‖σ) is continuous on (0, ∞), we can take the limit as α → 1.
   have h_cont :
-      Filter.Tendsto (fun α : ℝ => D̃_ α(Φ ρ‖Φ σ)) (𝓝[>] 1) (𝓝 (D̃_ 1(Φ ρ‖Φ σ))) ∧
+      Filter.Tendsto (fun α : ℝ => D̃_ α(Φ ρ‖Φ σ)) (𝓝[>] 1)
+          (𝓝 (D̃_ 1(Φ ρ‖Φ σ))) ∧
       Filter.Tendsto (fun α : ℝ => D̃_ α(ρ‖σ)) (𝓝[>] 1) (𝓝 (D̃_ 1(ρ‖σ))) := by
     constructor
-    · exact tendsto_nhdsWithin_of_tendsto_nhds (sandwichedRelRentropy.continuousOn (Φ ρ) (Φ σ) |>
+    · exact tendsto_nhdsWithin_of_tendsto_nhds
+        (sandwichedRelRentropy.continuousOn (Φ ρ) (Φ σ) |>
         ContinuousOn.continuousAt <| Ioi_mem_nhds zero_lt_one)
     · exact tendsto_nhdsWithin_of_tendsto_nhds (sandwichedRelRentropy.continuousOn ρ σ |>
         ContinuousOn.continuousAt <| Ioi_mem_nhds zero_lt_one)

--- a/QuantumInfo/Entropy/Relative.lean
+++ b/QuantumInfo/Entropy/Relative.lean
@@ -205,8 +205,9 @@ lemma HermitianMat.trace_rpow_le_trace_of_le_one
   · rw [ Real.zero_rpow ( by positivity ) ];
   · conv_rhs => rw [← (A.H.eigenvalues i).rpow_one]
     apply Real.rpow_le_rpow_of_exponent_ge
-    · exact lt_of_le_of_ne' (le_of_not_gt fun hi => hi0 <| by linarith
-        [ show 0 ≤ A.H.eigenvalues i by simpa using hA.eigenvalues_nonneg i ] ) hi0
+    · exact lt_of_le_of_ne' (le_of_not_gt fun hi => hi0 <| by
+        linarith
+          [ show 0 ≤ A.H.eigenvalues i by simpa using hA.eigenvalues_nonneg i ] ) hi0
     · exact A.eigenvalues_le_one_of_le_one hA1 i
     · exact hp
 
@@ -774,8 +775,9 @@ private lemma scalar_rpow_cross_term_of_continuous {b : ℝ → ℝ} {c : ℝ}
         (nhds (Real.log c)) := by
       have h_log : Filter.Tendsto (fun t => (Real.log (b (1 + t)) * t) / t) (nhdsWithin 0 {0}ᶜ)
           (nhds (Real.log c)) := by
-        exact Filter.Tendsto.congr' ( by filter_upwards [ self_mem_nhdsWithin ] with t ht using by
-          rw [ mul_div_cancel_right₀ _ ht ] ) ( Filter.Tendsto.log h_b hc_pos.ne' )
+        exact Filter.Tendsto.congr' ( by
+          filter_upwards [ self_mem_nhdsWithin ] with t ht using by
+            rw [ mul_div_cancel_right₀ _ ht ] ) ( Filter.Tendsto.log h_b hc_pos.ne' )
       have h_exp : Filter.Tendsto (fun t => (Real.exp (Real.log (b (1 + t)) * t) - 1) / t)
           (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
         have h_exp : HasDerivAt (fun t => Real.exp (Real.log (b (1 + t)) * t)) (Real.log c) 0 := by
@@ -874,9 +876,10 @@ private lemma scalar_rpow_cross_term_of_continuous_zero {b : ℝ → ℝ}
             generalize_proofs at *; (
             exact h_subst.congr' ( Filter.eventuallyEq_of_mem self_mem_nhdsWithin fun x hx => by
               rw [ Real.log_sqrt hx.out.le ] ; ring ) |> fun h => h.trans ( by norm_num ) ;);
-          exact tendsto_nhdsWithin_of_tendsto_nhds ( by simpa [ mul_assoc ] using
-            Filter.Tendsto.const_mul 2 ( Real.continuous_mul_log.tendsto 0 ) ) |>
-            fun h => h.trans ( by norm_num ) ;
+          exact tendsto_nhdsWithin_of_tendsto_nhds ( by
+            simpa [ mul_assoc ] using
+              Filter.Tendsto.const_mul 2 ( Real.continuous_mul_log.tendsto 0 ) ) |>
+              fun h => h.trans ( by norm_num ) ;
         exact tendsto_zero_iff_norm_tendsto_zero.mpr ( by simpa using h_sqrt_log.norm );
       have h_sqrt_log : Filter.Tendsto (fun α => Real.sqrt (|b α|) * |Real.log (|b α|)|)
           (nhdsWithin 1 {α | 0 < |b α|}) (nhds 0) := by
@@ -974,7 +977,8 @@ private lemma conj_rpow_continuousAt_zero
     · convert conj_supportProj_eq_of_ker_le A ρM hker |> Eq.symm;
     · fun_prop;
   rw [ Metric.tendsto_nhdsWithin_nhds ] at *;
-  exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by rcases h_conj ε hε with ⟨ δ, hδ, H ⟩ ;
+  exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by
+    rcases h_conj ε hε with ⟨ δ, hδ, H ⟩ ;
     exact ⟨ δ, hδ, by intro x hx; by_cases hx' : x = 0 <;> aesop ⟩ ;
 
 /-
@@ -1049,8 +1053,9 @@ private lemma rpow_slope_tendsto_uniformly (K : ℝ) :
         exact tendsto_nhdsWithin_of_tendsto_nhds
           ( by simpa using Real.continuous_mul_log.tendsto 0 );
       have := Metric.tendsto_nhdsWithin_nhds.mp h_cont ( ε / 4 ) ( by linarith );
-      exact ⟨ this.choose, this.choose_spec.1, fun x hx₁ hx₂ hx₃ => by simpa [ abs_mul ] using
-        this.choose_spec.2 hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ⟩;
+      exact ⟨ this.choose, this.choose_spec.1, fun x hx₁ hx₂ hx₃ => by
+        simpa [ abs_mul ] using
+          this.choose_spec.2 hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ⟩;
     have h_bound : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ → ∀ h, 0 < |h| → |h| < 1 / 2 →
         |x ^ (1 + h) - x| ≤ |h| * x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
       have h_bound : ∀ x ∈ Set.Icc 0 K, 0 < x → ∀ h : ℝ, 0 < |h| → |h| < 1 / 2 →
@@ -1197,7 +1202,8 @@ private lemma rpow_slope_tendsto_uniformly (K : ℝ) :
           ( CompactIccSpace.isCompact_Icc ) h_cont;
         norm_num +zetaDelta at *;
         exact ⟨ Max.max M 1, by positivity, fun x hx₁ hx₂ h hh₁ hh₂ => le_trans
-          ( by rw [ abs_of_nonneg ( by linarith : 0 ≤ x ) ] ;
+          ( by
+            rw [ abs_of_nonneg ( by linarith : 0 ≤ x ) ] ;
             exact mul_le_mul_of_nonneg_left
               ( Real.exp_le_exp.mpr <| by nlinarith [ abs_nonneg ( Real.log x ) ] ) <|
               by nlinarith [ abs_nonneg ( Real.log x ) ] )
@@ -1322,7 +1328,8 @@ private lemma cross_term_slope_tendsto_zero
         rw [ ← Finset.sum_sub_distrib ];
         exact lt_of_le_of_lt ( Finset.abs_sum_le_sum_abs _ _ ) ( lt_of_le_of_lt
           ( Finset.sum_le_sum fun i _ => le_of_lt ( by simpa [ hx ] using hδ x hx hx' i ) )
-          ( by norm_num;
+          ( by
+            norm_num;
             nlinarith [ mul_div_cancel₀ ε ( by positivity : ( Fintype.card d + 1 : ℝ ) ≠ 0 ) ] ) );
       · rw [ Metric.tendsto_nhdsWithin_nhds ];
         intro ε ε_pos;
@@ -2009,7 +2016,8 @@ private theorem sandwichedRelRentropy.continuousOn_Ioi_1_aux (ρ σ : MState d) 
             ( by linarith [ hx.out ] )
         have h_cont : ContinuousOn (fun α : ℝ => (σ.M ^ α)) (Set.Iio 0) := by
           apply_rules [ HermitianMat.continuousOn_rpow_neg ];
-        exact h_cont.comp ‹_› fun x hx => by rw [ Set.mem_Iio ] ;
+        exact h_cont.comp ‹_› fun x hx => by
+          rw [ Set.mem_Iio ] ;
           rw [ div_lt_iff₀ ] <;> linarith [ hx.out ] ;
       exact Continuous.comp_continuousOn ( by continuity ) h_cont;
     fun_prop;
@@ -2061,7 +2069,8 @@ private theorem sandwichedRelRentropy.continuousOn_Ioo_0_1_aux (ρ σ : MState d
             ( by linarith [ hx.1 ] )
         have h_rpow_cont : ContinuousOn (fun α : ℝ => (σ.M ^ α)) (Set.Ioi 0) := by
           apply_rules [ HermitianMat.continuousOn_rpow_pos ]
-        exact h_rpow_cont.comp h_exp_cont fun x hx => by rw [ Set.mem_Ioi ] ;
+        exact h_rpow_cont.comp h_exp_cont fun x hx => by
+          rw [ Set.mem_Ioi ] ;
           apply div_pos <;> linarith [ hx.1, hx.2 ]
       exact Continuous.comp_continuousOn ( by continuity ) h_cont
     fun_prop
@@ -2253,7 +2262,8 @@ private lemma approxLog_tendsto_at_pos {t : ℝ} (ht : 0 < t) :
   refine' Filter.Tendsto.congr' _ tendsto_const_nhds
   filter_upwards [Filter.eventually_gt_atTop ⌈-Real.log t⌉₊] with N hN
   unfold approxLog
-  rw [max_eq_left (by rw [← Real.log_le_log_iff (by positivity) (by positivity)];
+  rw [max_eq_left (by
+    rw [← Real.log_le_log_iff (by positivity) (by positivity)];
     linarith [Nat.le_ceil (-Real.log t),
       show (N : ℝ) ≥ ⌈-Real.log t⌉₊ + 1 by exact_mod_cast hN, Real.log_exp (-N)])]
 
@@ -2406,9 +2416,10 @@ private lemma neg_ker_exists_eigenWeight_pos (ρ x : MState d) (hx : ¬(x.M.ker 
   -- By `ker_le_iff_eigenWeight_zero`, ¬(x.M.ker ≤ ρ.M.ker) iff ∃ i, eigenvalue_i = 0 ∧
   -- eigenWeight ≠ 0. Use this fact.
   have h_eigenWeight_ne_zero : ∃ i, x.M.H.eigenvalues i = 0 ∧ eigenWeight ρ x i ≠ 0 := by
-    exact Classical.not_forall_not.1 fun h => hx <| by simpa using
-      ker_le_iff_eigenWeight_zero ρ x |>.2 fun i hi =>
-      Classical.not_not.1 fun hi' => h i ⟨ hi, hi' ⟩ ;
+    exact Classical.not_forall_not.1 fun h => hx <| by
+      simpa using
+        ker_le_iff_eigenWeight_zero ρ x |>.2 fun i hi =>
+        Classical.not_not.1 fun hi' => h i ⟨ hi, hi' ⟩
   exact h_eigenWeight_ne_zero.imp fun i hi =>
     ⟨ hi.1, lt_of_le_of_ne ( eigenWeight_nonneg ρ x i ) hi.2.symm ⟩
 

--- a/QuantumInfo/Entropy/Relative.lean
+++ b/QuantumInfo/Entropy/Relative.lean
@@ -24,9 +24,12 @@ variable {α : ℝ} {ρ σ : MState d}
 open scoped Matrix ComplexOrder InnerProductSpace RealInnerProductSpace HermitianMat
 
 /-!
-To do relative entropies, we start with the _sandwiched Renyi Relative Entropy_ which is a nice general form.
-Then instead of proving many theorems (like DPI, relabelling, additivity, etc.) several times, we just prove
-it for this one quantity, then it follows for other quantities (like the relative entropy) as a special case.
+To do relative entropies, we start with the _sandwiched Renyi Relative Entropy_ which is a nice
+general form.
+Then instead of proving many theorems (like DPI, relabelling, additivity, etc.) several times, we
+just prove
+it for this one quantity, then it follows for other quantities (like the relative entropy) as a
+special case.
 -/
 
 --Note: without the assumption `h`, we could still get nonnegativity, just not strict positivity.
@@ -51,7 +54,8 @@ This is the special case of `Real.rpow_arith_mean_le_arith_mean_rpow` applied to
 lemma weighted_jensen_rpow (b w : d → ℝ) (q : ℝ)
   (hb : ∀ j, 0 ≤ b j) (hw : ∀ j, 0 ≤ w j) (hsum : ∑ j, w j = 1) (hq : 1 ≤ q) :
     (∑ j, w j * b j) ^ q ≤ ∑ j, w j * b j ^ q :=
-  Real.rpow_arith_mean_le_arith_mean_rpow Finset.univ _ _ (fun i _ ↦ hw i) hsum (fun i _ ↦ hb i) hq
+  Real.rpow_arith_mean_le_arith_mean_rpow Finset.univ _ _ (fun i _ ↦ hw i) hsum
+    (fun i _ ↦ hb i) hq
 
 omit [DecidableEq d] in
 /--
@@ -69,12 +73,17 @@ lemma doubly_stochastic_holder (a b : d → ℝ) (w : d → d → ℝ)
   contrapose! h_contra with h_contra
   simp_all [ ← Finset.mul_sum, mul_assoc ]
   have h0q : 0 < q :=
-    lt_of_le_of_ne ( le_of_not_gt fun hq => by { rw [ inv_eq_one_div, div_eq_mul_inv ] at hpq; nlinarith [ inv_mul_cancel₀ ( by linarith : ( p : ℝ ) ≠ 0 ), inv_lt_zero.2 hq ] } ) (by grind)
+    lt_of_le_of_ne ( le_of_not_gt fun hq => by {
+      rw [ inv_eq_one_div, div_eq_mul_inv ] at hpq;
+      nlinarith [ inv_mul_cancel₀ ( by linarith : ( p : ℝ ) ≠ 0 ), inv_lt_zero.2 hq ] } )
+      (by grind)
   -- Apply Hölder's inequality with the sequences $a_i$ and $g_i = \sum_j w_{ij} b_j$.
-  have h_holder : (∑ i, a i * (∑ j, w i j * b j)) ≤ (∑ i, a i ^ p) ^ (1 / p) * (∑ i, (∑ j, w i j * b j) ^ q) ^ (1 / q) := by
+  have h_holder : (∑ i, a i * (∑ j, w i j * b j)) ≤
+      (∑ i, a i ^ p) ^ (1 / p) * (∑ i, (∑ j, w i j * b j) ^ q) ^ (1 / q) := by
     have := @Real.inner_le_Lp_mul_Lq
     simp_all
-    convert this Finset.univ a ( fun i => ∑ j, w i j * b j ) ( show p.HolderConjugate q from ?_ ) using 1
+    convert this Finset.univ a ( fun i => ∑ j, w i j * b j )
+      ( show p.HolderConjugate q from ?_ ) using 1
     · simp only [ha, abs_of_nonneg, mul_eq_mul_left_iff]
       left
       congr!
@@ -94,7 +103,11 @@ lemma doubly_stochastic_holder (a b : d → ℝ) (w : d → d → ℝ)
     rw [ Finset.sum_comm ]
     simp [ ← Finset.sum_mul, hcol]
   simp_all only [mul_comm];
-  simpa using h_holder.trans ( mul_le_mul_of_nonneg_left ( Real.rpow_le_rpow ( Finset.sum_nonneg fun _ _ => Real.rpow_nonneg ( Finset.sum_nonneg fun _ _ => mul_nonneg ( hb _ ) ( hw _ _ ) ) _ ) h_fubini (one_div_nonneg.mpr h0q.le)) ( Real.rpow_nonneg ( Finset.sum_nonneg fun _ _ => Real.rpow_nonneg ( ha _ ) _ ) _ ) ) |> le_trans <| by simp;
+  simpa using h_holder.trans ( mul_le_mul_of_nonneg_left ( Real.rpow_le_rpow
+    ( Finset.sum_nonneg fun _ _ => Real.rpow_nonneg
+      ( Finset.sum_nonneg fun _ _ => mul_nonneg ( hb _ ) ( hw _ _ ) ) _ ) h_fubini
+    (one_div_nonneg.mpr h0q.le)) ( Real.rpow_nonneg
+      ( Finset.sum_nonneg fun _ _ => Real.rpow_nonneg ( ha _ ) _ ) _ ) ) |> le_trans <| by simp;
 
 --PULLOUT
 /--
@@ -110,14 +123,17 @@ lemma HermitianMat.inner_le_trace_rpow_mul
     rw [trace_rpow_eq_sum, trace_rpow_eq_sum, inner_eq_doubly_stochastic_sum]
     refine doubly_stochastic_holder
       A.H.eigenvalues B.H.eigenvalues
-      (fun i j ↦ ‖(A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val) i j‖ ^ 2)
+      (fun i j ↦
+        ‖(A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val) i j‖ ^ 2)
       (fun i ↦ by simpa using hA.eigenvalues_nonneg i)
       (fun i ↦ by simpa using hB.eigenvalues_nonneg i)
       (by bound) ?_ ?_ p q hp hpq
-    · apply Matrix.unitary_row_sum_norm_sq (A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val)
+    · apply Matrix.unitary_row_sum_norm_sq
+        (A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val)
       simp [mul_assoc]
       simp [← mul_assoc, Matrix.IsHermitian.eigenvectorUnitary]
-    · apply Matrix.unitary_col_sum_norm_sq (A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val)
+    · apply Matrix.unitary_col_sum_norm_sq
+        (A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val)
       simp [mul_assoc]
       simp [← mul_assoc, Matrix.IsHermitian.eigenvectorUnitary]
   · rcases eq_or_ne q 0 with _ | _
@@ -145,7 +161,8 @@ lemma HermitianMat.eigenvalues_le_one_of_le_one
     (A : HermitianMat d ℂ) (hA1 : A ≤ 1) (i : d) :
     A.H.eigenvalues i ≤ 1 := by
   by_contra! h
-  obtain ⟨v, hv₁, hv₂⟩ : ∃ v : EuclideanSpace ℂ d, ‖v‖ = 1 ∧ A.mat.mulVec v = (A.H.eigenvalues i) • v := by
+  obtain ⟨v, hv₁, hv₂⟩ : ∃ v : EuclideanSpace ℂ d,
+      ‖v‖ = 1 ∧ A.mat.mulVec v = (A.H.eigenvalues i) • v := by
     use A.H.eigenvectorBasis i
     exact ⟨A.H.eigenvectorBasis.orthonormal.1 i, A.H.mulVec_eigenvectorBasis i⟩
   have h_eigenvalue : star v ⬝ᵥ A.mat.mulVec v = (A.H.eigenvalues i) * star v ⬝ᵥ v := by
@@ -175,21 +192,27 @@ lemma HermitianMat.trace_rpow_le_trace_of_le_one
     (A : HermitianMat d ℂ) (hA : 0 ≤ A) (hA1 : A ≤ 1)
     (p : ℝ) (hp : 1 ≤ p) :
     (A ^ p).trace ≤ A.trace := by
-  -- Rewrite both sides using trace_rpow_eq_sum: Tr[A^p] = ∑ λ_i^p and Tr[A] = ∑ λ_i (using trace_rpow_eq_sum and rpow_one for the latter).
-  have h_trace_eq_sum : (A ^ p).trace = ∑ i, (A.H.eigenvalues i) ^ p ∧ A.trace = ∑ i, (A.H.eigenvalues i) := by
-    exact ⟨ by rw [ HermitianMat.trace_rpow_eq_sum ], by rw [ show A.trace = ∑ i, ( A.H.eigenvalues i ) by simpa using HermitianMat.trace_rpow_eq_sum A 1 ] ⟩;
+  -- Rewrite both sides using trace_rpow_eq_sum: Tr[A^p] = ∑ λ_i^p and Tr[A] = ∑ λ_i (using
+  -- trace_rpow_eq_sum and rpow_one for the latter).
+  have h_trace_eq_sum : (A ^ p).trace = ∑ i, (A.H.eigenvalues i) ^ p ∧
+      A.trace = ∑ i, (A.H.eigenvalues i) := by
+    exact ⟨ by rw [ HermitianMat.trace_rpow_eq_sum ], by rw [ show
+      A.trace = ∑ i, ( A.H.eigenvalues i ) by
+        simpa using HermitianMat.trace_rpow_eq_sum A 1 ] ⟩;
   rw [ h_trace_eq_sum.1, h_trace_eq_sum.2 ];
   apply_rules [ Finset.sum_le_sum ];
   intro i hi; by_cases hi0 : A.H.eigenvalues i = 0 <;> simp_all
   · rw [ Real.zero_rpow ( by positivity ) ];
   · conv_rhs => rw [← (A.H.eigenvalues i).rpow_one]
     apply Real.rpow_le_rpow_of_exponent_ge
-    · exact lt_of_le_of_ne' (le_of_not_gt fun hi => hi0 <| by linarith [ show 0 ≤ A.H.eigenvalues i by simpa using hA.eigenvalues_nonneg i ] ) hi0
+    · exact lt_of_le_of_ne' (le_of_not_gt fun hi => hi0 <| by linarith
+        [ show 0 ≤ A.H.eigenvalues i by simpa using hA.eigenvalues_nonneg i ] ) hi0
     · exact A.eigenvalues_le_one_of_le_one hA1 i
     · exact hp
 
 private lemma trace_conj_rpow_eq_inner (hα₀ : 0 < α) (hα : α < 1) :
-    ((ρ.M ^ α).conj (σ.M ^ ((1 - α) / (2 * α) * α)).mat).trace = ⟪ρ.M ^ α, σ.M ^ (1 - α)⟫_ℝ := by
+    ((ρ.M ^ α).conj (σ.M ^ ((1 - α) / (2 * α) * α)).mat).trace =
+      ⟪ρ.M ^ α, σ.M ^ (1 - α)⟫_ℝ := by
   convert congr_arg _ ( HermitianMat.inner_eq_trace_rc _ _ ) using 2;
   rotate_left;
   rotate_left;
@@ -203,10 +226,14 @@ private lemma trace_conj_rpow_eq_inner (hα₀ : 0 < α) (hα : α < 1) :
   exact fun x => x.re;
   · unfold HermitianMat.conj;
     simp [ Matrix.trace, Matrix.mul_apply, inner]
-    rw [ show ( 1 - α ) / ( 2 * α ) * α = ( 1 - α ) / 2 by rw [ div_mul_eq_mul_div, div_eq_iff ] <;> linarith ];
+    rw [ show ( 1 - α ) / ( 2 * α ) * α = ( 1 - α ) / 2 by
+      rw [ div_mul_eq_mul_div, div_eq_iff ] <;> linarith ];
     -- By the properties of the trace, we can rearrange the terms inside the trace.
-    have h_trace : Matrix.trace ((σ.M ^ ((1 - α) / 2)).mat * (ρ.M ^ α).mat * (σ.M ^ ((1 - α) / 2)).mat) = Matrix.trace ((ρ.M ^ α).mat * (σ.M ^ (1 - α)).mat) := by
-      have h_trace : (σ.M ^ ((1 - α) / 2)).mat * (σ.M ^ ((1 - α) / 2)).mat = (σ.M ^ (1 - α)).mat := by
+    have h_trace : Matrix.trace
+        ((σ.M ^ ((1 - α) / 2)).mat * (ρ.M ^ α).mat * (σ.M ^ ((1 - α) / 2)).mat) =
+        Matrix.trace ((ρ.M ^ α).mat * (σ.M ^ (1 - α)).mat) := by
+      have h_trace :
+          (σ.M ^ ((1 - α) / 2)).mat * (σ.M ^ ((1 - α) / 2)).mat = (σ.M ^ (1 - α)).mat := by
         have := σ.nonneg;
         rw [ ← HermitianMat.mat_rpow_add this ]
         ring_nf
@@ -243,7 +270,8 @@ private theorem sandwiched_trace_of_lt_1 (hα₀ : 0 < α) (hα : α < 1) :
     calc ((ρ.M.conj (σ.M ^ t).mat) ^ α).trace
         ≤ (((ρ.M ^ (2 / 2)).trace) ^ (1 / 2) *
           (((σ.M ^ t) ^ (2 * α / (1 - α))).trace) ^ (1 / (2 * α / (1 - α)))) ^ (2 * α) :=
-          HermitianMat.trace_rpow_conj_le ρ.nonneg (HermitianMat.rpow_nonneg σ.nonneg) hα₀ hp hq hpq
+          HermitianMat.trace_rpow_conj_le ρ.nonneg (HermitianMat.rpow_nonneg σ.nonneg)
+            hα₀ hp hq hpq
       _ = 1 := by
           -- Simplify: ρ.M ^ (2/2) = ρ.M ^ 1 = ρ.M, Tr[ρ.M] = 1
           -- (σ.M ^ t) ^ (2α/(1-α)) = σ.M ^ (t * 2α/(1-α)) = σ.M ^ 1, Tr[σ.M] = 1
@@ -260,12 +288,14 @@ lemma HermitianMat.rpow_neg_mul_rpow_eq_supportProj
     {A : HermitianMat d ℂ} (hA : 0 ≤ A) {p : ℝ} (hp : p ≠ 0) :
     (A ^ (-p)).mat * (A ^ p).mat = A.supportProj.mat := by
   unfold HermitianMat.supportProj;
-  have h_cfc : (A ^ (-p)).mat * (A ^ p).mat = (A.cfc (fun x => x ^ (-p))) * (A.cfc (fun x => x ^ p)) := by
+  have h_cfc : (A ^ (-p)).mat * (A ^ p).mat =
+      (A.cfc (fun x => x ^ (-p))) * (A.cfc (fun x => x ^ p)) := by
     congr! 1;
   rw [ h_cfc, ← mat_cfc_mul ];
   have h_cfc : ∀ x : ℝ, 0 ≤ x → x ^ (-p) * x ^ p = if x = 0 then 0 else 1 := by
     intro x hx; by_cases hx' : x = 0 <;> simp [ hx', Real.rpow_neg, hx, hp ] ;
-  have h_cfc_eq : (A.cfc (fun x => x ^ (-p) * x ^ p)) = (A.cfc (fun x => if x = 0 then 0 else 1)) := by
+  have h_cfc_eq : (A.cfc (fun x => x ^ (-p) * x ^ p)) =
+      (A.cfc (fun x => if x = 0 then 0 else 1)) := by
     apply cfc_congr_of_nonneg hA;
     exact fun x hx => h_cfc x hx;
   convert congr_arg ( fun x : HermitianMat d ℂ => x.val ) h_cfc_eq using 1;
@@ -273,20 +303,25 @@ lemma HermitianMat.rpow_neg_mul_rpow_eq_supportProj
 
 lemma HermitianMat.supportProj_mul_self (A : HermitianMat d ℂ) :
     A.supportProj.mat * A.mat = A.mat := by
-  have h_supportProj_mul_A : ∀ (v : d → ℂ), (A.supportProj.val.mulVec (A.val.mulVec v)) = (A.val.mulVec v) := by
+  have h_supportProj_mul_A : ∀ (v : d → ℂ),
+      (A.supportProj.val.mulVec (A.val.mulVec v)) = (A.val.mulVec v) := by
     intro v
     have h_range : WithLp.toLp 2 (A.val.mulVec v) ∈ LinearMap.range A.val.toEuclideanLin := by
       exact ⟨ _, rfl ⟩
-    have h_supportProj_mul_A : ∀ (v : EuclideanSpace ℂ d), v ∈ LinearMap.range A.val.toEuclideanLin → (A.supportProj.val.toEuclideanLin v) = v := by
+    have h_supportProj_mul_A : ∀ (v : EuclideanSpace ℂ d),
+        v ∈ LinearMap.range A.val.toEuclideanLin →
+        (A.supportProj.val.toEuclideanLin v) = v := by
       intro v hv
-      have h_supportProj_mul_A : (A.supportProj.val.toEuclideanLin v) = (Submodule.orthogonalProjection (LinearMap.range A.val.toEuclideanLin) v) := by
+      have h_supportProj_mul_A : (A.supportProj.val.toEuclideanLin v) =
+          (Submodule.orthogonalProjection (LinearMap.range A.val.toEuclideanLin) v) := by
         simp only [val_eq_coe, Submodule.coe_orthogonalProjection_apply]
         simp [supportProj, projector]
         simp only [Submodule.starProjection]
         simp [-Submodule.coe_orthogonalProjection_apply]
         have key : ∀ (f : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d),
             Matrix.toEuclideanLin
-              ((LinearMap.toMatrix (EuclideanSpace.basisFun d ℂ).toBasis (EuclideanSpace.basisFun d ℂ).toBasis) f) = f := by
+              ((LinearMap.toMatrix (EuclideanSpace.basisFun d ℂ).toBasis
+                (EuclideanSpace.basisFun d ℂ).toBasis) f) = f := by
           intro f
           rw [Matrix.toEuclideanLin, Matrix.toLpLin_eq_toLin]
           exact Matrix.toLin_toMatrix _ _ f
@@ -304,7 +339,8 @@ lemma HermitianMat.inner_supportProj_self (A : HermitianMat d ℂ) :
   simp only [trace, IsMaximalSelfAdjoint.RCLike_selfadjMap, Matrix.trace, Matrix.diag_apply,
     mat_apply, map_sum, RCLike.re_to_complex]
   simp only [inner, IsMaximalSelfAdjoint.RCLike_selfadjMap, RCLike.re_to_complex];
-  convert congr_arg Complex.re ( congr_arg Matrix.trace ( HermitianMat.supportProj_mul_self A ) ) using 1;
+  convert congr_arg Complex.re
+    ( congr_arg Matrix.trace ( HermitianMat.supportProj_mul_self A ) ) using 1;
   · simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, mat_apply, Complex.re_sum,
       Complex.mul_re, Finset.sum_sub_distrib, mul_comm];
     exact congrArg₂ _ ( Finset.sum_comm ) ( Finset.sum_comm );
@@ -313,12 +349,18 @@ lemma HermitianMat.inner_supportProj_self (A : HermitianMat d ℂ) :
 lemma HermitianMat.mul_supportProj_of_ker_le {A B : HermitianMat d ℂ}
   (h : LinearMap.ker B.lin.toLinearMap ≤ LinearMap.ker A.lin.toLinearMap) :
     A.mat * B.supportProj.mat = A.mat := by
-  -- Since $B.supportProj$ is the projection onto $range B$, we have $B.supportProj * B.mat = B.mat$.
+  -- Since $B.supportProj$ is the projection onto $range B$, we have
+  -- $B.supportProj * B.mat = B.mat$.
   have h_supportProj_mul_B : B.supportProj.mat * B.mat = B.mat := by
     exact supportProj_mul_self B
-  have h_range_A_subset_range_B : LinearMap.range A.lin.toLinearMap ≤ LinearMap.range B.lin.toLinearMap := by
-    have h_orthogonal_complement : LinearMap.range (B.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d) = (LinearMap.ker (B.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d))ᗮ := by
-      have h_orthogonal_complement : ∀ (T : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d), T = T.adjoint → LinearMap.range T = (LinearMap.ker T)ᗮ := by
+  have h_range_A_subset_range_B :
+      LinearMap.range A.lin.toLinearMap ≤ LinearMap.range B.lin.toLinearMap := by
+    have h_orthogonal_complement :
+        LinearMap.range (B.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d) =
+        (LinearMap.ker (B.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d))ᗮ := by
+      have h_orthogonal_complement :
+          ∀ (T : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d), T = T.adjoint →
+          LinearMap.range T = (LinearMap.ker T)ᗮ := by
         intro T hT;
         refine' Submodule.eq_of_le_of_finrank_eq _ _;
         · rintro x ⟨y, rfl⟩
@@ -331,16 +373,22 @@ lemma HermitianMat.mul_supportProj_of_ker_le {A B : HermitianMat d ℂ}
           linarith;
       apply h_orthogonal_complement
       simp
-    have h_orthogonal_complement_A : LinearMap.range (A.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d) ≤ (LinearMap.ker (A.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d))ᗮ := by
+    have h_orthogonal_complement_A :
+        LinearMap.range (A.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d) ≤
+        (LinearMap.ker (A.lin : EuclideanSpace ℂ d →ₗ[ℂ] EuclideanSpace ℂ d))ᗮ := by
       intro x hx y hy
       simp_all only [LinearMap.mem_range, ContinuousLinearMap.coe_coe, LinearMap.mem_ker]
       obtain ⟨ z, rfl ⟩ := hx;
-      have h_orthogonal_complement_A : ∀ (y z : EuclideanSpace ℂ d), ⟪y, A.lin z⟫_ℂ = ⟪A.lin y, z⟫_ℂ := by
+      have h_orthogonal_complement_A : ∀ (y z : EuclideanSpace ℂ d),
+          ⟪y, A.lin z⟫_ℂ = ⟪A.lin y, z⟫_ℂ := by
         simp
       rw [ h_orthogonal_complement_A, hy, inner_zero_left ];
-    exact h_orthogonal_complement.symm ▸ le_trans h_orthogonal_complement_A ( Submodule.orthogonal_le h );
-  -- Since $B.supportProj$ is the projection onto $range B$, and $range A \subseteq range B$, we have $B.supportProj * A = A$.
-  have h_supportProj_mul_A : ∀ (v : EuclideanSpace ℂ d), B.supportProj.mat.mulVec (A.mat.mulVec v) = A.mat.mulVec v := by
+    exact h_orthogonal_complement.symm ▸
+      le_trans h_orthogonal_complement_A ( Submodule.orthogonal_le h );
+  -- Since $B.supportProj$ is the projection onto $range B$, and $range A \subseteq range B$, we
+  -- have $B.supportProj * A = A$.
+  have h_supportProj_mul_A : ∀ (v : EuclideanSpace ℂ d),
+      B.supportProj.mat.mulVec (A.mat.mulVec v) = A.mat.mulVec v := by
     intro v
     obtain ⟨w, hw⟩ : WithLp.toLp 2 (A.mat.mulVec v) ∈ LinearMap.range B.lin.toLinearMap := by
       exact h_range_A_subset_range_B ( Set.mem_range_self v );
@@ -348,8 +396,10 @@ lemma HermitianMat.mul_supportProj_of_ker_le {A B : HermitianMat d ℂ}
     replace hw := congr(WithLp.ofLp $hw)
     simp only [ContinuousLinearMap.coe_coe] at hw
     simpa only [← hw, ← Matrix.mulVec_mulVec] using h_supportProj_mul_B
-  -- By definition of matrix multiplication, if B.supportProj * A * v = A * v for all vectors v, then B.supportProj * A = A.
-  have h_matrix_eq : ∀ (M N : Matrix d d ℂ), (∀ v : EuclideanSpace ℂ d, M.mulVec (N.mulVec v) = N.mulVec v) → M * N = N := by
+  -- By definition of matrix multiplication, if B.supportProj * A * v = A * v for all vectors v,
+  -- then B.supportProj * A = A.
+  have h_matrix_eq : ∀ (M N : Matrix d d ℂ),
+      (∀ v : EuclideanSpace ℂ d, M.mulVec (N.mulVec v) = N.mulVec v) → M * N = N := by
     intro M N hMN
     ext i j
     specialize hMN (WithLp.toLp 2 ( Pi.single j 1 ))
@@ -369,7 +419,8 @@ lemma supportProj_inner_density (h : σ.M.ker ≤ ρ.M.ker) :
   simp
 
 /-
-⟪ρ.M.conj (σ.M ^ t).mat, σ.M ^ (-2 * t)⟫_ℝ = 1 for density matrices ρ, σ with ker(σ) ≤ ker(ρ).
+⟪ρ.M.conj (σ.M ^ t).mat, σ.M ^ (-2 * t)⟫_ℝ = 1 for density matrices ρ, σ with
+ker(σ) ≤ ker(ρ).
 -/
 private lemma sandwiched_inner_eq_one (h : σ.M.ker ≤ ρ.M.ker) (t : ℝ) :
     ⟪ρ.M.conj (σ.M ^ t).mat, σ.M ^ (-2 * t)⟫_ℝ = 1 := by
@@ -394,7 +445,8 @@ private theorem sandwiched_trace_of_gt_1 (h : σ.M.ker ≤ ρ.M.ker) (hα : α >
   set A := ρ.M.conj (σ.M ^ t).mat
   set B := σ.M ^ (-2 * t)
   have h_trace : ⟪A, B⟫ = 1 := sandwiched_inner_eq_one h t
-  have h_inner : ⟪A, B⟫ ≤ (A ^ α).trace ^ (1 / α) * (B ^ (α / (α - 1))).trace ^ (1 / (α / (α - 1))) := by
+  have h_inner :
+      ⟪A, B⟫ ≤ (A ^ α).trace ^ (1 / α) * (B ^ (α / (α - 1))).trace ^ (1 / (α / (α - 1))) := by
     apply HermitianMat.inner_le_trace_rpow_mul
     · positivity
     · exact HermitianMat.rpow_nonneg σ.nonneg --TODO positivity
@@ -423,7 +475,8 @@ private theorem sandwiched_trace_of_gt_1 (h : σ.M.ker ≤ ρ.M.ker) (hα : α >
   refine le_of_not_gt fun h => h_final.not_gt ?_
   simpa using Real.rpow_lt_one this h (by positivity)
 
-private theorem sandwichedRelRentropy_nonneg_α_lt_1 (h : σ.M.ker ≤ ρ.M.ker) (hα0 : 0 < α) (hα : α < 1) :
+private theorem sandwichedRelRentropy_nonneg_α_lt_1 (h : σ.M.ker ≤ ρ.M.ker) (hα0 : 0 < α)
+    (hα : α < 1) :
     0 ≤ ((ρ.M.conj (σ.M ^ ((1 - α)/(2 * α)) ).mat) ^ α).trace.log / (α - 1) := by
   apply div_nonneg_of_nonpos
   · apply Real.log_nonpos
@@ -458,8 +511,10 @@ private lemma hasDerivAt_trace_rpow_at_one (B : HermitianMat d ℂ) (hB : 0 ≤ 
       have := h_herm.apply i i
       simp_all [Complex.ext_iff]
       linarith
-    -- By definition of the trace, we have tr(B * B.log) = ∑ i, B.eigenvalues i * log(B.eigenvalues i).
-    have h_trace : (B.mat * B.log.mat).trace = ∑ i, B.H.eigenvalues i * Real.log (B.H.eigenvalues i) := by
+    -- By definition of the trace, we have tr(B * B.log) = ∑ i, B.eigenvalues i *
+    -- log(B.eigenvalues i).
+    have h_trace : (B.mat * B.log.mat).trace =
+        ∑ i, B.H.eigenvalues i * Real.log (B.H.eigenvalues i) := by
       have h_trace : (B ^ 1 * B.log.mat).trace = (B.cfc (fun x ↦ x * Real.log x)).trace := by
         have h_trace : B ^ 1 * B.log.mat = B.cfc (fun x ↦ x * Real.log x) := by
           have h_log : B ^ 1 * B.log.mat = B.cfc id * B.cfc Real.log := by
@@ -470,7 +525,8 @@ private lemma hasDerivAt_trace_rpow_at_one (B : HermitianMat d ℂ) (hB : 0 ≤ 
         rfl
       simp_all [ HermitianMat.trace_cfc_eq ];
     exact_mod_cast h_inner_def.trans h_trace;
-  have h_deriv : ∀ i, HasDerivAt (fun α : ℝ => (B.H.eigenvalues i) ^ α) (B.H.eigenvalues i * Real.log (B.H.eigenvalues i)) 1 := by
+  have h_deriv : ∀ i, HasDerivAt (fun α : ℝ => (B.H.eigenvalues i) ^ α)
+      (B.H.eigenvalues i * Real.log (B.H.eigenvalues i)) 1 := by
     intro i
     by_cases h_pos : 0 < B.H.eigenvalues i;
     · convert HasDerivAt.rpow ( hasDerivAt_const _ _ ) ( hasDerivAt_id 1 ) h_pos using 1
@@ -478,7 +534,9 @@ private lemma hasDerivAt_trace_rpow_at_one (B : HermitianMat d ℂ) (hB : 0 ≤ 
     · have h_zero : B.H.eigenvalues i = 0 := by
         exact le_antisymm ( le_of_not_gt h_pos ) ( by simpa using hB.eigenvalues_nonneg i )
       simp [h_zero]
-      exact (hasDerivAt_const _ _).congr_of_eventuallyEq (Filter.eventuallyEq_of_mem ( Ioi_mem_nhds zero_lt_one ) fun x hx => Real.zero_rpow hx.out.ne' )
+      exact (hasDerivAt_const _ _).congr_of_eventuallyEq
+        (Filter.eventuallyEq_of_mem ( Ioi_mem_nhds zero_lt_one )
+          fun x hx => Real.zero_rpow hx.out.ne' )
   simp only [HermitianMat.trace_rpow_eq_sum, ← Finset.sum_apply]
   convert HasDerivAt.sum fun i _ => h_deriv i using 1
 
@@ -487,10 +545,13 @@ PROBLEM
 Trace cyclicity for conj: Tr[conj(σ^t, ρ)] = ⟪ρ, σ^{2t}⟫ = Tr[ρ σ^{2t}].
     Since σ^t is Hermitian: Tr[σ^t ρ σ^t] = Tr[ρ (σ^t)²] = Tr[ρ σ^{2t}].
 PROVIDED SOLUTION
-By definition, (ρ.M.conj (σ.M ^ t).mat).mat = (σ.M ^ t).mat * ρ.M.mat * ((σ.M ^ t).mat)^* (from conj_apply_mat). Since σ.M ^ t is Hermitian, ((σ.M ^ t).mat)^* = (σ.M ^ t).mat (from σ.M ^ t property .H). So the trace is Tr[(σ^t).mat * ρ.mat * (σ^t).mat].
+By definition, (ρ.M.conj (σ.M ^ t).mat).mat = (σ.M ^ t).mat * ρ.M.mat * ((σ.M ^ t).mat)^* (from
+conj_apply_mat). Since σ.M ^ t is Hermitian, ((σ.M ^ t).mat)^* = (σ.M ^ t).mat (from σ.M ^ t
+property .H). So the trace is Tr[(σ^t).mat * ρ.mat * (σ^t).mat].
 By Matrix.trace_mul_comm applied to the product ((σ^t).mat * ρ.mat) and (σ^t).mat:
 Tr[(σ^t).mat * ρ.mat * (σ^t).mat] = Tr[(σ^t).mat * (σ^t).mat * ρ.mat].
-Now use mat_rpow_add with σ.nonneg and t + t = 2t (≠ 0 since t ≠ 0): (σ.M ^ (t+t)).mat = (σ.M ^ t).mat * (σ.M ^ t).mat. So the trace becomes Tr[(σ.M ^ (2*t)).mat * ρ.mat].
+Now use mat_rpow_add with σ.nonneg and t + t = 2t (≠ 0 since t ≠ 0): (σ.M ^ (t+t)).mat = (σ.M ^
+t).mat * (σ.M ^ t).mat. So the trace becomes Tr[(σ.M ^ (2*t)).mat * ρ.mat].
 By inner_eq_trace_rc: ⟪ρ.M, σ.M ^ (2*t)⟫ = (ρ.M.mat * (σ.M ^ (2*t)).mat).trace.
 By Matrix.trace_mul_comm: Tr[ρ.mat * (σ^{2t}).mat] = Tr[(σ^{2t}).mat * ρ.mat].
 Combine: the conj trace = Tr[(σ^{2t}).mat * ρ.mat] = Tr[ρ.mat * (σ^{2t}).mat] = ⟪ρ, σ^{2t}⟫.
@@ -498,9 +559,12 @@ Note: show t + t = 2 * t by ring, and 2 * t ≠ 0 from ht using two_mul_ne_zero 
 -/
 private lemma trace_conj_eq_inner_rpow {ρ σ : MState d} {t : ℝ} (ht : t ≠ 0) :
     (ρ.M.conj (σ.M ^ t).mat).trace = ⟪ρ.M, σ.M ^ (2 * t)⟫ := by
-  have h_cyclic : ((σ.M ^ t).mat * ρ.M.mat * (σ.M ^ t).mat).trace = ((σ.M ^ (2 * t)).mat * ρ.M.mat).trace := by
-    -- Since σ.M ^ t is Hermitian, we can use the property that the trace of a product is invariant under cyclic permutations.
-    have h_cyclic : Matrix.trace ((σ.M ^ t).mat * ρ.M.mat * (σ.M ^ t).mat) = Matrix.trace ((σ.M ^ t).mat * (σ.M ^ t).mat * ρ.M.mat) := by
+  have h_cyclic : ((σ.M ^ t).mat * ρ.M.mat * (σ.M ^ t).mat).trace =
+      ((σ.M ^ (2 * t)).mat * ρ.M.mat).trace := by
+    -- Since σ.M ^ t is Hermitian, we can use the property that the trace of a product is invariant
+    -- under cyclic permutations.
+    have h_cyclic : Matrix.trace ((σ.M ^ t).mat * ρ.M.mat * (σ.M ^ t).mat) =
+        Matrix.trace ((σ.M ^ t).mat * (σ.M ^ t).mat * ρ.M.mat) := by
       rw [ ← Matrix.trace_mul_comm ]
       simp [ Matrix.mul_assoc ]
     rw [ h_cyclic, two_mul ]
@@ -520,20 +584,26 @@ private lemma trace_conj_eq_inner_rpow {ρ σ : MState d} {t : ℝ} (ht : t ≠ 
 
 -- The weight of eigenvalue i in the inner product decomposition
 private def eigenWeight (ρ σ : MState d) (i : d) : ℝ :=
-  RCLike.re ((Matrix.vecMul (star (σ.M.H.eigenvectorBasis i : d → ℂ)) ρ.M.mat) ⬝ᵥ (σ.M.H.eigenvectorBasis i : d → ℂ))
+  RCLike.re ((Matrix.vecMul (star (σ.M.H.eigenvectorBasis i : d → ℂ)) ρ.M.mat) ⬝ᵥ
+    (σ.M.H.eigenvectorBasis i : d → ℂ))
 
 private lemma inner_cfc_eq_sum_eigenWeight (ρ σ : MState d) (f : ℝ → ℝ) :
     ⟪ρ.M, σ.M.cfc f⟫ = ∑ i, f (σ.M.H.eigenvalues i) * eigenWeight ρ σ i := by
-  -- By definition of the inner product in the context of Hermitian matrices, we can expand it using the trace.
+  -- By definition of the inner product in the context of Hermitian matrices, we can expand it
+  -- using the trace.
   have h_inner : ⟪ρ.M, σ.M.cfc f⟫ = RCLike.re (Matrix.trace (ρ.M.mat * (σ.M.cfc f).mat)) := by
     exact rfl;
-  have h_trace : Matrix.trace (ρ.M.mat * (σ.M.cfc f).mat) = ∑ i, f (σ.M.H.eigenvalues i) * (star (σ.M.H.eigenvectorBasis i) ⬝ᵥ ρ.M.mat.mulVec (σ.M.H.eigenvectorBasis i)) := by
+  have h_trace : Matrix.trace (ρ.M.mat * (σ.M.cfc f).mat) = ∑ i, f (σ.M.H.eigenvalues i) *
+      (star (σ.M.H.eigenvectorBasis i) ⬝ᵥ ρ.M.mat.mulVec (σ.M.H.eigenvectorBasis i)) := by
     rw [ Matrix.trace ];
-    have h_cfc_def : (σ.M.cfc f).mat = ∑ i, (f (Matrix.IsHermitian.eigenvalues σ.M.H i)) • Matrix.of (fun x y => (σ.M.H.eigenvectorBasis i x) * (star (σ.M.H.eigenvectorBasis i y))) := by
+    have h_cfc_def : (σ.M.cfc f).mat = ∑ i, (f (Matrix.IsHermitian.eigenvalues σ.M.H i)) •
+        Matrix.of (fun x y =>
+          (σ.M.H.eigenvectorBasis i x) * (star (σ.M.H.eigenvectorBasis i y))) := by
       convert σ.M.cfc_toMat_eq_sum_smul_proj f using 1;
       ext i j; simp [ Matrix.single ] ; ring_nf
       simp [ Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.of_apply ];
-      refine' Finset.sum_congr rfl fun x _ => _ ; simp [ Finset.sum_ite, Finset.filter_eq, Finset.filter_and ] ; ring_nf
+      refine' Finset.sum_congr rfl fun x _ => _ ;
+      simp [ Finset.sum_ite, Finset.filter_eq, Finset.filter_and ] ; ring_nf
       rw [ Finset.sum_eq_single x ] <;> aesop;
     simp [ h_cfc_def, Matrix.mulVec, dotProduct, Finset.mul_sum, mul_left_comm ];
     simp [ Matrix.sum_apply, Matrix.mul_apply ];
@@ -550,7 +620,8 @@ private lemma eigenWeight_nonneg (ρ σ : MState d) (i : d) : 0 ≤ eigenWeight 
     simp +zetaDelta at *;
     simp [ Matrix.dotProduct_mulVec ]
   rw [h_eigenWeight];
-  -- Since ρ is positive semi-definite, we have that the inner product of any vector with ρ is non-negative. Hence, we can write:
+  -- Since ρ is positive semi-definite, we have that the inner product of any vector with ρ is
+  -- non-negative. Hence, we can write:
   have := ρ.pos
   obtain ⟨ h₁, h₂ ⟩ := this;
   open ComplexOrder in
@@ -568,7 +639,8 @@ private lemma eigenWeight_zero_of_eigenvalue_zero {i : d} (hσ : σ.M.ker ≤ ρ
   have h_mulVec_zero' : ρ.M.mat.mulVec (σ.M.H.eigenvectorBasis i) = 0 := by
     specialize hσ congr(WithLp.toLp 2 $h_mulVec_zero)
     exact congr(WithLp.ofLp $hσ)
-  convert congr_arg ( fun x : d → ℂ => RCLike.re ( star ( σ.M.H.eigenvectorBasis i ) ⬝ᵥ x ) ) h_mulVec_zero' using 1;
+  convert congr_arg ( fun x : d → ℂ => RCLike.re ( star ( σ.M.H.eigenvectorBasis i ) ⬝ᵥ x ) )
+    h_mulVec_zero' using 1;
   · simp [Matrix.dotProduct_mulVec]
   · simp [dotProduct]
 
@@ -582,11 +654,13 @@ private lemma hasDerivAt_inner_rpow_at_zero (h : σ.M.ker ≤ ρ.M.ker) :
     HasDerivAt (fun u : ℝ => ⟪ρ.M, σ.M ^ u⟫) ⟪ρ.M, σ.M.log⟫ 0 := by
   convert HasDerivAt.congr_of_eventuallyEq ?_ ?_;
   exact fun u => ∑ i, ( σ.M.H.eigenvalues i ) ^ u * eigenWeight ρ σ i;
-  · have h_deriv : ∀ i, HasDerivAt (fun u : ℝ => (σ.M.H.eigenvalues i) ^ u * eigenWeight ρ σ i) (Real.log (σ.M.H.eigenvalues i) * eigenWeight ρ σ i) 0 := by
+  · have h_deriv : ∀ i, HasDerivAt (fun u : ℝ => (σ.M.H.eigenvalues i) ^ u * eigenWeight ρ σ i)
+        (Real.log (σ.M.H.eigenvalues i) * eigenWeight ρ σ i) 0 := by
       intro i
       rcases (σ.eigenvalue_nonneg i).lt_or_eq' with h_pos | h_zero
       · simp only [h_pos, Real.rpow_def_of_pos, mul_comm]
-        convert ((hasDerivAt_id 0).mul (hasDerivAt_const _ _)).exp.const_mul (eigenWeight ρ σ i ) using 1
+        convert ((hasDerivAt_id 0).mul (hasDerivAt_const _ _)).exp.const_mul
+          (eigenWeight ρ σ i ) using 1
         simp
       · simp [Real.rpow_def_of_nonpos, mul_comm, h_zero]
         convert hasDerivAt_const (0 : ℝ) (0 : ℝ) using 1
@@ -610,10 +684,12 @@ private lemma hasDerivAt_trace_conj_at_one {ρ σ : MState d}
       (fun α : ℝ => ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat)).trace)
       (-⟪ρ.M, σ.M.log⟫)
       1 := by
-  have h_chain : HasDerivAt (fun α : ℝ => ⟪ρ.M, σ.M ^ ((1 - α) / α)⟫) (⟪ρ.M, σ.M.log⟫ * (-1)) 1 := by
+  have h_chain :
+      HasDerivAt (fun α : ℝ => ⟪ρ.M, σ.M ^ ((1 - α) / α)⟫) (⟪ρ.M, σ.M.log⟫ * (-1)) 1 := by
     apply HasDerivAt.comp (h₂ := fun u => ⟪ρ.M, σ.M ^ u⟫) (h := fun α => (1 - α) / α)
     · simpa using hasDerivAt_inner_rpow_at_zero h
-    · simpa using HasDerivAt.div ( hasDerivAt_id ( 1 : ℝ ) |> HasDerivAt.const_sub 1 ) ( hasDerivAt_id ( 1 : ℝ ) ) ( by norm_num )
+    · simpa using HasDerivAt.div ( hasDerivAt_id ( 1 : ℝ ) |> HasDerivAt.const_sub 1 )
+        ( hasDerivAt_id ( 1 : ℝ ) ) ( by norm_num )
   ring_nf at h_chain
   apply h_chain.congr_of_eventuallyEq _
   filter_upwards [ lt_mem_nhds zero_lt_one ] with α hα
@@ -675,23 +751,33 @@ private lemma scalar_rpow_cross_term_of_continuous {b : ℝ → ℝ} {c : ℝ}
     (hb_pos : ∀ᶠ α in nhds 1, 0 < b α) :
     HasDerivAt (fun α => b α ^ α - b α) (c * Real.log c) 1 := by
   rw [ hasDerivAt_iff_tendsto_slope_zero ];
-  -- Use the fact that $b(1 + t)^{1 + t} - b(1 + t)$ can be rewritten as $b(1 + t) \cdot (b(1 + t)^t - 1)$.
-  suffices h_rewrite : Filter.Tendsto (fun t => t⁻¹ * (b (1 + t) * (b (1 + t) ^ t - 1))) (nhdsWithin 0 {0}ᶜ) (nhds (c * Real.log c)) by
+  -- Use the fact that $b(1 + t)^{1 + t} - b(1 + t)$ can be rewritten as
+  -- $b(1 + t) \cdot (b(1 + t)^t - 1)$.
+  suffices h_rewrite : Filter.Tendsto (fun t => t⁻¹ * (b (1 + t) * (b (1 + t) ^ t - 1)))
+      (nhdsWithin 0 {0}ᶜ) (nhds (c * Real.log c)) by
     refine' h_rewrite.congr' _;
     rw [ Filter.EventuallyEq, eventually_nhdsWithin_iff ];
     rw [ Metric.eventually_nhds_iff ] at *;
-    obtain ⟨ ε, ε_pos, hε ⟩ := hb_pos; use ε, ε_pos; intros y hy hy'; rw [ Real.rpow_add ( hε ( show Dist.dist ( 1 + y ) 1 < ε from by simpa using hy ) ), Real.rpow_one ]
+    obtain ⟨ ε, ε_pos, hε ⟩ := hb_pos; use ε, ε_pos; intros y hy hy';
+    rw [ Real.rpow_add ( hε ( show Dist.dist ( 1 + y ) 1 < ε from by simpa using hy ) ),
+      Real.rpow_one ]
     ring_nf
     norm_num [ hc ]
   -- Use the fact that $b(1 + t) \to c$ as $t \to 0$.
   have h_b : Filter.Tendsto (fun t => b (1 + t)) (nhdsWithin 0 {0}ᶜ) (nhds c) := by
-    exact hc ▸ hb_cont.tendsto.comp ( tendsto_nhdsWithin_of_tendsto_nhds ( by norm_num [ Filter.Tendsto ] ) );
+    exact hc ▸ hb_cont.tendsto.comp
+      ( tendsto_nhdsWithin_of_tendsto_nhds ( by norm_num [ Filter.Tendsto ] ) );
   -- Use the fact that $b(1 + t)^t - 1 \sim t \log(b(1 + t))$ as $t \to 0$.
-  have h_exp : Filter.Tendsto (fun t => t⁻¹ * (b (1 + t) ^ t - 1)) (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
-    have h_exp : Filter.Tendsto (fun t => (b (1 + t) ^ t - 1) / t) (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
-      have h_log : Filter.Tendsto (fun t => (Real.log (b (1 + t)) * t) / t) (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
-        exact Filter.Tendsto.congr' ( by filter_upwards [ self_mem_nhdsWithin ] with t ht using by rw [ mul_div_cancel_right₀ _ ht ] ) ( Filter.Tendsto.log h_b hc_pos.ne' )
-      have h_exp : Filter.Tendsto (fun t => (Real.exp (Real.log (b (1 + t)) * t) - 1) / t) (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
+  have h_exp : Filter.Tendsto (fun t => t⁻¹ * (b (1 + t) ^ t - 1)) (nhdsWithin 0 {0}ᶜ)
+      (nhds (Real.log c)) := by
+    have h_exp : Filter.Tendsto (fun t => (b (1 + t) ^ t - 1) / t) (nhdsWithin 0 {0}ᶜ)
+        (nhds (Real.log c)) := by
+      have h_log : Filter.Tendsto (fun t => (Real.log (b (1 + t)) * t) / t) (nhdsWithin 0 {0}ᶜ)
+          (nhds (Real.log c)) := by
+        exact Filter.Tendsto.congr' ( by filter_upwards [ self_mem_nhdsWithin ] with t ht using by
+          rw [ mul_div_cancel_right₀ _ ht ] ) ( Filter.Tendsto.log h_b hc_pos.ne' )
+      have h_exp : Filter.Tendsto (fun t => (Real.exp (Real.log (b (1 + t)) * t) - 1) / t)
+          (nhdsWithin 0 {0}ᶜ) (nhds (Real.log c)) := by
         have h_exp : HasDerivAt (fun t => Real.exp (Real.log (b (1 + t)) * t)) (Real.log c) 0 := by
           have h_log : HasDerivAt (fun t => Real.log (b (1 + t)) * t) (Real.log c) 0 := by
             rw [ hasDerivAt_iff_tendsto_slope_zero ];
@@ -699,7 +785,8 @@ private lemma scalar_rpow_cross_term_of_continuous {b : ℝ → ℝ} {c : ℝ}
           convert h_log.exp using 1 ; norm_num [ hc ];
         simpa [ div_eq_inv_mul ] using h_exp.tendsto_slope_zero;
       refine' h_exp.congr' _;
-      filter_upwards [ h_b.eventually ( lt_mem_nhds hc_pos ) ] with t ht using by rw [ Real.rpow_def_of_pos ht, mul_comm ] ;
+      filter_upwards [ h_b.eventually ( lt_mem_nhds hc_pos ) ] with t ht using by
+        rw [ Real.rpow_def_of_pos ht, mul_comm ] ;
     simpa only [ div_eq_inv_mul ] using h_exp;
   convert h_b.mul h_exp using 2 ; ring
 
@@ -713,59 +800,112 @@ private lemma scalar_rpow_cross_term_of_continuous_zero {b : ℝ → ℝ}
     (hb_nonneg : ∀ᶠ α in nhds 1, 0 ≤ b α) :
     HasDerivAt (fun α => b α ^ α - b α) 0 1 := by
   -- Let's choose any $\epsilon > 0$.
-  have h_eps : ∀ ε > 0, ∃ δ > 0, ∀ α, abs (α - 1) < δ → abs (b α ^ α - b α) ≤ ε * abs (α - 1) := by
-    -- Use the fact that $|b(α)^α - b(α)| ≤ |h| · sqrt(b(α)) · |log b(α)|$ for $0 < b(α) ≤ 1$ and $|h| ≤ 1/2$.
-    have h_bound : ∀ᶠ α in nhds 1, |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (|b α|) * |Real.log (|b α|)| := by
-      have h_bound : ∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 ∧ |α - 1| ≤ 1 / 2 → |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (b α) * |Real.log (b α)| := by
-        filter_upwards [ hb_nonneg ] with α hα₁ hα₂ ; rcases eq_or_lt_of_le hα₂.1 with hα₃ | hα₃ <;> simp_all [ Real.rpow_def_of_nonneg ] ; ring_nf ;
+  have h_eps : ∀ ε > 0, ∃ δ > 0, ∀ α, abs (α - 1) < δ →
+      abs (b α ^ α - b α) ≤ ε * abs (α - 1) := by
+    -- Use the fact that $|b(α)^α - b(α)| ≤ |h| · sqrt(b(α)) · |log b(α)|$ for $0 < b(α) ≤ 1$ and
+    -- $|h| ≤ 1/2$.
+    have h_bound : ∀ᶠ α in nhds 1,
+        |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (|b α|) * |Real.log (|b α|)| := by
+      have h_bound : ∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 ∧ |α - 1| ≤ 1 / 2 →
+          |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (b α) * |Real.log (b α)| := by
+        filter_upwards [ hb_nonneg ] with α hα₁ hα₂ ;
+        rcases eq_or_lt_of_le hα₂.1 with hα₃ | hα₃ <;> simp_all [ Real.rpow_def_of_nonneg ] ;
+        ring_nf ;
         · norm_num [ ← hα₃ ] at *;
           linarith [ abs_le.mp hα₂ ];
         · split_ifs <;> simp_all [ne_of_gt]
           -- Use the fact that $|e^{x} - 1| \leq |x| e^{|x|}$ for any $x$.
           have h_exp_bound : ∀ x : ℝ, |Real.exp x - 1| ≤ |x| * Real.exp |x| := by
-            intro x; rw [ abs_le ] ; constructor <;> cases abs_cases x <;> simp [ * ] <;> nlinarith [ Real.exp_pos x, Real.exp_neg x, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos x ) ), Real.add_one_le_exp x, Real.add_one_le_exp ( -x ), Real.exp_le_exp.2 ( by linarith : x ≤ |x| ), Real.exp_le_exp.2 ( by linarith : -x ≤ |x| ) ] ;
+            intro x; rw [ abs_le ] ;
+            constructor <;> cases abs_cases x <;> simp [ * ] <;> nlinarith [ Real.exp_pos x,
+              Real.exp_neg x, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos x ) ),
+              Real.add_one_le_exp x, Real.add_one_le_exp ( -x ),
+              Real.exp_le_exp.2 ( by linarith : x ≤ |x| ),
+              Real.exp_le_exp.2 ( by linarith : -x ≤ |x| ) ] ;
           -- Apply the exponential bound to $x = \log(b(\alpha)) \cdot (\alpha - 1)$.
-          have h_exp_bound_applied : |Real.exp (Real.log (b α) * (α - 1)) - 1| ≤ |Real.log (b α)| * |α - 1| * Real.exp (|Real.log (b α)| * |α - 1|) := by
-            simpa only [ abs_mul, mul_assoc ] using h_exp_bound ( Real.log ( b α ) * ( α - 1 ) ) |> le_trans <| by simp [ abs_mul, mul_assoc ] ;
+          have h_exp_bound_applied : |Real.exp (Real.log (b α) * (α - 1)) - 1| ≤
+              |Real.log (b α)| * |α - 1| * Real.exp (|Real.log (b α)| * |α - 1|) := by
+            simpa only [ abs_mul, mul_assoc ] using
+              h_exp_bound ( Real.log ( b α ) * ( α - 1 ) ) |> le_trans <|
+              by simp [ abs_mul, mul_assoc ] ;
           -- Use the fact that $|b(\alpha)| \leq \sqrt{b(\alpha)}$ for $0 < b(\alpha) \leq 1$.
           have h_sqrt_bound : |b α| * Real.exp (|Real.log (b α)| * |α - 1|) ≤ Real.sqrt (b α) := by
-            rw [ abs_of_nonneg hα₂.1 ] ; rw [ Real.sqrt_eq_rpow ] ; rw [ ← Real.log_le_log_iff ( by positivity ) ( by positivity ), Real.log_mul ( by positivity ) ( by positivity ), Real.log_rpow ( by positivity ) ] ; ring_nf ; norm_num [ hα₂.1, hα₂.2.1, hα₂.2.2 ] ;
-            cases abs_cases ( Real.log ( b α ) ) <;> cases abs_cases ( -1 + α ) <;> nlinarith [ Real.log_le_sub_one_of_pos hα₃, abs_le.mp hα₂.2.2 ] ;
-          rw [ show Real.exp ( Real.log ( b α ) * α ) = Real.exp ( Real.log ( b α ) * ( α - 1 ) ) * Real.exp ( Real.log ( b α ) ) by rw [ ← Real.exp_add ] ; ring_nf, Real.exp_log hα₃ ];
+            rw [ abs_of_nonneg hα₂.1 ] ; rw [ Real.sqrt_eq_rpow ] ;
+            rw [ ← Real.log_le_log_iff ( by positivity ) ( by positivity ),
+              Real.log_mul ( by positivity ) ( by positivity ),
+              Real.log_rpow ( by positivity ) ] ; ring_nf ;
+            norm_num [ hα₂.1, hα₂.2.1, hα₂.2.2 ] ;
+            cases abs_cases ( Real.log ( b α ) ) <;> cases abs_cases ( -1 + α ) <;>
+              nlinarith [ Real.log_le_sub_one_of_pos hα₃, abs_le.mp hα₂.2.2 ] ;
+          rw [ show Real.exp ( Real.log ( b α ) * α ) =
+            Real.exp ( Real.log ( b α ) * ( α - 1 ) ) * Real.exp ( Real.log ( b α ) ) by
+              rw [ ← Real.exp_add ] ; ring_nf, Real.exp_log hα₃ ];
           field_simp;
-          rw [ abs_mul ] ; nlinarith [ abs_nonneg ( Real.log ( b α ) ), abs_nonneg ( α - 1 ), abs_nonneg ( b α ), Real.sqrt_nonneg ( b α ), mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( Real.log ( b α ) ) ), mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( α - 1 ) ), mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( b α ) ) ] ;
+          rw [ abs_mul ] ; nlinarith [ abs_nonneg ( Real.log ( b α ) ), abs_nonneg ( α - 1 ),
+            abs_nonneg ( b α ), Real.sqrt_nonneg ( b α ),
+            mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( Real.log ( b α ) ) ),
+            mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( α - 1 ) ),
+            mul_le_mul_of_nonneg_left h_sqrt_bound ( abs_nonneg ( b α ) ) ] ;
       have h_bound : ∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 ∧ |α - 1| ≤ 1 / 2 := by
         have h_bound : ∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 := by
-          filter_upwards [ hb_nonneg, hb_cont.eventually ( Metric.ball_mem_nhds _ zero_lt_one ) ] with α hα₁ hα₂ using ⟨ hα₁, by linarith [ abs_lt.mp hα₂ ] ⟩;
-        filter_upwards [ h_bound, Metric.ball_mem_nhds 1 ( show ( 0 : ℝ ) < 1 / 2 by norm_num ) ] with α hα₁ hα₂ using ⟨ hα₁.1, hα₁.2, by simpa using hα₂.out.le ⟩;
-      filter_upwards [ h_bound, ‹∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 ∧ |α - 1| ≤ 1 / 2 → |b α ^ α - b α| ≤ |α - 1| * Real.sqrt ( b α ) * |Real.log ( b α )|› ] with α hα₁ hα₂ using by simpa [ abs_of_nonneg hα₁.1 ] using hα₂ hα₁;
+          filter_upwards [ hb_nonneg, hb_cont.eventually ( Metric.ball_mem_nhds _ zero_lt_one ) ]
+            with α hα₁ hα₂ using ⟨ hα₁, by linarith [ abs_lt.mp hα₂ ] ⟩;
+        filter_upwards [ h_bound, Metric.ball_mem_nhds 1 ( show ( 0 : ℝ ) < 1 / 2 by norm_num ) ]
+          with α hα₁ hα₂ using ⟨ hα₁.1, hα₁.2, by simpa using hα₂.out.le ⟩;
+      filter_upwards [ h_bound, ‹∀ᶠ α in nhds 1, 0 ≤ b α ∧ b α ≤ 1 ∧ |α - 1| ≤ 1 / 2 →
+        |b α ^ α - b α| ≤ |α - 1| * Real.sqrt ( b α ) * |Real.log ( b α )|› ]
+        with α hα₁ hα₂ using by simpa [ abs_of_nonneg hα₁.1 ] using hα₂ hα₁;
     -- Use the fact that $\sqrt{|b(α)|} \cdot |\log(|b(α)|)| \to 0$ as $b(α) \to 0$.
-    have h_sqrt_log : Filter.Tendsto (fun α => Real.sqrt (|b α|) * |Real.log (|b α|)|) (nhds 1) (nhds 0) := by
-      have h_sqrt_log : Filter.Tendsto (fun x => Real.sqrt x * |Real.log x|) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
-        have h_sqrt_log : Filter.Tendsto (fun x => Real.sqrt x * Real.log x) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
-          -- Let $y = \sqrt{x}$, so we can rewrite the limit as $\lim_{y \to 0^+} y \log(y^2) = \lim_{y \to 0^+} 2y \log(y)$.
-          suffices h_log_y : Filter.Tendsto (fun y => 2 * y * Real.log y) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) by
-            have h_subst : Filter.Tendsto (fun x => 2 * Real.sqrt x * Real.log (Real.sqrt x)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
-              exact h_log_y.comp <| Filter.Tendsto.inf ( Real.continuous_sqrt.tendsto' _ _ <| by norm_num ) <| Filter.tendsto_principal_principal.mpr fun x hx => Real.sqrt_pos.mpr hx;
+    have h_sqrt_log : Filter.Tendsto (fun α => Real.sqrt (|b α|) * |Real.log (|b α|)|)
+        (nhds 1) (nhds 0) := by
+      have h_sqrt_log : Filter.Tendsto (fun x => Real.sqrt x * |Real.log x|)
+          (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
+        have h_sqrt_log : Filter.Tendsto (fun x => Real.sqrt x * Real.log x)
+            (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
+          -- Let $y = \sqrt{x}$, so we can rewrite the limit as $\lim_{y \to 0^+} y \log(y^2) =
+          -- \lim_{y \to 0^+} 2y \log(y)$.
+          suffices h_log_y : Filter.Tendsto (fun y => 2 * y * Real.log y)
+              (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) by
+            have h_subst : Filter.Tendsto (fun x => 2 * Real.sqrt x * Real.log (Real.sqrt x))
+                (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
+              exact h_log_y.comp <|
+                Filter.Tendsto.inf ( Real.continuous_sqrt.tendsto' _ _ <| by norm_num ) <|
+                Filter.tendsto_principal_principal.mpr fun x hx => Real.sqrt_pos.mpr hx;
             generalize_proofs at *; (
-            exact h_subst.congr' ( Filter.eventuallyEq_of_mem self_mem_nhdsWithin fun x hx => by rw [ Real.log_sqrt hx.out.le ] ; ring ) |> fun h => h.trans ( by norm_num ) ;);
-          exact tendsto_nhdsWithin_of_tendsto_nhds ( by simpa [ mul_assoc ] using Filter.Tendsto.const_mul 2 ( Real.continuous_mul_log.tendsto 0 ) ) |> fun h => h.trans ( by norm_num ) ;
+            exact h_subst.congr' ( Filter.eventuallyEq_of_mem self_mem_nhdsWithin fun x hx => by
+              rw [ Real.log_sqrt hx.out.le ] ; ring ) |> fun h => h.trans ( by norm_num ) ;);
+          exact tendsto_nhdsWithin_of_tendsto_nhds ( by simpa [ mul_assoc ] using
+            Filter.Tendsto.const_mul 2 ( Real.continuous_mul_log.tendsto 0 ) ) |>
+            fun h => h.trans ( by norm_num ) ;
         exact tendsto_zero_iff_norm_tendsto_zero.mpr ( by simpa using h_sqrt_log.norm );
-      have h_sqrt_log : Filter.Tendsto (fun α => Real.sqrt (|b α|) * |Real.log (|b α|)|) (nhdsWithin 1 {α | 0 < |b α|}) (nhds 0) := by
+      have h_sqrt_log : Filter.Tendsto (fun α => Real.sqrt (|b α|) * |Real.log (|b α|)|)
+          (nhdsWithin 1 {α | 0 < |b α|}) (nhds 0) := by
         refine' h_sqrt_log.comp _;
         rw [ tendsto_nhdsWithin_iff ];
-        exact ⟨ tendsto_nhdsWithin_of_tendsto_nhds ( by simpa [ hc ] using hb_cont.abs.tendsto ), Filter.eventually_of_mem self_mem_nhdsWithin fun x hx => hx ⟩;
+        exact ⟨ tendsto_nhdsWithin_of_tendsto_nhds ( by simpa [ hc ] using hb_cont.abs.tendsto ),
+          Filter.eventually_of_mem self_mem_nhdsWithin fun x hx => hx ⟩;
       rw [ Metric.tendsto_nhdsWithin_nhds ] at h_sqrt_log;
-      exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by rcases h_sqrt_log ε hε with ⟨ δ, hδ, H ⟩ ; exact ⟨ δ, hδ, by intro x hx; by_cases hx' : 0 < |b x| <;> aesop ⟩ ;
+      exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by
+        rcases h_sqrt_log ε hε with ⟨ δ, hδ, H ⟩ ;
+        exact ⟨ δ, hδ, by intro x hx; by_cases hx' : 0 < |b x| <;> aesop ⟩ ;
     intro ε hε_pos
-    obtain ⟨δ₁, hδ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ α, abs (α - 1) < δ₁ → Real.sqrt (|b α|) * |Real.log (|b α|)| < ε := by
-      simpa using Metric.tendsto_nhds_nhds.mp h_sqrt_log ε hε_pos |> fun ⟨ δ₁, hδ₁₁, hδ₁₂ ⟩ => ⟨ δ₁, hδ₁₁, fun α hα => lt_of_abs_lt <| by simpa using hδ₁₂ hα ⟩;
-    obtain ⟨δ₂, hδ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ α, abs (α - 1) < δ₂ → |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (|b α|) * |Real.log (|b α|)| := by
-      exact Metric.mem_nhds_iff.mp h_bound |> fun ⟨ δ₂, hδ₂_pos, hδ₂ ⟩ => ⟨ δ₂, hδ₂_pos, fun α hα => hδ₂ hα ⟩;
-    exact ⟨ Min.min δ₁ δ₂, lt_min hδ₁_pos hδ₂_pos, fun α hα => le_trans ( hδ₂ α ( lt_of_lt_of_le hα ( min_le_right _ _ ) ) ) ( by nlinarith [ hδ₁ α ( lt_of_lt_of_le hα ( min_le_left _ _ ) ), abs_nonneg ( α - 1 ) ] ) ⟩;
+    obtain ⟨δ₁, hδ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ α, abs (α - 1) < δ₁ →
+        Real.sqrt (|b α|) * |Real.log (|b α|)| < ε := by
+      simpa using Metric.tendsto_nhds_nhds.mp h_sqrt_log ε hε_pos |>
+        fun ⟨ δ₁, hδ₁₁, hδ₁₂ ⟩ =>
+        ⟨ δ₁, hδ₁₁, fun α hα => lt_of_abs_lt <| by simpa using hδ₁₂ hα ⟩;
+    obtain ⟨δ₂, hδ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ α, abs (α - 1) < δ₂ →
+        |b α ^ α - b α| ≤ |α - 1| * Real.sqrt (|b α|) * |Real.log (|b α|)| := by
+      exact Metric.mem_nhds_iff.mp h_bound |>
+        fun ⟨ δ₂, hδ₂_pos, hδ₂ ⟩ => ⟨ δ₂, hδ₂_pos, fun α hα => hδ₂ hα ⟩;
+    exact ⟨ Min.min δ₁ δ₂, lt_min hδ₁_pos hδ₂_pos, fun α hα =>
+      le_trans ( hδ₂ α ( lt_of_lt_of_le hα ( min_le_right _ _ ) ) ) ( by
+        nlinarith [ hδ₁ α ( lt_of_lt_of_le hα ( min_le_left _ _ ) ), abs_nonneg ( α - 1 ) ] ) ⟩;
   rw [ hasDerivAt_iff_isLittleO_nhds_zero ];
   rw [ Asymptotics.isLittleO_iff ];
-  intro ε hε; rcases h_eps ε hε with ⟨ δ, hδ, H ⟩ ; filter_upwards [ Metric.ball_mem_nhds _ hδ ] with x hx using by simpa [ hc ] using H ( 1 + x ) ( by simpa using hx ) ;
+  intro ε hε; rcases h_eps ε hε with ⟨ δ, hδ, H ⟩ ;
+  filter_upwards [ Metric.ball_mem_nhds _ hδ ] with x hx using by
+    simpa [ hc ] using H ( 1 + x ) ( by simpa using hx ) ;
 
 /-- If ker A ≤ ker ρM, then conjugating ρM by the support projection of A gives back ρM.
     This is because ρM is supported entirely on the support (= range) of A. -/
@@ -773,8 +913,10 @@ private lemma conj_supportProj_eq_of_ker_le (A ρM : HermitianMat d ℂ) (hker :
     ρM.conj (A.supportProj).mat = ρM := by
   have h_conj_support : ρM.mat * A.supportProj.mat = ρM.mat := by
     apply HermitianMat.mul_supportProj_of_ker_le; assumption;
-  -- Using the conjugate transpose property and the fact that A.supportProj is Hermitian, we can simplify the expression.
-  have h_conj_support : (A.supportProj.mat).conjTranspose * ρM.mat * A.supportProj.mat = ρM.mat := by
+  -- Using the conjugate transpose property and the fact that A.supportProj is Hermitian, we can
+  -- simplify the expression.
+  have h_conj_support :
+      (A.supportProj.mat).conjTranspose * ρM.mat * A.supportProj.mat = ρM.mat := by
     rw [ ← Matrix.conjTranspose_inj ] at * ; aesop;
   simp_all [ HermitianMat.conj, Matrix.mul_assoc ]
 
@@ -785,20 +927,31 @@ private lemma conj_supportProj_eq_of_ker_le (A ρM : HermitianMat d ℂ) (hker :
 private lemma rpow_tendsto_supportProj
     (A : HermitianMat d ℂ)  :
     Filter.Tendsto (fun r : ℝ => A ^ r) (nhdsWithin 0 {(0 : ℝ)}ᶜ) (nhds A.supportProj) := by
-  -- By definition of $g$, we know that $A.cfc (g r)$ converges to $A.supportProj$ as $r$ approaches $0$.
-  have h_cfc_g_conv : Filter.Tendsto (fun r : ℝ => A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r)) (nhds 0) (nhds A.supportProj) := by
-    have h_cfc_g_conv : Continuous (fun r : ℝ => A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r)) := by
+  -- By definition of $g$, we know that $A.cfc (g r)$ converges to $A.supportProj$ as $r$ approaches
+  -- $0$.
+  have h_cfc_g_conv : Filter.Tendsto
+      (fun r : ℝ => A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r))
+      (nhds 0) (nhds A.supportProj) := by
+    have h_cfc_g_conv : Continuous
+        (fun r : ℝ => A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r)) := by
       -- Apply the continuity of the cfc function.
-      have h_cfc_cont : Continuous (fun r : ℝ => A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r)) := by
-        have h_g_cont : ∀ x : ℝ, Continuous (fun r : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r) := by
+      have h_cfc_cont : Continuous
+          (fun r : ℝ =>
+            A.cfc (fun x : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r)) := by
+        have h_g_cont : ∀ x : ℝ,
+            Continuous (fun r : ℝ => if r = 0 then (if x = 0 then 0 else 1) else x ^ r) := by
           intro x
           by_cases hx : x = 0 <;> simp [hx];
           · rw [ Metric.continuous_iff ] ; aesop;
-          · rw [ show ( fun r : ℝ => if r = 0 then 1 else x ^ r ) = fun r : ℝ => x ^ r by ext r; by_cases hr : r = 0 <;> simp [ hr ] ] ; exact Continuous.rpow continuous_const continuous_id' <| by continuity;
+          · rw [ show ( fun r : ℝ => if r = 0 then 1 else x ^ r ) = fun r : ℝ => x ^ r by
+              ext r; by_cases hr : r = 0 <;> simp [ hr ] ] ;
+            exact Continuous.rpow continuous_const continuous_id' <| by continuity;
         apply_rules [ HermitianMat.continuous_cfc_fun ];
       convert h_cfc_cont using 1;
     convert h_cfc_g_conv.tendsto 0 using 2 ; simp [ HermitianMat.supportProj_eq_cfc ];
-  exact Filter.Tendsto.congr' ( Filter.eventuallyEq_of_mem self_mem_nhdsWithin fun x hx => by aesop ) ( h_cfc_g_conv.mono_left inf_le_left )
+  exact Filter.Tendsto.congr'
+    ( Filter.eventuallyEq_of_mem self_mem_nhdsWithin fun x hx => by aesop )
+    ( h_cfc_g_conv.mono_left inf_le_left )
 
 set_option backward.isDefEq.respectTransparency false in
 /-- For PSD matrices A, ρ with A.ker ≤ ρ.ker, the function r ↦ ρ.conj (A ^ r).mat
@@ -809,15 +962,20 @@ private lemma conj_rpow_continuousAt_zero
     (A ρM : HermitianMat d ℂ)
     (hker : A.ker ≤ ρM.ker) :
     ContinuousAt (fun r : ℝ => ρM.conj (A ^ r).mat) 0 := by
-  have h_conj : Filter.Tendsto (fun r : ℝ => A ^ r) (nhdsWithin 0 {0}ᶜ) (nhds A.supportProj) := by
+  have h_conj :
+      Filter.Tendsto (fun r : ℝ => A ^ r) (nhdsWithin 0 {0}ᶜ) (nhds A.supportProj) := by
     convert rpow_tendsto_supportProj A using 1;
-  have h_conj : Filter.Tendsto (fun r : ℝ => (HermitianMat.conj (A ^ r).mat) ρM) (nhdsWithin 0 {0}ᶜ) (nhds ρM) := by
-    convert Filter.Tendsto.comp ( show Filter.Tendsto ( fun M : { M : Matrix d d ℂ // M.IsHermitian } ↦ ( HermitianMat.conj M.val ) ρM ) ( nhds ( A.supportProj ) ) ( nhds ρM ) from ?_ ) h_conj using 2;
+  have h_conj : Filter.Tendsto (fun r : ℝ => (HermitianMat.conj (A ^ r).mat) ρM)
+      (nhdsWithin 0 {0}ᶜ) (nhds ρM) := by
+    convert Filter.Tendsto.comp ( show Filter.Tendsto
+      ( fun M : { M : Matrix d d ℂ // M.IsHermitian } ↦ ( HermitianMat.conj M.val ) ρM )
+      ( nhds ( A.supportProj ) ) ( nhds ρM ) from ?_ ) h_conj using 2;
     convert Continuous.tendsto _ _;
     · convert conj_supportProj_eq_of_ker_le A ρM hker |> Eq.symm;
     · fun_prop;
   rw [ Metric.tendsto_nhdsWithin_nhds ] at *;
-  exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by rcases h_conj ε hε with ⟨ δ, hδ, H ⟩ ; exact ⟨ δ, hδ, by intro x hx; by_cases hx' : x = 0 <;> aesop ⟩ ;
+  exact Metric.tendsto_nhds_nhds.mpr fun ε hε => by rcases h_conj ε hε with ⟨ δ, hδ, H ⟩ ;
+    exact ⟨ δ, hδ, by intro x hx; by_cases hx' : x = 0 <;> aesop ⟩ ;
 
 /-
 ContinuousAt for B_of: the function α ↦ B(α) is continuous at α = 1.
@@ -833,15 +991,22 @@ private lemma B_of_continuousAt (ρ σ : MState d) (h : σ.M.ker ≤ ρ.M.ker) :
       -- Apply the hypothesis `h_cont` directly to conclude the proof.
       exact conj_rpow_continuousAt_zero σ.M ρ.M h
     have h_exp : ContinuousAt (fun α : ℝ => (1 - α) / (2 * α)) 1 := by
-      exact ContinuousAt.div ( continuousAt_const.sub continuousAt_id ) ( continuousAt_const.mul continuousAt_id ) ( by norm_num )
-    exact ContinuousAt.comp ( by simpa using h_inner ) h_exp |> ContinuousAt.congr <| Filter.eventuallyEq_of_mem ( Ioi_mem_nhds zero_lt_one ) fun x hx ↦ by aesop;
+      exact ContinuousAt.div ( continuousAt_const.sub continuousAt_id )
+        ( continuousAt_const.mul continuousAt_id ) ( by norm_num )
+    exact ContinuousAt.comp ( by simpa using h_inner ) h_exp |> ContinuousAt.congr <|
+      Filter.eventuallyEq_of_mem ( Ioi_mem_nhds zero_lt_one ) fun x hx ↦ by aesop;
   exact h_cont
 
 private lemma trace_cfc_sub_le (A : HermitianMat d ℂ) (f g : ℝ → ℝ) :
     |(A.cfc f).trace - (A.cfc g).trace| ≤
       (Fintype.card d : ℝ) * (⨆ i, |f (A.H.eigenvalues i) - g (A.H.eigenvalues i)|) := by
   rw [HermitianMat.trace_cfc_eq, HermitianMat.trace_cfc_eq]
-  convert Finset.abs_sum_le_sum_abs _ Finset.univ |> le_trans <| Finset.sum_le_card_nsmul _ _ _ fun i _ => show |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| ≤ ⨆ i, |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| from le_ciSup ( Finite.bddAbove_range fun i => |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| ) i using 1
+  convert Finset.abs_sum_le_sum_abs _ Finset.univ |> le_trans <|
+    Finset.sum_le_card_nsmul _ _ _ fun i _ =>
+      show |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| ≤
+        ⨆ i, |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| from
+      le_ciSup ( Finite.bddAbove_range fun i =>
+        |f ( A.H.eigenvalues i ) - g ( A.H.eigenvalues i )| ) i using 1
   · simp [← Finset.sum_sub_distrib]
   · simp
 
@@ -849,16 +1014,21 @@ private lemma trace_cfc_sub_le (A : HermitianMat d ℂ) (f g : ℝ → ℝ) :
 private lemma eigenvalues_bounded_near {M : ℝ → HermitianMat d ℂ}
     (hM_nonneg : ∀ᶠ α in nhds 1, 0 ≤ M α)
     (hM_cont : ContinuousAt M 1) :
-    ∃ K > 0, ∀ᶠ α in nhds 1, ∀ i, 0 ≤ (M α).H.eigenvalues i ∧ (M α).H.eigenvalues i ≤ K := by
+    ∃ K > 0, ∀ᶠ α in nhds 1, ∀ i,
+      0 ≤ (M α).H.eigenvalues i ∧ (M α).H.eigenvalues i ≤ K := by
   have h_op_norm_bound : ∃ K > 0, ∀ᶠ α in nhds 1, ‖M α‖ ≤ K := by
-    exact ⟨ ‖M 1‖ + 1, by positivity, hM_cont.norm.eventually ( ge_mem_nhds ( lt_add_one _ ) ) ⟩
-  have h_eigenvalue_bound : ∀ᶠ α in nhds 1, ∀ i, 0 ≤ (M α).H.eigenvalues i ∧ (M α).H.eigenvalues i ≤ ‖M α‖ := by
+    exact ⟨ ‖M 1‖ + 1, by positivity,
+      hM_cont.norm.eventually ( ge_mem_nhds ( lt_add_one _ ) ) ⟩
+  have h_eigenvalue_bound : ∀ᶠ α in nhds 1, ∀ i,
+      0 ≤ (M α).H.eigenvalues i ∧ (M α).H.eigenvalues i ≤ ‖M α‖ := by
     have h_eigenvalue_bound : ∀ᶠ α in nhds 1, ∀ i, |(M α).H.eigenvalues i| ≤ ‖M α‖ := by
       filter_upwards [ hM_nonneg, h_op_norm_bound.choose_spec.2 ] with α hα₁ hα₂ i
       exact HermitianMat.eigenvalue_norm_le (M α) i
     filter_upwards [ h_eigenvalue_bound, hM_nonneg ] with α hα hα' i
     exact ⟨ hα' |> fun h => by simpa using h.eigenvalues_nonneg i, le_of_abs_le ( hα i ) ⟩
-  exact ⟨ h_op_norm_bound.choose, h_op_norm_bound.choose_spec.1, h_eigenvalue_bound.and ( h_op_norm_bound.choose_spec.2 ) |> fun h => h.mono fun α hα i => ⟨ hα.1 i |>.1, hα.1 i |>.2.trans ( hα.2 ) ⟩ ⟩
+  exact ⟨ h_op_norm_bound.choose, h_op_norm_bound.choose_spec.1,
+    h_eigenvalue_bound.and ( h_op_norm_bound.choose_spec.2 ) |>
+    fun h => h.mono fun α hα i => ⟨ hα.1 i |>.1, hα.1 i |>.2.trans ( hα.2 ) ⟩ ⟩
 
 /-
 Uniform convergence of (x^{1+h} - x)/h to x * log x on [0, K] as h → 0.
@@ -869,98 +1039,186 @@ private lemma rpow_slope_tendsto_uniformly (K : ℝ) :
     ∀ ε > 0, ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ →
     ∀ x ∈ Set.Icc 0 K, |(x ^ (1 + h) - x) / h - x * Real.log x| < ε := by
   intro ε ε_pos
-  obtain ⟨δ₁, δ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ → |x * Real.log x| < ε / 4 ∧ ∀ h, 0 < |h| → |h| < 1 / 2 → |(x ^ (1 + h) - x) / h| < ε / 4 := by
-    obtain ⟨δ₁, δ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ → |x * Real.log x| < ε / 4 := by
-      have h_cont : Filter.Tendsto (fun x => x * Real.log x) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
-        exact tendsto_nhdsWithin_of_tendsto_nhds ( by simpa using Real.continuous_mul_log.tendsto 0 );
+  obtain ⟨δ₁, δ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ →
+      |x * Real.log x| < ε / 4 ∧
+      ∀ h, 0 < |h| → |h| < 1 / 2 → |(x ^ (1 + h) - x) / h| < ε / 4 := by
+    obtain ⟨δ₁, δ₁_pos, hδ₁⟩ : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ →
+        |x * Real.log x| < ε / 4 := by
+      have h_cont : Filter.Tendsto (fun x => x * Real.log x) (nhdsWithin 0 (Set.Ioi 0))
+          (nhds 0) := by
+        exact tendsto_nhdsWithin_of_tendsto_nhds
+          ( by simpa using Real.continuous_mul_log.tendsto 0 );
       have := Metric.tendsto_nhdsWithin_nhds.mp h_cont ( ε / 4 ) ( by linarith );
-      exact ⟨ this.choose, this.choose_spec.1, fun x hx₁ hx₂ hx₃ => by simpa [ abs_mul ] using this.choose_spec.2 hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ⟩;
-    have h_bound : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ → ∀ h, 0 < |h| → |h| < 1 / 2 → |x ^ (1 + h) - x| ≤ |h| * x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
-      have h_bound : ∀ x ∈ Set.Icc 0 K, 0 < x → ∀ h : ℝ, 0 < |h| → |h| < 1 / 2 → |x ^ (1 + h) - x| ≤ |h| * x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
+      exact ⟨ this.choose, this.choose_spec.1, fun x hx₁ hx₂ hx₃ => by simpa [ abs_mul ] using
+        this.choose_spec.2 hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ⟩;
+    have h_bound : ∃ δ₁ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₁ → ∀ h, 0 < |h| → |h| < 1 / 2 →
+        |x ^ (1 + h) - x| ≤ |h| * x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
+      have h_bound : ∀ x ∈ Set.Icc 0 K, 0 < x → ∀ h : ℝ, 0 < |h| → |h| < 1 / 2 →
+          |x ^ (1 + h) - x| ≤
+          |h| * x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
         intros x hx hx_pos h hh_pos hh_lt_half
-        have h_exp_bound : |Real.exp (h * Real.log x) - 1| ≤ |h| * |Real.log x| * Real.exp (|h| * |Real.log x|) := by
+        have h_exp_bound : |Real.exp (h * Real.log x) - 1| ≤
+            |h| * |Real.log x| * Real.exp (|h| * |Real.log x|) := by
           have h_exp_bound : ∀ y : ℝ, |Real.exp y - 1| ≤ |y| * Real.exp (|y|) := by
             intro y; rw [ abs_le ] ; constructor <;> cases abs_cases y <;> simp [ * ];
             · nlinarith [ Real.add_one_le_exp y ];
-            · nlinarith [ Real.exp_pos y, Real.exp_neg y, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y, Real.add_one_le_exp ( -y ) ];
-            · nlinarith [ Real.exp_pos y, Real.exp_neg y, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y, Real.add_one_le_exp ( -y ) ];
-            · nlinarith [ Real.exp_pos y, Real.exp_neg y, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y, Real.add_one_le_exp ( -y ) ];
+            · nlinarith [ Real.exp_pos y, Real.exp_neg y,
+                mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y,
+                Real.add_one_le_exp ( -y ) ];
+            · nlinarith [ Real.exp_pos y, Real.exp_neg y,
+                mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y,
+                Real.add_one_le_exp ( -y ) ];
+            · nlinarith [ Real.exp_pos y, Real.exp_neg y,
+                mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y,
+                Real.add_one_le_exp ( -y ) ];
           simpa only [ abs_mul ] using h_exp_bound ( h * Real.log x );
         rw [ Real.rpow_add hx_pos, Real.rpow_one ];
         rw [ Real.rpow_def_of_pos hx_pos ];
-        rw [ show x * Real.exp ( Real.log x * h ) - x = x * ( Real.exp ( h * Real.log x ) - 1 ) by ring_nf ]
+        rw [ show x * Real.exp ( Real.log x * h ) - x = x * ( Real.exp ( h * Real.log x ) - 1 ) by
+          ring_nf ]
         rw [ abs_mul, abs_of_nonneg hx_pos.le ]
         refine' le_trans ( mul_le_mul_of_nonneg_left h_exp_bound hx_pos.le ) _
         ring_nf
-        exact le_add_of_le_of_nonneg ( mul_le_mul_of_nonneg_left ( Real.exp_le_exp.mpr ( by nlinarith [ abs_nonneg h, abs_nonneg ( Real.log x ) ] ) ) ( by positivity ) ) ( by positivity );
+        exact le_add_of_le_of_nonneg ( mul_le_mul_of_nonneg_left
+          ( Real.exp_le_exp.mpr ( by nlinarith [ abs_nonneg h, abs_nonneg ( Real.log x ) ] ) )
+          ( by positivity ) ) ( by positivity );
       exact ⟨ δ₁, δ₁_pos, fun x hx hx' hx'' h hh hh' => h_bound x hx hx' h hh hh' ⟩;
-    obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₂ → x * (|Real.log x| + 1) * Real.exp (1 / 2 * (|Real.log x| + 1)) < ε / 4 := by
-      have h_bound : Filter.Tendsto (fun x => x * (|Real.log x| + 1) * Real.exp (1 / 2 * (|Real.log x| + 1))) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
+    obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₂ →
+        x * (|Real.log x| + 1) * Real.exp (1 / 2 * (|Real.log x| + 1)) < ε / 4 := by
+      have h_bound : Filter.Tendsto
+          (fun x => x * (|Real.log x| + 1) * Real.exp (1 / 2 * (|Real.log x| + 1)))
+          (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
         -- Let $y = -\log x$, so we can rewrite the limit as $y \to \infty$.
-        suffices h_log : Filter.Tendsto (fun y => Real.exp (-y) * (y + 1) * Real.exp ((y + 1) / 2)) Filter.atTop (nhds 0) by
-          have h_subst : Filter.Tendsto (fun x => Real.exp (-(-Real.log x)) * ((-Real.log x) + 1) * Real.exp ((-Real.log x + 1) / 2)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
-            exact h_log.comp ( Filter.tendsto_neg_atBot_atTop.comp ( Real.tendsto_log_nhdsNE_zero.mono_left <| nhdsWithin_mono _ <| by norm_num ) );
+        suffices h_log : Filter.Tendsto
+            (fun y => Real.exp (-y) * (y + 1) * Real.exp ((y + 1) / 2)) Filter.atTop (nhds 0) by
+          have h_subst : Filter.Tendsto
+              (fun x => Real.exp (-(-Real.log x)) * ((-Real.log x) + 1) *
+                Real.exp ((-Real.log x + 1) / 2)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0) := by
+            exact h_log.comp ( Filter.tendsto_neg_atBot_atTop.comp
+              ( Real.tendsto_log_nhdsNE_zero.mono_left <| nhdsWithin_mono _ <| by norm_num ) );
           refine' h_subst.congr' _;
           filter_upwards [ Ioo_mem_nhdsGT_of_mem ⟨ le_rfl, zero_lt_one ⟩ ] with x hx
           rw [ abs_of_nonpos ( Real.log_nonpos hx.1.le hx.2.le ) ]
           rw [ neg_neg, Real.exp_log hx.1 ]
           ring_nf
         -- We can factor out $e^{-y/2}$ and use the fact that $e^{-y/2} \to 0$ as $y \to \infty$.
-        suffices h_factor : Filter.Tendsto (fun y => Real.exp (-y / 2) * (y + 1)) Filter.atTop (nhds 0) by
+        suffices h_factor : Filter.Tendsto (fun y => Real.exp (-y / 2) * (y + 1)) Filter.atTop
+            (nhds 0) by
           convert h_factor.const_mul ( Real.exp ( 1 / 2 ) ) using 2 <;> ring_nf
           norm_num [ mul_assoc, ← Real.exp_add ] ; ring_nf
         -- Let $z = \frac{y}{2}$, so we can rewrite the limit as $z \to \infty$.
-        suffices h_z : Filter.Tendsto (fun z => Real.exp (-z) * (2 * z + 1)) Filter.atTop (nhds 0) by
-          convert h_z.comp ( Filter.tendsto_id.atTop_mul_const ( by norm_num : 0 < ( 2⁻¹ : ℝ ) ) ) using 2 ; norm_num ; ring_nf
+        suffices h_z : Filter.Tendsto (fun z => Real.exp (-z) * (2 * z + 1)) Filter.atTop
+            (nhds 0) by
+          convert h_z.comp
+            ( Filter.tendsto_id.atTop_mul_const ( by norm_num : 0 < ( 2⁻¹ : ℝ ) ) ) using 2 ;
+          norm_num ; ring_nf
         have := Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero 1;
-        convert this.const_mul 2 |> Filter.Tendsto.add <| Real.tendsto_exp_atBot.comp <| Filter.tendsto_neg_atTop_atBot using 2 <;> norm_num
+        convert this.const_mul 2 |> Filter.Tendsto.add <| Real.tendsto_exp_atBot.comp <|
+          Filter.tendsto_neg_atTop_atBot using 2 <;> norm_num
         ring;
       have := Metric.tendsto_nhdsWithin_nhds.mp h_bound ( ε / 4 ) ( by linarith );
-      obtain ⟨ δ₂, δ₂_pos, H ⟩ := this; exact ⟨ δ₂, δ₂_pos, fun x hx₁ hx₂ hx₃ => by linarith [ abs_lt.mp ( H hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ) ] ⟩ ;
-    obtain ⟨δ₃, δ₃_pos, hδ₃⟩ : ∃ δ₃ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₃ → ∀ h, 0 < |h| → |h| < 1 / 2 → |(x ^ (1 + h) - x) / h| ≤ x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
+      obtain ⟨ δ₂, δ₂_pos, H ⟩ := this;
+      exact ⟨ δ₂, δ₂_pos, fun x hx₁ hx₂ hx₃ => by
+        linarith [ abs_lt.mp ( H hx₂ ( by simpa [ abs_of_pos hx₂ ] using hx₃ ) ) ] ⟩ ;
+    obtain ⟨δ₃, δ₃_pos, hδ₃⟩ : ∃ δ₃ > 0, ∀ x ∈ Set.Icc 0 K, 0 < x → x < δ₃ → ∀ h, 0 < |h| →
+        |h| < 1 / 2 →
+        |(x ^ (1 + h) - x) / h| ≤ x * (|Real.log x| + 1) * Real.exp (|h| * (|Real.log x| + 1)) := by
       obtain ⟨ δ₃, δ₃_pos, hδ₃ ⟩ := h_bound;
-      exact ⟨ δ₃, δ₃_pos, fun x hx hx' hx'' h hh hh' => by rw [ abs_div, div_le_iff₀ ( by positivity ) ] ; convert hδ₃ x hx hx' hx'' h hh hh' using 1 ; ring ⟩;
-    refine' ⟨ Min.min δ₁ ( Min.min δ₂ δ₃ ), lt_min δ₁_pos ( lt_min δ₂_pos δ₃_pos ), fun x hx hx' hx'' => ⟨ hδ₁ x hx hx' ( lt_of_lt_of_le hx'' ( min_le_left _ _ ) ), fun h hh₁ hh₂ => lt_of_le_of_lt ( hδ₃ x hx hx' ( lt_of_lt_of_le hx'' ( min_le_right _ _ |> le_trans <| min_le_right _ _ ) ) h hh₁ hh₂ ) _ ⟩ ⟩;
-    exact lt_of_le_of_lt ( mul_le_mul_of_nonneg_left ( Real.exp_le_exp.mpr <| mul_le_mul_of_nonneg_right hh₂.le <| by positivity ) <| by positivity ) <| hδ₂ x hx hx' <| lt_of_lt_of_le hx'' <| min_le_right _ _ |> le_trans <| min_le_left _ _;
-  obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < δ₂ → |(x ^ (1 + h) - x) / h - x * Real.log x| < ε / 4 := by
-    have h_mean_value : ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < 1 / 2 → |(x ^ (1 + h) - x) / h - x * Real.log x| ≤ |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) := by
+      exact ⟨ δ₃, δ₃_pos, fun x hx hx' hx'' h hh hh' => by
+        rw [ abs_div, div_le_iff₀ ( by positivity ) ] ;
+        convert hδ₃ x hx hx' hx'' h hh hh' using 1 ; ring ⟩;
+    refine' ⟨ Min.min δ₁ ( Min.min δ₂ δ₃ ), lt_min δ₁_pos ( lt_min δ₂_pos δ₃_pos ),
+      fun x hx hx' hx'' => ⟨ hδ₁ x hx hx' ( lt_of_lt_of_le hx'' ( min_le_left _ _ ) ),
+      fun h hh₁ hh₂ => lt_of_le_of_lt ( hδ₃ x hx hx'
+        ( lt_of_lt_of_le hx'' ( min_le_right _ _ |> le_trans <| min_le_right _ _ ) )
+        h hh₁ hh₂ ) _ ⟩ ⟩;
+    exact lt_of_le_of_lt ( mul_le_mul_of_nonneg_left
+      ( Real.exp_le_exp.mpr <| mul_le_mul_of_nonneg_right hh₂.le <| by positivity )
+      <| by positivity ) <| hδ₂ x hx hx' <| lt_of_lt_of_le hx'' <|
+      min_le_right _ _ |> le_trans <| min_le_left _ _;
+  obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < δ₂ →
+      |(x ^ (1 + h) - x) / h - x * Real.log x| < ε / 4 := by
+    have h_mean_value : ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < 1 / 2 →
+        |(x ^ (1 + h) - x) / h - x * Real.log x| ≤
+        |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) := by
       intros x hx h h_pos h_lt
-      have h_mean_value : |(x ^ h - 1) / h - Real.log x| ≤ |h| * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) := by
+      have h_mean_value : |(x ^ h - 1) / h - Real.log x| ≤
+          |h| * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) := by
         -- Applying the inequality |e^y - 1 - y| ≤ |y|^2 e^|y| with y = h * Real.log x.
         have h_exp_ineq : ∀ y : ℝ, |Real.exp y - 1 - y| ≤ |y|^2 * Real.exp |y| := by
           intro y; rw [ abs_le ] ; constructor <;> cases abs_cases y <;> simp [ * ];
           · nlinarith [ Real.add_one_le_exp y, Real.exp_pos y ];
-          · nlinarith [ Real.add_one_le_exp y, Real.add_one_le_exp ( -y ), Real.exp_pos y, Real.exp_pos ( -y ) ];
-          · -- Using the Taylor series expansion of $e^y$, we have $e^y \leq 1 + y + y^2 e^y$ for $y \geq 0$.
+          · nlinarith [ Real.add_one_le_exp y, Real.add_one_le_exp ( -y ), Real.exp_pos y,
+              Real.exp_pos ( -y ) ];
+          · -- Using the Taylor series expansion of $e^y$, we have $e^y \leq 1 + y + y^2 e^y$ for
+            -- $y \geq 0$.
             have h_taylor : ∀ y : ℝ, 0 ≤ y → Real.exp y ≤ 1 + y + y^2 * Real.exp y := by
-              intro y hy; nlinarith [ Real.exp_pos y, Real.exp_neg y, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y, Real.add_one_le_exp ( -y ), mul_nonneg hy ( Real.exp_nonneg y ), mul_nonneg hy ( Real.exp_nonneg ( -y ) ) ] ;
+              intro y hy; nlinarith [ Real.exp_pos y, Real.exp_neg y,
+                mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y,
+                Real.add_one_le_exp ( -y ), mul_nonneg hy ( Real.exp_nonneg y ),
+                mul_nonneg hy ( Real.exp_nonneg ( -y ) ) ] ;
             linarith [ h_taylor y ( by linarith ) ];
-          · nlinarith [ Real.exp_pos y, Real.exp_neg y, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y, Real.add_one_le_exp ( -y ) ];
-        convert mul_le_mul_of_nonneg_left ( h_exp_ineq ( h * Real.log x ) ) ( inv_nonneg.mpr h_pos.le ) using 1 <;> norm_num [ Real.rpow_def_of_pos ( show 0 < x from lt_of_lt_of_le δ₁_pos hx.1 ), mul_comm ] ; ring_nf
+          · nlinarith [ Real.exp_pos y, Real.exp_neg y,
+              mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos y ) ), Real.add_one_le_exp y,
+              Real.add_one_le_exp ( -y ) ];
+        convert mul_le_mul_of_nonneg_left ( h_exp_ineq ( h * Real.log x ) )
+          ( inv_nonneg.mpr h_pos.le ) using 1 <;>
+          norm_num [ Real.rpow_def_of_pos ( show 0 < x from lt_of_lt_of_le δ₁_pos hx.1 ),
+            mul_comm ] ; ring_nf
         · rw [ ← abs_inv, ← abs_mul ] ; ring_nf;
           by_cases hh : h = 0 <;> aesop;
         · simp [ sq, mul_assoc, mul_comm, mul_left_comm, h_pos.ne' ];
-      convert mul_le_mul_of_nonneg_left h_mean_value ( show 0 ≤ x by linarith [ hx.1 ] ) using 1 <;> ring_nf
+      convert mul_le_mul_of_nonneg_left h_mean_value ( show 0 ≤ x by linarith [ hx.1 ] ) using 1
+        <;> ring_nf
 
-      rw [ show x ^ (1 + h) * h⁻¹ - x * h⁻¹ - x * Real.log x = x * ( -h⁻¹ + ( h⁻¹ * x ^ h - Real.log x ) ) by rw [ Real.rpow_add ( by linarith [ hx.1 ] ), Real.rpow_one ] ; ring ]
+      rw [ show x ^ (1 + h) * h⁻¹ - x * h⁻¹ - x * Real.log x =
+        x * ( -h⁻¹ + ( h⁻¹ * x ^ h - Real.log x ) ) by
+          rw [ Real.rpow_add ( by linarith [ hx.1 ] ), Real.rpow_one ] ; ring ]
       rw [ abs_mul, abs_of_nonneg ( by linarith [ hx.1 ] : 0 ≤ x ) ]
       ring_nf
 
-    -- Choose δ₂ such that |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) < ε / 4 for all x ∈ [δ₁, K] and |h| < δ₂.
-    obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < δ₂ → |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) < ε / 4 := by
-      -- Since $x * (\log x)^2 * \exp(|h| * |\log x|)$ is continuous on the compact interval $[\delta₁, K]$, it is bounded.
-      obtain ⟨M, hM⟩ : ∃ M > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < 1 / 2 → x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) ≤ M := by
-        have h_cont : ContinuousOn (fun x => x * (Real.log x) ^ 2 * Real.exp (1 / 2 * |Real.log x|)) (Set.Icc δ₁ K) := by
-          exact ContinuousOn.mul ( ContinuousOn.mul continuousOn_id ( ContinuousOn.pow ( Real.continuousOn_log.mono ( by exact fun x hx => ne_of_gt <| lt_of_lt_of_le δ₁_pos hx.1 ) ) _ ) ) ( ContinuousOn.rexp <| ContinuousOn.mul continuousOn_const <| ContinuousOn.abs <| Real.continuousOn_log.mono ( by exact fun x hx => ne_of_gt <| lt_of_lt_of_le δ₁_pos hx.1 ) );
-        obtain ⟨ M, hM ⟩ := IsCompact.exists_bound_of_continuousOn ( CompactIccSpace.isCompact_Icc ) h_cont;
+    -- Choose δ₂ such that |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) < ε / 4 for
+    -- all x ∈ [δ₁, K] and |h| < δ₂.
+    obtain ⟨δ₂, δ₂_pos, hδ₂⟩ : ∃ δ₂ > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < δ₂ →
+        |h| * x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) < ε / 4 := by
+      -- Since $x * (\log x)^2 * \exp(|h| * |\log x|)$ is continuous on the compact interval
+      -- $[\delta₁, K]$, it is bounded.
+      obtain ⟨M, hM⟩ : ∃ M > 0, ∀ x ∈ Set.Icc δ₁ K, ∀ h, 0 < |h| → |h| < 1 / 2 →
+          x * (Real.log x) ^ 2 * Real.exp (|h| * |Real.log x|) ≤ M := by
+        have h_cont : ContinuousOn
+            (fun x => x * (Real.log x) ^ 2 * Real.exp (1 / 2 * |Real.log x|)) (Set.Icc δ₁ K) := by
+          exact ContinuousOn.mul ( ContinuousOn.mul continuousOn_id ( ContinuousOn.pow
+            ( Real.continuousOn_log.mono
+              ( by exact fun x hx => ne_of_gt <| lt_of_lt_of_le δ₁_pos hx.1 ) ) _ ) )
+            ( ContinuousOn.rexp <| ContinuousOn.mul continuousOn_const <| ContinuousOn.abs <|
+              Real.continuousOn_log.mono
+                ( by exact fun x hx => ne_of_gt <| lt_of_lt_of_le δ₁_pos hx.1 ) );
+        obtain ⟨ M, hM ⟩ := IsCompact.exists_bound_of_continuousOn
+          ( CompactIccSpace.isCompact_Icc ) h_cont;
         norm_num +zetaDelta at *;
-        exact ⟨ Max.max M 1, by positivity, fun x hx₁ hx₂ h hh₁ hh₂ => le_trans ( by rw [ abs_of_nonneg ( by linarith : 0 ≤ x ) ] ; exact mul_le_mul_of_nonneg_left ( Real.exp_le_exp.mpr <| by nlinarith [ abs_nonneg ( Real.log x ) ] ) <| by nlinarith [ abs_nonneg ( Real.log x ) ] ) <| le_trans ( hM x hx₁ hx₂ ) <| le_max_left _ _ ⟩;
-      exact ⟨ Min.min ( 1 / 2 ) ( ε / 4 / M ), lt_min ( by norm_num ) ( div_pos ( by linarith ) hM.1 ), fun x hx h hh₁ hh₂ => by nlinarith [ min_le_left ( 1 / 2 ) ( ε / 4 / M ), min_le_right ( 1 / 2 ) ( ε / 4 / M ), mul_div_cancel₀ ( ε / 4 ) hM.1.ne', abs_nonneg h, hM.2 x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ), mul_le_mul_of_nonneg_left ( hM.2 x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) ) ( abs_nonneg h ) ] ⟩;
-    exact ⟨ Min.min δ₂ ( 1 / 2 ), lt_min δ₂_pos ( by norm_num ), fun x hx h hh₁ hh₂ => lt_of_le_of_lt ( h_mean_value x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_right _ _ ) ) ) ( hδ₂ x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) ) ⟩;
-  refine' ⟨ Min.min ( 1 / 2 ) δ₂, lt_min ( by positivity ) δ₂_pos, fun h hh₁ hh₂ x hx => _ ⟩ ; cases lt_or_ge x δ₁ <;> simp_all [ abs_lt ];
+        exact ⟨ Max.max M 1, by positivity, fun x hx₁ hx₂ h hh₁ hh₂ => le_trans
+          ( by rw [ abs_of_nonneg ( by linarith : 0 ≤ x ) ] ;
+            exact mul_le_mul_of_nonneg_left
+              ( Real.exp_le_exp.mpr <| by nlinarith [ abs_nonneg ( Real.log x ) ] ) <|
+              by nlinarith [ abs_nonneg ( Real.log x ) ] )
+          <| le_trans ( hM x hx₁ hx₂ ) <| le_max_left _ _ ⟩;
+      exact ⟨ Min.min ( 1 / 2 ) ( ε / 4 / M ),
+        lt_min ( by norm_num ) ( div_pos ( by linarith ) hM.1 ), fun x hx h hh₁ hh₂ => by
+        nlinarith [ min_le_left ( 1 / 2 ) ( ε / 4 / M ), min_le_right ( 1 / 2 ) ( ε / 4 / M ),
+          mul_div_cancel₀ ( ε / 4 ) hM.1.ne', abs_nonneg h,
+          hM.2 x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ),
+          mul_le_mul_of_nonneg_left
+            ( hM.2 x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) ) ( abs_nonneg h ) ] ⟩;
+    exact ⟨ Min.min δ₂ ( 1 / 2 ), lt_min δ₂_pos ( by norm_num ), fun x hx h hh₁ hh₂ =>
+      lt_of_le_of_lt ( h_mean_value x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_right _ _ ) ) )
+      ( hδ₂ x hx h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) ) ⟩;
+  refine' ⟨ Min.min ( 1 / 2 ) δ₂, lt_min ( by positivity ) δ₂_pos, fun h hh₁ hh₂ x hx => _ ⟩ ;
+  cases lt_or_ge x δ₁ <;> simp_all [ abs_lt ];
   · cases lt_or_eq_of_le hx.1 <;> simp_all [ abs_of_nonneg ];
-    · constructor <;> cases abs_cases ( Real.log x ) <;> nlinarith [ hδ₁ x hx.1 hx.2 ‹_› ‹_›, hδ₁ x hx.1 hx.2 ‹_› ‹_› |>.2 h hh₁ hh₂.1.1 hh₂.1.2 ];
-    · by_cases h : 1 + h = 0 <;> simp_all [ division_def ] ; linarith [ Real.log_le_sub_one_of_pos ( show 0 < ε by linarith ) ] ;
+    · constructor <;> cases abs_cases ( Real.log x ) <;> nlinarith [ hδ₁ x hx.1 hx.2 ‹_› ‹_›,
+        hδ₁ x hx.1 hx.2 ‹_› ‹_› |>.2 h hh₁ hh₂.1.1 hh₂.1.2 ];
+    · by_cases h : 1 + h = 0 <;> simp_all [ division_def ] ;
+      linarith [ Real.log_le_sub_one_of_pos ( show 0 < ε by linarith ) ] ;
       norm_num [ ← ‹0 = x› ] at * ; aesop;
   · constructor <;> linarith [ hδ₂ x ‹_› hx.2 h hh₁ hh₂.2.1 hh₂.2.2 ]
 
@@ -974,13 +1232,18 @@ private lemma trace_cfc_tendsto_of_tendsto (f : ℝ → ℝ)
     (hM_cont : ContinuousAt M 1) (hM_nonneg : ∀ᶠ α in nhds 1, 0 ≤ M α)
     (hM_one : M 1 = ρ.M) :
     Filter.Tendsto (fun α => ((M α).cfc f).trace) (nhds 1) (nhds ((ρ.M.cfc f).trace)) := by
-  have h_cfc_cont : ContinuousWithinAt (fun A : HermitianMat d ℂ => A.cfc f) {A : HermitianMat d ℂ | 0 ≤ A} ρ := by
-    have h_cont : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc f) {A : HermitianMat d ℂ | 0 ≤ A} := by
-      have h_cont_trace : ContinuousOn (fun A : HermitianMat d ℂ => (A.cfc f)) {A : HermitianMat d ℂ | 0 ≤ A} := by
-        have h_cont_cfc : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc f) {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ Set.Ici 0} := by
+  have h_cfc_cont : ContinuousWithinAt (fun A : HermitianMat d ℂ => A.cfc f)
+      {A : HermitianMat d ℂ | 0 ≤ A} ρ := by
+    have h_cont : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc f)
+        {A : HermitianMat d ℂ | 0 ≤ A} := by
+      have h_cont_trace : ContinuousOn (fun A : HermitianMat d ℂ => (A.cfc f))
+          {A : HermitianMat d ℂ | 0 ≤ A} := by
+        have h_cont_cfc : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc f)
+            {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ Set.Ici 0} := by
           intro A hA
           exact HermitianMat.continuousWithinAt_cfc_of_continuousOn hf hA
-        have h_spectrum_subset : ∀ A : HermitianMat d ℂ, 0 ≤ A → spectrum ℝ A.mat ⊆ Set.Ici 0 := by
+        have h_spectrum_subset :
+            ∀ A : HermitianMat d ℂ, 0 ≤ A → spectrum ℝ A.mat ⊆ Set.Ici 0 := by
           intro A hA
           exact (HermitianMat.posSemidef_iff_spectrum_Ici A).mp hA
         exact h_cont_cfc.mono fun A hA => h_spectrum_subset A hA
@@ -988,7 +1251,8 @@ private lemma trace_cfc_tendsto_of_tendsto (f : ℝ → ℝ)
     exact h_cont _ ( by simp [ ρ.2 ] ) |> ContinuousWithinAt.mono <| Set.Subset.refl _;
   have h_trace_cont : Continuous (fun A : HermitianMat d ℂ => A.trace) := by
     exact HermitianMat.trace_Continuous;
-  have h_comp_cont : Filter.Tendsto (fun α => (M α).cfc f) (nhds 1) (nhds ((ρ : HermitianMat d ℂ).cfc f)) := by
+  have h_comp_cont : Filter.Tendsto (fun α => (M α).cfc f) (nhds 1)
+      (nhds ((ρ : HermitianMat d ℂ).cfc f)) := by
     convert h_cfc_cont.tendsto.comp _ using 2;
     exact tendsto_nhdsWithin_iff.mpr ⟨ hM_cont.tendsto.trans ( by simp [ hM_one ] ), hM_nonneg ⟩;
   exact h_trace_cont.continuousAt.tendsto.comp h_comp_cont
@@ -1013,25 +1277,41 @@ private lemma cross_term_slope_tendsto_zero
   -- Let $G_h(x) = \frac{x^{1+h} - x}{h}$ for $h \neq 0$ and $G_0(x) = x \log x$.
   set Gh : ℝ → ℝ → ℝ := fun h x => if h = 0 then x * Real.log x else (x ^ (1 + h) - x) / h;
   -- Using the triangle inequality decomposition with $G_0(x) = x \log x$, we get:
-  have h_triangle : Filter.Tendsto (fun h => (∑ i, Gh h ((M (1 + h)).H.eigenvalues i)) - (∑ i, Gh h (ρ.M.H.eigenvalues i))) (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
+  have h_triangle : Filter.Tendsto
+      (fun h => (∑ i, Gh h ((M (1 + h)).H.eigenvalues i)) - (∑ i, Gh h (ρ.M.H.eigenvalues i)))
+      (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
     -- By the properties of the trace and the continuity of $G_h$, we can bound the difference.
-    have h_bound : ∀ ε > 0, ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ x ∈ Set.Icc 0 K, |Gh h x - x * Real.log x| < ε := by
+    have h_bound : ∀ ε > 0, ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ x ∈ Set.Icc 0 K,
+        |Gh h x - x * Real.log x| < ε := by
       intro ε ε_pos
-      obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ x ∈ Set.Icc 0 K, |(x ^ (1 + h) - x) / h - x * Real.log x| < ε := by
+      obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ x ∈ Set.Icc 0 K,
+          |(x ^ (1 + h) - x) / h - x * Real.log x| < ε := by
         have := rpow_slope_tendsto_uniformly K ε ε_pos; aesop;
       use δ, δ_pos
       intro h hh_pos hh_lt
       aesop;
     -- Using the bound, we can show that the difference tends to zero.
-    have h_diff_zero : Filter.Tendsto (fun h => ∑ i, (Gh h ((M (1 + h)).H.eigenvalues i) - (M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i))) (nhdsWithin 0 {0}ᶜ) (nhds 0) ∧ Filter.Tendsto (fun h => ∑ i, (Gh h (ρ.M.H.eigenvalues i) - ρ.M.H.eigenvalues i * Real.log (ρ.M.H.eigenvalues i))) (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
+    have h_diff_zero : Filter.Tendsto
+        (fun h => ∑ i, (Gh h ((M (1 + h)).H.eigenvalues i) -
+          (M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i)))
+        (nhdsWithin 0 {0}ᶜ) (nhds 0) ∧ Filter.Tendsto
+        (fun h => ∑ i, (Gh h (ρ.M.H.eigenvalues i) -
+          ρ.M.H.eigenvalues i * Real.log (ρ.M.H.eigenvalues i)))
+        (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
       constructor;
-      · have h_diff_zero : ∀ ε > 0, ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ i, |Gh h ((M (1 + h)).H.eigenvalues i) - (M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i)| < ε := by
+      · have h_diff_zero : ∀ ε > 0, ∃ δ > 0, ∀ h : ℝ, 0 < |h| → |h| < δ → ∀ i,
+            |Gh h ((M (1 + h)).H.eigenvalues i) -
+              (M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i)| < ε := by
           intro ε hε_pos
           obtain ⟨δ, hδ_pos, hδ⟩ := h_bound ε hε_pos
-          obtain ⟨δ', hδ'_pos, hδ'⟩ : ∃ δ' > 0, ∀ h : ℝ, |h| < δ' → ∀ i, 0 ≤ (M (1 + h)).H.eigenvalues i ∧ (M (1 + h)).H.eigenvalues i ≤ K := by
+          obtain ⟨δ', hδ'_pos, hδ'⟩ : ∃ δ' > 0, ∀ h : ℝ, |h| < δ' → ∀ i,
+              0 ≤ (M (1 + h)).H.eigenvalues i ∧ (M (1 + h)).H.eigenvalues i ≤ K := by
             rcases Metric.mem_nhds_iff.mp hK with ⟨ δ', hδ'_pos, hδ' ⟩;
-            exact ⟨ δ', hδ'_pos, fun h hh i => hδ' ( mem_ball_iff_norm.mpr <| by simpa using hh ) i ⟩;
-          exact ⟨ Min.min δ δ', lt_min hδ_pos hδ'_pos, fun h hh₁ hh₂ i => hδ h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) _ ( hδ' h ( lt_of_lt_of_le hh₂ ( min_le_right _ _ ) ) i ) ⟩;
+            exact ⟨ δ', hδ'_pos, fun h hh i =>
+              hδ' ( mem_ball_iff_norm.mpr <| by simpa using hh ) i ⟩;
+          exact ⟨ Min.min δ δ', lt_min hδ_pos hδ'_pos, fun h hh₁ hh₂ i =>
+            hδ h hh₁ ( lt_of_lt_of_le hh₂ ( min_le_left _ _ ) ) _
+            ( hδ' h ( lt_of_lt_of_le hh₂ ( min_le_right _ _ ) ) i ) ⟩;
         rw [ Metric.tendsto_nhdsWithin_nhds ];
         intro ε hε_pos
         obtain ⟨δ, hδ_pos, hδ⟩ := h_diff_zero (ε / (Fintype.card d + 1)) (by
@@ -1040,9 +1320,15 @@ private lemma cross_term_slope_tendsto_zero
         simp +zetaDelta at *;
         rw [ if_neg hx ];
         rw [ ← Finset.sum_sub_distrib ];
-        exact lt_of_le_of_lt ( Finset.abs_sum_le_sum_abs _ _ ) ( lt_of_le_of_lt ( Finset.sum_le_sum fun i _ => le_of_lt ( by simpa [ hx ] using hδ x hx hx' i ) ) ( by norm_num; nlinarith [ mul_div_cancel₀ ε ( by positivity : ( Fintype.card d + 1 : ℝ ) ≠ 0 ) ] ) );
+        exact lt_of_le_of_lt ( Finset.abs_sum_le_sum_abs _ _ ) ( lt_of_le_of_lt
+          ( Finset.sum_le_sum fun i _ => le_of_lt ( by simpa [ hx ] using hδ x hx hx' i ) )
+          ( by norm_num;
+            nlinarith [ mul_div_cancel₀ ε ( by positivity : ( Fintype.card d + 1 : ℝ ) ≠ 0 ) ] ) );
       · rw [ Metric.tendsto_nhdsWithin_nhds ];
-        intro ε ε_pos; rcases h_bound ( ε / ( Fintype.card d + 1 ) ) ( div_pos ε_pos ( Nat.cast_add_one_pos _ ) ) with ⟨ δ, δ_pos, H ⟩ ; use δ, δ_pos; intro x hx hx'; simp_all [ dist_eq_norm ] ;
+        intro ε ε_pos;
+        rcases h_bound ( ε / ( Fintype.card d + 1 ) )
+          ( div_pos ε_pos ( Nat.cast_add_one_pos _ ) ) with ⟨ δ, δ_pos, H ⟩ ;
+        use δ, δ_pos; intro x hx hx'; simp_all [ dist_eq_norm ] ;
         rw [ ← Finset.sum_sub_distrib ];
         refine' lt_of_le_of_lt ( Finset.abs_sum_le_sum_abs _ _ ) _;
         refine' lt_of_le_of_lt ( Finset.sum_le_sum fun i _ => le_of_lt ( H x hx hx' _ _ _ ) ) _;
@@ -1050,25 +1336,45 @@ private lemma cross_term_slope_tendsto_zero
         · exact hK i |>.2.self_of_nhds |> fun h => by simpa [ hM_one ] using h;
         · simp [ div_eq_mul_inv ];
           nlinarith [ mul_inv_cancel_left₀ ( by positivity : ( Fintype.card d : ℝ ) + 1 ≠ 0 ) ε ];
-    have h_diff_zero : Filter.Tendsto (fun h => ∑ i, ((M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i)) - ∑ i, (ρ.M.H.eigenvalues i * Real.log (ρ.M.H.eigenvalues i))) (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
-      have h_diff_zero : Filter.Tendsto (fun h => ((M (1 + h)).cfc (fun x => x * Real.log x)).trace - (ρ.M.cfc (fun x => x * Real.log x)).trace) (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
-        have h_diff_zero : Filter.Tendsto (fun h => ((M (1 + h)).cfc (fun x => x * Real.log x)).trace) (nhdsWithin 0 {0}ᶜ) (nhds ((ρ.M.cfc (fun x => x * Real.log x)).trace)) := by
-          have h_diff_zero : Filter.Tendsto (fun α => ((M α).cfc (fun x => x * Real.log x)).trace) (nhds 1) (nhds ((ρ.M.cfc (fun x => x * Real.log x)).trace)) := by
+    have h_diff_zero : Filter.Tendsto
+        (fun h => ∑ i, ((M (1 + h)).H.eigenvalues i * Real.log ((M (1 + h)).H.eigenvalues i)) -
+          ∑ i, (ρ.M.H.eigenvalues i * Real.log (ρ.M.H.eigenvalues i)))
+        (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
+      have h_diff_zero : Filter.Tendsto
+          (fun h => ((M (1 + h)).cfc (fun x => x * Real.log x)).trace -
+            (ρ.M.cfc (fun x => x * Real.log x)).trace) (nhdsWithin 0 {0}ᶜ) (nhds 0) := by
+        have h_diff_zero : Filter.Tendsto
+            (fun h => ((M (1 + h)).cfc (fun x => x * Real.log x)).trace) (nhdsWithin 0 {0}ᶜ)
+            (nhds ((ρ.M.cfc (fun x => x * Real.log x)).trace)) := by
+          have h_diff_zero : Filter.Tendsto
+              (fun α => ((M α).cfc (fun x => x * Real.log x)).trace) (nhds 1)
+              (nhds ((ρ.M.cfc (fun x => x * Real.log x)).trace)) := by
             convert trace_cfc_tendsto_of_tendsto _ _ _ _ _ using 1;
             · exact Continuous.continuousOn ( Real.continuous_mul_log );
             · exact hM_cont;
             · exact hM_nonneg;
             · exact hM_one;
-          exact h_diff_zero.comp ( tendsto_nhdsWithin_of_tendsto_nhds ( by norm_num [ Filter.Tendsto ] ) );
+          exact h_diff_zero.comp
+            ( tendsto_nhdsWithin_of_tendsto_nhds ( by norm_num [ Filter.Tendsto ] ) );
         simpa using h_diff_zero.sub_const ( ( ρ.M.cfc fun x => x * Real.log x ).trace );
       convert h_diff_zero using 2;
       rw [ HermitianMat.trace_cfc_eq, HermitianMat.trace_cfc_eq ];
-    convert h_diff_zero.add ( ‹Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ( M ( 1 + h ) ).H.eigenvalues i ) - ( M ( 1 + h ) ).H.eigenvalues i * Real.log ( ( M ( 1 + h ) ).H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ∧ Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ρ.M.H.eigenvalues i ) - ρ.M.H.eigenvalues i * Real.log ( ρ.M.H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ›.1.sub ‹Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ( M ( 1 + h ) ).H.eigenvalues i ) - ( M ( 1 + h ) ).H.eigenvalues i * Real.log ( ( M ( 1 + h ) ).H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ∧ Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ρ.M.H.eigenvalues i ) - ρ.M.H.eigenvalues i * Real.log ( ρ.M.H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ›.2 ) using 2 <;> simp [ Finset.sum_sub_distrib ] ; ring;
+    convert h_diff_zero.add ( ‹Filter.Tendsto ( fun h => ∑ i, ( Gh h
+      ( ( M ( 1 + h ) ).H.eigenvalues i ) - ( M ( 1 + h ) ).H.eigenvalues i * Real.log
+      ( ( M ( 1 + h ) ).H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ∧
+      Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ρ.M.H.eigenvalues i ) - ρ.M.H.eigenvalues i *
+      Real.log ( ρ.M.H.eigenvalues i ) ) ) ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ›.1.sub
+      ‹Filter.Tendsto ( fun h => ∑ i, ( Gh h ( ( M ( 1 + h ) ).H.eigenvalues i ) -
+      ( M ( 1 + h ) ).H.eigenvalues i * Real.log ( ( M ( 1 + h ) ).H.eigenvalues i ) ) )
+      ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ∧ Filter.Tendsto ( fun h => ∑ i,
+      ( Gh h ( ρ.M.H.eigenvalues i ) - ρ.M.H.eigenvalues i * Real.log ( ρ.M.H.eigenvalues i ) ) )
+      ( nhdsWithin 0 { 0 } ᶜ ) ( nhds 0 ) ›.2 ) using 2 <;> simp [ Finset.sum_sub_distrib ] ; ring;
   refine' h_triangle.congr' _;
   rw [ Filter.EventuallyEq, eventually_nhdsWithin_iff ];
   rw [ Metric.eventually_nhds_iff ] at *;
   obtain ⟨ ε, ε_pos, hε ⟩ := hK; use ε, ε_pos; intro y hy hy'; simp_all [ div_eq_inv_mul] ;
-  have h_trace_rpow : ∀ (A : HermitianMat d ℂ) (p : ℝ), (A ^ p).trace = ∑ i, (A.H.eigenvalues i) ^ p := by
+  have h_trace_rpow : ∀ (A : HermitianMat d ℂ) (p : ℝ),
+      (A ^ p).trace = ∑ i, (A.H.eigenvalues i) ^ p := by
     exact fun A p => HermitianMat.trace_rpow_eq_sum A p;
   have := h_trace_rpow ( M ( 1 + y ) ) 1; have := h_trace_rpow ( ρ : HermitianMat d ℂ ) 1; simp_all
   simp +zetaDelta at *;
@@ -1086,9 +1392,11 @@ private lemma hasDerivAt_trace_rpow_sub_trace_variable_base
     (hM_cont : ContinuousAt M 1)
     (hM_one : M 1 = ρ.M) :
     HasDerivAt (fun α : ℝ => (M α ^ α).trace - (M α).trace) ⟪ρ.M, ρ.M.log⟫ 1 := by
-  have h_deriv : HasDerivAt (fun α : ℝ => ((M α) ^ α).trace - (M α).trace - ((ρ.M) ^ α).trace + ρ.M.trace) 0 1 := by
+  have h_deriv : HasDerivAt
+      (fun α : ℝ => ((M α) ^ α).trace - (M α).trace - ((ρ.M) ^ α).trace + ρ.M.trace) 0 1 := by
     convert hasDerivAt_iff_tendsto_slope_zero.mpr _ using 1
-    convert cross_term_slope_tendsto_zero hM_nonneg hM_cont hM_one using 2 ; norm_num [ hM_one ] ; ring!
+    convert cross_term_slope_tendsto_zero hM_nonneg hM_cont hM_one using 2 ;
+    norm_num [ hM_one ] ; ring!
   convert h_deriv.add ( hasDerivAt_trace_rpow_sub_trace ρ.M ρ.nonneg ) using 1 <;> norm_num
   ring_nf
   ext; norm_num; ring
@@ -1105,14 +1413,18 @@ private lemma rpow_trace_cross_term_vanishes {ρ σ : MState d}
         - (ρ.M ^ α).trace + 1)
       0
       1 := by
-  have h_cross_term : HasDerivAt (fun α : ℝ => ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace - (ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat).trace) ⟪ρ.M, ρ.M.log⟫ 1 ∧ HasDerivAt (fun α : ℝ => (ρ.M ^ α).trace) ⟪ρ.M, ρ.M.log⟫ 1 := by
+  have h_cross_term : HasDerivAt
+      (fun α : ℝ => ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace
+        - (ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat).trace) ⟪ρ.M, ρ.M.log⟫ 1 ∧
+      HasDerivAt (fun α : ℝ => (ρ.M ^ α).trace) ⟪ρ.M, ρ.M.log⟫ 1 := by
     apply And.intro;
     · convert hasDerivAt_trace_rpow_sub_trace_variable_base _ _ _ using 1;
       · exact Filter.Eventually.of_forall fun α => B_of_nonneg ρ σ α;
       · convert B_of_continuousAt ρ σ h using 1;
       · simp [ HermitianMat.conj ];
     · convert hasDerivAt_trace_rpow_at_one ρ.M ( by exact ρ.nonneg ) using 1
-  convert HasDerivAt.add ( HasDerivAt.sub h_cross_term.1 h_cross_term.2 ) ( hasDerivAt_const _ _ ) using 1
+  convert HasDerivAt.add ( HasDerivAt.sub h_cross_term.1 h_cross_term.2 )
+    ( hasDerivAt_const _ _ ) using 1
   ring
 
 private theorem sandwichedRelRentropy.hasDerivAt_trace_at_one {ρ σ : MState d}
@@ -1143,7 +1455,9 @@ private theorem sandwichedRelRentropy.limit_at_one (ρ σ : MState d)
       (fun α : ℝ ↦ ((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace.log / (α - 1))
       (nhdsWithin 1 (Set.Ioi 0 \ {1}))
       (nhds ⟪ρ.M, ρ.M.log - σ.M.log⟫) := by
-  have h_log_approx : HasDerivAt (fun α : ℝ ↦ Real.log (((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace)) (⟪ρ.M, ρ.M.log - σ.M.log⟫) 1 := by
+  have h_log_approx : HasDerivAt
+      (fun α : ℝ ↦ Real.log (((ρ.M.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace))
+      (⟪ρ.M, ρ.M.log - σ.M.log⟫) 1 := by
     have h_deriv := sandwichedRelRentropy.hasDerivAt_trace_at_one h
     convert h_deriv.log (by simp) using 1
     simp
@@ -1183,17 +1497,20 @@ section additivity
 --TODO Cleanup. Ugh.
 
 /--
-If the kernels of the components are contained, then the kernel of the Kronecker product is contained.
+If the kernels of the components are contained, then the kernel of the Kronecker product is
+contained.
 -/
 lemma ker_kron_le_of_le {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [DecidableEq d₂]
     (A C : Matrix d₁ d₁ ℂ) (B D : Matrix d₂ d₂ ℂ)
     (hA : LinearMap.ker A.toEuclideanLin ≤ LinearMap.ker C.toEuclideanLin)
     (hB : LinearMap.ker B.toEuclideanLin ≤ LinearMap.ker D.toEuclideanLin) :
-    LinearMap.ker (A.kronecker B).toEuclideanLin ≤ LinearMap.ker (C.kronecker D).toEuclideanLin := by
+    LinearMap.ker (A.kronecker B).toEuclideanLin ≤
+      LinearMap.ker (C.kronecker D).toEuclideanLin := by
   intro x hx
   simp only [Matrix.kronecker, LinearMap.mem_ker, Matrix.toLpLin_apply,
     WithLp.toLp_eq_zero] at hx ⊢
-  -- By definition of Kronecker product, we know that $(A \otimes B)x = 0$ if and only if for all $i$ and $j$, $\sum_{k,l} A_{ik} B_{jl} x_{kl} = 0$.
+  -- By definition of Kronecker product, we know that $(A \otimes B)x = 0$ if and only if for all
+  -- $i$ and $j$, $\sum_{k,l} A_{ik} B_{jl} x_{kl} = 0$.
   have h_kronecker : ∀ i j, ∑ k, A i k • ∑ l, B j l • x (k, l) = 0 := by
     intro i j
     replace hx := congr_fun hx ( i, j )
@@ -1204,7 +1521,8 @@ lemma ker_kron_le_of_le {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [Decid
   -- Apply the hypothesis `hA` to each term in the sum.
   have h_apply_hA : ∀ i j, ∑ k, C i k • ∑ l, B j l • x (k, l) = 0 := by
     intro i j
-    specialize hA ( show (WithLp.toLp 2 ( fun k => ∑ l, B j l • x ( k, l ) )) ∈ LinearMap.ker ( Matrix.toEuclideanLin A ) from ?_ )
+    specialize hA ( show (WithLp.toLp 2 ( fun k => ∑ l, B j l • x ( k, l ) )) ∈
+      LinearMap.ker ( Matrix.toEuclideanLin A ) from ?_ )
     · simp_all only [smul_eq_mul, LinearMap.mem_ker]
       ext i_1 : 1
       simp_all only [PiLp.zero_apply]
@@ -1216,7 +1534,8 @@ lemma ker_kron_le_of_le {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [Decid
   have h_apply_hB : ∑ l, D j l • ∑ k, C i k • x (k, l) = 0 := by
     specialize hB
     simp_all only [funext_iff, Pi.zero_apply, Prod.forall, smul_eq_mul]
-    have := hB ( show  (WithLp.toLp 2 ( fun l => ∑ k, C i k * x ( k, l ) )) ∈ LinearMap.ker ( Matrix.toEuclideanLin B ) from ?_ )
+    have := hB ( show  (WithLp.toLp 2 ( fun l => ∑ k, C i k * x ( k, l ) )) ∈
+      LinearMap.ker ( Matrix.toEuclideanLin B ) from ?_ )
     · simp_all only [LinearMap.mem_ker] ;
       exact congr(WithLp.ofLp $this j)
     · ext j
@@ -1236,13 +1555,15 @@ lemma ker_kron_le_of_le {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [Decid
 
 --TODO: Generalize to arbitrary PSD matrices.
 /--
-If the kernel of a product state is contained in another, the left component kernel is contained.
+If the kernel of a product state is contained in another, the left component kernel is
+contained.
 -/
 lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂)
   (h : (σ₁ ⊗ᴹ σ₂).M.ker ≤ (ρ₁ ⊗ᴹ ρ₂).M.ker) :
     σ₁.M.ker ≤ ρ₁.M.ker := by
   intro u hu
-  obtain ⟨v, hv⟩ : ∃ v : EuclideanSpace ℂ d₂, v ∉ (σ₂ :HermitianMat d₂ ℂ).ker ∧ v ∉ (ρ₂ :HermitianMat d₂ ℂ).ker := by
+  obtain ⟨v, hv⟩ : ∃ v : EuclideanSpace ℂ d₂,
+      v ∉ (σ₂ :HermitianMat d₂ ℂ).ker ∧ v ∉ (ρ₂ :HermitianMat d₂ ℂ).ker := by
     have h_union : (σ₂ : HermitianMat d₂ ℂ).ker ≠ ⊤ ∧ (ρ₂ : HermitianMat d₂ ℂ).ker ≠ ⊤ := by
       constructor <;> intro h_top;
       · have h_contra : σ₂.M = 0 := by
@@ -1265,7 +1586,8 @@ lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSta
           simp [ HermitianMat.lin ];
           rfl
         exact ρ₂.pos.ne' h_contra;
-    have h_union : ∀ (U V : Submodule ℂ (EuclideanSpace ℂ d₂)), U ≠ ⊤ → V ≠ ⊤ → ∃ v : EuclideanSpace ℂ d₂, v ∉ U ∧ v ∉ V := by
+    have h_union : ∀ (U V : Submodule ℂ (EuclideanSpace ℂ d₂)), U ≠ ⊤ → V ≠ ⊤ →
+        ∃ v : EuclideanSpace ℂ d₂, v ∉ U ∧ v ∉ V := by
       intros U V hU hV;
       by_contra h_contra;
       have h_union : U ⊔ V = ⊤ := by
@@ -1283,10 +1605,12 @@ lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSta
         exact ⟨ h_union.choose, h_union.choose_spec.2, h_union.choose_spec.1 ⟩;
       obtain ⟨ v, hv₁, hv₂ ⟩ := h_union;
       obtain ⟨ w, hw₁, hw₂ ⟩ : ∃ w : EuclideanSpace ℂ d₂, w ∉ V ∧ w ∈ U := by
-        obtain ⟨ w, hw ⟩ := ( show ∃ w : EuclideanSpace ℂ d₂, w ∉ V from by simpa [ Submodule.eq_top_iff' ] using hV ) ; use w; simp_all [ Submodule.eq_top_iff' ] ;
+        obtain ⟨ w, hw ⟩ := ( show ∃ w : EuclideanSpace ℂ d₂, w ∉ V from by
+          simpa [ Submodule.eq_top_iff' ] using hV ) ; use w; simp_all [ Submodule.eq_top_iff' ] ;
         exact Classical.not_not.1 fun hw' => hw <| h_contra _ hw';
       have h_union : v + w ∉ U ∧ v + w ∉ V := by
-        exact ⟨ fun h => hv₁ <| by simpa using U.sub_mem h hw₂, fun h => hw₁ <| by simpa using V.sub_mem h hv₂ ⟩;
+        exact ⟨ fun h => hv₁ <| by simpa using U.sub_mem h hw₂,
+          fun h => hw₁ <| by simpa using V.sub_mem h hv₂ ⟩;
       exact h_contra ⟨ v + w, h_union.1, h_union.2 ⟩;
     exact h_union _ _ ( by tauto ) ( by tauto );
   -- Consider $z = u \otimes v$.
@@ -1294,8 +1618,11 @@ lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSta
   have hz : z ∈ (σ₁ ⊗ᴹ σ₂ : HermitianMat (d₁ × d₂) ℂ).ker := by
     ext ⟨i, j⟩
     simp [z]
-    have h_kronecker : ∀ (A : Matrix d₁ d₁ ℂ) (B : Matrix d₂ d₂ ℂ) (u : d₁ → ℂ) (v : d₂ → ℂ), (A.kronecker B).mulVec (fun p => u p.1 * v p.2) = fun p => (A.mulVec u) p.1 * (B.mulVec v) p.2 := by
-      intro A B u v; ext ⟨ i, j ⟩ ; simp [ Matrix.mulVec, dotProduct, Finset.mul_sum, mul_comm, mul_left_comm ] ;
+    have h_kronecker : ∀ (A : Matrix d₁ d₁ ℂ) (B : Matrix d₂ d₂ ℂ) (u : d₁ → ℂ) (v : d₂ → ℂ),
+        (A.kronecker B).mulVec (fun p => u p.1 * v p.2) =
+          fun p => (A.mulVec u) p.1 * (B.mulVec v) p.2 := by
+      intro A B u v; ext ⟨ i, j ⟩ ;
+      simp [ Matrix.mulVec, dotProduct, Finset.mul_sum, mul_comm, mul_left_comm ] ;
       exact Fintype.sum_prod_type_right fun x => A i x.1 * (B j x.2 * (u x.1 * v x.2));
     convert congr_fun ( h_kronecker σ₁.1.mat σ₂.1.mat u v ) ( i, j ) using 1 ; simp
     exact Or.inl ( by simpa [ Matrix.mulVec ] using congr(WithLp.ofLp $hu i) );
@@ -1303,7 +1630,8 @@ lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSta
     exact h hz;
   have hz'' : ∀ a b, (ρ₁.M.val.mulVec u) a * (ρ₂.M.val.mulVec v) b = 0 := by
     intro a b
-    have hz'' : (ρ₁.M.val.mulVec u) a * (ρ₂.M.val.mulVec v) b = ((ρ₁ ⊗ᴹ ρ₂ : HermitianMat (d₁ × d₂) ℂ).val.mulVec z) (a, b) := by
+    have hz'' : (ρ₁.M.val.mulVec u) a * (ρ₂.M.val.mulVec v) b =
+        ((ρ₁ ⊗ᴹ ρ₂ : HermitianMat (d₁ × d₂) ℂ).val.mulVec z) (a, b) := by
       simp [ Matrix.mulVec, dotProduct];
       simp [  Finset.sum_mul, mul_assoc, mul_comm];
       simp [ z, Finset.mul_sum, mul_assoc, mul_left_comm ];
@@ -1320,7 +1648,8 @@ lemma ker_le_of_ker_kron_le_left (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSta
 --TODO: Rewrite the proof using the `ker_le_of_ker_kron_le_left` lemma, and the fact that
 -- there's a unitary whose conjugation swaps the kronecker product.
 /--
-If the kernel of a product state is contained in another, the right component kernel is contained.
+If the kernel of a product state is contained in another, the right component kernel is
+contained.
 -/
 lemma ker_le_of_ker_kron_le_right (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂)
   (h : (σ₁ ⊗ᴹ σ₂).M.ker ≤ (ρ₁ ⊗ᴹ ρ₂).M.ker) :
@@ -1340,12 +1669,14 @@ lemma ker_le_of_ker_kron_le_right (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSt
         exact ρ.pos.ne' h_contra;
       exact ⟨ h_ker_ne_top σ₁, h_ker_ne_top ρ₁ ⟩;
     have h_z : ∃ u : EuclideanSpace ℂ d₁, u ∉ σ₁.M.ker ∧ u ∉ ρ₁.M.ker := by
-      have h_z : ∀ (U V : Submodule ℂ (EuclideanSpace ℂ d₁)), U ≠ ⊤ → V ≠ ⊤ → ∃ u : EuclideanSpace ℂ d₁, u ∉ U ∧ u ∉ V := by
+      have h_z : ∀ (U V : Submodule ℂ (EuclideanSpace ℂ d₁)), U ≠ ⊤ → V ≠ ⊤ →
+          ∃ u : EuclideanSpace ℂ d₁, u ∉ U ∧ u ∉ V := by
         intro U V hU hV
         by_contra h_contra
         push Not at h_contra;
         have h_union : ∃ u : EuclideanSpace ℂ d₁, u ∉ U ∧ u ∈ V := by
-          exact Exists.elim ( show ∃ u : EuclideanSpace ℂ d₁, u ∉ U from by simpa [ Submodule.eq_top_iff' ] using hU ) fun u hu => ⟨ u, hu, h_contra u hu ⟩;
+          exact Exists.elim ( show ∃ u : EuclideanSpace ℂ d₁, u ∉ U from by
+            simpa [ Submodule.eq_top_iff' ] using hU ) fun u hu => ⟨ u, hu, h_contra u hu ⟩;
         obtain ⟨ u, hu₁, hu₂ ⟩ := h_union;
         have h_union : ∀ v : EuclideanSpace ℂ d₁, v ∈ U → v + u ∈ V := by
           intro v hv; specialize h_contra ( v + u ) ; simp_all [ Submodule.add_mem_iff_right ] ;
@@ -1353,13 +1684,15 @@ lemma ker_le_of_ker_kron_le_right (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSt
           exact fun v hv => by simpa using V.sub_mem ( h_union v hv ) hu₂;
         exact hV ( eq_top_iff.mpr fun x hx => by by_cases hxU : x ∈ U <;> aesop );
       exact h_z _ _ ( by tauto ) ( by tauto );
-    exact ⟨ h_z.choose, by intro h; simpa [ h ] using h_z.choose_spec.1, h_z.choose_spec.1, h_z.choose_spec.2 ⟩;
+    exact ⟨ h_z.choose, by intro h; simpa [ h ] using h_z.choose_spec.1, h_z.choose_spec.1,
+      h_z.choose_spec.2 ⟩;
   obtain ⟨ u, hu₁, hu₂, hu₃ ⟩ := h_z;
   -- Consider the vector $z = u \otimes v$.
   set z : EuclideanSpace ℂ (d₁ × d₂) := .toLp 2 ( fun p => u p.1 * v p.2 );
   have hz : z ∈ (σ₁ ⊗ᴹ σ₂).M.ker := by
     -- By definition of $z$, we have $(σ₁ ⊗ σ₂).mat.mulVec z = σ₁.mat.mulVec u ⊗ σ₂.mat.mulVec v$.
-    have hz_mul : (σ₁ ⊗ᴹ σ₂).M.mat.mulVec z = fun p => (σ₁.M.mat.mulVec u) p.1 * (σ₂.M.mat.mulVec v) p.2 := by
+    have hz_mul : (σ₁ ⊗ᴹ σ₂).M.mat.mulVec z =
+        fun p => (σ₁.M.mat.mulVec u) p.1 * (σ₂.M.mat.mulVec v) p.2 := by
       ext p; simp [z, Matrix.mulVec]
       simp [ dotProduct, Finset.mul_sum, Finset.sum_mul, mul_assoc, mul_comm, mul_left_comm ];
       rw [ ← Finset.sum_product' ];
@@ -1376,7 +1709,8 @@ lemma ker_le_of_ker_kron_le_right (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSt
     exact h hz;
   have hz'' : ∀ i j, (ρ₁.M.val.mulVec u) i * (ρ₂.M.val.mulVec v) j = 0 := by
     intro i j;
-    have hz'' : (ρ₁.M.val.kronecker ρ₂.M.val).mulVec (fun p => u p.1 * v p.2) (i, j) = (ρ₁.M.val.mulVec u) i * (ρ₂.M.val.mulVec v) j := by
+    have hz'' : (ρ₁.M.val.kronecker ρ₂.M.val).mulVec (fun p => u p.1 * v p.2) (i, j) =
+        (ρ₁.M.val.mulVec u) i * (ρ₂.M.val.mulVec v) j := by
       simp [ Matrix.mulVec, dotProduct, Finset.mul_sum, mul_assoc, mul_comm, mul_left_comm ];
       simp [ mul_assoc, Finset.mul_sum, Finset.sum_mul ];
       rw [ ← Finset.sum_product' ];
@@ -1389,8 +1723,10 @@ lemma ker_le_of_ker_kron_le_right (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MSt
         ring_nf
     exact hz''.symm.trans ( by simpa using congr(WithLp.ofLp $hz' ( i, j )) );
   contrapose! hz'';
-  obtain ⟨ i, hi ⟩ := Function.ne_iff.mp ( show ρ₁.M.val.mulVec u ≠ 0 from fun h => hu₃ <| congr(WithLp.toLp 2 $h))
-  obtain ⟨ j, hj ⟩ := Function.ne_iff.mp ( show ρ₂.M.val.mulVec v ≠ 0 from fun h => hz'' <| congr(WithLp.toLp 2 $h))
+  obtain ⟨ i, hi ⟩ := Function.ne_iff.mp
+    ( show ρ₁.M.val.mulVec u ≠ 0 from fun h => hu₃ <| congr(WithLp.toLp 2 $h))
+  obtain ⟨ j, hj ⟩ := Function.ne_iff.mp
+    ( show ρ₂.M.val.mulVec v ≠ 0 from fun h => hz'' <| congr(WithLp.toLp 2 $h))
   use i, j
   aesop;
 
@@ -1407,10 +1743,13 @@ lemma ker_prod_le_iff (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂) :
 --TODO: Generalize to RCLike.
 omit [DecidableEq d₁] [DecidableEq d₂] in
 lemma HermitianMat.inner_kron
-    (A : HermitianMat d₁ ℂ) (B : HermitianMat d₂ ℂ) (C : HermitianMat d₁ ℂ) (D : HermitianMat d₂ ℂ) :
+    (A : HermitianMat d₁ ℂ) (B : HermitianMat d₂ ℂ) (C : HermitianMat d₁ ℂ)
+    (D : HermitianMat d₂ ℂ) :
     ⟪A ⊗ₖ B, C ⊗ₖ D⟫ = ⟪A, C⟫ * ⟪B, D⟫ := by
   -- Apply the property of the trace of Kronecker products.
-  have h_trace_kron : ∀ (A₁ B₁ : Matrix d₁ d₁ ℂ) (A₂ B₂ : Matrix d₂ d₂ ℂ), Matrix.trace (Matrix.kroneckerMap (· * ·) A₁ A₂ * Matrix.kroneckerMap (· * ·) B₁ B₂) = Matrix.trace (A₁ * B₁) * Matrix.trace (A₂ * B₂) := by
+  have h_trace_kron : ∀ (A₁ B₁ : Matrix d₁ d₁ ℂ) (A₂ B₂ : Matrix d₂ d₂ ℂ),
+      Matrix.trace (Matrix.kroneckerMap (· * ·) A₁ A₂ * Matrix.kroneckerMap (· * ·) B₁ B₂) =
+        Matrix.trace (A₁ * B₁) * Matrix.trace (A₂ * B₂) := by
     intro A₁ B₁ A₂ B₂
     rw [← Matrix.mul_kronecker_mul, Matrix.trace_kronecker]
   simp_all only [inner, IsMaximalSelfAdjoint.RCLike_selfadjMap, kronecker_mat, RCLike.mul_re,
@@ -1418,10 +1757,14 @@ lemma HermitianMat.inner_kron
   simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, mat_apply, Complex.im_sum,
     Complex.mul_im];
   left;
-  have h_symm : ∀ x x_1, (A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re = -((A x_1 x).re * (C x x_1).im + (A x_1 x).im * (C x x_1).re) := by
-    intro x y; have := congr_fun ( congr_fun A.2 y ) x; have := congr_fun ( congr_fun C.2 y ) x; simp_all [ Complex.ext_iff ] ;
+  have h_symm : ∀ x x_1, (A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re =
+      -((A x_1 x).re * (C x x_1).im + (A x_1 x).im * (C x x_1).re) := by
+    intro x y; have := congr_fun ( congr_fun A.2 y ) x; have := congr_fun ( congr_fun C.2 y ) x;
+    simp_all [ Complex.ext_iff ] ;
     grind;
-  have h_sum_zero : ∑ x, ∑ x_1, ((A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re) = ∑ x, ∑ x_1, -((A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re) := by
+  have h_sum_zero :
+      ∑ x, ∑ x_1, ((A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re) =
+        ∑ x, ∑ x_1, -((A x x_1).re * (C x_1 x).im + (A x x_1).im * (C x_1 x).re) := by
     rw [ Finset.sum_comm ];
     exact Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => h_symm _ _ ▸ rfl;
   norm_num [ Finset.sum_add_distrib ] at * ; linarith
@@ -1436,7 +1779,8 @@ lemma continuousOn_rpow_uniform {K : Set ℝ} (hK : IsCompact K) :
   simp only [Set.mem_singleton_iff, UniformOnFun.toFun_ofFun, Metric.tendstoUniformlyOn_iff,
     Function.comp_apply, forall_eq]
   intro ε hεpos;
-  have h_unif_cont : UniformContinuousOn (fun (p : ℝ × ℝ) => p.1 ^ p.2) (K ×ˢ Set.Icc (r / 2) (r * 2)) := by
+  have h_unif_cont : UniformContinuousOn (fun (p : ℝ × ℝ) => p.1 ^ p.2)
+      (K ×ˢ Set.Icc (r / 2) (r * 2)) := by
     apply IsCompact.uniformContinuousOn_of_continuous
     · exact hK.prod CompactIccSpace.isCompact_Icc
     · refine continuousOn_of_forall_continuousAt fun p ⟨hp₁, ⟨hp₂₁, hp₂₂⟩⟩ ↦ ?_
@@ -1444,7 +1788,9 @@ lemma continuousOn_rpow_uniform {K : Set ℝ} (hK : IsCompact K) :
       fun_prop (disch := assumption)
   rw [Metric.uniformContinuousOn_iff] at h_unif_cont
   obtain ⟨δ, hδpos, H⟩ := h_unif_cont ε hεpos
-  filter_upwards [Ioo_mem_nhds (show r / 2 < r by linarith) (show r < r * 2 by linarith), Ioo_mem_nhds (show r - δ < r by linarith) (show r < r + δ by linarith)] with n ⟨_, _⟩ ⟨_, _⟩ x hx
+  filter_upwards [Ioo_mem_nhds (show r / 2 < r by linarith) (show r < r * 2 by linarith),
+    Ioo_mem_nhds (show r - δ < r by linarith) (show r < r + δ by linarith)]
+    with n ⟨_, _⟩ ⟨_, _⟩ x hx
   refine H (x, r) ⟨hx, ?_⟩ (x, n) ⟨hx, ?_⟩ ?_
   · constructor <;> linarith
   · constructor <;> linarith
@@ -1455,9 +1801,12 @@ theorem sandwichedRelRentropy_additive_alpha_one_aux (ρ₁ σ₁ : MState d₁)
   (h1 : σ₁.M.ker ≤ ρ₁.M.ker) (h2 : σ₂.M.ker ≤ ρ₂.M.ker) :
     ⟪(ρ₁ ⊗ᴹ ρ₂).M, (ρ₁ ⊗ᴹ ρ₂).M.log - (σ₁ ⊗ᴹ σ₂).M.log⟫ =
     ⟪ρ₁.M, ρ₁.M.log - σ₁.M.log⟫_ℝ + ⟪ρ₂.M, ρ₂.M.log - σ₂.M.log⟫ := by
-  have h_log_kron : (ρ₁ ⊗ᴹ ρ₂).M.log = ρ₁.M.log ⊗ₖ ρ₂.M.supportProj + ρ₁.M.supportProj ⊗ₖ ρ₂.M.log ∧ (σ₁ ⊗ᴹ σ₂).M.log = σ₁.M.log ⊗ₖ σ₂.M.supportProj + σ₁.M.supportProj ⊗ₖ σ₂.M.log := by
+  have h_log_kron :
+      (ρ₁ ⊗ᴹ ρ₂).M.log = ρ₁.M.log ⊗ₖ ρ₂.M.supportProj + ρ₁.M.supportProj ⊗ₖ ρ₂.M.log ∧
+      (σ₁ ⊗ᴹ σ₂).M.log = σ₁.M.log ⊗ₖ σ₂.M.supportProj + σ₁.M.supportProj ⊗ₖ σ₂.M.log := by
     constructor <;> apply HermitianMat.log_kron_with_proj;
-  have h_inner_supportProj : ∀ (A : HermitianMat d₁ ℂ) (B : HermitianMat d₂ ℂ), ⟪A ⊗ₖ B, ρ₁ ⊗ᴹ ρ₂⟫ = ⟪A, ρ₁⟫ * ⟪B, ρ₂⟫ := by
+  have h_inner_supportProj : ∀ (A : HermitianMat d₁ ℂ) (B : HermitianMat d₂ ℂ),
+      ⟪A ⊗ₖ B, ρ₁ ⊗ᴹ ρ₂⟫ = ⟪A, ρ₁⟫ * ⟪B, ρ₂⟫ := by
     exact fun A B => HermitianMat.inner_kron A B ρ₁ ρ₂;
   simp only [HermitianMat.ker] at h1 h2
   simp_all only [inner_sub_right, inner_add_right, real_inner_comm,
@@ -1465,9 +1814,12 @@ theorem sandwichedRelRentropy_additive_alpha_one_aux (ρ₁ σ₁ : MState d₁)
     HermitianMat.inner_supportProj_of_ker_le]
   abel
 
-/-- The Sandwiched Renyi Relative Entropy, defined with ln (nits). Note that at `α = 1` this definition
-  switch to the standard Relative Entropy, for continuity. For α ≤ 0, this gives junk value 0. (There
-  is no conventional value for α < 0; there is a continuous limit at α = 0, but it is complicated and
+/-- The Sandwiched Renyi Relative Entropy, defined with ln (nits). Note that at `α = 1` this
+  definition
+  switch to the standard Relative Entropy, for continuity. For α ≤ 0, this gives junk value 0.
+  (There
+  is no conventional value for α < 0; there is a continuous limit at α = 0, but it is complicated
+  and
   unneeded at the moment.)-/
 def SandwichedRelRentropy (α : ℝ) (ρ σ : MState d) : ENNReal :=
   open Classical in
@@ -1528,21 +1880,28 @@ lemma sandwiched_term_product (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState 
 /-
 The Sandwiched Renyi Relative entropy is additive for alpha != 1.
 -/
-theorem sandwichedRelRentropy_additive_alpha_ne_one {α : ℝ} (hα : α ≠ 1) (ρ₁ σ₁ : MState d₁) (ρ₂ σ₂ : MState d₂) :
+theorem sandwichedRelRentropy_additive_alpha_ne_one {α : ℝ} (hα : α ≠ 1) (ρ₁ σ₁ : MState d₁)
+    (ρ₂ σ₂ : MState d₂) :
     D̃_ α(ρ₁ ⊗ᴹ ρ₂‖σ₁ ⊗ᴹ σ₂) = D̃_ α(ρ₁‖σ₁) + D̃_ α(ρ₂‖σ₂) := by
   by_cases hα0 : 0 < α; swap
   · simp [SandwichedRelRentropy, hα0]
   by_cases h_ker : σ₁.M.ker ≤ ρ₁.M.ker ∧ σ₂.M.ker ≤ ρ₂.M.ker
   · simp_all [SandwichedRelRentropy]
-    -- Apply the additivity of the trace term to split the logarithm into the sum of the logarithms.
-    have h_trace_add : Real.log ((ρ₁ ⊗ᴹ ρ₂).M.conj ((σ₁ ⊗ᴹ σ₂).M ^ ((1 - α) / (2 * α))).mat ^ α).trace = Real.log ((ρ₁.M.conj (σ₁.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace + Real.log ((ρ₂.M.conj (σ₂.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace := by
+    -- Apply the additivity of the trace term to split the logarithm into the sum of the
+    -- logarithms.
+    have h_trace_add :
+        Real.log ((ρ₁ ⊗ᴹ ρ₂).M.conj ((σ₁ ⊗ᴹ σ₂).M ^ ((1 - α) / (2 * α))).mat ^ α).trace =
+          Real.log ((ρ₁.M.conj (σ₁.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace +
+          Real.log ((ρ₂.M.conj (σ₂.M ^ ((1 - α) / (2 * α))).mat) ^ α).trace := by
       rw [ sandwiched_term_product, Real.log_mul ];
       · exact (sandwiched_trace_pos h_ker.1).ne'
       · exact (sandwiched_trace_pos h_ker.2).ne'
     split_ifs <;> simp_all
     · norm_num [ add_div ];
       exact rfl;
-    · exact False.elim ( ‹¬ ( σ₁ ⊗ᴹ σ₂ |> MState.M |> HermitianMat.ker ) ≤ ( ρ₁ ⊗ᴹ ρ₂ |> MState.M |> HermitianMat.ker ) › ( by simpa [ HermitianMat.ker ] using ker_prod_le_iff _ _ _ _ |>.2 h_ker ) );
+    · exact False.elim ( ‹¬ ( σ₁ ⊗ᴹ σ₂ |> MState.M |> HermitianMat.ker ) ≤
+        ( ρ₁ ⊗ᴹ ρ₂ |> MState.M |> HermitianMat.ker ) ›
+        ( by simpa [ HermitianMat.ker ] using ker_prod_le_iff _ _ _ _ |>.2 h_ker ) );
   · have h_ker_prod : ¬((σ₁ ⊗ᴹ σ₂).M.ker ≤ (ρ₁ ⊗ᴹ ρ₂).M.ker) := by
       simp_all  [ ker_prod_le_iff ]
     rw [not_and_or] at h_ker
@@ -1622,7 +1981,8 @@ lemma Complex.continuousOn_cpow_const_Ioi (z : ℂ) :
 /--
 The function α ↦ (1 - α) / (2 * α) maps the interval (1, ∞) to (-∞, 0).
 -/
-lemma maps_to_Iio_of_Ioi_1 : Set.MapsTo (fun α : ℝ => (1 - α) / (2 * α)) (Set.Ioi 1) (Set.Iio 0) := by
+lemma maps_to_Iio_of_Ioi_1 :
+    Set.MapsTo (fun α : ℝ => (1 - α) / (2 * α)) (Set.Ioi 1) (Set.Iio 0) := by
   intro x hx
   rw [Set.mem_Ioi] at hx
   rw [Set.mem_Iio]
@@ -1637,15 +1997,20 @@ theorem frontier_singleton {X : Type*} [TopologicalSpace X] [T1Space X] [Perfect
   simp [frontier]
 
 private theorem sandwichedRelRentropy.continuousOn_Ioi_1_aux (ρ σ : MState d) :
-    ContinuousOn (fun (α : ℝ) ↦ ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α)) (Set.Ioi 1) := by
-  have h_cont : ContinuousOn (fun α : ℝ => (HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M) (Set.Ioi 1) := by
+    ContinuousOn (fun (α : ℝ) ↦ ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α))
+      (Set.Ioi 1) := by
+  have h_cont : ContinuousOn (fun α : ℝ => (HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M)
+      (Set.Ioi 1) := by
     have h_cont : ContinuousOn (fun α : ℝ => (σ.M ^ ((1 - α) / (2 * α))).mat) (Set.Ioi 1) := by
       have h_cont : ContinuousOn (fun α : ℝ => σ.M ^ ((1 - α) / (2 * α))) (Set.Ioi 1) := by
         have h_cont : ContinuousOn (fun α : ℝ => (1 - α) / (2 * α)) (Set.Ioi 1) := by
-          exact continuousOn_of_forall_continuousAt fun x hx => ContinuousAt.div ( continuousAt_const.sub continuousAt_id ) ( continuousAt_const.mul continuousAt_id ) ( by linarith [ hx.out ] )
+          exact continuousOn_of_forall_continuousAt fun x hx => ContinuousAt.div
+            ( continuousAt_const.sub continuousAt_id ) ( continuousAt_const.mul continuousAt_id )
+            ( by linarith [ hx.out ] )
         have h_cont : ContinuousOn (fun α : ℝ => (σ.M ^ α)) (Set.Iio 0) := by
           apply_rules [ HermitianMat.continuousOn_rpow_neg ];
-        exact h_cont.comp ‹_› fun x hx => by rw [ Set.mem_Iio ] ; rw [ div_lt_iff₀ ] <;> linarith [ hx.out ] ;
+        exact h_cont.comp ‹_› fun x hx => by rw [ Set.mem_Iio ] ;
+          rw [ div_lt_iff₀ ] <;> linarith [ hx.out ] ;
       exact Continuous.comp_continuousOn ( by continuity ) h_cont;
     fun_prop;
   -- Apply the lemma HermitianMat.continuousOn_rpow_joint_nonneg_pos with the given conditions.
@@ -1684,15 +2049,20 @@ private theorem sandwichedRelRentropy.continuousOn_Ioi_1 (ρ σ : MState d) :
       grind only [→ Set.EqOn.eq_of_mem, = Set.mem_Ioi, Set.EqOn, cases Or]
 
 private theorem sandwichedRelRentropy.continuousOn_Ioo_0_1_aux (ρ σ : MState d) :
-    ContinuousOn (fun (α : ℝ) ↦ ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α)) (Set.Ioo 0 1) := by
-  have h_cont : ContinuousOn (fun α : ℝ => (HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M) (Set.Ioo 0 1) := by
+    ContinuousOn (fun (α : ℝ) ↦ ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α))
+      (Set.Ioo 0 1) := by
+  have h_cont : ContinuousOn (fun α : ℝ => (HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M)
+      (Set.Ioo 0 1) := by
     have h_cont : ContinuousOn (fun α : ℝ => (σ.M ^ ((1 - α) / (2 * α))).mat) (Set.Ioo 0 1) := by
       have h_cont : ContinuousOn (fun α : ℝ => σ.M ^ ((1 - α) / (2 * α))) (Set.Ioo 0 1) := by
         have h_exp_cont : ContinuousOn (fun α : ℝ => (1 - α) / (2 * α)) (Set.Ioo 0 1) := by
-          exact continuousOn_of_forall_continuousAt fun x hx => ContinuousAt.div ( continuousAt_const.sub continuousAt_id ) ( continuousAt_const.mul continuousAt_id ) ( by linarith [ hx.1 ] )
+          exact continuousOn_of_forall_continuousAt fun x hx => ContinuousAt.div
+            ( continuousAt_const.sub continuousAt_id ) ( continuousAt_const.mul continuousAt_id )
+            ( by linarith [ hx.1 ] )
         have h_rpow_cont : ContinuousOn (fun α : ℝ => (σ.M ^ α)) (Set.Ioi 0) := by
           apply_rules [ HermitianMat.continuousOn_rpow_pos ]
-        exact h_rpow_cont.comp h_exp_cont fun x hx => by rw [ Set.mem_Ioi ] ; apply div_pos <;> linarith [ hx.1, hx.2 ]
+        exact h_rpow_cont.comp h_exp_cont fun x hx => by rw [ Set.mem_Ioi ] ;
+          apply div_pos <;> linarith [ hx.1, hx.2 ]
       exact Continuous.comp_continuousOn ( by continuity ) h_cont
     fun_prop
   apply HermitianMat.continuousOn_rpow_joint_nonneg_pos
@@ -1736,8 +2106,14 @@ private theorem sandwichedRelRentropy.continuousAt_1 (ρ σ : MState d) :
   by_cases h : σ.M.ker ≤ ρ.M.ker
   · simp only [ContinuousWithinAt, SandwichedRelRentropy, dif_pos h, zero_lt_one, if_true]
     -- Use the fact that the limit of the real-valued function is the inner product.
-    have h_real_limit : Filter.Tendsto (fun α : ℝ => if α = 1 then ⟪ρ.M, ρ.M.log - σ.M.log⟫ else Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1)) (nhdsWithin 1 (Set.Ioi 0)) (nhds ⟪ρ.M, ρ.M.log - σ.M.log⟫) := by
-      have h_real_limit : Filter.Tendsto (fun α : ℝ => Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1)) (nhdsWithin 1 (Set.Ioi 0 \ {1})) (nhds ⟪ρ.M, ρ.M.log - σ.M.log⟫) := by
+    have h_real_limit : Filter.Tendsto
+        (fun α : ℝ => if α = 1 then ⟪ρ.M, ρ.M.log - σ.M.log⟫ else
+          Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1))
+        (nhdsWithin 1 (Set.Ioi 0)) (nhds ⟪ρ.M, ρ.M.log - σ.M.log⟫) := by
+      have h_real_limit : Filter.Tendsto
+          (fun α : ℝ =>
+            Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1))
+          (nhdsWithin 1 (Set.Ioi 0 \ {1})) (nhds ⟪ρ.M, ρ.M.log - σ.M.log⟫) := by
         exact sandwichedRelRentropy.limit_at_one ρ σ h
       rw [ Metric.tendsto_nhdsWithin_nhds ] at *
       intro ε hε
@@ -1745,8 +2121,12 @@ private theorem sandwichedRelRentropy.continuousAt_1 (ρ σ : MState d) :
       use δ, hδ
       intro x hx₁ hx₂
       by_cases hx₃ : x = 1 <;> simp [*]
-    -- Since the real-valued function tends to the inner product, the ENNReal version should also tend to the same limit because the ENNReal conversion is continuous.
-    have h_ennreal_limit : Filter.Tendsto (fun α : ℝ => ENNReal.ofReal (if α = 1 then ⟪ρ.M, ρ.M.log - σ.M.log⟫ else Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1))) (nhdsWithin 1 (Set.Ioi 0)) (nhds (ENNReal.ofReal ⟪ρ.M, ρ.M.log - σ.M.log⟫)) := by
+    -- Since the real-valued function tends to the inner product, the ENNReal version should also
+    -- tend to the same limit because the ENNReal conversion is continuous.
+    have h_ennreal_limit : Filter.Tendsto
+        (fun α : ℝ => ENNReal.ofReal (if α = 1 then ⟪ρ.M, ρ.M.log - σ.M.log⟫ else
+          Real.log ((HermitianMat.conj (σ.M ^ ((1 - α) / (2 * α))).mat) ρ.M ^ α).trace / (α - 1)))
+        (nhdsWithin 1 (Set.Ioi 0)) (nhds (ENNReal.ofReal ⟪ρ.M, ρ.M.log - σ.M.log⟫)) := by
       exact (ENNReal.tendsto_ofReal h_real_limit).comp Filter.tendsto_id
     convert h_ennreal_limit.congr' _ using 2
     · symm
@@ -1810,9 +2190,12 @@ theorem sandwichedRelRentropy_heq_congr
       {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
       {ρ₁ σ₁ : MState d₁} {ρ₂ σ₂ : MState d₂} (hd : d₁ = d₂) (hρ : ρ₁ ≍ ρ₂) (hσ : σ₁ ≍ σ₂) :
     D̃_ α(ρ₁‖σ₁) = D̃_ α(ρ₂‖σ₂) := by
-  --Why does this thm need to exist? Why not just `subst d₁` and `simp [heq_eq_eq]`? Well, even though d₁
-  --and d₂ are equal, we then end up with two distinct instances of `Fintype d₁` and `DecidableEq d₁`,
-  --and ρ₁ and ρ₂ refer to them each and so have different types. And then we'd need to `subst` those away
+  --Why does this thm need to exist? Why not just `subst d₁` and `simp [heq_eq_eq]`? Well, even
+  --though d₁
+  --and d₂ are equal, we then end up with two distinct instances of `Fintype d₁` and
+  --`DecidableEq d₁`,
+  --and ρ₁ and ρ₂ refer to them each and so have different types. And then we'd need to `subst`
+  --those away
   --too. This is kind of tedious, so it's better to just have this theorem around.
   rw [heq_iff_exists_eq_cast] at hρ hσ
   obtain ⟨_, rfl⟩ := hρ
@@ -1829,7 +2212,8 @@ theorem sandwichedRelRentropy_congr {α : ℝ}
   simp
 
 @[gcongr]
-theorem qRelEntropy_heq_congr {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+theorem qRelEntropy_heq_congr {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+      [DecidableEq d₂]
       {ρ₁ σ₁ : MState d₁} {ρ₂ σ₂ : MState d₂} (hd : d₁ = d₂) (hρ : ρ₁ ≍ ρ₂) (hσ : σ₁ ≍ σ₂) :
     𝐃(ρ₁‖σ₁) = 𝐃(ρ₂‖σ₂) := by
   exact sandwichedRelRentropy_heq_congr hd hρ hσ
@@ -1869,12 +2253,15 @@ private lemma approxLog_tendsto_at_pos {t : ℝ} (ht : 0 < t) :
   refine' Filter.Tendsto.congr' _ tendsto_const_nhds
   filter_upwards [Filter.eventually_gt_atTop ⌈-Real.log t⌉₊] with N hN
   unfold approxLog
-  rw [max_eq_left (by rw [← Real.log_le_log_iff (by positivity) (by positivity)]; linarith [Nat.le_ceil (-Real.log t), show (N : ℝ) ≥ ⌈-Real.log t⌉₊ + 1 by exact_mod_cast hN, Real.log_exp (-N)])]
+  rw [max_eq_left (by rw [← Real.log_le_log_iff (by positivity) (by positivity)];
+    linarith [Nat.le_ceil (-Real.log t),
+      show (N : ℝ) ≥ ⌈-Real.log t⌉₊ + 1 by exact_mod_cast hN, Real.log_exp (-N)])]
 
 open ComplexOrder in
 private lemma inner_cfc_approxLog_ge (ρ σ : MState d) (N : ℕ) (hσ : σ.M.ker ≤ ρ.M.ker) :
     ⟪ρ.M, σ.M.log⟫ ≤ ⟪ρ.M, σ.M.cfc (approxLog N)⟫ := by
-  rw [inner_cfc_eq_sum_eigenWeight, show σ.M.log = σ.M.cfc Real.log from rfl, inner_cfc_eq_sum_eigenWeight]
+  rw [inner_cfc_eq_sum_eigenWeight, show σ.M.log = σ.M.cfc Real.log from rfl,
+    inner_cfc_eq_sum_eigenWeight]
   apply Finset.sum_le_sum
   intro i _
   have hpsd : σ.M.mat.PosSemidef := by
@@ -1929,15 +2316,20 @@ private lemma eigenWeight_eq_zero_iff (ρ x : MState d) (i : d) :
   have h_forward : eigenWeight ρ x i = 0 → (x.M.H.eigenvectorBasis i) ∈ ρ.M.ker := by
     unfold eigenWeight
     intro h_zero
-    have h_inner : star (x.M.H.eigenvectorBasis i : d → ℂ) ⬝ᵥ (ρ.M.mat.mulVec (x.M.H.eigenvectorBasis i : d → ℂ)) = 0 := by
+    have h_inner : star (x.M.H.eigenvectorBasis i : d → ℂ) ⬝ᵥ
+        (ρ.M.mat.mulVec (x.M.H.eigenvectorBasis i : d → ℂ)) = 0 := by
       convert h_zero using 1
-      have h_real : ∀ (v : d → ℂ), star v ⬝ᵥ (ρ.M.mat.mulVec v) = star (star v ⬝ᵥ (ρ.M.mat.mulVec v)) := by
+      have h_real : ∀ (v : d → ℂ),
+          star v ⬝ᵥ (ρ.M.mat.mulVec v) = star (star v ⬝ᵥ (ρ.M.mat.mulVec v)) := by
         intro v
         have h_real : star v ⬝ᵥ (ρ.M.mat.mulVec v) = star (star v ⬝ᵥ (ρ.M.mat.mulVec v)) := by
-          have h_inner : ∀ (v w : d → ℂ), star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
+          have h_inner : ∀ (v w : d → ℂ),
+              star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
             intro v w
-            have h_inner : star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
-              have h_inner : star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
+            have h_inner :
+                star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
+              have h_inner :
+                  star v ⬝ᵥ (ρ.M.mat.mulVec w) = star (star w ⬝ᵥ (ρ.M.mat.mulVec v)) := by
                 have h_inner : ρ.M.mat = star ρ.M.mat := by
                   exact ρ.M.2.symm ▸ rfl
                 conv_rhs => rw [ h_inner ]
@@ -1949,14 +2341,16 @@ private lemma eigenWeight_eq_zero_iff (ρ x : MState d) (i : d) :
             exact h_inner
           exact h_inner v v ▸ by simp [ Matrix.mulVec, dotProduct ] ;
         exact h_real.trans ( by simp [] )
-      have h_real : ∀ (v : d → ℂ), star v ⬝ᵥ (ρ.M.mat.mulVec v) = RCLike.re (star v ⬝ᵥ (ρ.M.mat.mulVec v)) := by
+      have h_real : ∀ (v : d → ℂ),
+          star v ⬝ᵥ (ρ.M.mat.mulVec v) = RCLike.re (star v ⬝ᵥ (ρ.M.mat.mulVec v)) := by
         intro v; specialize h_real v; rw [ eq_comm ] at h_real; simp_all [ Complex.ext_iff ] ;
         linarith! [ h_real ] ;
       rw [ h_real ] ; norm_cast; simp [Matrix.dotProduct_mulVec ]
     exact HermitianMat.mem_ker_of_inner_mulVec_zero ρ.2 _ h_inner
   refine ⟨h_forward, fun h ↦ ?_⟩
   -- Since ρ e_i = 0, we have e_i^* ρ e_i = 0.
-  have h_zero : (Matrix.vecMul (star (x.M.H.eigenvectorBasis i : d → ℂ)) ρ.M.mat) ⬝ᵥ (x.M.H.eigenvectorBasis i : d → ℂ) = 0 := by
+  have h_zero : (Matrix.vecMul (star (x.M.H.eigenvectorBasis i : d → ℂ)) ρ.M.mat) ⬝ᵥ
+      (x.M.H.eigenvectorBasis i : d → ℂ) = 0 := by
     have h_zero : ρ.M.mat.mulVec (x.M.H.eigenvectorBasis i : d → ℂ) = 0 := by
       exact congr(WithLp.ofLp $h)
     convert congr_arg ( fun v => star ( x.M.H.eigenvectorBasis i : d → ℂ ) ⬝ᵥ v ) h_zero using 1
@@ -1973,16 +2367,20 @@ private lemma ker_le_iff_eigenWeight_zero (ρ x : MState d) :
   · intro h v hv
     obtain ⟨w, hw⟩ : ∃ w : d → ℂ, v = ∑ i, w i • x.M.H.eigenvectorBasis i := by
       exact ⟨ _, Eq.symm ( x.M.H.eigenvectorBasis.sum_repr v ) ⟩;
-    -- Since $v \in \ker(x.M)$, we have $x.M(v) = 0$. Using the eigenvector basis, this implies that for each $i$, if the eigenvalue is non-zero, then $w i = 0$.
+    -- Since $v \in \ker(x.M)$, we have $x.M(v) = 0$. Using the eigenvector basis, this implies that
+    -- for each $i$, if the eigenvalue is non-zero, then $w i = 0$.
     have h_w_zero : ∀ i, x.M.H.eigenvalues i ≠ 0 → w i = 0 := by
       intro i hi
-      have h_eigenvalue : x.M.val.mulVec v = ∑ i, (x.M.H.eigenvalues i) • w i • x.M.H.eigenvectorBasis i := by
-        have h_eigenvalue : ∀ i, x.M.val.mulVec (x.M.H.eigenvectorBasis i) = x.M.H.eigenvalues i • x.M.H.eigenvectorBasis i := by
+      have h_eigenvalue :
+          x.M.val.mulVec v = ∑ i, (x.M.H.eigenvalues i) • w i • x.M.H.eigenvectorBasis i := by
+        have h_eigenvalue : ∀ i, x.M.val.mulVec (x.M.H.eigenvectorBasis i) =
+            x.M.H.eigenvalues i • x.M.H.eigenvectorBasis i := by
           exact fun i => x.M.H.mulVec_eigenvectorBasis i |> fun h => by simpa [ mul_comm ] using h;
         rw [ hw]
         simp only [WithLp.ofLp_sum, WithLp.ofLp_smul]
         rw [Matrix.mulVec_sum ];
-        exact Finset.sum_congr rfl fun i _ => by rw [ Matrix.mulVec_smul, h_eigenvalue i, SMulCommClass.smul_comm ]
+        exact Finset.sum_congr rfl fun i _ => by
+          rw [ Matrix.mulVec_smul, h_eigenvalue i, SMulCommClass.smul_comm ]
       have h_eigenvalue_zero : ∑ i, (x.M.H.eigenvalues i) • w i • x.M.H.eigenvectorBasis i = 0 := by
         replace h_eigenvalue := congr(WithLp.toLp 2 $h_eigenvalue)
         simp only [HermitianMat.val_eq_coe, MState.mat_M, WithLp.ofLp_sum, WithLp.ofLp_smul,
@@ -1991,52 +2389,86 @@ private lemma ker_le_iff_eigenWeight_zero (ρ x : MState d) :
         rfl
       have h_eigenvalue_zero : ∀ i, (x.M.H.eigenvalues i) • w i = 0 := by
         intro i
-        have h_eigenvalue_zero : (x.M.H.eigenvalues i) • w i = inner ℂ (x.M.H.eigenvectorBasis i) (∑ j, (x.M.H.eigenvalues j) • w j • x.M.H.eigenvectorBasis j) := by
-          simp [ orthonormal_iff_ite.mp ( show Orthonormal ℂ ( fun i => x.M.H.eigenvectorBasis i ) from ?_ ) ]
+        have h_eigenvalue_zero : (x.M.H.eigenvalues i) • w i = inner ℂ (x.M.H.eigenvectorBasis i)
+            (∑ j, (x.M.H.eigenvalues j) • w j • x.M.H.eigenvectorBasis j) := by
+          simp [ orthonormal_iff_ite.mp
+            ( show Orthonormal ℂ ( fun i => x.M.H.eigenvectorBasis i ) from ?_ ) ]
         aesop
       simpa [ hi ] using h_eigenvalue_zero i |> fun h => by simpa [ hi ] using h;
     simp_all [ eigenWeight_eq_zero_iff ];
-    exact Submodule.sum_mem _ fun i _ => if hi : x.M.H.eigenvalues i = 0 then by simpa [ hi, h_w_zero i ] using Submodule.smul_mem _ ( w i ) ( h i hi ) else by simp [ h_w_zero i hi ] ;
+    exact Submodule.sum_mem _ fun i _ =>
+      if hi : x.M.H.eigenvalues i = 0 then by
+        simpa [ hi, h_w_zero i ] using Submodule.smul_mem _ ( w i ) ( h i hi )
+      else by simp [ h_w_zero i hi ] ;
 
 private lemma neg_ker_exists_eigenWeight_pos (ρ x : MState d) (hx : ¬(x.M.ker ≤ ρ.M.ker)) :
     ∃ i, x.M.H.eigenvalues i = 0 ∧ 0 < eigenWeight ρ x i := by
-  -- By `ker_le_iff_eigenWeight_zero`, ¬(x.M.ker ≤ ρ.M.ker) iff ∃ i, eigenvalue_i = 0 ∧ eigenWeight ≠ 0. Use this fact.
+  -- By `ker_le_iff_eigenWeight_zero`, ¬(x.M.ker ≤ ρ.M.ker) iff ∃ i, eigenvalue_i = 0 ∧
+  -- eigenWeight ≠ 0. Use this fact.
   have h_eigenWeight_ne_zero : ∃ i, x.M.H.eigenvalues i = 0 ∧ eigenWeight ρ x i ≠ 0 := by
-    exact Classical.not_forall_not.1 fun h => hx <| by simpa using ker_le_iff_eigenWeight_zero ρ x |>.2 fun i hi => Classical.not_not.1 fun hi' => h i ⟨ hi, hi' ⟩ ;
-  exact h_eigenWeight_ne_zero.imp fun i hi => ⟨ hi.1, lt_of_le_of_ne ( eigenWeight_nonneg ρ x i ) hi.2.symm ⟩
+    exact Classical.not_forall_not.1 fun h => hx <| by simpa using
+      ker_le_iff_eigenWeight_zero ρ x |>.2 fun i hi =>
+      Classical.not_not.1 fun hi' => h i ⟨ hi, hi' ⟩ ;
+  exact h_eigenWeight_ne_zero.imp fun i hi =>
+    ⟨ hi.1, lt_of_le_of_ne ( eigenWeight_nonneg ρ x i ) hi.2.symm ⟩
 
 private lemma approxLog_at_zero (N : ℕ) : approxLog N 0 = -(N : ℝ) := by
   simp [approxLog, max_eq_right (Real.exp_pos (-N)).le]
 
 private lemma inner_cfc_approxLog_tendsto_bot (ρ x : MState d) (hx : ¬(x.M.ker ≤ ρ.M.ker)) :
     Filter.Tendsto (fun N : ℕ => ⟪ρ.M, x.M.cfc (approxLog N)⟫) Filter.atTop Filter.atBot := by
-  have h_split_sum : Filter.Tendsto (fun N : ℕ => ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0), approxLog N (x.M.H.eigenvalues i) * eigenWeight ρ x i) Filter.atTop Filter.atBot := by
-    have h_split_sum : Filter.Tendsto (fun N : ℕ => ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0), (-↑N) * eigenWeight ρ x i) Filter.atTop Filter.atBot := by
-      have h_split_sum : ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0), eigenWeight ρ x i > 0 := by
-        obtain ⟨ i, hi, hi' ⟩ := neg_ker_exists_eigenWeight_pos ρ x hx; exact lt_of_lt_of_le hi' ( Finset.single_le_sum ( fun i _ => eigenWeight_nonneg ρ x i ) ( by aesop ) ) ;
+  have h_split_sum : Filter.Tendsto
+      (fun N : ℕ => ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0),
+        approxLog N (x.M.H.eigenvalues i) * eigenWeight ρ x i) Filter.atTop Filter.atBot := by
+    have h_split_sum : Filter.Tendsto
+        (fun N : ℕ => ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0),
+          (-↑N) * eigenWeight ρ x i) Filter.atTop Filter.atBot := by
+      have h_split_sum :
+          ∑ i ∈ Finset.univ.filter (fun i => x.M.H.eigenvalues i = 0), eigenWeight ρ x i > 0 := by
+        obtain ⟨ i, hi, hi' ⟩ := neg_ker_exists_eigenWeight_pos ρ x hx;
+        exact lt_of_lt_of_le hi'
+          ( Finset.single_le_sum ( fun i _ => eigenWeight_nonneg ρ x i ) ( by aesop ) ) ;
       simp only [neg_mul];
-      simpa only [ Finset.sum_neg_distrib, Finset.mul_sum _ _ _ ] using Filter.tendsto_neg_atTop_atBot.comp ( tendsto_natCast_atTop_atTop.atTop_mul_const h_split_sum );
+      simpa only [ Finset.sum_neg_distrib, Finset.mul_sum _ _ _ ] using
+        Filter.tendsto_neg_atTop_atBot.comp
+        ( tendsto_natCast_atTop_atTop.atTop_mul_const h_split_sum );
     apply h_split_sum.congr'
     filter_upwards [ Filter.eventually_gt_atTop 0 ] with N hN
     refine Finset.sum_congr rfl fun i hi => ?_
-    rw [ show approxLog N ( x.M.H.eigenvalues i ) = -↑N from by rw [ show x.M.H.eigenvalues i = 0 from Finset.mem_filter.mp hi |>.2 ] ; exact approxLog_at_zero N ] ;
-  convert h_split_sum.atBot_add ( show Filter.Tendsto ( fun N : ℕ => ∑ i ∈ Finset.univ.filter ( fun i => x.M.H.eigenvalues i ≠ 0 ), approxLog N ( x.M.H.eigenvalues i ) * eigenWeight ρ x i ) Filter.atTop ( nhds ( ∑ i ∈ Finset.univ.filter ( fun i => x.M.H.eigenvalues i ≠ 0 ), Real.log ( x.M.H.eigenvalues i ) * eigenWeight ρ x i ) ) from ?_ ) using 2;
+    rw [ show approxLog N ( x.M.H.eigenvalues i ) = -↑N from by
+      rw [ show x.M.H.eigenvalues i = 0 from Finset.mem_filter.mp hi |>.2 ] ;
+      exact approxLog_at_zero N ] ;
+  convert h_split_sum.atBot_add ( show Filter.Tendsto
+    ( fun N : ℕ => ∑ i ∈ Finset.univ.filter ( fun i => x.M.H.eigenvalues i ≠ 0 ),
+      approxLog N ( x.M.H.eigenvalues i ) * eigenWeight ρ x i ) Filter.atTop
+    ( nhds ( ∑ i ∈ Finset.univ.filter ( fun i => x.M.H.eigenvalues i ≠ 0 ),
+      Real.log ( x.M.H.eigenvalues i ) * eigenWeight ρ x i ) ) from ?_ ) using 2;
   · rw [ inner_cfc_eq_sum_eigenWeight, Finset.sum_filter_add_sum_filter_not ];
   · apply tendsto_finsetSum
     intro i hi
-    exact Filter.Tendsto.mul ((approxLog_tendsto_at_pos ( show 0 < x.M.H.eigenvalues i from lt_of_le_of_ne (x.eigenvalue_nonneg i) (Ne.symm (by aesop))))) tendsto_const_nhds
+    exact Filter.Tendsto.mul ((approxLog_tendsto_at_pos
+      ( show 0 < x.M.H.eigenvalues i from
+        lt_of_le_of_ne (x.eigenvalue_nonneg i) (Ne.symm (by aesop))))) tendsto_const_nhds
 
 end lowerSemicontinuous_2
 
 open Classical in
-theorem qRelativeEnt_lowerSemicontinuous_2 (ρ x : MState d) (hx : ¬(x.M.ker ≤ ρ.M.ker)) (y : ENNReal) (hy : y < ⊤) :
+theorem qRelativeEnt_lowerSemicontinuous_2 (ρ x : MState d) (hx : ¬(x.M.ker ≤ ρ.M.ker))
+    (y : ENNReal) (hy : y < ⊤) :
     ∀ᶠ (x' : MState d) in nhds x,
       y < (if x'.M.ker ≤ ρ.M.ker then ⟪ρ.M, ρ.M.log - x'.M.log⟫ else ⊤ : EReal) := by
-  -- Since $y < \top$, we can choose a neighborhood around $x$ where the inner product is less than $y$.
-  have h_inner_lt_y : ∀ᶠ x' in nhds x, x'.M.ker ≤ ρ.M.ker → ⟪ρ.M, ρ.M.log - x'.M.log⟫ > y.toReal := by
-    have h_inner_lt_y : Filter.Tendsto (fun N : ℕ => ⟪ρ.M, ρ.M.log - x.M.cfc (approxLog N)⟫) Filter.atTop Filter.atTop := by
-      have h_inner_lt_y : Filter.Tendsto (fun N : ℕ => ⟪ρ.M, ρ.M.log⟫ - ⟪ρ.M, x.M.cfc (approxLog N)⟫) Filter.atTop Filter.atTop := by
-        exact Filter.Tendsto.add_atTop tendsto_const_nhds ( Filter.tendsto_neg_atBot_atTop.comp ( inner_cfc_approxLog_tendsto_bot ρ x hx ) ) |> Filter.Tendsto.congr ( by aesop ) ;
+  -- Since $y < \top$, we can choose a neighborhood around $x$ where the inner product is less than
+  -- $y$.
+  have h_inner_lt_y : ∀ᶠ x' in nhds x,
+      x'.M.ker ≤ ρ.M.ker → ⟪ρ.M, ρ.M.log - x'.M.log⟫ > y.toReal := by
+    have h_inner_lt_y : Filter.Tendsto (fun N : ℕ => ⟪ρ.M, ρ.M.log - x.M.cfc (approxLog N)⟫)
+        Filter.atTop Filter.atTop := by
+      have h_inner_lt_y : Filter.Tendsto
+          (fun N : ℕ => ⟪ρ.M, ρ.M.log⟫ - ⟪ρ.M, x.M.cfc (approxLog N)⟫)
+          Filter.atTop Filter.atTop := by
+        exact Filter.Tendsto.add_atTop tendsto_const_nhds
+          ( Filter.tendsto_neg_atBot_atTop.comp ( inner_cfc_approxLog_tendsto_bot ρ x hx ) ) |>
+          Filter.Tendsto.congr ( by aesop ) ;
       convert h_inner_lt_y using 1
       ext1 N
       simp [inner_sub_right]
@@ -2046,7 +2478,8 @@ theorem qRelativeEnt_lowerSemicontinuous_2 (ρ x : MState d) (hx : ¬(x.M.ker �
       simp only [inner_sub_right]
       exact continuous_const.sub (continuous_inner_cfc_approxLog ρ N)
     have h_cont : ∀ᶠ x' in nhds x, ⟪ρ.M, ρ.M.log - x'.M.cfc (approxLog N)⟫ > y.toReal := by
-      exact h_cont.continuousAt.eventually ( lt_mem_nhds hN ) |> fun h => h.mono fun x' hx' => hx' |> fun hx'' => by simpa using hx'';
+      exact h_cont.continuousAt.eventually ( lt_mem_nhds hN ) |>
+        fun h => h.mono fun x' hx' => hx' |> fun hx'' => by simpa using hx'';
     filter_upwards [h_cont] with x' hx' hx''
     apply lt_of_lt_of_le hx'
     have h_inner_le : ⟪ρ.M, x'.M.log⟫ ≤ ⟪ρ.M, x'.M.cfc (approxLog N)⟫ := by
@@ -2055,7 +2488,9 @@ theorem qRelativeEnt_lowerSemicontinuous_2 (ρ x : MState d) (hx : ¬(x.M.ker �
     exact sub_le_sub_left h_inner_le _
   filter_upwards [ h_inner_lt_y ] with x' hx';
   split_ifs <;> simp_all [ ENNReal.toReal ];
-  · convert ENNReal.ofReal_lt_ofReal_iff (show 0 < ⟪ρ.M, ρ.M.log - x'.M.log⟫ from lt_of_le_of_lt (by positivity) hx' ) |>.2 hx' using 1
+  · convert ENNReal.ofReal_lt_ofReal_iff
+      (show 0 < ⟪ρ.M, ρ.M.log - x'.M.log⟫ from lt_of_le_of_lt (by positivity) hx' ) |>.2 hx'
+      using 1
     cases y
     · simp at hy
     simp only [ENNReal.ofReal, ENNReal.toNNReal_coe, Real.toNNReal_coe, ENNReal.coe_lt_coe]
@@ -2070,7 +2505,8 @@ latter here). Will need the fact that all the cfc / eigenvalue stuff is continuo
 carefully handling what happens with the kernel subspace, which will make this a pain.
 -/
 @[fun_prop]
-theorem qRelativeEnt.lowerSemicontinuous (ρ : MState d) : LowerSemicontinuous fun σ => 𝐃(ρ‖σ) := by
+theorem qRelativeEnt.lowerSemicontinuous (ρ : MState d) :
+    LowerSemicontinuous fun σ => 𝐃(ρ‖σ) := by
   simp_rw [qRelativeEnt, SandwichedRelRentropy, if_true, lowerSemicontinuous_iff]
   simp only [zero_lt_one, ↓reduceDIte]
   intro x
@@ -2087,7 +2523,8 @@ theorem qRelativeEnt.lowerSemicontinuous (ρ : MState d) : LowerSemicontinuous f
       apply lt_of_lt_of_le hy'.1
       refine mod_cast max_le (a := y') (b := 0) (c := ⟪ρ.M, ρ.M.log⟫ - ⟪ρ.M, σ.M.log⟫) ?_ ?_
       · linarith
-      · linarith [ show 0 ≤ y' from le_of_not_gt fun h => by norm_num [ Real.toNNReal_of_nonpos h.le ] at hy' ]
+      · linarith [ show 0 ≤ y' from
+          le_of_not_gt fun h => by norm_num [ Real.toNNReal_of_nonpos h.le ] at hy' ]
     · exact hy'.1.trans_le (by simp)
   · intro y hy
     simp only [hx, ↓reduceDIte] at hy ⊢
@@ -2098,14 +2535,17 @@ theorem qRelativeEnt.lowerSemicontinuous (ρ : MState d) : LowerSemicontinuous f
     · simp at junk
     · exact hy
 
-/-- Joint convexity of Quantum relative entropy. We can't state this with `ConvexOn` because that requires
+/-- Joint convexity of Quantum relative entropy. We can't state this with `ConvexOn` because that
+requires
 an `AddCommMonoid`, which `MState`s are not. Instead we state it with `Mixable`.
 
 TODO:
- * Add the `Mixable` instance that infers from the `Coe` so that the right hand side can be written as
+ * Add the `Mixable` instance that infers from the `Coe` so that the right hand side can be written
+as
 `p [𝐃(ρ₁‖σ₁) ↔ 𝐃(ρ₂‖σ₂)]`
  * Define (joint) convexity as its own thing - a `ConvexOn` for `Mixable` types.
- * Maybe, more broadly, find a way to make `ConvexOn` work with the subset of `Matrix` that corresponds to `MState`.
+ * Maybe, more broadly, find a way to make `ConvexOn` work with the subset of `Matrix` that
+corresponds to `MState`.
 -/
 @[sorryful]
 theorem qRelativeEnt_joint_convexity :
@@ -2342,7 +2782,8 @@ private lemma log_add_eps_eq_cfc (A : HermitianMat d 𝕜) (ε : ℝ) :
 
 private lemma inner_cfc_eq_sum (A C : HermitianMat d 𝕜) (f : ℝ → ℝ) :
     ⟪C, A.cfc f⟫ = ∑ i, f (A.H.eigenvalues i) *
-      RCLike.re ((C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 * A.H.eigenvectorUnitary.val.conjTranspose)).trace) := by
+      RCLike.re ((C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 *
+        A.H.eigenvectorUnitary.val.conjTranspose)).trace) := by
   apply congr(RCLike.re ((C.val * $(A.cfc_toMat_eq_sum_smul_proj f)).trace)).trans
   simp only [HermitianMat.val_eq_coe, Matrix.mul_sum, Algebra.mul_smul_comm, Matrix.trace_sum,
     Matrix.trace_smul, RCLike.real_smul_eq_coe_mul, map_sum, RCLike.mul_re,
@@ -2350,7 +2791,8 @@ private lemma inner_cfc_eq_sum (A C : HermitianMat d 𝕜) (f : ℝ → ℝ) :
 
 private lemma eigenproj_coeff_zero_of_ker_le {A C : HermitianMat d 𝕜}
     (hker : A.ker ≤ C.ker) {i : d} (hi : A.H.eigenvalues i = 0) :
-    RCLike.re ((C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 * A.H.eigenvectorUnitary.val.conjTranspose)).trace) = 0 := by
+    RCLike.re ((C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 *
+      A.H.eigenvectorUnitary.val.conjTranspose)).trace) = 0 := by
   have h_eigenvector_in_ker_C : C.mat.mulVec (A.H.eigenvectorBasis i) = 0 := by
     have h_eigenvector_in_ker : (A.H.eigenvectorBasis i) ∈ LinearMap.ker A.lin.toLinearMap := by
       have := congr(WithLp.toLp 2 $(A.H.mulVec_eigenvectorBasis i))
@@ -2358,10 +2800,13 @@ private lemma eigenproj_coeff_zero_of_ker_le {A C : HermitianMat d 𝕜}
       exact congr(WithLp.toLp 2 $this)
     specialize hker h_eigenvector_in_ker
     exact congr(WithLp.ofLp $hker)
-  have h_trace_zero : (C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 * A.H.eigenvectorUnitary.val.conjTranspose)).trace = (star (A.H.eigenvectorBasis i)) ⬝ᵥ (C.mat.mulVec (A.H.eigenvectorBasis i)) := by
+  have h_trace_zero : (C.mat * (A.H.eigenvectorUnitary.val * Matrix.single i i 1 *
+      A.H.eigenvectorUnitary.val.conjTranspose)).trace =
+      (star (A.H.eigenvectorBasis i)) ⬝ᵥ (C.mat.mulVec (A.H.eigenvectorBasis i)) := by
     simp [Matrix.trace, Matrix.mulVec, dotProduct]
     simp [Matrix.mul_apply, Matrix.single, Matrix.conjTranspose_apply]
-    simp [Finset.sum_ite, Finset.filter_eq, Finset.filter_and, mul_comm, mul_left_comm, Finset.mul_sum]
+    simp [Finset.sum_ite, Finset.filter_eq, Finset.filter_and, mul_comm, mul_left_comm,
+      Finset.mul_sum]
     refine Finset.sum_congr rfl fun j hj => Finset.sum_congr rfl fun k hk => ?_
     rw [Finset.sum_eq_single i]
     · simp_all only [Finset.mem_univ, ↓reduceIte, Finset.inter_univ, Finset.sum_singleton]
@@ -2431,8 +2876,10 @@ theorem qRelEntropy_le_add_of_le_smul (ρ : MState d) {σ₁ σ₂ : MState d} (
         · exact hσ
         · exact hker₁
         · exact hker
-      have h_final : (qRelativeEnt ρ σ₁).toEReal ≤ (qRelativeEnt ρ σ₂).toEReal + ENNReal.toEReal (ENNReal.ofReal (Real.log α)) := by
-        simp_all only [qRelativeEnt_ker, inner_sub_right, tsub_le_iff_right, EReal.coe_sub, EReal.coe_ennreal_ofReal]
+      have h_final : (qRelativeEnt ρ σ₁).toEReal ≤
+          (qRelativeEnt ρ σ₂).toEReal + ENNReal.toEReal (ENNReal.ofReal (Real.log α)) := by
+        simp_all only [qRelativeEnt_ker, inner_sub_right, tsub_le_iff_right, EReal.coe_sub,
+          EReal.coe_ennreal_ofReal]
         cases max_cases (Real.log α) 0
         <;> simp only [sup_of_le_left, *]
         <;> norm_cast at *

--- a/QuantumInfo/Entropy/SSA.lean
+++ b/QuantumInfo/Entropy/SSA.lean
@@ -19,7 +19,8 @@ noncomputable section
 
 variable {d d₁ d₂ d₃ m n : Type*}
 variable [Fintype d] [Fintype d₁] [Fintype d₂] [Fintype d₃] [Fintype m] [Fintype n]
-variable [DecidableEq d] [DecidableEq d₁] [DecidableEq d₂] [DecidableEq d₃] [DecidableEq m] [DecidableEq n]
+variable [DecidableEq d] [DecidableEq d₁] [DecidableEq d₂] [DecidableEq d₃] [DecidableEq m]
+  [DecidableEq n]
 variable {dA dB dC dA₁ dA₂ : Type*}
 variable [Fintype dA] [Fintype dB] [Fintype dC] [Fintype dA₁] [Fintype dA₂]
 variable [DecidableEq dA] [DecidableEq dB] [DecidableEq dC] [DecidableEq dA₁] [DecidableEq dA₂]
@@ -30,22 +31,27 @@ variable {α : ℝ}
 open scoped InnerProductSpace RealInnerProductSpace Kronecker Matrix
 
 /-
-The operator norm of a matrix is the operator norm of the linear map it represents, with respect to the Euclidean norm.
+The operator norm of a matrix is the operator norm of the linear map it represents, with respect to
+the Euclidean norm.
 -/
-/-- The operator norm of a matrix, with respect to the Euclidean norm (l2 norm) on the domain and codomain. -/
+/-- The operator norm of a matrix, with respect to the Euclidean norm (l2 norm) on the domain and
+codomain. -/
 noncomputable def Matrix.opNorm [RCLike 𝕜] (A : Matrix m n 𝕜) : ℝ :=
   ‖LinearMap.toContinuousLinearMap (Matrix.toEuclideanLin A)‖
 
 /-
 An isometry preserves the Euclidean norm.
 -/
-theorem Matrix.isometry_preserves_norm (A : Matrix n m 𝕜) (hA : A.Isometry) (x : EuclideanSpace 𝕜 m) :
+theorem Matrix.isometry_preserves_norm (A : Matrix n m 𝕜) (hA : A.Isometry)
+    (x : EuclideanSpace 𝕜 m) :
     ‖Matrix.toEuclideanLin A x‖ = ‖x‖ := by
   rw [ ← sq_eq_sq₀ ( by positivity ) ( by positivity ), Matrix.Isometry ] at *;
   simp [ EuclideanSpace.norm_eq]
-  have h_inner : ∀ x y : EuclideanSpace 𝕜 m, inner 𝕜 (toEuclideanLin A x) (toEuclideanLin A y) = inner 𝕜 x y := by
+  have h_inner : ∀ x y : EuclideanSpace 𝕜 m,
+      inner 𝕜 (toEuclideanLin A x) (toEuclideanLin A y) = inner 𝕜 x y := by
     intro x y
-    have h_inner_eq : inner 𝕜 (toEuclideanLin A x) (toEuclideanLin A y) = inner 𝕜 x (toEuclideanLin A.conjTranspose (toEuclideanLin A y)) := by
+    have h_inner_eq : inner 𝕜 (toEuclideanLin A x) (toEuclideanLin A y) =
+        inner 𝕜 x (toEuclideanLin A.conjTranspose (toEuclideanLin A y)) := by
       simp [ Matrix.toEuclideanLin, inner ];
       simp [ Matrix.mulVec, dotProduct, Finset.mul_sum, mul_comm, ];
       simp [ Matrix.mul_apply, mul_assoc, mul_comm, mul_left_comm, Finset.mul_sum]
@@ -58,7 +64,8 @@ theorem Matrix.isometry_preserves_norm (A : Matrix n m 𝕜) (hA : A.Isometry) (
 /-
 The operator norm of an isometry is 1 (assuming the domain is non-empty).
 -/
-theorem Matrix.opNorm_isometry [Nonempty m] (A : Matrix n m 𝕜) (hA : A.Isometry) : Matrix.opNorm A = 1 := by
+theorem Matrix.opNorm_isometry [Nonempty m] (A : Matrix n m 𝕜) (hA : A.Isometry) :
+    Matrix.opNorm A = 1 := by
   have h_opNorm : ∀ x : EuclideanSpace 𝕜 m, ‖Matrix.toEuclideanLin A x‖ = ‖x‖ := by
     convert Matrix.isometry_preserves_norm A hA;
   refine' le_antisymm ( csInf_le _ _ ) ( le_csInf _ _ );
@@ -75,7 +82,8 @@ def map_to_tensor_MES : Matrix ((d₁ × d₂) × d₂) d₁ ℂ :=
   Matrix.of fun ((i, j), k) l => if i = l ∧ j = k then 1 else 0
 
 theorem map_to_tensor_MES_prop (A : Matrix (d₁ × d₂) (d₁ × d₂) ℂ) :
-    (map_to_tensor_MES d₁ d₂).conjTranspose * (Matrix.kronecker A (1 : Matrix d₂ d₂ ℂ)) * (map_to_tensor_MES d₁ d₂) =
+    (map_to_tensor_MES d₁ d₂).conjTranspose * (Matrix.kronecker A (1 : Matrix d₂ d₂ ℂ)) *
+      (map_to_tensor_MES d₁ d₂) =
     A.traceRight := by
   ext i j; simp [map_to_tensor_MES, Matrix.mul_apply]
   simp [ Finset.sum_ite, Matrix.one_apply]
@@ -115,8 +123,14 @@ lemma V_rho_conj_mul_self_eq (ρAB : HermitianMat (dA × dB) ℂ) (hρ : ρAB.ma
   -- By definition of $V_rho$, we can write out the product $V_rho^H * V_rho$.
   simp [V_rho];
   simp [ ← Matrix.mul_assoc ];
-  have h_simp : (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ))ᴴ * (Matrix.kroneckerMap (fun x1 x2 => x1 * x2) (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ)) = Matrix.kroneckerMap (fun x1 x2 => x1 * x2) (ρAB : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ) := by
-    have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ)ᴴ * (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) = ρAB := by
+  have h_simp : (Matrix.kroneckerMap (fun x1 x2 => x1 * x2)
+        (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ))ᴴ *
+      (Matrix.kroneckerMap (fun x1 x2 => x1 * x2)
+        (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ)) =
+      Matrix.kroneckerMap (fun x1 x2 => x1 * x2)
+        (ρAB : Matrix (dA × dB) (dA × dB) ℂ) (1 : Matrix dB dB ℂ) := by
+    have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ)ᴴ *
+        (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) = ρAB := by
       convert ρAB.sqrt_sq ( show 0 ≤ ρAB from ?_ ) using 1;
       · simp [ HermitianMat.sqrt ];
       · positivity
@@ -139,28 +153,37 @@ The partial trace (left) of a positive definite matrix is positive definite.
 -/
 lemma PosDef_traceRight [Nonempty dB] (A : HermitianMat (dA × dB) ℂ) (hA : A.mat.PosDef) :
     A.traceRight.mat.PosDef := by
-  have h_trace_right_pos_def : ∀ (x : EuclideanSpace ℂ dA), x ≠ 0 → 0 < ∑ k : dB, (star x) ⬝ᵥ (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) := by
+  have h_trace_right_pos_def : ∀ (x : EuclideanSpace ℂ dA), x ≠ 0 →
+      0 < ∑ k : dB, (star x) ⬝ᵥ
+        (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) := by
     intro x hx_ne_zero
-    have h_inner_pos : ∀ k : dB, 0 ≤ (star x) ⬝ᵥ (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) := by
+    have h_inner_pos : ∀ k : dB, 0 ≤ (star x) ⬝ᵥ
+        (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) := by
       have := (Matrix.posDef_iff_dotProduct_mulVec.mp hA).2;
       intro k
       specialize @this ( fun i => if h : i.2 = k then x i.1 else 0 )
       simp_all only [ne_eq, dite_eq_ite, dotProduct, Pi.star_apply, RCLike.star_def, Matrix.mulVec,
         HermitianMat.mat_apply, mul_ite, mul_zero, HermitianMat.val_eq_coe, Matrix.submatrix_apply]
-      convert this ( show ( fun i : dA × dB => if i.2 = k then x i.1 else 0 ) ≠ 0 from fun h => hx_ne_zero <| by ext i; simpa using congr_fun h ( i, k ) ) |> le_of_lt using 1;
-      rw [ ← Finset.sum_subset ( Finset.subset_univ ( Finset.image ( fun i : dA => ( i, k ) ) Finset.univ ) ) ]
+      convert this ( show ( fun i : dA × dB => if i.2 = k then x i.1 else 0 ) ≠ 0 from
+        fun h => hx_ne_zero <| by ext i; simpa using congr_fun h ( i, k ) ) |> le_of_lt using 1;
+      rw [ ← Finset.sum_subset
+        ( Finset.subset_univ ( Finset.image ( fun i : dA => ( i, k ) ) Finset.univ ) ) ]
       · simp only [Finset.sum_ite, Finset.sum_const_zero, add_zero, Set.InjOn, Finset.coe_univ,
-          Set.mem_univ, Prod.mk.injEq, and_true, imp_self, implies_true, Finset.sum_image, ↓reduceIte];
+          Set.mem_univ, Prod.mk.injEq, and_true, imp_self, implies_true, Finset.sum_image,
+          ↓reduceIte];
         refine' Finset.sum_congr rfl fun i hi => _;
         refine' congr_arg _ ( Finset.sum_bij ( fun j _ => ( j, k ) ) _ _ _ _ ) <;> simp
       · simp only [Finset.mem_univ, Finset.mem_image, true_and, not_exists, ne_eq, Finset.sum_ite,
           Finset.sum_const_zero, add_zero, mul_eq_zero, map_eq_zero, ite_eq_right_iff, forall_const,
           Prod.forall, Prod.mk.injEq, not_and, forall_eq];
         exact fun a b hb => Or.inl fun h => False.elim <| hb <| h.symm;
-    obtain ⟨k, hk⟩ : ∃ k : dB, (star x) ⬝ᵥ (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) > 0 := by
-      have := @(Matrix.posDef_iff_dotProduct_mulVec.mp hA).2 ( fun i => x i.1 * ( if i.2 = Classical.arbitrary dB then 1 else 0 ) )
+    obtain ⟨k, hk⟩ : ∃ k : dB, (star x) ⬝ᵥ
+        (Matrix.mulVec (A.val.submatrix (fun i => (i, k)) (fun i => (i, k))) x) > 0 := by
+      have := @(Matrix.posDef_iff_dotProduct_mulVec.mp hA).2
+        ( fun i => x i.1 * ( if i.2 = Classical.arbitrary dB then 1 else 0 ) )
       simp_all only [ne_eq, dotProduct, Pi.star_apply, RCLike.star_def, Matrix.mulVec,
-        HermitianMat.val_eq_coe, Matrix.submatrix_apply, HermitianMat.mat_apply, mul_ite, mul_one, mul_zero]
+        HermitianMat.val_eq_coe, Matrix.submatrix_apply, HermitianMat.mat_apply, mul_ite, mul_one,
+        mul_zero]
       contrapose! this
       simp_all only [ne_eq, funext_iff, Pi.zero_apply, ite_eq_right_iff, Prod.forall, forall_eq,
         not_forall, Finset.sum_ite, Finset.sum_const_zero, add_zero] ;
@@ -169,20 +192,24 @@ lemma PosDef_traceRight [Nonempty dB] (A : HermitianMat (dA × dB) ℂ) (hA : A.
         change _ ≠ 0
         simpa using hx_ne_zero
       convert this ( Classical.arbitrary dB ) using 1;
-      rw [ ← Finset.sum_subset ( Finset.subset_univ ( Finset.univ.image fun i : dA => ( i, Classical.arbitrary dB ) ) ) ]
+      rw [ ← Finset.sum_subset
+        ( Finset.subset_univ ( Finset.univ.image fun i : dA => ( i, Classical.arbitrary dB ) ) ) ]
       · simp only [Finset.coe_univ, Prod.mk.injEq, and_true, implies_true, Set.injOn_of_eq_iff_eq,
           Finset.sum_image, ↓reduceIte, gt_iff_lt]
         congr! 3;
         refine' Finset.sum_bij ( fun y hy => y.1 ) _ _ _ _ <;> simp
       · simp only [Finset.mem_univ, Finset.mem_image, true_and, not_exists, ne_eq, mul_eq_zero,
-          map_eq_zero, ite_eq_right_iff, forall_const, Prod.forall, Prod.mk.injEq, not_and, forall_eq]
+          map_eq_zero, ite_eq_right_iff, forall_const, Prod.forall, Prod.mk.injEq, not_and,
+          forall_eq]
         exact fun a b hb => Or.inl fun h => False.elim <| hb <| h.symm ▸ rfl
-    exact lt_of_lt_of_le hk ( Finset.single_le_sum ( fun k _ => h_inner_pos k ) ( Finset.mem_univ k ) );
+    exact lt_of_lt_of_le hk
+      ( Finset.single_le_sum ( fun k _ => h_inner_pos k ) ( Finset.mem_univ k ) );
   rw [Matrix.posDef_iff_dotProduct_mulVec]
   refine' ⟨A.traceRight.2, fun x hx => _ ⟩;
   · convert h_trace_right_pos_def (WithLp.toLp 2 x) (by simpa using hx) using 1;
     unfold HermitianMat.traceRight
-    simp only [dotProduct, Pi.star_apply, RCLike.star_def, HermitianMat.mat_mk, HermitianMat.val_eq_coe]
+    simp only [dotProduct, Pi.star_apply, RCLike.star_def, HermitianMat.mat_mk,
+      HermitianMat.val_eq_coe]
     simp only [Matrix.mulVec, dotProduct, mul_comm, Matrix.submatrix_apply, HermitianMat.mat_apply];
     simp only [Matrix.traceRight, HermitianMat.mat_apply, Matrix.of_apply, mul_comm, Finset.mul_sum]
     rw [Finset.sum_comm_cycle]
@@ -197,7 +224,9 @@ V_rho is an isometry.
 theorem V_rho_isometry [Nonempty dB] (ρAB : HermitianMat (dA × dB) ℂ) (hρ : ρAB.mat.PosDef) :
     (V_rho ρAB)ᴴ * (V_rho ρAB) = 1 := by
   -- Since ρA is positive definite, we can use the fact that ρA_inv_sqrt * ρA * ρA_inv_sqrt = I.
-  have h_pos_def : (ρAB.traceRight⁻¹.sqrt : Matrix dA dA ℂ) * (ρAB.traceRight : Matrix dA dA ℂ) * (ρAB.traceRight⁻¹.sqrt : Matrix dA dA ℂ) = 1 := by
+  have h_pos_def : (ρAB.traceRight⁻¹.sqrt : Matrix dA dA ℂ) *
+      (ρAB.traceRight : Matrix dA dA ℂ) *
+      (ρAB.traceRight⁻¹.sqrt : Matrix dA dA ℂ) = 1 := by
     convert HermitianMat.sqrt_inv_mul_self_mul_sqrt_inv_eq_one _;
     exact PosDef_traceRight _ hρ
   rw [← h_pos_def]
@@ -206,7 +235,8 @@ theorem V_rho_isometry [Nonempty dB] (ρAB : HermitianMat (dA × dB) ℂ) (hρ :
 /--
 V_sigma is an isometry.
 -/
-theorem V_sigma_isometry [Nonempty dB] (σBC : HermitianMat (dB × dC) ℂ) (hσ : σBC.mat.PosDef) :
+theorem V_sigma_isometry [Nonempty dB] (σBC : HermitianMat (dB × dC) ℂ)
+    (hσ : σBC.mat.PosDef) :
     (V_sigma σBC).conjTranspose * (V_sigma σBC) = 1 := by
   simp [V_sigma]
   exact V_rho_isometry _ (hσ.reindex _)
@@ -221,7 +251,8 @@ variable {dA dB dC : Type*} [Fintype dA] [Fintype dB] [Fintype dC]
 variable [DecidableEq dA] [DecidableEq dB] [DecidableEq dC]
 
 /-- The operator W from the paper, defined as a matrix product. -/
-noncomputable def W_mat (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMat (dB × dC) ℂ) : Matrix ((dA × dB) × dC) ((dA × dB) × dC) ℂ :=
+noncomputable def W_mat (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMat (dB × dC) ℂ) :
+    Matrix ((dA × dB) × dC) ((dA × dB) × dC) ℂ :=
   let ρA := ρAB.traceRight
   let σC := σBC.traceLeft
   let ρAB_sqrt := (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ)
@@ -231,7 +262,8 @@ noncomputable def W_mat (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMa
 
   let term1 := ρAB_sqrt ⊗ₖ σC_inv_sqrt
   let term2 := ρA_inv_sqrt ⊗ₖ σBC_sqrt
-  let term2_reindexed := term2.reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm
+  let term2_reindexed :=
+    term2.reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm
 
   term1 * term2_reindexed
 
@@ -242,16 +274,21 @@ theorem Matrix.opNorm_mul_le {l m n 𝕜 : Type*} [Fintype l] [Fintype m] [Finty
     [DecidableEq l] [DecidableEq m] [DecidableEq n] [RCLike 𝕜]
     (A : Matrix l m 𝕜) (B : Matrix m n 𝕜) :
     Matrix.opNorm (A * B) ≤ Matrix.opNorm A * Matrix.opNorm B := by
-  have h_opNorm_mul_le : ∀ (A : Matrix l m 𝕜) (B : Matrix m n 𝕜), Matrix.opNorm (A * B) ≤ Matrix.opNorm A * Matrix.opNorm B := by
+  have h_opNorm_mul_le : ∀ (A : Matrix l m 𝕜) (B : Matrix m n 𝕜),
+      Matrix.opNorm (A * B) ≤ Matrix.opNorm A * Matrix.opNorm B := by
     intro A B
-    have h_comp : Matrix.toEuclideanLin (A * B) = Matrix.toEuclideanLin A ∘ₗ Matrix.toEuclideanLin B := by
+    have h_comp : Matrix.toEuclideanLin (A * B) =
+        Matrix.toEuclideanLin A ∘ₗ Matrix.toEuclideanLin B := by
       ext; simp [toEuclideanLin]
-    convert ContinuousLinearMap.opNorm_comp_le ( Matrix.toEuclideanLin A |> LinearMap.toContinuousLinearMap ) ( Matrix.toEuclideanLin B |> LinearMap.toContinuousLinearMap ) using 1;
+    convert ContinuousLinearMap.opNorm_comp_le
+      ( Matrix.toEuclideanLin A |> LinearMap.toContinuousLinearMap )
+      ( Matrix.toEuclideanLin B |> LinearMap.toContinuousLinearMap ) using 1;
     unfold Matrix.opNorm;
     exact congr_arg _ ( by aesop );
   exact h_opNorm_mul_le A B
 
-theorem Matrix.opNorm_reindex_proven {l m n p : Type*} [Fintype l] [Fintype m] [Fintype n] [Fintype p]
+theorem Matrix.opNorm_reindex_proven {l m n p : Type*} [Fintype l] [Fintype m] [Fintype n]
+    [Fintype p]
     [DecidableEq l] [DecidableEq m] [DecidableEq n] [DecidableEq p]
     (e : m ≃ l) (f : n ≃ p) (A : Matrix m n 𝕜) :
     Matrix.opNorm (A.reindex e f) = Matrix.opNorm A := by
@@ -259,14 +296,18 @@ theorem Matrix.opNorm_reindex_proven {l m n p : Type*} [Fintype l] [Fintype m] [
   · refine' csInf_le _ _;
     · exact ⟨ 0, fun c hc => hc.1 ⟩;
     · refine' ⟨ norm_nonneg _, fun x => _ ⟩;
-      convert ContinuousLinearMap.le_opNorm ( LinearMap.toContinuousLinearMap ( Matrix.toEuclideanLin A ) ) (WithLp.toLp 2 ( fun i => x ( f i ) )) using 1;
+      convert ContinuousLinearMap.le_opNorm
+        ( LinearMap.toContinuousLinearMap ( Matrix.toEuclideanLin A ) )
+        (WithLp.toLp 2 ( fun i => x ( f i ) )) using 1;
       · simp [ Matrix.toEuclideanLin, EuclideanSpace.norm_eq ];
         rw [ ← Equiv.sum_comp e.symm ] ; aesop;
       · simp [ EuclideanSpace.norm_eq, Matrix.opNorm ];
         exact Or.inl ( by rw [ ← Equiv.sum_comp f ] );
   · refine' ContinuousLinearMap.opNorm_le_bound _ _ fun a => _;
     · exact ContinuousLinearMap.opNorm_nonneg _;
-    · convert ContinuousLinearMap.le_opNorm ( LinearMap.toContinuousLinearMap ( toEuclideanLin ( Matrix.reindex e f A ) ) ) (WithLp.toLp 2 ( fun i => a ( f.symm i ) )) using 1;
+    · convert ContinuousLinearMap.le_opNorm
+        ( LinearMap.toContinuousLinearMap ( toEuclideanLin ( Matrix.reindex e f A ) ) )
+        (WithLp.toLp 2 ( fun i => a ( f.symm i ) )) using 1;
       · simp [ EuclideanSpace.norm_eq, Matrix.toEuclideanLin ];
         rw [ ← Equiv.sum_comp e.symm ]
         simp [ Matrix.mulVec, dotProduct ] ;
@@ -277,13 +318,15 @@ theorem Matrix.opNorm_reindex_proven {l m n p : Type*} [Fintype l] [Fintype m] [
 /--
 Define U_rho as the Kronecker product of V_rho and the identity.
 -/
-noncomputable def U_rho (ρAB : HermitianMat (dA × dB) ℂ) : Matrix (((dA × dB) × dB) × dC) (dA × dC) ℂ :=
+noncomputable def U_rho (ρAB : HermitianMat (dA × dB) ℂ) :
+    Matrix (((dA × dB) × dB) × dC) (dA × dC) ℂ :=
   Matrix.kronecker (V_rho ρAB) (1 : Matrix dC dC ℂ)
 
 /--
 Define U_sigma as the Kronecker product of the identity and V_sigma.
 -/
-noncomputable def U_sigma (σBC : HermitianMat (dB × dC) ℂ) : Matrix (dA × (dB × (dB × dC))) (dA × dC) ℂ :=
+noncomputable def U_sigma (σBC : HermitianMat (dB × dC) ℂ) :
+    Matrix (dA × (dB × (dB × dC))) (dA × dC) ℂ :=
   Matrix.kronecker (1 : Matrix dA dA ℂ) (V_sigma σBC)
 
 /--
@@ -324,7 +367,8 @@ theorem conjTranspose_isometry_mul_isometry_le_one {m n k : Type*}
       have h_le : (A * Aᴴ) ≤ 1 := by
         apply isometry_mul_conjTranspose_le_one A hA;
       -- Apply the fact that if $X \leq Y$, then $CXC^* \leq CYC^*$ for any matrix $C$.
-      have h_conj : ∀ (C : Matrix n k ℂ) (X Y : Matrix k k ℂ), X ≤ Y → C * X * Cᴴ ≤ C * Y * Cᴴ :=
+      have h_conj : ∀ (C : Matrix n k ℂ) (X Y : Matrix k k ℂ),
+          X ≤ Y → C * X * Cᴴ ≤ C * Y * Cᴴ :=
         fun C X Y a => Matrix.PosSemidef.mul_mul_conjTranspose_mono C a
       simpa [ Matrix.mul_assoc ] using h_conj Bᴴ ( A * Aᴴ ) 1 h_le;
     aesop;
@@ -345,7 +389,8 @@ theorem HermitianMat.inv_kronecker {m n : Type*} [Fintype m] [DecidableEq m]
     [A.NonSingular] [B.NonSingular] :
     (A ⊗ₖ B)⁻¹ = A⁻¹ ⊗ₖ B⁻¹ := by
   have h_inv : (A ⊗ₖ B).mat * (A⁻¹ ⊗ₖ B⁻¹).mat = 1 := by
-    have h_inv : (A ⊗ₖ B).mat * (A⁻¹ ⊗ₖ B⁻¹).mat = (A.mat * A⁻¹.mat) ⊗ₖ (B.mat * B⁻¹.mat) := by
+    have h_inv : (A ⊗ₖ B).mat * (A⁻¹ ⊗ₖ B⁻¹).mat =
+        (A.mat * A⁻¹.mat) ⊗ₖ (B.mat * B⁻¹.mat) := by
       ext i j; simp [ Matrix.mul_apply, Matrix.kroneckerMap ] ;
       simp only [mul_assoc, Finset.sum_mul]
       simp only [Finset.mul_sum]
@@ -376,14 +421,17 @@ theorem HermitianMat.PosDef_reindex {d d₂ : Type*} [Fintype d] [DecidableEq d]
   convert hA.reindex e
 
 /-- The sandwich matrix S used in the proof of intermediate_ineq.
-  This is derived from W_mat_sq_le_one by algebraic manipulation (conjugation and simplification). -/
-private noncomputable def S_mat (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMat (dB × dC) ℂ) :
+  This is derived from W_mat_sq_le_one by algebraic manipulation (conjugation and
+  simplification). -/
+private noncomputable def S_mat (ρAB : HermitianMat (dA × dB) ℂ)
+    (σBC : HermitianMat (dB × dC) ℂ) :
     Matrix ((dA × dB) × dC) ((dA × dB) × dC) ℂ :=
   (ρAB.traceRight⁻¹.sqrt.mat ⊗ₖ σBC.sqrt.mat).reindex
     (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm
 
 /- W†W = S * (ρ_AB ⊗ σ_C⁻¹) * S, i.e. W†W equals the conj of LHS by S.
-This follows from: W = (ρAB^½ ⊗ σC^{-½}) * S, so W†W = S† * (ρAB^½ ⊗ σC^{-½})† * (ρAB^½ ⊗ σC^{-½}) * S
+This follows from: W = (ρAB^½ ⊗ σC^{-½}) * S, so
+W†W = S† * (ρAB^½ ⊗ σC^{-½})† * (ρAB^½ ⊗ σC^{-½}) * S
 = S * (ρAB ⊗ σC⁻¹) * S (using sqrt_sq and Hermiticity of S).
 -/
 private lemma W_mat_sq_eq_conj [Nonempty dA] [Nonempty dB] [Nonempty dC]
@@ -393,7 +441,10 @@ private lemma W_mat_sq_eq_conj [Nonempty dA] [Nonempty dB] [Nonempty dC]
       S_mat ρAB σBC * (ρAB ⊗ₖ (σBC.traceLeft)⁻¹).mat * S_mat ρAB σBC := by
   unfold W_mat S_mat;
   simp [ Matrix.mul_assoc, Matrix.conjTranspose_mul, Matrix.conjTranspose_kronecker ];
-  have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) * (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) = ρAB ∧ (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) * (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) = σBC.traceLeft⁻¹ := by
+  have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) *
+        (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) = ρAB ∧
+      (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) *
+        (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) = σBC.traceLeft⁻¹ := by
     constructor;
     · exact sqrt_sq (by positivity)
     · convert sqrt_sq ( show 0 ≤ ( σBC.traceLeft⁻¹ : HermitianMat dC ℂ ) from ?_ ) using 1;
@@ -403,26 +454,36 @@ private lemma W_mat_sq_eq_conj [Nonempty dA] [Nonempty dB] [Nonempty dC]
         convert h_inv_pos.inv using 1;
       convert h_inv_pos.posSemidef using 1;
       exact zero_le_iff;
-  have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) * (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) = (ρAB : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ (σBC.traceLeft⁻¹ : Matrix dC dC ℂ) := by
-    have h_simp : ∀ (A B C D : Matrix (dA × dB) (dA × dB) ℂ) (E F : Matrix dC dC ℂ), (A ⊗ₖ E) * (B ⊗ₖ F) = (A * B) ⊗ₖ (E * F) := by
+  have h_simp : (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ
+        (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) *
+      (ρAB.sqrt : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ
+        (σBC.traceLeft⁻¹.sqrt : Matrix dC dC ℂ) =
+      (ρAB : Matrix (dA × dB) (dA × dB) ℂ) ⊗ₖ
+        (σBC.traceLeft⁻¹ : Matrix dC dC ℂ) := by
+    have h_simp : ∀ (A B C D : Matrix (dA × dB) (dA × dB) ℂ) (E F : Matrix dC dC ℂ),
+        (A ⊗ₖ E) * (B ⊗ₖ F) = (A * B) ⊗ₖ (E * F) := by
       exact fun A B C D E F => Eq.symm (Matrix.mul_kronecker_mul A B E F);
     aesop;
   simp_all [ ← Matrix.mul_assoc ]
 
 /- **Step 2**: S * (ρ_A ⊗ σ_BC⁻¹).reindex * S = I.
-This follows from (ρ_A^{-½} * ρ_A * ρ_A^{-½}) ⊗ (σ_BC^½ * σ_BC⁻¹ * σ_BC^½) = I ⊗ I = I.
+This follows from
+(ρ_A^{-½} * ρ_A * ρ_A^{-½}) ⊗ (σ_BC^½ * σ_BC⁻¹ * σ_BC^½) = I ⊗ I = I.
 -/
 private lemma S_mat_conj_rhs_eq_one [Nonempty dA] [Nonempty dB] [Nonempty dC]
     (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMat (dB × dC) ℂ)
     (hρ : ρAB.mat.PosDef) (hσ : σBC.mat.PosDef) :
-    S_mat ρAB σBC * ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm).mat *
+    S_mat ρAB σBC *
+        ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm).mat *
       S_mat ρAB σBC = 1 := by
   have h_comm : Commute (σBC.sqrt.mat) (σBC⁻¹.mat) := by
     have h_comm : Commute (σBC.sqrt.mat) (σBC.mat) := by
       exact commute_sqrt_left rfl;
-    have h_comm_inv : Commute (σBC.sqrt.mat) (σBC.mat) → Commute (σBC.sqrt.mat) (σBC⁻¹.mat) := by
+    have h_comm_inv :
+        Commute (σBC.sqrt.mat) (σBC.mat) → Commute (σBC.sqrt.mat) (σBC⁻¹.mat) := by
       intro h_comm
-      have h_comm_inv : Commute (σBC.sqrt.mat) (σBC.mat) → Commute (σBC.sqrt.mat) (σBC.mat⁻¹) := by
+      have h_comm_inv :
+          Commute (σBC.sqrt.mat) (σBC.mat) → Commute (σBC.sqrt.mat) (σBC.mat⁻¹) := by
         intro h_comm
         have h_inv : σBC.mat⁻¹ * σBC.sqrt.mat = σBC.sqrt.mat * σBC.mat⁻¹ := by
           have h_inv : σBC.mat⁻¹ * σBC.sqrt.mat * σBC.mat = σBC.sqrt.mat := by
@@ -430,7 +491,8 @@ private lemma S_mat_conj_rhs_eq_one [Nonempty dA] [Nonempty dB] [Nonempty dC]
             rw [ ← mul_assoc, Matrix.nonsing_inv_mul _ ];
             · rw [ one_mul ];
             · exact isUnit_iff_ne_zero.mpr hσ.det_pos.ne';
-          have h_inv : σBC.mat⁻¹ * σBC.sqrt.mat * σBC.mat * σBC.mat⁻¹ = σBC.sqrt.mat * σBC.mat⁻¹ := by
+          have h_inv : σBC.mat⁻¹ * σBC.sqrt.mat * σBC.mat * σBC.mat⁻¹ =
+              σBC.sqrt.mat * σBC.mat⁻¹ := by
             rw [h_inv];
           convert h_inv using 1 ; simp [ mul_assoc, hσ.det_pos.ne' ]
         exact h_inv.symm;
@@ -441,11 +503,14 @@ private lemma S_mat_conj_rhs_eq_one [Nonempty dA] [Nonempty dB] [Nonempty dC]
     rw [ ← Matrix.mul_assoc, HermitianMat.sqrt_sq ];
     convert hσ.posSemidef using 1;
     exact zero_le_iff;
-  have h_comm : ρAB.traceRight⁻¹.sqrt.mat * ρAB.traceRight.mat * ρAB.traceRight⁻¹.sqrt.mat = 1 := by
+  have h_comm : ρAB.traceRight⁻¹.sqrt.mat * ρAB.traceRight.mat *
+      ρAB.traceRight⁻¹.sqrt.mat = 1 := by
     have h_comm : ρAB.traceRight.mat.PosDef := by
       apply_rules [ PosDef_traceRight ];
     convert sqrt_inv_mul_self_mul_sqrt_inv_eq_one h_comm using 1;
-  convert congr_arg₂ ( fun x y => Matrix.kronecker x y |> Matrix.reindex ( Equiv.prodAssoc dA dB dC ).symm ( Equiv.prodAssoc dA dB dC ).symm ) h_comm ( show ( σBC.sqrt.mat * σBC⁻¹.mat * σBC.sqrt.mat ) = 1 from ?_ ) using 1;
+  convert congr_arg₂ ( fun x y => Matrix.kronecker x y |> Matrix.reindex
+      ( Equiv.prodAssoc dA dB dC ).symm ( Equiv.prodAssoc dA dB dC ).symm ) h_comm
+    ( show ( σBC.sqrt.mat * σBC⁻¹.mat * σBC.sqrt.mat ) = 1 from ?_ ) using 1;
   · unfold S_mat; simp [ *, Matrix.mul_assoc ] ;
     ext ⟨ i, j ⟩ ⟨ k, l ⟩ ; simp [ Matrix.mul_apply, Matrix.kroneckerMap_apply ] ; ring_nf
     simp only [mul_assoc, Finset.mul_sum _ _ _, Finset.sum_mul];
@@ -470,13 +535,17 @@ private lemma W_mat_eq_factored
       (F ⊗ₖ (1 : Matrix dC dC ℂ)) *
         ((1 : Matrix dA dA ℂ) ⊗ₖ G).reindex
           (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm := by
-  -- By definition of matrix multiplication and the properties of the Kronecker product, we can expand both sides.
-  ext ⟨⟨a, b⟩, c⟩ ⟨⟨a', b'⟩, c'⟩; simp [Matrix.mul_apply, Matrix.kroneckerMap, Matrix.one_apply, Matrix.reindex];
+  -- By definition of matrix multiplication and the properties of the Kronecker product, we can
+  -- expand both sides.
+  ext ⟨⟨a, b⟩, c⟩ ⟨⟨a', b'⟩, c'⟩;
+  simp [Matrix.mul_apply, Matrix.kroneckerMap, Matrix.one_apply, Matrix.reindex];
   unfold W_mat; simp [ Matrix.mul_apply, Matrix.kroneckerMap, Matrix.reindex ] ;
   simp [ Finset.sum_ite, Finset.mul_sum _ _ _, Finset.sum_mul, mul_assoc, mul_comm, mul_left_comm];
   simp [ Finset.sum_filter, Finset.sum_sigma' ];
   rw [ ← Finset.sum_filter ];
-  refine' Finset.sum_bij ( fun x _ => ⟨ ⟨ ⟨ a', x.1.2 ⟩, c ⟩, ⟨ ⟨ x.1.2, x.2 ⟩, x.1 ⟩ ⟩ ) _ _ _ _ <;> simp;
+  refine' Finset.sum_bij
+    ( fun x _ => ⟨ ⟨ ⟨ a', x.1.2 ⟩, c ⟩, ⟨ ⟨ x.1.2, x.2 ⟩, x.1 ⟩ ⟩ ) _ _ _ _
+    <;> simp;
   aesop
 
 /- Connection between F and V_rho via the MES:
@@ -489,7 +558,8 @@ private lemma F_tensor_MES_eq_V_rho
   unfold V_rho; simp [ Matrix.mul_apply, Matrix.kroneckerMap_apply, map_to_tensor_MES ] ;
   simp [ Finset.sum_ite, Matrix.one_apply, mul_comm, Finset.mul_sum]
   rw [ Finset.sum_sigma' ] ; simp [ eq_comm, Finset.filter_filter ] ;
-  refine' Finset.sum_bij ( fun x _ => ⟨ ⟨ ⟨ k, j ⟩, j ⟩, x, j ⟩ ) _ _ _ _ <;> simp [ eq_comm ];
+  refine' Finset.sum_bij ( fun x _ => ⟨ ⟨ ⟨ k, j ⟩, j ⟩, x, j ⟩ ) _ _ _ _
+    <;> simp [ eq_comm ];
   · aesop ( simp_config := { singlePass := true } ) ;
   · intro a; rw [ Finset.sum_eq_single ⟨ ( a, j ), j ⟩ ] <;> aesop;
 
@@ -531,7 +601,8 @@ private lemma T₁_isometry [Nonempty dB]
   have h_kron : (V_rho ρAB ⊗ₖ (1 : Matrix (dB × dC) (dB × dC) ℂ))ᴴ *
       (V_rho ρAB ⊗ₖ (1 : Matrix (dB × dC) (dB × dC) ℂ)) = 1 := by
     have hV := V_rho_isometry ρAB hρ
-    convert congr_arg (fun m => Matrix.kroneckerMap (· * ·) m (1 : Matrix (dB × dC) (dB × dC) ℂ)) hV using 1
+    convert congr_arg
+      (fun m => Matrix.kroneckerMap (· * ·) m (1 : Matrix (dB × dC) (dB × dC) ℂ)) hV using 1
     · ext i j
       simp [Matrix.mul_apply, Matrix.kroneckerMap, Matrix.one_apply]
       by_cases hij : i.2 = j.2 <;> simp [hij, Finset.sum_ite]
@@ -540,7 +611,8 @@ private lemma T₁_isometry [Nonempty dB]
     · ext i j
       simp [Matrix.one_apply]
       aesop
-  convert congr_arg (Matrix.reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm) h_kron using 1
+  convert congr_arg
+    (Matrix.reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm) h_kron using 1
   ext i j
   simp [Matrix.one_apply]
   aesop
@@ -551,7 +623,8 @@ private lemma T₂_sq_le_one [Nonempty dB]
     (T₂_mat dA dB dC σBC)ᴴ * (T₂_mat dA dB dC σBC) ≤ 1 := by
   have hT₂_isometry : (V_sigma σBC).conjTranspose * (V_sigma σBC) = 1 :=
     V_sigma_isometry σBC hσ
-  convert isometry_mul_conjTranspose_le_one (Matrix.kronecker (1 : Matrix (dA × dB) (dA × dB) ℂ) (V_sigma σBC)) _ using 1
+  convert isometry_mul_conjTranspose_le_one
+    (Matrix.kronecker (1 : Matrix (dA × dB) (dA × dB) ℂ) (V_sigma σBC)) _ using 1
   · ext ⟨i, j⟩ ⟨k, l⟩
     simp [Matrix.mul_apply]
     ring_nf
@@ -561,7 +634,8 @@ private lemma T₂_sq_le_one [Nonempty dB]
     congr! 2
     · exact eq_comm
     · aesop
-  · convert congr_arg (Matrix.kronecker (1 : Matrix (dA × dB) (dA × dB) ℂ)) hT₂_isometry using 1
+  · convert congr_arg
+      (Matrix.kronecker (1 : Matrix (dA × dB) (dA × dB) ℂ)) hT₂_isometry using 1
     · ext ⟨ i, j ⟩ ⟨ k, l ⟩
       simp [ Matrix.mul_apply]
       ring_nf
@@ -615,7 +689,8 @@ private lemma W_mat_entry (ρAB : HermitianMat (dA × dB) ℂ) (σBC : Hermitian
   simp only [HermitianMat.mat_apply]
   -- Collapse ite sums: ρ part
   have h_ite_rho : ∀ (i : dA) (x : dB) (f : dA × dB → ℂ),
-      (∑ i_1 : (dA × dB) × dB, if i_1.1.1 = i ∧ i_1.1.2 = i_1.2 then if x = i_1.2 then f i_1.1 else 0 else 0) =
+      (∑ i_1 : (dA × dB) × dB,
+        if i_1.1.1 = i ∧ i_1.1.2 = i_1.2 then if x = i_1.2 then f i_1.1 else 0 else 0) =
       f (i, x) := by
     intro i x f; rw [Finset.sum_eq_single ⟨(i, x), x⟩]
     · simp
@@ -626,7 +701,8 @@ private lemma W_mat_entry (ρAB : HermitianMat (dA × dB) ℂ) (σBC : Hermitian
   simp_rw [← Finset.sum_mul]
   -- Now the σ inner sum has the same shape as h_ite_rho but for dC×dB
   have h_ite_sigma : ∀ (i : dC) (x : dB) (f : dC × dB → ℂ),
-      (∑ i_1 : (dC × dB) × dB, if i_1.1.1 = i ∧ i_1.1.2 = i_1.2 then if x = i_1.2 then f i_1.1 else 0 else 0) =
+      (∑ i_1 : (dC × dB) × dB,
+        if i_1.1.1 = i ∧ i_1.1.2 = i_1.2 then if x = i_1.2 then f i_1.1 else 0 else 0) =
       f (i, x) := by
     intro i x f; rw [Finset.sum_eq_single ⟨(i, x), x⟩]
     · simp
@@ -637,7 +713,8 @@ private lemma W_mat_entry (ρAB : HermitianMat (dA × dB) ℂ) (σBC : Hermitian
     arg 2; ext x_outer
     arg 2; arg 2; ext x_1
     arg 1
-    rw [h_ite_sigma x_1 x_outer (fun p => star ((σBC.reindex (Equiv.prodComm dB dC)).sqrt (c', b') p))]
+    rw [h_ite_sigma x_1 x_outer
+      (fun p => star ((σBC.reindex (Equiv.prodComm dB dC)).sqrt (c', b') p))]
   -- Now relate reindexed σBC terms to original terms
   -- cfc_reindex: (A.reindex e).sqrt = A.sqrt.reindex e
   simp only [show (σBC.reindex (Equiv.prodComm dB dC)).sqrt =
@@ -651,7 +728,8 @@ private lemma W_mat_entry (ρAB : HermitianMat (dA × dB) ℂ) (σBC : Hermitian
       Matrix.submatrix_apply, Equiv.prodComm_symm, Equiv.prodComm_apply, Prod.swap]]
   -- Hermiticity
   have h1 : σBC.sqrt.matᴴ = σBC.sqrt.mat := σBC.sqrt.2
-  have h2 : σBC.traceLeft⁻¹.sqrt.matᴴ = σBC.traceLeft⁻¹.sqrt.mat := σBC.traceLeft⁻¹.sqrt.2
+  have h2 : σBC.traceLeft⁻¹.sqrt.matᴴ = σBC.traceLeft⁻¹.sqrt.mat :=
+    σBC.traceLeft⁻¹.sqrt.2
   -- Expand product of sums and match
   simp_rw [Finset.sum_mul, Finset.mul_sum]
   -- Both sides are triple sums with the same structure. Match element-wise.
@@ -696,11 +774,13 @@ private lemma RHS_entry (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMa
       exfalso; apply hne; ext <;> grind only
     · intro h; exact absurd (Finset.mem_univ _) h
   simp_rw [h_inner, ite_mul, zero_mul]
-  rw [show Finset.univ (α := BigIdx dA dB dC) = (Finset.univ ×ˢ Finset.univ : Finset (((dA × dB) × dB) × (dB × dC)))
+  rw [show Finset.univ (α := BigIdx dA dB dC) =
+    (Finset.univ ×ˢ Finset.univ : Finset (((dA × dB) × dB) × (dB × dC)))
     from Finset.univ_product_univ.symm]
   rw [Finset.sum_product]
   simp only [Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
-  rw [show Finset.univ (α := (dA × dB) × dB) = (Finset.univ ×ˢ Finset.univ : Finset ((dA × dB) × dB))
+  rw [show Finset.univ (α := (dA × dB) × dB) =
+    (Finset.univ ×ˢ Finset.univ : Finset ((dA × dB) × dB))
     from Finset.univ_product_univ.symm]
   rw [Finset.sum_product]
   simp only [RCLike.star_def, Finset.sum_ite_irrel, Finset.sum_const_zero, Finset.sum_ite_eq',
@@ -748,26 +828,35 @@ private lemma S_mat_isUnit [Nonempty dA] [Nonempty dB] [Nonempty dC]
   -- Since ρAB and σBC are positive definite, their square roots are also invertible.
   have h_inv_sqrt : IsUnit (ρAB.traceRight⁻¹.sqrt.mat.det) ∧ IsUnit (σBC.sqrt.mat.det) := by
     constructor;
-    · have h_det_ne_zero : ∀ (A : HermitianMat (dA) ℂ), A.mat.PosDef → (A.sqrt).mat.det ≠ 0 := by
+    · have h_det_ne_zero :
+          ∀ (A : HermitianMat (dA) ℂ), A.mat.PosDef → (A.sqrt).mat.det ≠ 0 := by
         intro A hA
         have h_det_ne_zero : (A.sqrt).mat.PosDef := by
           exact sqrt_posDef hA;
         exact h_det_ne_zero.det_pos.ne';
-      exact isUnit_iff_ne_zero.mpr ( h_det_ne_zero _ <| by simpa using PosDef_traceRight _ hρ |> fun h => h.inv );
+      exact isUnit_iff_ne_zero.mpr
+        ( h_det_ne_zero _ <| by simpa using PosDef_traceRight _ hρ |> fun h => h.inv );
     · have h_inv_sqrt : σBC.sqrt.mat.PosDef := by
         exact sqrt_posDef hσ;
       exact isUnit_iff_ne_zero.mpr h_inv_sqrt.det_pos.ne';
   unfold S_mat;
   simp_all [ Matrix.det_kronecker]
 
-/-- The intermediate operator inequality: ρ_AB ⊗ σ_C⁻¹ ≤ (ρ_A ⊗ σ_BC⁻¹).reindex(assoc⁻¹).
-  This is derived from W_mat_sq_le_one by algebraic manipulation (conjugation and simplification). -/
+/-- The intermediate operator inequality:
+  ρ_AB ⊗ σ_C⁻¹ ≤ (ρ_A ⊗ σ_BC⁻¹).reindex(assoc⁻¹).
+  This is derived from W_mat_sq_le_one by algebraic manipulation (conjugation and
+  simplification). -/
 theorem intermediate_ineq [Nonempty dA] [Nonempty dB] [Nonempty dC]
     (ρAB : HermitianMat (dA × dB) ℂ) (σBC : HermitianMat (dB × dC) ℂ)
     (hρ : ρAB.mat.PosDef) (hσ : σBC.mat.PosDef) :
     ρAB ⊗ₖ (σBC.traceLeft)⁻¹ ≤
       (ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm := by
-  have h_sorted : (ρAB.traceRight⁻¹.sqrt.mat ⊗ₖ σBC.sqrt.mat).reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm * (ρAB ⊗ₖ (σBC.traceLeft)⁻¹).mat * (ρAB.traceRight⁻¹.sqrt.mat ⊗ₖ σBC.sqrt.mat).reindex (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm ≤ (1 : Matrix ((dA × dB) × dC) ((dA × dB) × dC) ℂ) := by
+  have h_sorted : (ρAB.traceRight⁻¹.sqrt.mat ⊗ₖ σBC.sqrt.mat).reindex
+        (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm *
+      (ρAB ⊗ₖ (σBC.traceLeft)⁻¹).mat *
+      (ρAB.traceRight⁻¹.sqrt.mat ⊗ₖ σBC.sqrt.mat).reindex
+        (Equiv.prodAssoc dA dB dC).symm (Equiv.prodAssoc dA dB dC).symm ≤
+      (1 : Matrix ((dA × dB) × dC) ((dA × dB) × dC) ℂ) := by
     convert W_mat_sq_le_one ρAB σBC hρ hσ using 1;
     convert W_mat_sq_eq_conj ρAB σBC hρ hσ |> Eq.symm using 1;
   convert h_sorted using 1;
@@ -779,7 +868,12 @@ theorem intermediate_ineq [Nonempty dA] [Nonempty dB] [Nonempty dC]
     convert S_mat_conj_rhs_eq_one ρAB σBC hρ hσ using 1;
   · have := S_mat_isUnit ρAB σBC hρ hσ;
     cases' this.nonempty_invertible with u hu;
-    have h_pos_semidef : Matrix.PosSemidef ((S_mat ρAB σBC)⁻¹ * (S_mat ρAB σBC * ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm).mat * S_mat ρAB σBC - S_mat ρAB σBC * (ρAB ⊗ₖ (σBC.traceLeft)⁻¹).mat * S_mat ρAB σBC) * (S_mat ρAB σBC)⁻¹ᴴ) := by
+    have h_pos_semidef : Matrix.PosSemidef ((S_mat ρAB σBC)⁻¹ *
+        (S_mat ρAB σBC *
+            ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm).mat *
+            S_mat ρAB σBC -
+          S_mat ρAB σBC * (ρAB ⊗ₖ (σBC.traceLeft)⁻¹).mat * S_mat ρAB σBC) *
+        (S_mat ρAB σBC)⁻¹ᴴ) := by
       exact Matrix.PosSemidef.mul_mul_conjTranspose_same h (S_mat ρAB σBC)⁻¹;
     simp_all [ Matrix.mul_assoc, Matrix.sub_mul, Matrix.mul_sub ];
     simp_all [ Matrix.posSemidef_iff_dotProduct_mulVec, Matrix.IsHermitian ];
@@ -798,12 +892,18 @@ theorem operator_ineq_SSA [Nonempty dA] [Nonempty dB] [Nonempty dC]
     (hρ : ρAB.mat.PosDef) (hσ : σBC.mat.PosDef) :
     ρAB.traceRight⁻¹ ⊗ₖ σBC ≤
       (ρAB⁻¹ ⊗ₖ σBC.traceLeft).reindex (Equiv.prodAssoc dA dB dC) := by
-  have h_inv_symm : ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm)⁻¹ ≤ (ρAB ⊗ₖ σBC.traceLeft⁻¹)⁻¹ := by
+  have h_inv_symm :
+      ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm)⁻¹ ≤
+      (ρAB ⊗ₖ σBC.traceLeft⁻¹)⁻¹ := by
     apply HermitianMat.inv_antitone;
-    · apply HermitianMat.PosDef_kronecker ρAB (σBC.traceLeft)⁻¹ hρ (PosDef_traceLeft σBC hσ).inv;
+    · apply HermitianMat.PosDef_kronecker ρAB (σBC.traceLeft)⁻¹ hρ
+        (PosDef_traceLeft σBC hσ).inv;
     · exact intermediate_ineq ρAB σBC hρ hσ;
-  have h_inv_symm : ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm)⁻¹ = (ρAB.traceRight⁻¹ ⊗ₖ σBC).reindex (Equiv.prodAssoc dA dB dC).symm := by
-    have h_inv_symm : (ρAB.traceRight ⊗ₖ σBC⁻¹)⁻¹ = ρAB.traceRight⁻¹ ⊗ₖ (σBC⁻¹)⁻¹ := by
+  have h_inv_symm :
+      ((ρAB.traceRight ⊗ₖ σBC⁻¹).reindex (Equiv.prodAssoc dA dB dC).symm)⁻¹ =
+      (ρAB.traceRight⁻¹ ⊗ₖ σBC).reindex (Equiv.prodAssoc dA dB dC).symm := by
+    have h_inv_symm : (ρAB.traceRight ⊗ₖ σBC⁻¹)⁻¹ =
+        ρAB.traceRight⁻¹ ⊗ₖ (σBC⁻¹)⁻¹ := by
       convert HermitianMat.inv_kronecker _ _ using 1;
       · infer_instance;
       · exact ⟨ ⟨ Classical.arbitrary dB, Classical.arbitrary dC ⟩ ⟩;
@@ -815,19 +915,23 @@ theorem operator_ineq_SSA [Nonempty dA] [Nonempty dB] [Nonempty dC]
             exact nonSingular_of_posDef hσ
           exact nonSingular_iff_inv.mpr h_inv_symm;
         exact h_inv_symm;
-    convert congr_arg ( fun x : HermitianMat _ _ => x.reindex ( Equiv.prodAssoc dA dB dC ).symm ) h_inv_symm using 1;
+    convert congr_arg
+      ( fun x : HermitianMat _ _ => x.reindex ( Equiv.prodAssoc dA dB dC ).symm )
+      h_inv_symm using 1;
     · apply HermitianMat.inv_reindex
     · convert rfl;
       apply HermitianMat.ext;
       convert Matrix.nonsing_inv_nonsing_inv _ _;
       exact isUnit_iff_ne_zero.mpr ( hσ.det_pos.ne' );
   have h_inv_symm : (ρAB ⊗ₖ σBC.traceLeft⁻¹)⁻¹ = ρAB⁻¹ ⊗ₖ σBC.traceLeft := by
-    have h_inv_symm : (ρAB ⊗ₖ σBC.traceLeft⁻¹)⁻¹ = ρAB⁻¹ ⊗ₖ (σBC.traceLeft⁻¹)⁻¹ := by
+    have h_inv_symm :
+        (ρAB ⊗ₖ σBC.traceLeft⁻¹)⁻¹ = ρAB⁻¹ ⊗ₖ (σBC.traceLeft⁻¹)⁻¹ := by
       convert HermitianMat.inv_kronecker ρAB ( σBC.traceLeft⁻¹ ) using 1;
       · exact nonSingular_of_posDef hρ;
       · have h_inv_symm : σBC.traceLeft.mat.PosDef := by
           exact PosDef_traceLeft σBC hσ;
-        -- Since σBC.traceLeft is positive definite, its inverse is also positive definite, and hence non-singular.
+        -- Since σBC.traceLeft is positive definite, its inverse is also positive definite, and
+        -- hence non-singular.
         have h_inv_pos_def : (σBC.traceLeft⁻¹).mat.PosDef := by
           convert h_inv_symm.inv using 1;
         exact nonSingular_of_posDef h_inv_pos_def;
@@ -840,13 +944,16 @@ theorem operator_ineq_SSA [Nonempty dA] [Nonempty dB] [Nonempty dC]
           convert Matrix.nonsing_inv_mul _ _;
           exact isUnit_iff_ne_zero.mpr h_inv_symm.det_pos.ne';
         exact h_inv_symm
-      have h_inv_symm : (σBC.traceLeft⁻¹ : HermitianMat dC ℂ).mat⁻¹ = σBC.traceLeft.mat := by
+      have h_inv_symm :
+          (σBC.traceLeft⁻¹ : HermitianMat dC ℂ).mat⁻¹ = σBC.traceLeft.mat := by
         rw [ Matrix.inv_eq_right_inv h_inv_symm ];
       exact Eq.symm (HermitianMat.ext (id (Eq.symm h_inv_symm)));
     rw [h_inv_symm];
-  have h_inv_symm : (ρAB.traceRight⁻¹ ⊗ₖ σBC).reindex (Equiv.prodAssoc dA dB dC).symm ≤ ρAB⁻¹ ⊗ₖ σBC.traceLeft := by
+  have h_inv_symm : (ρAB.traceRight⁻¹ ⊗ₖ σBC).reindex (Equiv.prodAssoc dA dB dC).symm ≤
+      ρAB⁻¹ ⊗ₖ σBC.traceLeft := by
     aesop;
-  convert HermitianMat.reindex_le_reindex_iff ( Equiv.prodAssoc dA dB dC ) _ _ |>.2 h_inv_symm using 1
+  convert HermitianMat.reindex_le_reindex_iff ( Equiv.prodAssoc dA dB dC ) _ _ |>.2 h_inv_symm
+    using 1
 
 open scoped InnerProductSpace RealInnerProductSpace
 
@@ -859,8 +966,11 @@ private lemma inner_kron_one_eq_inner_traceRight
     (A : HermitianMat d₁ ℂ) (M : HermitianMat (d₁ × d₂) ℂ) :
     ⟪A ⊗ₖ (1 : HermitianMat d₂ ℂ), M⟫ = ⟪A, M.traceRight⟫ := by
   rw [inner_comm];
-  -- By definition of partial trace, we have that the trace of M multiplied by (A ⊗ I) is equal to the trace of A multiplied by the partial trace of M.
-  have h_partial_trace : Matrix.trace (M.mat * (A.mat ⊗ₖ 1 : Matrix (d₁ × d₂) (d₁ × d₂) ℂ)) = Matrix.trace (A.mat * M.traceRight.mat) := by
+  -- By definition of partial trace, we have that the trace of M multiplied by (A ⊗ I) is equal to
+  -- the trace of A multiplied by the partial trace of M.
+  have h_partial_trace :
+      Matrix.trace (M.mat * (A.mat ⊗ₖ 1 : Matrix (d₁ × d₂) (d₁ × d₂) ℂ)) =
+      Matrix.trace (A.mat * M.traceRight.mat) := by
     simp [ Matrix.trace, Matrix.mul_apply ];
     simp [ Matrix.traceRight, Matrix.one_apply, mul_comm ];
     simp only [Finset.sum_sigma', Finset.mul_sum _ _ _];
@@ -883,14 +993,16 @@ private lemma inner_one_kron_eq_inner_traceLeft
 open HermitianMat in
 private lemma hermitianMat_log_inv_eq_neg
     (A : HermitianMat d₁ ℂ) [A.NonSingular] : A⁻¹.log = -A.log := by
-  -- By the property of continuous functional calculus, the logarithm of the inverse of a matrix is the negative of the logarithm of the matrix.
+  -- By the property of continuous functional calculus, the logarithm of the inverse of a matrix is
+  -- the negative of the logarithm of the matrix.
   have h_log_inv : A⁻¹.log = A.cfc (Real.log ∘ (·⁻¹)) := by
     have h_log_inv : A⁻¹ = A.cfc (·⁻¹) := by
       exact Eq.symm HermitianMat.cfc_inv;
     rw [ h_log_inv, HermitianMat.log ];
     exact Eq.symm (HermitianMat.cfc_comp A (fun x => x⁻¹) Real.log);
   simp [ HermitianMat.log ];
-  convert congr_arg ( fun f => A.cfc f ) ( show Real.log ∘ ( fun x => x⁻¹ ) = -Real.log from funext fun x => ?_ ) using 1
+  convert congr_arg ( fun f => A.cfc f )
+    ( show Real.log ∘ ( fun x => x⁻¹ ) = -Real.log from funext fun x => ?_ ) using 1
   · exact Eq.symm (HermitianMat.cfc_neg A Real.log);
   · by_cases hx : x = 0 <;> simp [ hx, Real.log_inv ]
 
@@ -967,26 +1079,35 @@ private lemma MState.approx_by_pd
     ∃ (ρn : ℕ → MState d₁), (∀ n, (ρn n).M.mat.PosDef) ∧
       Filter.Tendsto ρn Filter.atTop (nhds ρ) := by
   have h_ne1 := ρ.nonempty
-  -- Define the sequence of PD states ρn as the mixture of ρ with the uniform state at weight εn = 1/(n+2).
+  -- Define the sequence of PD states ρn as the mixture of ρ with the uniform state at weight
+  -- εn = 1/(n+2).
   set εn : ℕ → ℝ := fun n => 1 / (n + 2)
   set ρn : ℕ → MState d₁ := fun n => Mixable.mix ⟨εn n, by
     exact ⟨ by positivity, by rw [ div_le_iff₀ ] <;> linarith ⟩⟩ (MState.uniform) ρ
   refine' ⟨ ρn, _, _ ⟩;
   · intro n
-    have h_pos_def : (ρn n).M = (1 - εn n) • ρ.M + εn n • (MState.uniform (d := d₁)).M := by
+    have h_pos_def : (ρn n).M =
+        (1 - εn n) • ρ.M + εn n • (MState.uniform (d := d₁)).M := by
       refine' add_comm _ _ |> Eq.trans <| _;
       congr! 1
       aesop;
-    have h_pos_def : ∀ (A : Matrix d₁ d₁ ℂ), A.PosSemidef → ∀ (B : Matrix d₁ d₁ ℂ), B.PosDef → ∀ (ε : ℝ), 0 < ε ∧ ε < 1 → (1 - ε) • A + ε • B ∈ {M : Matrix d₁ d₁ ℂ | M.PosDef} := by
+    have h_pos_def : ∀ (A : Matrix d₁ d₁ ℂ), A.PosSemidef →
+        ∀ (B : Matrix d₁ d₁ ℂ), B.PosDef →
+        ∀ (ε : ℝ), 0 < ε ∧ ε < 1 →
+        (1 - ε) • A + ε • B ∈ {M : Matrix d₁ d₁ ℂ | M.PosDef} := by
       intro A hA B hB ε hε
-      simp only [ Matrix.posSemidef_iff_dotProduct_mulVec, Matrix.posDef_iff_dotProduct_mulVec ] at *
+      simp only [ Matrix.posSemidef_iff_dotProduct_mulVec,
+        Matrix.posDef_iff_dotProduct_mulVec ] at *
       constructor <;> simp_all
       · simp_all [ Matrix.IsHermitian, Matrix.conjTranspose_add, Matrix.conjTranspose_smul ];
       · intro x hx_ne_zero
         have h_pos : 0 < (1 - ε) * (star x ⬝ᵥ A *ᵥ x) + ε * (star x ⬝ᵥ B *ᵥ x) := by
-          exact add_pos_of_nonneg_of_pos ( mul_nonneg ( sub_nonneg.2 <| mod_cast hε.2.le ) <| mod_cast hA.2 x ) <| mul_pos ( mod_cast hε.1 ) <| mod_cast hB.2 hx_ne_zero;
+          exact add_pos_of_nonneg_of_pos
+            ( mul_nonneg ( sub_nonneg.2 <| mod_cast hε.2.le ) <| mod_cast hA.2 x )
+            <| mul_pos ( mod_cast hε.1 ) <| mod_cast hB.2 hx_ne_zero;
         convert h_pos using 1 ; simp [ Matrix.add_mulVec ] ; ring_nf!
-        simp [ Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _, mul_assoc, mul_left_comm, sub_mul, mul_sub ] ; ring!;
+        simp [ Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _, mul_assoc, mul_left_comm, sub_mul,
+          mul_sub ] ; ring!;
     convert h_pos_def _ _ _ _ _ ⟨ _, _ ⟩ <;> norm_num [ * ];
     congr! 1
     exact psd ρ
@@ -994,8 +1115,14 @@ private lemma MState.approx_by_pd
     · exact one_div_pos.mpr ( by linarith );
     · exact div_lt_one ( by positivity ) |>.2 ( by linarith )
   · -- Show that the sequence ρn converges to ρ.
-    have h_conv : Filter.Tendsto (fun n => εn n • (MState.uniform : MState d₁).M + (1 - εn n) • ρ.M) Filter.atTop (nhds ρ.M) := by
-      exact le_trans ( Filter.Tendsto.add ( Filter.Tendsto.smul ( tendsto_const_nhds.div_atTop <| Filter.tendsto_atTop_add_const_right _ _ tendsto_natCast_atTop_atTop ) tendsto_const_nhds ) ( Filter.Tendsto.smul ( tendsto_const_nhds.sub <| tendsto_const_nhds.div_atTop <| Filter.tendsto_atTop_add_const_right _ _ tendsto_natCast_atTop_atTop ) tendsto_const_nhds ) ) ( by simp );
+    have h_conv : Filter.Tendsto
+        (fun n => εn n • (MState.uniform : MState d₁).M + (1 - εn n) • ρ.M)
+        Filter.atTop (nhds ρ.M) := by
+      exact le_trans ( Filter.Tendsto.add ( Filter.Tendsto.smul ( tendsto_const_nhds.div_atTop
+        <| Filter.tendsto_atTop_add_const_right _ _ tendsto_natCast_atTop_atTop )
+        tendsto_const_nhds ) ( Filter.Tendsto.smul ( tendsto_const_nhds.sub
+        <| tendsto_const_nhds.div_atTop <| Filter.tendsto_atTop_add_const_right _ _
+        tendsto_natCast_atTop_atTop ) tendsto_const_nhds ) ) ( by simp );
     rw [ tendsto_iff_dist_tendsto_zero ] at *;
     convert h_conv using 1;
     ext n; simp [ρn, Mixable.mix];
@@ -1005,11 +1132,18 @@ set_option backward.isDefEq.respectTransparency false in
 @[fun_prop]
 private lemma MState.traceLeft_continuous :
     Continuous (MState.traceLeft : MState (d₁ × d₂) → MState d₂) := by
-  -- Since the matrix traceLeft is continuous, the function that maps a state to its partial trace is also continuous.
-  have h_traceLeft_cont : Continuous (fun ρ : HermitianMat (d₁ × d₂) ℂ => ρ.traceLeft) := by
-    have h_cont : Continuous (fun ρ : Matrix (d₁ × d₂) (d₁ × d₂) ℂ => ρ.traceLeft) := by
-      exact continuous_pi fun _ => continuous_pi fun _ => continuous_finsetSum _ fun _ _ => continuous_apply _ |> Continuous.comp <| continuous_apply _ |> Continuous.comp <| continuous_id';
-    convert h_cont.comp ( show Continuous fun ρ : HermitianMat ( d₁ × d₂ ) ℂ => ρ.1 from ?_ ) using 1;
+  -- Since the matrix traceLeft is continuous, the function that maps a state to its partial trace
+  -- is also continuous.
+  have h_traceLeft_cont :
+      Continuous (fun ρ : HermitianMat (d₁ × d₂) ℂ => ρ.traceLeft) := by
+    have h_cont :
+        Continuous (fun ρ : Matrix (d₁ × d₂) (d₁ × d₂) ℂ => ρ.traceLeft) := by
+      exact continuous_pi fun _ => continuous_pi fun _ => continuous_finsetSum _ fun _ _ =>
+        continuous_apply _ |> Continuous.comp <| continuous_apply _ |> Continuous.comp
+        <| continuous_id';
+    convert h_cont.comp
+      ( show Continuous fun ρ : HermitianMat ( d₁ × d₂ ) ℂ => ρ.1 from ?_ )
+      using 1;
     · constructor <;> intro h <;> rw [ continuous_induced_rng ] at * <;> aesop;
     · fun_prop;
   exact continuous_induced_rng.mpr ( by continuity )
@@ -1024,9 +1158,13 @@ private lemma MState.traceRight_continuous :
   intro s hs hρs;
   rcases hs with ⟨ t, ht, rfl ⟩;
   -- The traceRight map is continuous, so the preimage of an open set under traceRight is open.
-  have h_traceRight_cont : Continuous (HermitianMat.traceRight : HermitianMat (d₁ × d₂) ℂ → HermitianMat d₁ ℂ) := by
+  have h_traceRight_cont :
+      Continuous (HermitianMat.traceRight :
+        HermitianMat (d₁ × d₂) ℂ → HermitianMat d₁ ℂ) := by
     -- The traceRight map is a linear map, hence continuous.
-    have h_traceRight_linear : ∃ (f : HermitianMat (d₁ × d₂) ℂ →ₗ[ℝ] HermitianMat d₁ ℂ), ∀ A, f A = A.traceRight := by
+    have h_traceRight_linear :
+        ∃ (f : HermitianMat (d₁ × d₂) ℂ →ₗ[ℝ] HermitianMat d₁ ℂ),
+          ∀ A, f A = A.traceRight := by
       refine' ⟨ _, _ ⟩;
       refine' { .. };
       exact fun A => A.traceRight;
@@ -1037,14 +1175,20 @@ private lemma MState.traceRight_continuous :
     convert f.continuous_of_finiteDimensional;
     exact funext fun A => hf A ▸ rfl;
   have := h_traceRight_cont.isOpen_preimage t ht;
-  exact Filter.mem_of_superset ( this.preimage ( continuous_induced_dom ) |> IsOpen.mem_nhds <| by simpa using hρs ) fun x hx => hx
+  exact Filter.mem_of_superset
+    ( this.preimage ( continuous_induced_dom ) |> IsOpen.mem_nhds <| by simpa using hρs )
+    fun x hx => hx
 
 @[fun_prop]
 private lemma MState.assoc'_continuous :
-    Continuous (MState.assoc' : MState (d₁ × d₂ × d₃) → MState ((d₁ × d₂) × d₃)) := by
+    Continuous
+      (MState.assoc' : MState (d₁ × d₂ × d₃) → MState ((d₁ × d₂) × d₃)) := by
   apply continuous_induced_rng.mpr;
-  -- The reindex function is continuous because it is a composition of continuous functions (permutations).
-  have h_reindex_cont : Continuous (fun ρ : HermitianMat (d₁ × d₂ × d₃) ℂ => ρ.reindex (Equiv.prodAssoc d₁ d₂ d₃).symm) := by
+  -- The reindex function is continuous because it is a composition of continuous functions
+  -- (permutations).
+  have h_reindex_cont : Continuous
+      (fun ρ : HermitianMat (d₁ × d₂ × d₃) ℂ =>
+        ρ.reindex (Equiv.prodAssoc d₁ d₂ d₃).symm) := by
     apply continuous_induced_rng.mpr;
     fun_prop (disch := norm_num);
   convert h_reindex_cont.comp _ using 2;
@@ -1057,12 +1201,23 @@ lemma Sᵥₙ_wm (ρ : MState (d₁ × d₂ × d₃)) :
   have h_ne123 := ρ.nonempty
   obtain ⟨ ρn, hρn_pos, hρn ⟩ := MState.approx_by_pd ρ;
   -- Apply the inequality for each ρn and then take the limit.
-  have h_lim : Filter.Tendsto (fun n => Sᵥₙ (ρn n).traceRight + Sᵥₙ (ρn n).traceLeft.traceLeft) Filter.atTop (nhds (Sᵥₙ ρ.traceRight + Sᵥₙ ρ.traceLeft.traceLeft)) ∧ Filter.Tendsto (fun n => Sᵥₙ (ρn n).assoc'.traceRight + Sᵥₙ (ρn n).traceLeft) Filter.atTop (nhds (Sᵥₙ ρ.assoc'.traceRight + Sᵥₙ ρ.traceLeft)) := by
+  have h_lim : Filter.Tendsto
+        (fun n => Sᵥₙ (ρn n).traceRight + Sᵥₙ (ρn n).traceLeft.traceLeft) Filter.atTop
+        (nhds (Sᵥₙ ρ.traceRight + Sᵥₙ ρ.traceLeft.traceLeft)) ∧
+      Filter.Tendsto
+        (fun n => Sᵥₙ (ρn n).assoc'.traceRight + Sᵥₙ (ρn n).traceLeft) Filter.atTop
+        (nhds (Sᵥₙ ρ.assoc'.traceRight + Sᵥₙ ρ.traceLeft)) := by
     constructor <;> refine' Filter.Tendsto.add _ _;
-    · exact Sᵥₙ_continuous.continuousAt.tendsto.comp ( MState.traceRight_continuous.continuousAt.tendsto.comp hρn );
-    · exact Sᵥₙ_continuous.comp ( MState.traceLeft_continuous.comp ( MState.traceLeft_continuous ) ) |> fun h => h.continuousAt.tendsto.comp hρn;
-    · convert Sᵥₙ_continuous.continuousAt.tendsto.comp ( MState.traceRight_continuous.continuousAt.tendsto.comp ( MState.assoc'_continuous.continuousAt.tendsto.comp hρn ) ) using 1;
-    · exact Sᵥₙ_continuous.continuousAt.tendsto.comp ( MState.traceLeft_continuous.continuousAt.tendsto.comp hρn );
+    · exact Sᵥₙ_continuous.continuousAt.tendsto.comp
+        ( MState.traceRight_continuous.continuousAt.tendsto.comp hρn );
+    · exact Sᵥₙ_continuous.comp
+        ( MState.traceLeft_continuous.comp ( MState.traceLeft_continuous ) )
+        |> fun h => h.continuousAt.tendsto.comp hρn;
+    · convert Sᵥₙ_continuous.continuousAt.tendsto.comp
+        ( MState.traceRight_continuous.continuousAt.tendsto.comp
+        ( MState.assoc'_continuous.continuousAt.tendsto.comp hρn ) ) using 1;
+    · exact Sᵥₙ_continuous.continuousAt.tendsto.comp
+        ( MState.traceLeft_continuous.continuousAt.tendsto.comp hρn );
   have ⟨_, hn23⟩ := nonempty_prod.mp h_ne123
   have ⟨_, _⟩ := nonempty_prod.mp hn23
   exact le_of_tendsto_of_tendsto' h_lim.1 h_lim.2 fun n => Sᵥₙ_wm_pd _ ( hρn_pos n )
@@ -1089,9 +1244,11 @@ private lemma S_BC_of_BCR_eq (ρ : MState (dA × dB × dC)) :
     simp
     simp [ Matrix.traceLeft, Matrix.traceRight, Matrix.submatrix ];
     have := ρ.purify_spec;
-    replace this := congr_arg ( fun x => x.M.val ) this ; simp_all [ MState.traceRight, MState.pure ];
+    replace this := congr_arg ( fun x => x.M.val ) this ;
+    simp_all [ MState.traceRight, MState.pure ];
     simp [ ← this, Matrix.traceRight, Matrix.vecMulVec ];
-    exact Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+    exact Finset.sum_comm.trans
+      ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
   rw [h_marginal]
 
 /-- Equivalence to relabel the purification as (dA × dB) × (dC × R). -/
@@ -1120,14 +1277,17 @@ private lemma BCR_traceLeft_eq_purify_traceLeft (ρ : MState (dA × dB × dC)) :
     ext i₁ j₁
     rw [ ← Finset.sum_product' ]
     simp [ perm_A_BCR' ]
-    exact Finset.sum_bij ( fun x _ => ( x.2, x.1 ) ) ( by simp ) ( by simp ) ( by simp ) ( by simp );
+    exact Finset.sum_bij ( fun x _ => ( x.2, x.1 ) ) ( by simp ) ( by simp ) ( by simp )
+      ( by simp );
   · rfl
 
 /- The traceRight of the AB|CR-relabeled purification has same entropy as ρ.assoc'.traceRight. -/
 private lemma purify_AB_traceRight_eq (ρ : MState (dA × dB × dC)) :
     Sᵥₙ ((MState.pure ρ.purify).relabel (perm_AB_CR' dA dB dC).symm).traceRight =
     Sᵥₙ ρ.assoc'.traceRight := by
-  have h_traceRight : ((MState.pure ρ.purify).relabel (perm_AB_CR' dA dB dC).symm).traceRight = ρ.assoc'.traceRight := by
+  have h_traceRight :
+      ((MState.pure ρ.purify).relabel (perm_AB_CR' dA dB dC).symm).traceRight =
+      ρ.assoc'.traceRight := by
     have h_traceRight : (MState.pure ρ.purify).traceRight = ρ := by
       exact MState.purify_spec ρ;
     convert congr_arg ( fun m => m.assoc'.traceRight ) h_traceRight using 1;
@@ -1153,7 +1313,9 @@ private lemma S_B_of_BCR_eq (ρ : MState (dA × dB × dC)) :
   simp [ HermitianMat.traceLeft, HermitianMat.traceRight, perm_A_BCR' ];
   unfold Matrix.traceLeft Matrix.traceRight; simp [Matrix.vecMulVec ] ;
   -- By definition of purification, we know that ρ.purify is a purification of ρ.m.
-  have h_purify : ∀ (i j : dA × dB × dC), ρ.m i j = ∑ r : dA × dB × dC, ρ.purify (i, r) * (starRingEnd ℂ) (ρ.purify (j, r)) := by
+  have h_purify : ∀ (i j : dA × dB × dC),
+      ρ.m i j =
+        ∑ r : dA × dB × dC, ρ.purify (i, r) * (starRingEnd ℂ) (ρ.purify (j, r)) := by
     intro i j
     have := ρ.purify_spec;
     replace this := congr_arg ( fun m => m.M i j ) this
@@ -1198,7 +1360,8 @@ theorem Sᵥₙ_strong_subadditivity (ρ₁₂₃ : MState (d₁ × d₂ × d₃
 theorem Sᵥₙ_subadditivity (ρ : MState (d₁ × d₂)) :
     Sᵥₙ ρ ≤ Sᵥₙ ρ.traceRight + Sᵥₙ ρ.traceLeft := by
   have := Sᵥₙ_strong_subadditivity (ρ.relabel (d₂ := d₁ × Unit × d₂)
-    ⟨fun x ↦ (x.1, x.2.2), fun x ↦ (x.1, ⟨(), x.2⟩), fun x ↦ by simp, fun x ↦ by simp⟩)
+    ⟨fun x ↦ (x.1, x.2.2), fun x ↦ (x.1, ⟨(), x.2⟩), fun x ↦ by simp,
+      fun x ↦ by simp⟩)
   simp [Sᵥₙ_relabel] at this
   convert this using 1
   congr 1
@@ -1218,7 +1381,8 @@ theorem Sᵥₙ_pure_tripartite_triangle (ψ : Ket ((d₁ × d₂) × d₃)) :
     MState.traceLeft_right_assoc, MState.traceRight_assoc]
 
 /-- One direction of the Araki-Lieb triangle inequality: S(A) ≤ S(B) + S(AB). -/
-theorem Sᵥₙ_triangle_ineq_one_way (ρ : MState (d₁ × d₂)) : Sᵥₙ ρ.traceRight ≤ Sᵥₙ ρ.traceLeft + Sᵥₙ ρ := by
+theorem Sᵥₙ_triangle_ineq_one_way (ρ : MState (d₁ × d₂)) :
+    Sᵥₙ ρ.traceRight ≤ Sᵥₙ ρ.traceLeft + Sᵥₙ ρ := by
   have := Sᵥₙ_pure_tripartite_triangle ρ.purify
   have := Sᵥₙ_of_partial_eq ρ.purify
   aesop
@@ -1279,7 +1443,8 @@ theorem qcmi_le_2_log_dim (ρ : MState (dA × dB × dC)) :
 /-- The quantum conditional mutual information `QCMI ρABC` is at most 2 log dC. -/
 theorem qcmi_le_2_log_dim' (ρ : MState (dA × dB × dC)) :
     qcmi ρ ≤ 2 * Real.log (Fintype.card dC) := by
-  have h_araki_lieb_assoc' : Sᵥₙ ρ.assoc'.traceRight - Sᵥₙ ρ.traceLeft.traceLeft ≤ Sᵥₙ ρ := by
+  have h_araki_lieb_assoc' :
+      Sᵥₙ ρ.assoc'.traceRight - Sᵥₙ ρ.traceLeft.traceLeft ≤ Sᵥₙ ρ := by
     apply le_of_abs_le
     rw [← ρ.traceLeft_assoc', ← Sᵥₙ_of_assoc'_eq ρ]
     exact Sᵥₙ_triangle_subaddivity ρ.assoc'
@@ -1293,7 +1458,8 @@ It should be something like this, but it's hard to track the indices correctly:
 theorem qcmi_chain_rule (ρ : MState ((dA₁ × dA₂) × dB × dC)) :
     let ρA₁BC := ρ.assoc.SWAP.assoc.traceLeft.SWAP;
     let ρA₂BA₁C : MState (dA₂ × (dA₁ × dB) × dC) :=
-      ((CPTPMap.id ⊗ₖ CPTPMap.assoc').compose (CPTPMap.assoc.compose (CPTPMap.SWAP ⊗ₖ CPTPMap.id))) ρ;
+      ((CPTPMap.id ⊗ₖ CPTPMap.assoc').compose
+        (CPTPMap.assoc.compose (CPTPMap.SWAP ⊗ₖ CPTPMap.id))) ρ;
     qcmi ρ = qcmi ρA₁BC + qcmi ρA₂BA₁C
      := by
   admit

--- a/QuantumInfo/Entropy/VonNeumann.lean
+++ b/QuantumInfo/Entropy/VonNeumann.lean
@@ -100,7 +100,8 @@ theorem Sᵥₙ_nonneg (ρ : MState d) : 0 ≤ Sᵥₙ ρ :=
   Hₛ_nonneg _
 
 /-- von Neumman entropy is at most log d. -/
-theorem Sᵥₙ_le_log_d (ρ : MState d) : Sᵥₙ ρ ≤ Real.log (Finset.card Finset.univ (α := d)):=
+theorem Sᵥₙ_le_log_d (ρ : MState d) :
+    Sᵥₙ ρ ≤ Real.log (Finset.card Finset.univ (α := d)):=
   Hₛ_le_log_d _
 
 /-- von Neumman entropy of pure states is zero. -/
@@ -126,7 +127,8 @@ theorem Sᵥₙ_eq_trace_cfc_negMulLog (ρ : MState d) :
     Sᵥₙ ρ = (ρ.M.cfc Real.negMulLog).trace := by
   open HermitianMat in
   unfold Real.negMulLog
-  rw [Sᵥₙ_eq_neg_trace_log, trace, log, inner_eq_re_trace, IsMaximalSelfAdjoint.RCLike_selfadjMap]
+  rw [Sᵥₙ_eq_neg_trace_log, trace, log, inner_eq_re_trace,
+    IsMaximalSelfAdjoint.RCLike_selfadjMap]
   nth_rw 2 [← cfc_id ρ.M]
   rw [← mat_cfc_mul, RCLike.re_to_complex, ← Complex.neg_re, ← Matrix.trace_neg]
   rw [← mat_neg, ← ρ.M.cfc_neg]
@@ -152,13 +154,15 @@ theorem Sᵥₙ_of_SWAP_eq (ρ : MState (d₁ × d₂)) : Sᵥₙ ρ.SWAP = Sᵥ
 
 /-- Von Neumann entropy is unchanged under assoc. -/
 @[simp]
-theorem Sᵥₙ_of_assoc_eq (ρ : MState ((d₁ × d₂) × d₃)) : Sᵥₙ ρ.assoc = Sᵥₙ ρ := by
+theorem Sᵥₙ_of_assoc_eq (ρ : MState ((d₁ × d₂) × d₃)) :
+    Sᵥₙ ρ.assoc = Sᵥₙ ρ := by
   apply Hₛ_eq_of_multiset_map_eq
   apply ρ.multiset_spectrum_relabel_eq
 
 /-- Von Neumann entropy is unchanged under assoc'. -/
 @[simp]
-theorem Sᵥₙ_of_assoc'_eq (ρ : MState (d₁ × (d₂ × d₃))) : Sᵥₙ ρ.assoc' = Sᵥₙ ρ := by
+theorem Sᵥₙ_of_assoc'_eq (ρ : MState (d₁ × (d₂ × d₃))) :
+    Sᵥₙ ρ.assoc' = Sᵥₙ ρ := by
   rw [← Sᵥₙ_of_assoc_eq, ρ.assoc_assoc']
 
 @[fun_prop]
@@ -184,7 +188,8 @@ section partial_trace_pure
 /--
 Convert a vector on a product space to a matrix.
 -/
-def vecToMat {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] (v : d₁ × d₂ → ℂ) : Matrix d₁ d₂ ℂ :=
+def vecToMat {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] (v : d₁ × d₂ → ℂ) :
+    Matrix d₁ d₂ ℂ :=
   Matrix.of (fun i j => v (i, j))
 
 /--
@@ -200,7 +205,8 @@ The left partial trace of a pure state is the product of the transpose of the
 matrix representation and its conjugate.
 -/
 lemma traceLeft_eq_transpose_mul_conj (ψ : Ket (d₁ × d₂)) :
-    (MState.pure ψ).traceLeft.M.val = (vecToMat ψ.vec).transpose * (vecToMat ψ.vec).map star := by
+    (MState.pure ψ).traceLeft.M.val =
+      (vecToMat ψ.vec).transpose * (vecToMat ψ.vec).map star := by
   unfold vecToMat; aesop;
 
 /--
@@ -217,12 +223,14 @@ Shannon entropy is determined by the multiset of non-zero probabilities.
 -/
 private lemma Hₛ_eq_of_nonzero_multiset_eq {α β : Type*} [Fintype α] [Fintype β]
   (d₁ : ProbDistribution α) (d₂ : ProbDistribution β)
-  (h : (Finset.univ.val.map d₁.prob).filter (· ≠ 0) = (Finset.univ.val.map d₂.prob ).filter (· ≠ 0)) :
+  (h : (Finset.univ.val.map d₁.prob).filter (· ≠ 0) =
+    (Finset.univ.val.map d₂.prob ).filter (· ≠ 0)) :
     Hₛ d₁ = Hₛ d₂ := by
   -- By reindexing the sums, we can show that the Shannon entropies are equal.
   simp [Hₛ]
   -- Since the multisets of non-zero probabilities are equal, their sums are equal.
-  have h_sum_eq : ∑ x ∈ Finset.univ.filter (fun x => d₁.prob x ≠ 0), H₁ (d₁.prob x) = ∑ x ∈ Finset.univ.filter (fun x => d₂.prob x ≠ 0), H₁ (d₂.prob x) := by
+  have h_sum_eq : ∑ x ∈ Finset.univ.filter (fun x => d₁.prob x ≠ 0), H₁ (d₁.prob x) =
+      ∑ x ∈ Finset.univ.filter (fun x => d₂.prob x ≠ 0), H₁ (d₂.prob x) := by
     convert congr_arg ( fun m => m.map ( fun x => H₁ x ) |> Multiset.sum ) h using 1;
     · simp [ Finset.sum, Multiset.filter_map ];
     · simp [ Finset.sum, Multiset.filter_map ];
@@ -244,7 +252,9 @@ The non-zero eigenvalues of AB and BA are the same.
 private lemma nonzero_eigenvalues_eq_of_mul_comm {n m : Type*} [Fintype n] [Fintype m]
   [DecidableEq n] [DecidableEq m] (A : Matrix n m ℂ) (B : Matrix m n ℂ) :
     (A * B).charpoly.roots.filter (· ≠ 0) = (B * A).charpoly.roots.filter (· ≠ 0) := by
-  have h_roots : (Polynomial.X ^ Fintype.card m * (Matrix.charpoly (A * B))).roots.filter (· ≠ 0) = (Polynomial.X ^ Fintype.card n * (Matrix.charpoly (B * A))).roots.filter (· ≠ 0) := by
+  have h_roots :
+      (Polynomial.X ^ Fintype.card m * (Matrix.charpoly (A * B))).roots.filter (· ≠ 0) =
+      (Polynomial.X ^ Fintype.card n * (Matrix.charpoly (B * A))).roots.filter (· ≠ 0) := by
     rw [A.charpoly_mul_comm' B]
   convert h_roots using 1
   · simp [Polynomial.roots_mul, Matrix.charpoly_monic, Polynomial.Monic.ne_zero]
@@ -264,19 +274,25 @@ private lemma Sᵥₙ_eq_of_nonzero_eigenvalues_eq (ρ₁ : MState d₁) (ρ₂ 
 Filtering non-zero elements commutes with mapping `RCLike.ofReal` for multisets.
 -/
 private lemma multiset_filter_map_ofReal_eq {R : Type*} [RCLike R] (M : Multiset ℝ) :
-    (M.map (RCLike.ofReal : ℝ → R)).filter (· ≠ 0) = (M.filter (· ≠ 0)).map RCLike.ofReal := by
+    (M.map (RCLike.ofReal : ℝ → R)).filter (· ≠ 0) =
+      (M.filter (· ≠ 0)).map RCLike.ofReal := by
   simp [Multiset.filter_map]
 
 /-
 The non-zero roots of the characteristic polynomial are the non-zero eigenvalues mapped
 to complex numbers.
 -/
-private lemma charpoly_roots_filter_ne_zero_eq_eigenvalues_filter_ne_zero {d : Type*} [Fintype d] [DecidableEq d] (A : Matrix d d ℂ) (hA : A.IsHermitian) :
-    A.charpoly.roots.filter (· ≠ 0) = ((Finset.univ.val.map hA.eigenvalues).filter (· ≠ 0)).map RCLike.ofReal := by
+private lemma charpoly_roots_filter_ne_zero_eq_eigenvalues_filter_ne_zero {d : Type*} [Fintype d]
+    [DecidableEq d] (A : Matrix d d ℂ) (hA : A.IsHermitian) :
+    A.charpoly.roots.filter (· ≠ 0) =
+      ((Finset.univ.val.map hA.eigenvalues).filter (· ≠ 0)).map RCLike.ofReal := by
   convert congr_arg _ ?_;
   rw [ multiset_filter_map_ofReal_eq ];
-  -- Since A is Hermitian, its characteristic polynomial is equal to the product of (X - eigenvalue) over all eigenvalues.
-  have h_charpoly : A.charpoly = Multiset.prod (Multiset.map (fun i => Polynomial.X - Polynomial.C (RCLike.ofReal (hA.eigenvalues i))) (Finset.univ.val)) := by
+  -- Since A is Hermitian, its characteristic polynomial is equal to the product of
+  -- (X - eigenvalue) over all eigenvalues.
+  have h_charpoly : A.charpoly = Multiset.prod (Multiset.map
+      (fun i => Polynomial.X - Polynomial.C (RCLike.ofReal (hA.eigenvalues i)))
+      (Finset.univ.val)) := by
     convert Matrix.IsHermitian.charpoly_eq hA using 1;
   rw [ h_charpoly, Polynomial.roots_multiset_prod ];
   · simp [ Multiset.bind_map ];
@@ -294,17 +310,22 @@ If the non-zero roots of the characteristic polynomials of two states are equal,
 their von Neumann entropies are equal.
 -/
 private lemma Sᵥₙ_eq_of_charpoly_roots_eq (ρ₁ : MState d₁) (ρ₂ : MState d₂)
-    (h : (ρ₁.M.1.charpoly.roots.filter (· ≠ 0)) = (ρ₂.M.1.charpoly.roots.filter (· ≠ 0))) :
+    (h : (ρ₁.M.1.charpoly.roots.filter (· ≠ 0)) =
+      (ρ₂.M.1.charpoly.roots.filter (· ≠ 0))) :
     Sᵥₙ ρ₁ = Sᵥₙ ρ₂ := by
   convert Sᵥₙ_eq_of_nonzero_eigenvalues_eq ρ₁ ρ₂ _;
-  have h_spectrum_eq_aux : (Matrix.charpoly (ρ₁.M.1)).roots.filter (· ≠ 0) = (Multiset.map (fun i => ρ₁.spectrum.prob i) Finset.univ.val).filter (· ≠ 0) ∧ (Matrix.charpoly (ρ₂.M.1)).roots.filter (· ≠ 0) = (Multiset.map (fun i => ρ₂.spectrum.prob i) Finset.univ.val).filter (· ≠ 0) := by
+  have h_spectrum_eq_aux : (Matrix.charpoly (ρ₁.M.1)).roots.filter (· ≠ 0) =
+        (Multiset.map (fun i => ρ₁.spectrum.prob i) Finset.univ.val).filter (· ≠ 0) ∧
+      (Matrix.charpoly (ρ₂.M.1)).roots.filter (· ≠ 0) =
+        (Multiset.map (fun i => ρ₂.spectrum.prob i) Finset.univ.val).filter (· ≠ 0) := by
     constructor;
     · convert charpoly_roots_filter_ne_zero_eq_eigenvalues_filter_ne_zero _ _;
       any_goals exact ρ₁.M.isSelfAdjoint;
       simp [ ProbDistribution.prob, MState.spectrum ];
       simp [ Multiset.filter_map, ProbDistribution.mk' ];
       simp [ Subtype.ext_iff ];
-    · convert charpoly_roots_filter_ne_zero_eq_eigenvalues_filter_ne_zero ρ₂.M.1 (HermitianMat.H ρ₂.M) using 1;
+    · convert charpoly_roots_filter_ne_zero_eq_eigenvalues_filter_ne_zero ρ₂.M.1
+        (HermitianMat.H ρ₂.M) using 1;
       simp [ ProbDistribution.prob, MState.spectrum ];
       simp [ Multiset.filter_map, ProbDistribution.mk' ];
       simp [ Subtype.ext_iff ];
@@ -338,7 +359,8 @@ theorem qMutualInfo_symm (ρ : MState (d₁ × d₂)) :
 even after relabeling. -/
 @[simp]
 theorem Sᵥₙ_pure_complement (ψ : Ket d₁) (e : d₂ × d₃ ≃ d₁) :
-    Sᵥₙ ((MState.pure ψ).relabel e).traceLeft = Sᵥₙ ((MState.pure ψ).relabel e).traceRight := by
+    Sᵥₙ ((MState.pure ψ).relabel e).traceLeft =
+      Sᵥₙ ((MState.pure ψ).relabel e).traceRight := by
   obtain ⟨ψ', hψ'⟩ := MState.relabel_pure_exists ψ e
   simp only [hψ', Sᵥₙ_of_partial_eq]
 

--- a/QuantumInfo/ForMathlib/ComplexLaplaceTransform.lean
+++ b/QuantumInfo/ForMathlib/ComplexLaplaceTransform.lean
@@ -24,7 +24,8 @@ def ComplexLaplaceTransform {α : Type*} [MeasurableSpace α] [MeasureTheory.Mea
   ∫ x, ComplexLaplaceIntegrand E z x
 
 /-- The complex convergence domain of a Laplace transform. -/
-def ComplexLaplaceConvergenceDomain {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α]
+def ComplexLaplaceConvergenceDomain {α : Type*} [MeasurableSpace α]
+    [MeasureTheory.MeasureSpace α]
     (E : α → WithTop ℝ) : Set ℂ :=
   {z | MeasureTheory.Integrable (μ := MeasureTheory.volume) (ComplexLaplaceIntegrand E z)}
 
@@ -75,7 +76,8 @@ private theorem norm_complexLaplaceIntegrand_horizontal_le_endpointEnvelope
   · simp only [h, dite_false]
     set e : ℝ := (E x).untop h
     rw [Complex.norm_exp, Complex.norm_exp, Complex.norm_exp]
-    rcases Set.mem_uIcc.mp ht with ⟨hat, htb⟩ | ⟨hbt, hta⟩ <;> rcases le_total 0 e with he | he
+    rcases Set.mem_uIcc.mp ht with ⟨hat, htb⟩ | ⟨hbt, hta⟩ <;>
+      rcases le_total 0 e with he | he
     · refine le_add_of_le_of_nonneg ?_ (Real.exp_pos _).le
       exact Real.exp_le_exp.mpr (by
         simp only [neg_mul, Complex.mul_re, Complex.neg_re, Complex.ofReal_re, Complex.ofReal_im,
@@ -149,14 +151,16 @@ theorem measurable_complexLaplaceIntegrand
 
 /-- Interior convergence gives integrability throughout a neighborhood of the parameter. -/
 theorem eventually_integrable_complexLaplaceIntegrand_of_mem_interior_convergenceDomain
-    {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α] {E : α → WithTop ℝ} {z : ℂ}
+    {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α] {E : α → WithTop ℝ}
+    {z : ℂ}
     (hz : z ∈ interior (ComplexLaplaceConvergenceDomain E)) :
     ∀ᶠ w in nhds z,
       MeasureTheory.Integrable (μ := MeasureTheory.volume) (ComplexLaplaceIntegrand E w) :=
   Filter.mem_of_superset (IsOpen.mem_nhds isOpen_interior hz) _root_.interior_subset
 
 theorem continuousAt_complexLaplaceTransform_of_mem_interior_convergenceDomain
-    {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α] {E : α → WithTop ℝ} {z : ℂ}
+    {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α] {E : α → WithTop ℝ}
+    {z : ℂ}
     (hz : z ∈ interior (ComplexLaplaceConvergenceDomain E)) :
     ContinuousAt (ComplexLaplaceTransform E) z := by
   rcases Metric.isOpen_iff.mp isOpen_interior z hz with ⟨ε, hε_pos, hε⟩
@@ -177,23 +181,27 @@ theorem continuousAt_complexLaplaceTransform_of_mem_interior_convergenceDomain
       (F := fun w x => ComplexLaplaceIntegrand E w x)
       (f := fun x => ComplexLaplaceIntegrand E z x)
       (ComplexLaplaceEnvelope E z (ε / 2))
-      ((eventually_integrable_complexLaplaceIntegrand_of_mem_interior_convergenceDomain (E := E) hz).mono
+      ((eventually_integrable_complexLaplaceIntegrand_of_mem_interior_convergenceDomain
+          (E := E) hz).mono
         fun _ hw => hw.aestronglyMeasurable)
       (Filter.Eventually.mono (Metric.ball_mem_nhds z (by positivity : 0 < ε / 2)) fun w hw =>
         Filter.Eventually.of_forall fun x => norm_complexLaplaceIntegrand_le_envelope
           (Metric.mem_closedBall.mpr (le_of_lt (Metric.mem_ball.mp hw))) x)
       hbound_int
-      (Filter.Eventually.of_forall fun x => (analyticAt_complexLaplaceIntegrand E x z).continuousAt)
+      (Filter.Eventually.of_forall fun x =>
+        (analyticAt_complexLaplaceIntegrand E x z).continuousAt)
 
 theorem continuousOn_complexLaplaceTransform_interior_convergenceDomain
     {α : Type*} [MeasurableSpace α] [MeasureTheory.MeasureSpace α] {E : α → WithTop ℝ} :
     ContinuousOn (ComplexLaplaceTransform E) (interior (ComplexLaplaceConvergenceDomain E)) := by
   intro z hz
-  exact (continuousAt_complexLaplaceTransform_of_mem_interior_convergenceDomain hz).continuousWithinAt
+  exact
+    (continuousAt_complexLaplaceTransform_of_mem_interior_convergenceDomain hz).continuousWithinAt
 
 private theorem integrable_uncurry_complexLaplaceIntegrand_horizontal
     {α : Type*} [MeasureTheory.MeasureSpace α]
-    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)] {E : α → WithTop ℝ}
+    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)]
+    {E : α → WithTop ℝ}
     {a b : ℂ}
     (hE : Measurable E)
     (ha : MeasureTheory.Integrable (μ := MeasureTheory.volume) (ComplexLaplaceIntegrand E a))
@@ -227,14 +235,16 @@ private theorem integrable_uncurry_complexLaplaceIntegrand_horizontal
     (show Measurable fun p : ℝ × α =>
       ComplexLaplaceEndpointEnvelope E a (b.re + a.im * Complex.I) p.2 from
         ((measurable_complexLaplaceIntegrand hE a).norm.add
-          (measurable_complexLaplaceIntegrand hE (b.re + a.im * Complex.I)).norm).comp measurable_snd))]
+          (measurable_complexLaplaceIntegrand hE (b.re + a.im * Complex.I)).norm).comp
+            measurable_snd))]
   filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_uIoc] with t ht
   exact Filter.Eventually.of_forall fun x =>
     norm_complexLaplaceIntegrand_horizontal_le_endpointEnvelope (Set.uIoc_subset_uIcc ht) x
 
 private theorem integrable_uncurry_complexLaplaceIntegrand_vertical
     {α : Type*} [MeasureTheory.MeasureSpace α]
-    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)] {E : α → WithTop ℝ}
+    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)]
+    {E : α → WithTop ℝ}
     {a b : ℂ}
     (hE : Measurable E)
     (hb : MeasureTheory.Integrable (μ := MeasureTheory.volume) (ComplexLaplaceIntegrand E b))
@@ -263,7 +273,8 @@ private theorem integrable_uncurry_complexLaplaceIntegrand_vertical
 
 private theorem wedgeIntegral_complexLaplaceTransform_eq_integral
     {α : Type*} [MeasureTheory.MeasureSpace α]
-    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)] {E : α → WithTop ℝ}
+    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)]
+    {E : α → WithTop ℝ}
     {a b : ℂ}
     (hE : Measurable E)
     (hab : Complex.Rectangle a b ⊆ interior (ComplexLaplaceConvergenceDomain E)) :
@@ -292,20 +303,25 @@ private theorem wedgeIntegral_complexLaplaceTransform_eq_integral
   rw [← MeasureTheory.integral_smul, ← MeasureTheory.integral_add]
   · rcases le_total a.re b.re with hab | hba
     · simpa [intervalIntegral.integral_of_le hab, Function.uncurry, Set.uIoc_of_le hab]
-        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner).integral_prod_right
+        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner)
+          .integral_prod_right
     · simpa [intervalIntegral.integral_of_ge hba, Function.uncurry, Set.uIoc_of_ge hba]
-        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner).integral_prod_right.neg
+        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner)
+          .integral_prod_right.neg
   · refine (?_ : MeasureTheory.Integrable _ MeasureTheory.volume).smul Complex.I
     rcases le_total a.im b.im with hab | hba
     · simpa [intervalIntegral.integral_of_le hab, Function.uncurry, Set.uIoc_of_le hab]
-        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner).integral_prod_right
+        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner)
+          .integral_prod_right
     · simpa [intervalIntegral.integral_of_ge hba, Function.uncurry, Set.uIoc_of_ge hba]
-        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner).integral_prod_right.neg
+        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner)
+          .integral_prod_right.neg
 
 /-- A complex Laplace transform is analytic on the interior of its convergence domain. -/
 theorem analyticAt_complexLaplaceTransform_of_mem_interior_convergenceDomain
     {α : Type*} [MeasureTheory.MeasureSpace α]
-    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)] {E : α → WithTop ℝ} {z : ℂ}
+    [MeasureTheory.SFinite (MeasureTheory.volume : MeasureTheory.Measure α)]
+    {E : α → WithTop ℝ} {z : ℂ}
     (hE : Measurable E)
     (hz : z ∈ interior (ComplexLaplaceConvergenceDomain E)) :
     AnalyticAt ℂ (ComplexLaplaceTransform E) z := by
@@ -319,7 +335,8 @@ theorem analyticAt_complexLaplaceTransform_of_mem_interior_convergenceDomain
       apply MeasureTheory.integral_congr_ae
       filter_upwards with x
       exact (DifferentiableOn.isConservativeOn
-        (fun y _hy => (analyticAt_complexLaplaceIntegrand E x y).differentiableAt.differentiableWithinAt))
+        (fun y _hy =>
+          (analyticAt_complexLaplaceIntegrand E x y).differentiableAt.differentiableWithinAt))
         a b (Set.subset_univ _)
   exact ((Complex.isConservativeOn_and_continuousOn_iff_isDifferentiableOn Metric.isOpen_ball).1
     ⟨hcons, continuousOn_complexLaplaceTransform_interior_convergenceDomain.mono hr⟩).analyticAt

--- a/QuantumInfo/ForMathlib/ComplexLaplaceTransform.lean
+++ b/QuantumInfo/ForMathlib/ComplexLaplaceTransform.lean
@@ -303,19 +303,19 @@ private theorem wedgeIntegral_complexLaplaceTransform_eq_integral
   rw [← MeasureTheory.integral_smul, ← MeasureTheory.integral_add]
   · rcases le_total a.re b.re with hab | hba
     · simpa [intervalIntegral.integral_of_le hab, Function.uncurry, Set.uIoc_of_le hab]
-        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner)
-          .integral_prod_right
+        using (integrable_uncurry_complexLaplaceIntegrand_horizontal
+         hE ha hcorner).integral_prod_right
     · simpa [intervalIntegral.integral_of_ge hba, Function.uncurry, Set.uIoc_of_ge hba]
-        using (integrable_uncurry_complexLaplaceIntegrand_horizontal hE ha hcorner)
-          .integral_prod_right.neg
+        using (integrable_uncurry_complexLaplaceIntegrand_horizontal
+         hE ha hcorner).integral_prod_right.neg
   · refine (?_ : MeasureTheory.Integrable _ MeasureTheory.volume).smul Complex.I
     rcases le_total a.im b.im with hab | hba
     · simpa [intervalIntegral.integral_of_le hab, Function.uncurry, Set.uIoc_of_le hab]
-        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner)
-          .integral_prod_right
+        using (integrable_uncurry_complexLaplaceIntegrand_vertical
+          hE hb hcorner).integral_prod_right
     · simpa [intervalIntegral.integral_of_ge hba, Function.uncurry, Set.uIoc_of_ge hba]
-        using (integrable_uncurry_complexLaplaceIntegrand_vertical hE hb hcorner)
-          .integral_prod_right.neg
+        using (integrable_uncurry_complexLaplaceIntegrand_vertical
+          hE hb hcorner).integral_prod_right.neg
 
 /-- A complex Laplace transform is analytic on the interior of its convergence domain. -/
 theorem analyticAt_complexLaplaceTransform_of_mem_interior_convergenceDomain

--- a/QuantumInfo/ForMathlib/ContinuousLinearMap.lean
+++ b/QuantumInfo/ForMathlib/ContinuousLinearMap.lean
@@ -27,7 +27,8 @@ namespace ContinuousLinearMap
 variable {n 𝕜 : Type*} [Fintype n] [RCLike 𝕜]
 
 /-- The support of a Hermitian matrix is the sum of its nonzero eigenspaces. -/
-theorem support_eq_sup_eigenspace_nonzero (A : EuclideanSpace 𝕜 n →L[𝕜] EuclideanSpace 𝕜 n)
+theorem support_eq_sup_eigenspace_nonzero
+    (A : EuclideanSpace 𝕜 n →L[𝕜] EuclideanSpace 𝕜 n)
     (hA : A.IsSymmetric) : A.range = ⨆ μ ≠ 0, Module.End.eigenspace A μ := by
   apply le_antisymm
   · rintro x ⟨y, hy⟩

--- a/QuantumInfo/ForMathlib/ContinuousSup.lean
+++ b/QuantumInfo/ForMathlib/ContinuousSup.lean
@@ -36,7 +36,8 @@ theorem sSup_image_eq_sSup_image_closure {f : β → α}
     exact csSup_le ((h.mono subset_closure).image f) fun y hy ↦
       (h_image_closure.trans h_closure_image) hy
 
-theorem sInf_image_eq_sInf_image_closure {f : β → α} (hS : IsCompact (closure S)) (hf : Continuous f) :
+theorem sInf_image_eq_sInf_image_closure {f : β → α} (hS : IsCompact (closure S))
+    (hf : Continuous f) :
     sInf (f '' S) = sInf (f '' closure S) :=
   sSup_image_eq_sSup_image_closure (α := αᵒᵈ) hS hf
 
@@ -92,22 +93,26 @@ end Bornology.IsBounded
 
 namespace LinearMap
 
-/-- For bilinear maps in suitably well-behaved spaces with `IsModuleTopology`, taking the supremum in one
-argument is still `Continuous`, by `Bornology.IsBounded.continuous_iSup`. -/
+/-- For bilinear maps in suitably well-behaved spaces with `IsModuleTopology`, taking the supremum
+in one argument is still `Continuous`, by `Bornology.IsBounded.continuous_iSup`. -/
 theorem continuous_iSup {E F 𝕜 : Type*}
-  [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalRing 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜]
+  [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalRing 𝕜] [ConditionallyCompleteLinearOrder 𝕜]
+  [OrderTopology 𝕜]
   [AddCommGroup E] [TopologicalSpace E] [Module 𝕜 E] [IsModuleTopology 𝕜 E]
-  [AddCommGroup F] [Module 𝕜 F] [PseudoMetricSpace F] [ProperSpace F] [Module.Finite 𝕜 F] [IsModuleTopology 𝕜 F]
+  [AddCommGroup F] [Module 𝕜 F] [PseudoMetricSpace F] [ProperSpace F] [Module.Finite 𝕜 F]
+  [IsModuleTopology 𝕜 F]
   (f : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) {S : Set F} (hS : Bornology.IsBounded S) :
     Continuous fun x ↦ ⨆ y : S, f x y :=
   hS.continuous_iSup <| by fun_prop
 
-/-- For bilinear maps in suitably well-behaved spaces with `IsModuleTopology`, taking the infimum in one
-argument is still `Continuous`, by `Bornology.IsBounded.continuous_iInf`. -/
+/-- For bilinear maps in suitably well-behaved spaces with `IsModuleTopology`, taking the infimum
+in one argument is still `Continuous`, by `Bornology.IsBounded.continuous_iInf`. -/
 theorem continuous_iInf {E F 𝕜 : Type*}
-  [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalRing 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜]
+  [CommRing 𝕜] [TopologicalSpace 𝕜] [IsTopologicalRing 𝕜] [ConditionallyCompleteLinearOrder 𝕜]
+  [OrderTopology 𝕜]
   [AddCommGroup E] [TopologicalSpace E] [Module 𝕜 E] [IsModuleTopology 𝕜 E]
-  [AddCommGroup F] [Module 𝕜 F] [PseudoMetricSpace F] [ProperSpace F] [Module.Finite 𝕜 F] [IsModuleTopology 𝕜 F]
+  [AddCommGroup F] [Module 𝕜 F] [PseudoMetricSpace F] [ProperSpace F] [Module.Finite 𝕜 F]
+  [IsModuleTopology 𝕜 F]
   (f : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) {S : Set F} (hS : Bornology.IsBounded S) :
     Continuous fun x ↦ ⨅ y : S, f x y :=
   hS.continuous_iInf <| by fun_prop
@@ -115,7 +120,8 @@ theorem continuous_iInf {E F 𝕜 : Type*}
 /-- A specialization of `LinearMap.continuous_iSup` to finite dimensional spaces, in place
 of requiring a (non-instance) `IsModuleTopology`. -/
 theorem continuous_iSup' {E F 𝕜 : Type*}
-  [NontriviallyNormedField 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜] [CompleteSpace 𝕜]
+  [NontriviallyNormedField 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜]
+  [CompleteSpace 𝕜]
   [AddCommGroup E] [TopologicalSpace E] [IsTopologicalAddGroup E] [T2Space E]
   [Module 𝕜 E] [ContinuousSMul 𝕜 E] [FiniteDimensional 𝕜 E]
   [PseudoMetricSpace F] [ProperSpace F] [AddCommGroup F] [IsTopologicalAddGroup F] [T2Space F]
@@ -129,7 +135,8 @@ theorem continuous_iSup' {E F 𝕜 : Type*}
 /-- A specialization of `LinearMap.continuous_iInf` to finite dimensional spaces, in place
 of requiring a (non-instance) `IsModuleTopology`. -/
 theorem continuous_iInf' {E F 𝕜 : Type*}
-  [NontriviallyNormedField 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜] [CompleteSpace 𝕜]
+  [NontriviallyNormedField 𝕜] [ConditionallyCompleteLinearOrder 𝕜] [OrderTopology 𝕜]
+  [CompleteSpace 𝕜]
   [AddCommGroup E] [TopologicalSpace E] [IsTopologicalAddGroup E] [T2Space E]
   [Module 𝕜 E] [ContinuousSMul 𝕜 E] [FiniteDimensional 𝕜 E]
   [PseudoMetricSpace F] [ProperSpace F] [AddCommGroup F] [IsTopologicalAddGroup F] [T2Space F]
@@ -185,9 +192,12 @@ theorem LinearMap.BilinForm.continuous_iSup_fst
     Continuous fun x ↦ ⨆ y : S, f y x := by
   exact LinearMap.BilinForm.continuous_iSup f.flip hS
   --Old "direct" proof:
-  -- -- Since $f$ is continuous, there exists $C > 0$ such that for all $y \in S$ and $x \in E$, $|f y x| \leq C \|y\| \|x\|$.
+  -- -- Since $f$ is continuous, there exists $C > 0$ such that for all $y \in S$ and $x \in E$,
+  -- -- $|f y x| \leq C \|y\| \|x\|$.
   -- obtain ⟨C, hC1, hC2⟩ : ∃ C > 0, ∀ y ∈ S, ∀ x : E, |f y x| ≤ C * ‖y‖ * ‖x‖ := by
-  --   -- Since $f$ is continuous, there exists $C > 0$ such that for all $y, x \in E$, $|f y x| \leq C \|y\| \|x\|$ by the boundedness of continuous bilinear maps on finite-dimensional spaces.
+  --   -- Since $f$ is continuous, there exists $C > 0$ such that for all $y, x \in E$,
+  --   -- $|f y x| \leq C \|y\| \|x\|$ by the boundedness of continuous bilinear maps on
+  --   -- finite-dimensional spaces.
   --   have h_cont : ∃ C > 0, ∀ y x : E, |f y x| ≤ C * ‖y‖ * ‖x‖ := by
   --     have h_bounded : Continuous (fun p : E × E => f p.1 p.2) := by
   --       have _ := isModuleTopologyOfFiniteDimensional (𝕜 := ℝ) (E := E)
@@ -199,7 +209,8 @@ theorem LinearMap.BilinForm.continuous_iSup_fst
   --           simp [Metric.closedBall, dist_eq_norm]
   --         exact h_closed_unit_ball.prod h_closed_unit_ball;
   --       obtain ⟨C, hC⟩ := h_compact.exists_bound_of_continuousOn h_bounded.continuousOn;
-  --       exact ⟨C ⊔ 1, zero_lt_one.trans_le (le_max_right _ _), fun y x hy hx ↦ (hC (y, x) ⟨hy, hx⟩ ).trans (le_max_left _ _)⟩;
+  --       exact ⟨C ⊔ 1, zero_lt_one.trans_le (le_max_right _ _),
+  --         fun y x hy hx ↦ (hC (y, x) ⟨hy, hx⟩ ).trans (le_max_left _ _)⟩;
   --     refine ⟨C, hC₀, fun y x ↦ ?_⟩;
   --     rcases eq_or_ne y 0 with rfl | hy; · simp
   --     rcases eq_or_ne x 0 with rfl | hx; · simp
@@ -231,7 +242,8 @@ theorem LinearMap.BilinForm.continuous_iSup_fst
   -- have h_sup_triangle : |(⨆ y : S, f y a) - (⨆ y : S, f y b)| ≤ C * M * ‖a - b‖ := by
   --   rw [abs_sub_le_iff]
   --   constructor
-  --   · -- Applying the inequality $f y a \leq f y b + C * M * ‖a - b‖$ to each term in the supremum, we get:
+  --   · -- Applying the inequality $f y a \leq f y b + C * M * ‖a - b‖$ to each term in the
+  --     -- supremum, we get:
   --     have h_le (y : S) : f y a ≤ f y b + C * M * ‖a - b‖ := by
   --       linarith [abs_le.mp (h_triangle y y.2)]
   --     rw [sub_le_iff_le_add, add_comm]
@@ -239,7 +251,8 @@ theorem LinearMap.BilinForm.continuous_iSup_fst
   --     · exact ⟨⟨ y, hy ⟩⟩
   --     · refine add_le_add ?_ le_rfl
   --       refine le_csSup ?_ (Set.mem_range_self _)
-  --       exact ⟨C * M * ‖b‖, Set.forall_mem_range.2 fun y => le_of_abs_le ((hC2 _ y.2 _).trans (by gcongr; exact hM2 _ y.2))⟩;
+  --       exact ⟨C * M * ‖b‖, Set.forall_mem_range.2
+  --         fun y => le_of_abs_le ((hC2 _ y.2 _).trans (by gcongr; exact hM2 _ y.2))⟩;
   --   · rw [sub_le_iff_le_add']
   --     -- Applying the triangle inequality to each term in the supremum, we get:
   --     have h_sup_triangle (y) (hy : y ∈ S) : f y b ≤ f y a + C * M * ‖a - b‖ := by

--- a/QuantumInfo/ForMathlib/Filter.lean
+++ b/QuantumInfo/ForMathlib/Filter.lean
@@ -17,29 +17,41 @@ open Topology
 theorem Filter.Tendsto_inv_nat_mul_div_real (m : ℕ)
    : Filter.Tendsto (fun (x : ℕ) => ((↑x)⁻¹ * ↑(x / m) : ℝ)) Filter.atTop (𝓝 (1 / ↑m)) := by
   --Thanks aristotle!
-  -- This simplifies to $\lim_{x \to \infty} \frac{\lfloor x / m \rfloor}{x} = \frac{1}{m}$ because the floor function grows asymptotically like $x / m$.
-  have h_floor : Filter.Tendsto (fun x : ℕ => (Nat.floor (x / m : ℝ) : ℝ) / x) Filter.atTop (nhds (1 / (m : ℝ))) := by
+  -- This simplifies to $\lim_{x \to \infty} \frac{\lfloor x / m \rfloor}{x} = \frac{1}{m}$
+  -- because the floor function grows asymptotically like $x / m$.
+  have h_floor : Filter.Tendsto (fun x : ℕ => (Nat.floor (x / m : ℝ) : ℝ) / x) Filter.atTop
+      (nhds (1 / (m : ℝ))) := by
     -- We'll use the fact that the floor function is bounded and apply the squeeze theorem.
-    have h_floor_bound : ∀ x : ℕ, x > 0 → (Nat.floor (x / m : ℝ) : ℝ) / x ≥ (1 / m - 1 / x) ∧ (Nat.floor (x / m : ℝ) : ℝ) / x ≤ 1 / m := by
+    have h_floor_bound : ∀ x : ℕ, x > 0 → (Nat.floor (x / m : ℝ) : ℝ) / x ≥ (1 / m - 1 / x) ∧
+        (Nat.floor (x / m : ℝ) : ℝ) / x ≤ 1 / m := by
       cases eq_or_ne m 0
       · rename_i h
         intro x a
         subst h
-        simp_all only [gt_iff_lt, CharP.cast_eq_zero, div_zero, Nat.floor_zero, zero_div, one_div, zero_sub, ge_iff_le,
+        simp_all only [gt_iff_lt, CharP.cast_eq_zero, div_zero, Nat.floor_zero, zero_div, one_div,
+          zero_sub, ge_iff_le,
           Left.neg_nonpos_iff, inv_nonneg, Nat.cast_nonneg, le_refl, and_self]
       · intro x a
         simp_all only [ne_eq, gt_iff_lt, one_div, ge_iff_le, tsub_le_iff_right]
         apply And.intro
-        · rw [ inv_eq_one_div, div_add', div_le_div_iff₀ ] <;> first | positivity | nlinarith [ Nat.lt_floor_add_one ( ( x : ℝ ) / m ), show ( x : ℝ ) ≥ 1 by exact Nat.one_le_cast.mpr a, mul_div_cancel₀ ( x : ℝ ) ( show ( m : ℝ ) ≠ 0 by positivity ), inv_mul_cancel₀ ( show ( x : ℝ ) ≠ 0 by positivity ) ] ;
+        · rw [ inv_eq_one_div, div_add', div_le_div_iff₀ ] <;> first | positivity | nlinarith
+            [ Nat.lt_floor_add_one ( ( x : ℝ ) / m ),
+              show ( x : ℝ ) ≥ 1 by exact Nat.one_le_cast.mpr a,
+              mul_div_cancel₀ ( x : ℝ ) ( show ( m : ℝ ) ≠ 0 by positivity ),
+              inv_mul_cancel₀ ( show ( x : ℝ ) ≠ 0 by positivity ) ] ;
         · rw [ div_le_iff₀ ( by positivity ) ];
           simpa [ div_eq_inv_mul ] using Nat.floor_le ( by positivity : 0 ≤ ( x : ℝ ) / m );
     -- Apply the squeeze theorem to conclude the proof.
-    have h_squeeze : Filter.Tendsto (fun x : ℕ => (1 / m : ℝ) - 1 / x) Filter.atTop (nhds (1 / m)) := by
+    have h_squeeze : Filter.Tendsto (fun x : ℕ => (1 / m : ℝ) - 1 / x) Filter.atTop
+        (nhds (1 / m)) := by
       simpa using tendsto_const_nhds.sub (tendsto_inv_atTop_nhds_zero_nat (𝕜 := ℝ))
-    exact tendsto_of_tendsto_of_tendsto_of_le_of_le' h_squeeze tendsto_const_nhds ( Filter.eventually_atTop.mpr ⟨ 1, fun x hx => h_floor_bound x hx |>.1 ⟩ ) ( Filter.eventually_atTop.mpr ⟨ 1, fun x hx => h_floor_bound x hx |>.2 ⟩ );
+    exact tendsto_of_tendsto_of_tendsto_of_le_of_le' h_squeeze tendsto_const_nhds
+      ( Filter.eventually_atTop.mpr ⟨ 1, fun x hx => h_floor_bound x hx |>.1 ⟩ )
+      ( Filter.eventually_atTop.mpr ⟨ 1, fun x hx => h_floor_bound x hx |>.2 ⟩ );
   -- Apply the hypothesis `h_floor` to conclude the proof.
   convert h_floor using 1;
-  -- By definition of floor function, we know that ⌊(x : ℝ) / m⌋₊ is the greatest integer less than or equal to (x : ℝ) / m.
+  -- By definition of floor function, we know that ⌊(x : ℝ) / m⌋₊ is the greatest integer less
+  -- than or equal to (x : ℝ) / m.
   funext x; simp [Nat.floor_div_natCast];
   ring
 

--- a/QuantumInfo/ForMathlib/Filter.lean
+++ b/QuantumInfo/ForMathlib/Filter.lean
@@ -34,8 +34,8 @@ theorem Filter.Tendsto_inv_nat_mul_div_real (m : ℕ)
       · intro x a
         simp_all only [ne_eq, gt_iff_lt, one_div, ge_iff_le, tsub_le_iff_right]
         apply And.intro
-        · rw [ inv_eq_one_div, div_add', div_le_div_iff₀ ] <;> first | positivity | nlinarith
-            [ Nat.lt_floor_add_one ( ( x : ℝ ) / m ),
+        · rw [ inv_eq_one_div, div_add', div_le_div_iff₀ ] <;> first | positivity |
+            nlinarith [Nat.lt_floor_add_one ( ( x : ℝ ) / m ),
               show ( x : ℝ ) ≥ 1 by exact Nat.one_le_cast.mpr a,
               mul_div_cancel₀ ( x : ℝ ) ( show ( m : ℝ ) ≠ 0 by positivity ),
               inv_mul_cancel₀ ( show ( x : ℝ ) ≠ 0 by positivity ) ] ;

--- a/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/JensenOperatorInequality.lean
+++ b/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/JensenOperatorInequality.lean
@@ -280,7 +280,8 @@ theorem theorem_2_5_2_iv_imp_v {f : ℝ → ℝ} (hiv : CondIVAll.{u} f)
     rw [show star Xtilde = blockOp (ℋ := ℋ) (star X) (star Y) 0 0 by
       simp [Xtilde]]
     rw [show Xtilde = blockOp (ℋ := ℋ) X 0 Y 0 by rfl]
-    rw [blockDiagonal_eq_blockOp_wrap, blockOp_mul_wrap, blockOp_mul_wrap, blockDiagonal_eq_blockOp_wrap]
+    rw [blockDiagonal_eq_blockOp_wrap, blockOp_mul_wrap, blockOp_mul_wrap,
+      blockDiagonal_eq_blockOp_wrap]
     congr 1 <;> simp [mul_assoc]
   have hleft_block :
       cfcR (ℋ := HSum ℋ) f (star Xtilde * Atilde * Xtilde) =

--- a/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/JensenOperatorInequalityIImpIV.lean
+++ b/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/JensenOperatorInequalityIImpIV.lean
@@ -297,7 +297,8 @@ private theorem nontrivial_hsumL [Nontrivial ℋ] : Nontrivial (L (HSum ℋ)) :=
   exact ⟨0, blockDiagonal (ℋ := ℋ) (1 : L ℋ) 0, hdiag_ne_zero.symm⟩
 
 set_option synthInstance.maxHeartbeats 100000 in
--- `CFC.sqrt` on block-diagonal operators triggers expensive instance search through the product map.
+-- `CFC.sqrt` on block-diagonal operators triggers expensive instance search through the product
+-- map.
 set_option linter.unusedSectionVars false in
 set_option maxHeartbeats 400000 in
 private lemma sqrt_blockDiagonal_of_nonneg
@@ -689,8 +690,10 @@ theorem theorem_2_5_2_i_ici_all_imp_iv {f : ℝ → ℝ} (hf : CondIciAll.{u} f)
       cfcR (ℋ := HSum ℋ) f
           ((1 / 2 : ℝ) • ((star U : L (HSum ℋ)) * Atilde * (U : L (HSum ℋ))) +
             (1 / 2 : ℝ) • ((star V : L (HSum ℋ)) * Atilde * (V : L (HSum ℋ)))) ≤
-        ((1 / 2 : ℝ) • cfcR (ℋ := HSum ℋ) f ((star U : L (HSum ℋ)) * Atilde * (U : L (HSum ℋ))) +
-          (1 / 2 : ℝ) • cfcR (ℋ := HSum ℋ) f ((star V : L (HSum ℋ)) * Atilde * (V : L (HSum ℋ)))) := by
+        ((1 / 2 : ℝ) •
+              cfcR (ℋ := HSum ℋ) f ((star U : L (HSum ℋ)) * Atilde * (U : L (HSum ℋ))) +
+          (1 / 2 : ℝ) •
+              cfcR (ℋ := HSum ℋ) f ((star V : L (HSum ℋ)) * Atilde * (V : L (HSum ℋ)))) := by
     have hhalf : (1 - (2⁻¹ : ℝ)) = (2⁻¹ : ℝ) := by norm_num
     simpa [hhalf] using
       (hconv₂

--- a/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LiebAndoTrace.lean
+++ b/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LiebAndoTrace.lean
@@ -1045,7 +1045,8 @@ private lemma phiK_weightedSum_operatorPowerMean_eq
       simp only [phiK_operatorPowerMean_eq_liebTraceMap (ℋ := ℋ) (s := s) K A₁ B₁ hA₁ hB₁,
     phiK_operatorPowerMean_eq_liebTraceMap (ℋ := ℋ) (s := s) K A₂ B₂ hA₂ hB₂]
 
--- The `HSOp`-valued `operatorPowerMean` terms are large enough that the skeleton itself is expensive.
+-- The `HSOp`-valued `operatorPowerMean` terms are large enough that the skeleton itself is
+-- expensive.
 theorem liebTrace_jointlyConcaveOn_pdSet
     {s : ℝ} (hs0 : 0 < s) (hs1 : s < 1) (K : L ℋ) :
     JointlyConcaveOn (pdSet (ℋ := ℋ)) (pdSet (ℋ := ℋ))

--- a/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LownerHeinzCore.lean
+++ b/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LownerHeinzCore.lean
@@ -214,17 +214,22 @@ private lemma spectrum_convexCombo_Ioi {A B : 𝓐} {t : ℝ}
     · have ht' : t = 1 := by simpa [sub_eq_zero] using (sub_eq_zero.mp h1t).symm
       subst ht'
       simpa [rC, h1t] using hrB
-    · simpa [rC] using add_pos_of_pos_of_nonneg (mul_pos (lt_of_le_of_ne' (sub_nonneg.mpr ht1) (by simpa using h1t)) hrA) (mul_nonneg ht0 (le_of_lt hrB))
+    · simpa [rC] using add_pos_of_pos_of_nonneg
+        (mul_pos (lt_of_le_of_ne' (sub_nonneg.mpr ht1) (by simpa using h1t)) hrA)
+        (mul_nonneg ht0 (le_of_lt hrB))
   have hrC_le : algebraMap ℝ (𝓐) rC ≤ C := by
     have hsum : (1 - t) • algebraMap ℝ (𝓐) rA + t • algebraMap ℝ (𝓐) rB ≤ C := by
-      simpa [C] using add_le_add (smul_le_smul_of_nonneg_left hrA_le (sub_nonneg.mpr ht1)) (smul_le_smul_of_nonneg_left hrB_le ht0)
+      simpa [C] using add_le_add
+        (smul_le_smul_of_nonneg_left hrA_le (sub_nonneg.mpr ht1))
+        (smul_le_smul_of_nonneg_left hrB_le ht0)
     have hLHS :
         (1 - t) • algebraMap ℝ (𝓐) rA + t • algebraMap ℝ (𝓐) rB =
           algebraMap ℝ (𝓐) rC := by
       simp [rC, Algebra.smul_def]
     simpa [hLHS] using hsum
   intro x hx
-  simpa [C] using (CFC.exists_pos_algebraMap_le_iff (A := 𝓐) (a := C) (ha := hC)).1 ⟨rC, hrC, hrC_le⟩ x hx
+  simpa [C] using
+    (CFC.exists_pos_algebraMap_le_iff (A := 𝓐) (a := C) (ha := hC)).1 ⟨rC, hrC, hrC_le⟩ x hx
 
 omit [Nontrivial (𝓐)] in
 omit [NonnegSpectrumClass ℝ 𝓐] in
@@ -261,7 +266,8 @@ private lemma posSemidef_block_one_inv {A : 𝓐} (hA : IsSelfAdjoint A)
     apply cfc_congr
     intro x hx
     dsimp only
-    rw [← Real.rpow_add (As hx), show ((-1 : ℝ) / 2 + (1 : ℝ) / 2 : ℝ) = 0 from by ring, Real.rpow_zero]
+    rw [← Real.rpow_add (As hx), show ((-1 : ℝ) / 2 + (1 : ℝ) / 2 : ℝ) = 0 from by ring,
+      Real.rpow_zero]
   have invSqrtA_mul_invSqrtA : invSqrtA * invSqrtA = cfcR (fun x : ℝ ↦ x ^ (-1 : ℝ)) A := by
     dsimp [invSqrtA, cfcR]
     rw [← cfc_mul _ _ A hcont_invSqrt hcont_invSqrt]
@@ -278,7 +284,8 @@ private lemma posSemidef_block_one_inv {A : 𝓐} (hA : IsSelfAdjoint A)
             apply cfc_congr
             intro x hx
             dsimp only
-            rw [← Real.rpow_add (As hx), show ((1 : ℝ) / 2 + (1 : ℝ) / 2 : ℝ) = 1 from by ring, Real.rpow_one]
+            rw [← Real.rpow_add (As hx), show ((1 : ℝ) / 2 + (1 : ℝ) / 2 : ℝ) = 1 from by ring,
+              Real.rpow_one]
       _ = A := cfc_id' (R := ℝ) (a := A) (ha := hA)
   have invA_eq : cfcR (fun x : ℝ ↦ x ^ (-1 : ℝ)) A = cfcR (fun x : ℝ ↦ x⁻¹) A := by
     dsimp [cfcR]
@@ -479,7 +486,8 @@ theorem one_div_add_t_operatorAntitoneOn_Ici : ∀ (t : ℝ), 0 < t →
       simpa [Set.Ici] using (Bs hx)
     exact le_of_lt (add_pos_of_nonneg_of_pos hx0 ht)
   have hub_le_hua : (uB : 𝓐) ≤ (uA : 𝓐) := by
-    simpa [huA_val, huB_val, add_assoc, add_left_comm, add_comm] using add_le_add_right BA (algebraMap ℝ (𝓐) t)
+    simpa [huA_val, huB_val, add_assoc, add_left_comm, add_comm] using
+      add_le_add_right BA (algebraMap ℝ (𝓐) t)
   have hinv : (↑uA⁻¹ : 𝓐) ≤ (↑uB⁻¹ : 𝓐) := by
     simpa using
       (CStarAlgebra.inv_le_inv (A := 𝓐) (a := uB) (b := uA) huB_nonneg hub_le_hua)
@@ -521,7 +529,8 @@ theorem one_div_add_t_operatorConvexOn_Ici : ∀ (t : ℝ), 0 < t →
       simpa [Set.Ici] using (Bs hx)
     simpa [cfcR, cfc_id' (R := ℝ) (a := B) (ha := hB)] using h0
   have C_nonneg : 0 ≤ C := by
-    simpa [C] using add_nonneg (smul_nonneg (sub_nonneg.mpr hθ1) A_nonneg) (smul_nonneg hθ0 B_nonneg)
+    simpa [C] using
+      add_nonneg (smul_nonneg (sub_nonneg.mpr hθ1) A_nonneg) (smul_nonneg hθ0 B_nonneg)
   have hA_shift : cfcR shift A = A + T := by
     dsimp [cfcR, shift, T]
     simpa [cfc_id' (R := ℝ) (a := A) (ha := hA)] using
@@ -592,7 +601,9 @@ theorem one_div_add_t_operatorConvexOn_Ici : ∀ (t : ℝ), 0 < t →
       simpa [Set.Ici] using (Bs hx)
     exact ne_of_gt (by simpa [shift] using (add_pos_of_nonneg_of_pos hx0 ht))
   have hshift_ne0_C : ∀ x ∈ spectrum ℝ C, shift x ≠ 0 :=
-    fun x hx ↦ ne_of_gt (by simpa [shift] using (add_pos_of_nonneg_of_pos (spectrum_nonneg_of_nonneg C_nonneg hx) ht))
+    fun x hx ↦ ne_of_gt
+      (by simpa [shift] using
+        (add_pos_of_nonneg_of_pos (spectrum_nonneg_of_nonneg C_nonneg hx) ht))
   have hA_inv : cfcR (fun x : ℝ ↦ (x + t)⁻¹) A = Ring.inverse A1 := by
     have h' : cfc (fun x : ℝ ↦ (shift x)⁻¹) A = Ring.inverse (cfc shift A) := by
       simpa [shift] using (cfc_inv (R := ℝ) (A := 𝓐) (p := IsSelfAdjoint)
@@ -946,11 +957,13 @@ private lemma cfcₙ_rpowIntegrand₀₁_eq_smul_cfcR_ratio {q : NNReal} (hq : q
     {t : ℝ} (htpos : 0 < t) (X : 𝓐) (hX0 : 0 ≤ X) :
     cfcₙ (Real.rpowIntegrand₀₁ (q : ℝ) t) X =
       (t ^ ((q : ℝ) - 1)) • cfcR (fun x : ℝ => x / (x + t)) X := by
-  have hq_real : ((q : ℝ) : ℝ) ∈ Set.Ioo (0 : ℝ) 1 := ⟨(NNReal.coe_pos).2 hq.1, (NNReal.coe_lt_coe).2 hq.2⟩
+  have hq_real : ((q : ℝ) : ℝ) ∈ Set.Ioo (0 : ℝ) 1 :=
+    ⟨(NNReal.coe_pos).2 hq.1, (NNReal.coe_lt_coe).2 hq.2⟩
   let ratio : ℝ → ℝ := fun x => x / (x + t)
   let r : ℝ := t ^ ((q : ℝ) - 1)
   have hcont_ratio : ContinuousOn ratio (spectrum ℝ X) :=
-    continuousOn_id.div (continuousOn_id.add continuousOn_const) (fun x hx ↦ ne_of_gt (add_pos_of_nonneg_of_pos (spectrum_nonneg_of_nonneg hX0 hx) htpos))
+    continuousOn_id.div (continuousOn_id.add continuousOn_const)
+      (fun x hx ↦ ne_of_gt (add_pos_of_nonneg_of_pos (spectrum_nonneg_of_nonneg hX0 hx) htpos))
   have hcfcₙ : cfcₙ (Real.rpowIntegrand₀₁ (q : ℝ) t) X =
       cfcR (Real.rpowIntegrand₀₁ (q : ℝ) t) X := by
     have hqs : quasispectrum ℝ X ⊆ Set.Ici (0 : ℝ) := by
@@ -965,7 +978,9 @@ private lemma cfcₙ_rpowIntegrand₀₁_eq_smul_cfcR_ratio {q : NNReal} (hq : q
   have hEq :
       (spectrum ℝ X).EqOn (Real.rpowIntegrand₀₁ (q : ℝ) t) (fun x : ℝ ↦ r * ratio x) := by
     intro x hx
-    simp [r, ratio, Real.rpowIntegrand₀₁_eq_pow_div hq_real (le_of_lt htpos) (spectrum_nonneg_of_nonneg hX0 hx),
+    simp [r, ratio,
+      Real.rpowIntegrand₀₁_eq_pow_div hq_real (le_of_lt htpos)
+        (spectrum_nonneg_of_nonneg hX0 hx),
       add_comm, mul_div_assoc]
   have hcfc_congr :
       cfcR (Real.rpowIntegrand₀₁ (q : ℝ) t) X =
@@ -1002,7 +1017,8 @@ private lemma cfcR_ratio_weighted_le {t : ℝ} (htpos : 0 < t) {A B : 𝓐} (hA0
   have hneg :=
     (by
       dsimp [OperatorConcaveOn, OperatorConvexOn] at hOp
-      have := hOp (A := A) (B := B) (t := b) (IsSelfAdjoint.of_nonneg hA0) (IsSelfAdjoint.of_nonneg hB0)
+      have := hOp (A := A) (B := B) (t := b) (IsSelfAdjoint.of_nonneg hA0)
+        (IsSelfAdjoint.of_nonneg hB0)
         hb hb1 (hspec A hA0) (hspec B hB0)
       exact this)
   have hneg' :
@@ -1011,10 +1027,12 @@ private lemma cfcR_ratio_weighted_le {t : ℝ} (htpos : 0 < t) {A B : 𝓐} (hA0
           + b • cfcR (fun x : ℝ ↦ - (x / (x + t))) B := hneg
   have hneg'' :
       -cfcR (fun x : ℝ => x / (x + t)) ((1 - b) • A + b • B)
-        ≤ -((1 - b) • cfcR (fun x : ℝ => x / (x + t)) A + b • cfcR (fun x : ℝ => x / (x + t)) B) := by
+        ≤ -((1 - b) • cfcR (fun x : ℝ => x / (x + t)) A
+            + b • cfcR (fun x : ℝ => x / (x + t)) B) := by
     have h' :
         -cfcR (fun x : ℝ => x / (x + t)) ((1 - b) • A + b • B)
-          ≤ -(b • cfcR (fun x : ℝ => x / (x + t)) B + (1 - b) • cfcR (fun x : ℝ => x / (x + t)) A) := by
+          ≤ -(b • cfcR (fun x : ℝ => x / (x + t)) B
+              + (1 - b) • cfcR (fun x : ℝ => x / (x + t)) A) := by
       simpa [cfcR, cfc_neg, smul_neg, neg_add] using hneg'
     simpa [add_comm, add_left_comm, add_assoc] using h'
   simpa [ha1, add_comm, add_left_comm, add_assoc] using neg_le_neg_iff.mp hneg''
@@ -1185,7 +1203,8 @@ theorem power_Icc_zero_one_operatorConcaveOn_Ici : ∀ p ∈ Set.Icc (0 : ℝ) 1
         ≤ cfcR (fun x : ℝ ↦ x ^ p) C := by
     simpa [hcalc A hA0, hcalc B hB0, hcalc C hC0, C] using hconcC
   -- convert concavity into convexity of `x ↦ -x^p`
-  simpa [cfcR, cfc_neg, smul_neg, neg_add, add_assoc, add_left_comm, add_comm] using neg_le_neg hconcC'
+  simpa [cfcR, cfc_neg, smul_neg, neg_add, add_assoc, add_left_comm, add_comm] using
+    neg_le_neg hconcC'
 
 private lemma sq_mul_div_add (x t : ℝ) (hxt : x + t ≠ 0) :
     (x * x) / (x + t) = x - t + (t * t) / (x + t) := by
@@ -1208,7 +1227,8 @@ private lemma convexOn_cfcR_one_div_add_t (t : ℝ) (htpos : 0 < t) :
   have hOp := one_div_add_t_operatorConvexOn_Ici (𝓐 := 𝓐) t htpos
   dsimp [OperatorConvexOn] at hOp
   simpa [one_div, ha1] using
-    hOp (A := A) (B := B) (t := b) (IsSelfAdjoint.of_nonneg hA0) (IsSelfAdjoint.of_nonneg hB0) hb hb1 (hspec A hA0) (hspec B hB0)
+    hOp (A := A) (B := B) (t := b) (IsSelfAdjoint.of_nonneg hA0) (IsSelfAdjoint.of_nonneg hB0)
+      hb hb1 (hspec A hA0) (hspec B hB0)
 
 omit [Nontrivial (𝓐)] in
 private lemma G_eqOn_rpowIntegrand₀₁_mul {q : NNReal} (hq_real : (q : ℝ) ∈ Set.Ioo (0 : ℝ) 1)
@@ -1393,7 +1413,8 @@ private lemma convexOn_G_rpowIntegrand₀₁_mul {q : NNReal} (hq_real : (q : �
   simpa using this.symm
 
 omit [Nontrivial (𝓐)] in
-private lemma ae_cfcₙ_mul_id_rpowIntegrand₀₁_restrict_Ioi {q : NNReal} (hq_real : (q : ℝ) ∈ Set.Ioo (0 : ℝ) 1)
+private lemma ae_cfcₙ_mul_id_rpowIntegrand₀₁_restrict_Ioi {q : NNReal}
+    (hq_real : (q : ℝ) ∈ Set.Ioo (0 : ℝ) 1)
     (μ : MeasureTheory.Measure ℝ) (A : 𝓐) (hA0 : 0 ≤ A) :
     ∀ᵐ t ∂(μ.restrict (Set.Ioi (0 : ℝ))),
       cfcₙ (fun x : ℝ ↦ x * Real.rpowIntegrand₀₁ (q : ℝ) t x) A =
@@ -1450,7 +1471,8 @@ private lemma convexOn_nnrpow_Ioo_one_add {q : NNReal} (hq : q ∈ Set.Ioo (0 : 
       ∀ᵐ t ∂ν, ConvexOn ℝ (Set.Ici (0 : 𝓐)) (fun A : 𝓐 => G t A) := by
     filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioi] with t ht
     have hconv :
-        ConvexOn ℝ (Set.Ici (0 : 𝓐)) (fun X : 𝓐 ↦ cfcₙ (fun x : ℝ ↦ x * Real.rpowIntegrand₀₁ (q : ℝ) t x) X) :=
+        ConvexOn ℝ (Set.Ici (0 : 𝓐))
+          (fun X : 𝓐 ↦ cfcₙ (fun x : ℝ ↦ x * Real.rpowIntegrand₀₁ (q : ℝ) t x) X) :=
       convexOn_G_rpowIntegrand₀₁_mul  hq_real t ht
     simpa [G] using hconv
   have hconv_int :
@@ -1854,7 +1876,8 @@ theorem power_Icc_neg_one_zero_neg_operatorMonotoneOn_Ioi : ∀ p ∈ Set.Icc (-
       intro x hx
       have hx0 : (0 : ℝ) < x := by simpa [Set.Ioi] using hspB hx
       simpa [Set.Ici] using (le_of_lt hx0)
-    exact (power_Icc_zero_one_operatorMonotoneOn_Ici  q hq (A := A) (B := B) hA0 hB0 hBA hspA' hspB')
+    exact (power_Icc_zero_one_operatorMonotoneOn_Ici  q hq (A := A) (B := B) hA0 hB0 hBA hspA'
+      hspB')
   let Aq : 𝓐 := cfcR  (fun x : ℝ ↦ x ^ q) A
   let Bq : 𝓐 := cfcR  (fun x : ℝ ↦ x ^ q) B
   have hAq0 : 0 ≤ Aq := by

--- a/QuantumInfo/ForMathlib/HermitianMat/Basic.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Basic.lean
@@ -316,7 +316,8 @@ add_aesop_rules safe norm (rule_sets := [Commutes])
   [mat_zero, mat_one, mat_smul, mat_add, mat_sub, mat_neg, mat_pow, mat_zpow, mat_inv]
 
 @[aesop safe apply (rule_sets := [Commutes])]
-theorem _root_.Matrix.inv_commute {α : Type*} {A : Matrix m m α} [CommRing α] : Commute A⁻¹ A := by
+theorem _root_.Matrix.inv_commute {α : Type*} {A : Matrix m m α} [CommRing α] :
+    Commute A⁻¹ A := by
   rcases A.nonsing_inv_cancel_or_zero with h | h
   · simp [Commute, SemiconjBy, h]
   . simp [h]
@@ -354,16 +355,18 @@ section conj
 variable [CommRing α] [StarRing α] [Fintype n]
 variable (A : HermitianMat n α)
 
-/-- The Hermitian matrix given by conjugating by a (possibly rectangular) Matrix. If we required `B` to be
-square, this would apply to any `Semigroup`+`StarMul` (as proved by `IsSelfAdjoint.conjugate`). But this lets
-us conjugate to other sizes too, as is done in e.g. Kraus operators. That is, it's a _heterogeneous_ conjguation.
+/-- The Hermitian matrix given by conjugating by a (possibly rectangular) Matrix. If we required `B`
+to be square, this would apply to any `Semigroup`+`StarMul` (as proved by
+`IsSelfAdjoint.conjugate`). But this lets us conjugate to other sizes too, as is done in e.g. Kraus
+operators. That is, it's a _heterogeneous_ conjguation.
 -/
 def conj {m} (B : Matrix m n α) : HermitianMat n α →+ HermitianMat m α where
   toFun A :=
     ⟨B * A.mat * B.conjTranspose, by
     ext
     simp only [Matrix.star_apply, Matrix.mul_apply, Matrix.conjTranspose_apply, Finset.sum_mul,
-      star_sum, star_mul', star_star, show ∀ (a b : n), star (A.mat b a) = A.mat a b from congrFun₂ A.property]
+      star_sum, star_mul', star_star,
+      show ∀ (a b : n), star (A.mat b a) = A.mat a b from congrFun₂ A.property]
     rw [Finset.sum_comm]
     congr! 2
     ring⟩
@@ -454,7 +457,8 @@ noncomputable def eigenspace (μ : 𝕜) : Submodule 𝕜 (EuclideanSpace 𝕜 n
 noncomputable def ker : Submodule 𝕜 (EuclideanSpace 𝕜 n) :=
   LinearMap.ker A.lin.toLinearMap
 
-theorem mem_ker_iff_mulVec_zero (x : EuclideanSpace 𝕜 n) : x ∈ A.ker ↔ A.mat.mulVec x = 0 := by
+theorem mem_ker_iff_mulVec_zero (x : EuclideanSpace 𝕜 n) :
+    x ∈ A.ker ↔ A.mat.mulVec x = 0 := by
   simp [ker, LinearMap.mem_ker, lin, Matrix.toLpLin_apply]
 
 /-- The kernel of a Hermitian matrix is its zero eigenspace. -/
@@ -531,7 +535,8 @@ theorem diagonal_one : (diagonal 𝕜 1) = (1 : HermitianMat n 𝕜) := by
 lemma diagonal_add : diagonal 𝕜 (f + g) = diagonal 𝕜 f + diagonal 𝕜 g := by
   ext1; simp
 
-lemma diagonal_add_apply : diagonal 𝕜 (fun x ↦ f x + g x) = diagonal 𝕜 f + diagonal 𝕜 g := by
+lemma diagonal_add_apply :
+    diagonal 𝕜 (fun x ↦ f x + g x) = diagonal 𝕜 f + diagonal 𝕜 g := by
   ext1; simp
 
 lemma diagonal_sub : diagonal 𝕜 (f - g) = diagonal 𝕜 f - diagonal 𝕜 g := by
@@ -598,7 +603,8 @@ theorem kronecker_add : A ⊗ₖ (B + C) = A ⊗ₖ B + A ⊗ₖ C := by
   ext1; simp [Matrix.kronecker_add]
 
 lemma kronecker_diagonal [DecidableEq m] [DecidableEq n] (d₁ : m → ℝ) (d₂ : n → ℝ) :
-    (diagonal 𝕜 d₁ ⊗ₖ diagonal 𝕜 d₂) = diagonal 𝕜 (fun (i : m × n) => d₁ i.1 * d₂ i.2) := by
+    (diagonal 𝕜 d₁ ⊗ₖ diagonal 𝕜 d₂) =
+      diagonal 𝕜 (fun (i : m × n) => d₁ i.1 * d₂ i.2) := by
   ext1
   simp [Matrix.diagonal_kronecker_diagonal]
 
@@ -625,7 +631,8 @@ theorem kron_id_commute_id_kro [Fintype m] [Fintype n] [DecidableEq m] [Decidabl
   commutes
 
 /-
-The conjugate of a Kronecker product by a Kronecker product is the Kronecker product of the conjugates.
+The conjugate of a Kronecker product by a Kronecker product is the Kronecker product of the
+conjugates.
 -/
 lemma kronecker_conj [Fintype m] [Fintype n]
     (A : HermitianMat m α) (B : HermitianMat n α) (C : Matrix p m α) (D : Matrix q n α) :
@@ -671,7 +678,8 @@ theorem range_le_ker_imp_zero {A : HermitianMat d 𝕜}
 /--
 If ker M ⊆ ker A, then range (A Mᴴ) = range A.
 -/
-theorem _root_.Matrix.range_mul_conjTranspose_of_ker_le_ker {A : Matrix d d 𝕜} {M : Matrix d₂ d 𝕜}
+theorem _root_.Matrix.range_mul_conjTranspose_of_ker_le_ker
+    {A : Matrix d d 𝕜} {M : Matrix d₂ d 𝕜}
     (h : LinearMap.ker M.toEuclideanLin ≤ LinearMap.ker A.toEuclideanLin) :
     LinearMap.range (A * M.conjTranspose).toEuclideanLin = LinearMap.range A.toEuclideanLin := by
   apply le_antisymm
@@ -680,9 +688,12 @@ theorem _root_.Matrix.range_mul_conjTranspose_of_ker_le_ker {A : Matrix d d 𝕜
     simp [Matrix.toEuclideanLin]
   · intro x hx;
     -- Since $x \in \text{range}(A)$, there exists $y \in \text{range}(Mᴴ)$ such that $A y = x$.
-    obtain ⟨y, hy⟩ : ∃ y ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)), A.toEuclideanLin y = x := by
-      have h_range_MH : LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)) = (LinearMap.ker (Matrix.toEuclideanLin M))ᗮ := by
-        have h_orthogonal : (LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)))ᗮ = LinearMap.ker (Matrix.toEuclideanLin M) := by
+    obtain ⟨y, hy⟩ : ∃ y ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)),
+        A.toEuclideanLin y = x := by
+      have h_range_MH : LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)) =
+          (LinearMap.ker (Matrix.toEuclideanLin M))ᗮ := by
+        have h_orthogonal : (LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)))ᗮ =
+            LinearMap.ker (Matrix.toEuclideanLin M) := by
           ext x
           rw [Matrix.toEuclideanLin_conjTranspose_eq_adjoint]
           simp only [Submodule.mem_orthogonal, LinearMap.mem_ker, LinearMap.mem_range]
@@ -698,16 +709,26 @@ theorem _root_.Matrix.range_mul_conjTranspose_of_ker_le_ker {A : Matrix d d 𝕜
             rw [← hz, LinearMap.adjoint_inner_left, h, inner_zero_right]
         rw [← h_orthogonal, Submodule.orthogonal_orthogonal]
       obtain ⟨ y, rfl ⟩ := hx;
-      -- Since $y$ is in the range of $Mᴴ$, we can write $y$ as $y = y_1 + y_2$ where $y_1 \in \text{range}(Mᴴ)$ and $y_2 \in \text{ker}(M)$.
-      obtain ⟨y1, y2, hy1, hy2, hy⟩ : ∃ y1 y2 : EuclideanSpace 𝕜 d, y1 ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)) ∧ y2 ∈ LinearMap.ker (Matrix.toEuclideanLin M) ∧ y = y1 + y2 := by
-        have h_decomp : ∀ y : EuclideanSpace 𝕜 d, ∃ y1 ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)), ∃ y2 ∈ LinearMap.ker (Matrix.toEuclideanLin M), y = y1 + y2 := by
+      -- Since $y$ is in the range of $Mᴴ$, we can write $y$ as $y = y_1 + y_2$ where
+      -- $y_1 \in \text{range}(Mᴴ)$ and $y_2 \in \text{ker}(M)$.
+      obtain ⟨y1, y2, hy1, hy2, hy⟩ : ∃ y1 y2 : EuclideanSpace 𝕜 d,
+          y1 ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)) ∧
+          y2 ∈ LinearMap.ker (Matrix.toEuclideanLin M) ∧ y = y1 + y2 := by
+        have h_decomp : ∀ y : EuclideanSpace 𝕜 d,
+            ∃ y1 ∈ LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose)),
+            ∃ y2 ∈ LinearMap.ker (Matrix.toEuclideanLin M), y = y1 + y2 := by
           intro y
-          have h_decomp : y ∈ (LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose))) ⊔ (LinearMap.ker (Matrix.toEuclideanLin M)) := by
+          have h_decomp : y ∈ (LinearMap.range (Matrix.toEuclideanLin (M.conjTranspose))) ⊔
+              (LinearMap.ker (Matrix.toEuclideanLin M)) := by
             rw [ h_range_MH ];
             rw [ sup_comm, Submodule.sup_orthogonal_of_hasOrthogonalProjection ];
             exact Submodule.mem_top;
           rw [ Submodule.mem_sup ] at h_decomp ; tauto;
-        exact ⟨ _, _, h_decomp y |> Classical.choose_spec |> And.left, h_decomp y |> Classical.choose_spec |> And.right |> Classical.choose_spec |> And.left, h_decomp y |> Classical.choose_spec |> And.right |> Classical.choose_spec |> And.right ⟩;
+        exact ⟨ _, _,
+          h_decomp y |> Classical.choose_spec |> And.left,
+          h_decomp y |> Classical.choose_spec |> And.right |> Classical.choose_spec |> And.left,
+          h_decomp y |> Classical.choose_spec |> And.right |> Classical.choose_spec
+            |> And.right ⟩;
       exact ⟨ y1, hy1, by rw [ hy, map_add, LinearMap.mem_ker.mp ( h hy2 ) ] ; simp ⟩;
     obtain ⟨ z, rfl ⟩ := hy.1;
     exact ⟨ z, by simpa [ Matrix.toEuclideanLin ] using hy.2 ⟩
@@ -716,7 +737,8 @@ theorem conj_ne_zero {A : HermitianMat d 𝕜} {M : Matrix d₂ d 𝕜} (hA : A 
     (h : LinearMap.ker M.toEuclideanLin ≤ A.ker) : A.conj M ≠ 0 := by
   by_contra h_contra
   have h_range : LinearMap.range A.mat.toEuclideanLin ≤ LinearMap.ker A.mat.toEuclideanLin := by
-    have h_range : LinearMap.range (A.mat * M.conjTranspose).toEuclideanLin ≤ LinearMap.ker M.toEuclideanLin := by
+    have h_range : LinearMap.range (A.mat * M.conjTranspose).toEuclideanLin ≤
+        LinearMap.ker M.toEuclideanLin := by
       rintro x ⟨y, rfl⟩
       replace h_contra := congr($(h_contra).mat)
       simp_all [Matrix.toLpLin_apply, Matrix.mul_assoc]

--- a/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
@@ -538,9 +538,9 @@ lemma dist_lt_of_continuous' {X : Type*} [TopologicalSpace X]
       ⟨ ht'_t, ht ⟩;
     have := hUV t' ( ht_fin.1 t' ht'_fin ) x₀
       ⟨ mem_of_mem_nhds ( hU t' ( ht_fin.1 t' ht'_fin ) ), hx₀ ⟩ t ⟨ ht'_t, ht ⟩;
-    exact abs_lt.mpr ⟨ by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
-      abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ], by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
-      abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ] ⟩
+    exact abs_lt.mpr ⟨by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
+      (abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2›)], by linarith [abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
+      (abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2›)] ⟩
 
 /--
 The functional calculus is continuous on matrices with spectrum in a compact set.
@@ -566,8 +566,9 @@ lemma continuousOn_cfc_of_compact {K : Set ℝ} {g : ℝ → ℝ} (hK : IsCompac
             exact continuousOn_iff_continuous_restrict.mp hg );
         exact ⟨ _, this.choose.continuous.continuousOn,
           fun x hx => by simpa using congr_arg ( fun f => f ⟨ x, hx ⟩ ) this.choose_spec ⟩;
-      exact fun ε εpos => by rcases this a b f hf.1 ε εpos with ⟨ p, hp ⟩ ;
-        exact ⟨ p, fun x hx => by simpa only [ hf.2 x hx ] using hp x ( hab hx ) ⟩ ;
+      exact fun ε εpos => by
+        rcases this a b f hf.1 ε εpos with ⟨ p, hp ⟩
+        exact ⟨ p, fun x hx => by simpa only [ hf.2 x hx ] using hp x ( hab hx ) ⟩
     exact ⟨ fun n => Classical.choose ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ),
       fun n x hx => le_of_lt ( Classical.choose_spec
         ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ) x hx ) ⟩;
@@ -623,7 +624,8 @@ lemma continuousOn_cfc_of_compact {K : Set ℝ} {g : ℝ → ℝ} (hK : IsCompac
           A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) ) +
         ( A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) - A.cfc g ) by abel1 ];
     exact lt_of_le_of_lt ( norm_add₃_le .. )
-      ( by linarith [ norm_sub_rev ( a.cfc g ) ( a.cfc fun x => Polynomial.eval x ( p_n N ) ),
+      (by
+      linarith [ norm_sub_rev ( a.cfc g ) ( a.cfc fun x => Polynomial.eval x ( p_n N ) ),
         norm_sub_rev ( A.cfc fun x => Polynomial.eval x ( p_n N ) ) ( A.cfc g ),
         hδ a ha ha' ] );
   contradiction
@@ -783,7 +785,8 @@ lemma spectrum_subset_of_isOpen (A₀ : HermitianMat d ℂ) (U : Set ℝ)
     obtain ⟨δ_min, hδ_min_pos, hδ_min⟩ : ∃ δ_min > 0, ∀ i ∈ t, δ_min ≤ δ i := by
       by_cases ht : t.Nonempty <;> simp_all [ Finset.Nonempty ];
       · exact ⟨ Finset.min' ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩,
-          by have := Finset.min'_mem ( t.image δ )
+          by
+          have := Finset.min'_mem ( t.image δ )
             ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩ ; aesop,
           fun i hi => Finset.min'_le _ _ ( Finset.mem_image_of_mem δ hi ) ⟩;
       · exact ⟨ 1, zero_lt_one ⟩
@@ -920,8 +923,9 @@ lemma continuousWithinAt_cfc_of_continuousOn {T : Set ℝ} {g : ℝ → ℝ}
         have := spectrum_subset_of_isOpen A₀ ( Metric.thickening δ ( spectrum ℝ A₀.mat ) ) h_open
           ( Metric.self_subset_thickening δ_pos _ ) ; aesop;
       generalize_proofs at *; (
-      exact ⟨ _, h_spectrum_subset, fun B hB => fun x hx => by simpa [ dist_eq_norm ] using
-        Metric.mem_thickening_iff.mp ( hB hx ) ⟩)
+      exact ⟨ _, h_spectrum_subset, fun B hB => fun x hx => by
+        simpa [ dist_eq_norm ] using
+          Metric.mem_thickening_iff.mp ( hB hx ) ⟩)
     generalize_proofs at *; (
     refine' ⟨ U, hU.1, fun B hB => _ ⟩
     have h_diff_small : ∀ x ∈ spectrum ℝ B.mat,
@@ -936,7 +940,8 @@ lemma continuousWithinAt_cfc_of_continuousOn {T : Set ℝ} {g : ℝ → ℝ}
       · positivity;
       · exact fun x hx => hx
     generalize_proofs at *; (
-    exact h_diff_small.trans_lt ( by rw [ mul_div, div_lt_iff₀ ] <;>
+    exact h_diff_small.trans_lt ( by
+      rw [ mul_div, div_lt_iff₀ ] <;>
       nlinarith [ Real.sqrt_nonneg ( Fintype.card d : ℝ ),
         Real.sq_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ] ))));
   rw [ Metric.continuousWithinAt_iff ] at *;

--- a/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
@@ -26,7 +26,8 @@ namespace HermitianMat
 
 noncomputable section CFC
 
-variable {d d₂ 𝕜 : Type*} [Fintype d] [DecidableEq d] [Fintype d₂] [DecidableEq d₂] [RCLike 𝕜]
+variable {d d₂ 𝕜 : Type*} [Fintype d] [DecidableEq d] [Fintype d₂] [DecidableEq d₂]
+variable [RCLike 𝕜]
 variable {X : Type*} [TopologicalSpace X]
 variable (A : HermitianMat d 𝕜) (f : ℝ → ℝ) (g : ℝ → ℝ) (q r : ℝ)
 
@@ -129,9 +130,11 @@ set_option backward.isDefEq.respectTransparency false in
 Spectral decomposition of `A.cfc f` as a sum of scaled projections (matrix version).
 -/
 theorem cfc_toMat_eq_sum_smul_proj : (A.cfc f).mat =
-    ∑ i, f (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
+    ∑ i, f (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+      A.H.eigenvectorUnitary.val.conjTranspose) := by
   rw [A.mat_cfc, A.H.cfc_eq, Matrix.IsHermitian.cfc]
-  have h : ( Matrix.diagonal ( RCLike.ofReal ∘ f ∘ Matrix.IsHermitian.eigenvalues A.H ) : Matrix d d 𝕜 ) = ∑ i, f ( A.H.eigenvalues i ) • Matrix.single i i 1 := by
+  have h : ( Matrix.diagonal ( RCLike.ofReal ∘ f ∘ Matrix.IsHermitian.eigenvalues A.H ) :
+      Matrix d d 𝕜 ) = ∑ i, f ( A.H.eigenvalues i ) • Matrix.single i i 1 := by
     ext i j ; by_cases hij : i = j <;> simp [ hij ];
     · simp [ Matrix.sum_apply, Matrix.single ];
       simp [ Algebra.smul_def ];
@@ -313,7 +316,8 @@ theorem lt_smul_of_norm_lt {r : ℝ} (h : ‖A‖ ≤ r) : A ≤ r • 1 := by
   rw [sub_nonneg]
   apply le_of_sq_le_sq _ hr
   refine le_trans ?_ h'
-  exact Finset.single_le_sum (f := fun x ↦ (A.H.eigenvalues x)^2) (by intros; positivity) (Finset.mem_univ _)
+  exact Finset.single_le_sum (f := fun x ↦ (A.H.eigenvalues x)^2) (by intros; positivity)
+    (Finset.mem_univ _)
 
 theorem ball_subset_Icc : Metric.ball A r ⊆ Set.Icc (A - r • 1) (A + r • 1) := by
   intro x
@@ -371,7 +375,8 @@ protected theorem cfc_continuous {f : ℝ → ℝ} (hf : Continuous f) :
     apply ContinuousOn.mono ?_ (ball_subset_Icc A r)
     obtain ⟨a, b, hab⟩ := spectrum_subset_of_mem_Icc (A - r • 1) (A + r • 1)
     open ComplexOrder in
-    refine ContinuousOn.cfc (s := fun _ ↦ Set.Icc a b) (t := Set.Icc (A - r • 1) (A + r • 1)) (A := CStarMatrix d d ℂ) f ?_ (by fun_prop) ?_ (fun x _ ↦ x.H)
+    refine ContinuousOn.cfc (s := fun _ ↦ Set.Icc a b) (t := Set.Icc (A - r • 1) (A + r • 1))
+      (A := CStarMatrix d d ℂ) f ?_ (by fun_prop) ?_ (fun x _ ↦ x.H)
     · intro _ _
       exact isCompact_Icc
     · simp only [Set.mem_Icc]
@@ -394,7 +399,8 @@ theorem Matrix.PosDef.spectrum_subset_Ioi {d 𝕜 : Type*} [Fintype d] [Decidabl
   aesop
 
 /--
-If f is a continuous family of functions parameterized by x, then (fun x => A.cfc (f x)) is also continuous.
+If f is a continuous family of functions parameterized by x, then (fun x => A.cfc (f x)) is also
+continuous.
 -/
 @[fun_prop]
 theorem continuous_cfc_fun {f : X → ℝ → ℝ} (hf : ∀ i, Continuous (f · i)) :
@@ -405,7 +411,8 @@ theorem continuous_cfc_fun {f : X → ℝ → ℝ} (hf : ∀ i, Continuous (f ·
 
 variable {f : X → ℝ → ℝ} {S : Set X}
 /--
-ContinuousOn variant for when all the matrices (A x) have a spectrum in a set T, and f is continuous on a set S.
+ContinuousOn variant for when all the matrices (A x) have a spectrum in a set T, and f is continuous
+on a set S.
 -/
 @[fun_prop]
 theorem continuousOn_cfc_fun {T : Set ℝ}
@@ -430,11 +437,14 @@ lemma norm_cfc_le_sqrt_card_mul_bound {A : HermitianMat d ℂ} {f : ℝ → ℝ}
     (hC : 0 ≤ C) (hf : ∀ x ∈ spectrum ℝ A.mat, ‖f x‖ ≤ C) :
     ‖A.cfc f‖ ≤ Real.sqrt (Fintype.card d) * C := by
   rw [ ← Real.sqrt_sq ( norm_nonneg _ ) ];
-  -- Recall that the Frobenius norm of a Hermitian matrix is the square root of the sum of the squares of its eigenvalues.
-  have h_frobenius_eigenvalues : ∀ (M : HermitianMat d ℂ), ‖M‖ ^ 2 = ∑ i ∈ Finset.univ, (M.H.eigenvalues i) ^ 2 := by
+  -- Recall that the Frobenius norm of a Hermitian matrix is the square root of the sum of the
+  -- squares of its eigenvalues.
+  have h_frobenius_eigenvalues : ∀ (M : HermitianMat d ℂ), ‖M‖ ^ 2 =
+      ∑ i ∈ Finset.univ, (M.H.eigenvalues i) ^ 2 := by
     exact fun M => norm_eq_sum_eigenvalues_sq M;
   -- Applying the bound on the eigenvalues to the Frobenius norm.
-  have h_bound : ∑ i ∈ Finset.univ, ((A.cfc f).H.eigenvalues i) ^ 2 ≤ (Fintype.card d) * C ^ 2 := by
+  have h_bound : ∑ i ∈ Finset.univ, ((A.cfc f).H.eigenvalues i) ^ 2 ≤
+      (Fintype.card d) * C ^ 2 := by
     have h_bound : ∀ i, ((A.cfc f).H.eigenvalues i) ^ 2 ≤ C ^ 2 := by
       intro i
       have h_eigenvalue_bound : |(A.cfc f).H.eigenvalues i| ≤ C := by
@@ -445,13 +455,17 @@ lemma norm_cfc_le_sqrt_card_mul_bound {A : HermitianMat d ℂ} {f : ℝ → ℝ}
         aesop;
       nlinarith only [ abs_le.mp h_eigenvalue_bound ];
     exact le_trans ( Finset.sum_le_sum fun _ _ => h_bound _ ) ( by simp );
-  rw [ h_frobenius_eigenvalues, Real.sqrt_le_left ] <;> nlinarith [ Real.sqrt_nonneg ( Fintype.card d : ℝ ), Real.mul_self_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ]
+  rw [ h_frobenius_eigenvalues, Real.sqrt_le_left ] <;>
+    nlinarith [ Real.sqrt_nonneg ( Fintype.card d : ℝ ),
+      Real.mul_self_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ]
 
 /-
-The norm of the difference of two functional calculus applications is bounded by `sqrt(d)` times the sup norm of the difference of the functions.
+The norm of the difference of two functional calculus applications is bounded by `sqrt(d)` times the
+sup norm of the difference of the functions.
 -/
 lemma norm_cfc_sub_cfc_le_sqrt_card {A : HermitianMat d ℂ} {f g : ℝ → ℝ} :
-    ‖A.cfc f - A.cfc g‖ ≤ Real.sqrt (Fintype.card d) * ⨆ x ∈ spectrum ℝ A.mat, ‖f x - g x‖ := by
+    ‖A.cfc f - A.cfc g‖ ≤
+      Real.sqrt (Fintype.card d) * ⨆ x ∈ spectrum ℝ A.mat, ‖f x - g x‖ := by
   rw [ ← HermitianMat.cfc_sub ];
   refine' le_trans ( norm_cfc_le_sqrt_card_mul_bound _ _ ) _;
   exact ⨆ x ∈ spectrum ℝ A.mat, ‖f x - g x‖;
@@ -465,7 +479,10 @@ lemma norm_cfc_sub_cfc_le_sqrt_card {A : HermitianMat d ℂ} {f g : ℝ → ℝ}
       refine' ⟨ ∑ x ∈ M, ‖f x - g x‖, Set.forall_mem_range.2 fun x => _ ⟩;
       rw [ ← hM ];
       rw [ @ciSup_eq_ite ];
-      split_ifs <;> [ exact Finset.single_le_sum ( fun x _ => norm_nonneg ( f x - g x ) ) ( by assumption ) ; exact le_trans ( by norm_num ) ( Finset.sum_nonneg fun x _ => norm_nonneg ( f x - g x ) ) ];
+      split_ifs <;>
+        [ exact Finset.single_le_sum ( fun x _ => norm_nonneg ( f x - g x ) ) ( by assumption ) ;
+          exact le_trans ( by norm_num )
+            ( Finset.sum_nonneg fun x _ => norm_nonneg ( f x - g x ) ) ];
     · exact ⟨ x, by aesop ⟩;
   · rfl
 
@@ -481,7 +498,8 @@ lemma norm_cfc_sub_le_of_sup_le {A : HermitianMat d ℂ} {f g : ℝ → ℝ} {T 
   exact Real.iSup_le (fun i => h_sup x (hT i)) hε
 
 /--
-If $f$ is jointly continuous on $S \times T$ and $T$ is compact, then $x \mapsto f(x, \cdot)$ is continuous into the space of bounded functions on $T$ with the uniform norm.
+If $f$ is jointly continuous on $S \times T$ and $T$ is compact, then $x \mapsto f(x, \cdot)$ is
+continuous into the space of bounded functions on $T$ with the uniform norm.
 -/
 lemma dist_lt_of_continuous' {X : Type*} [TopologicalSpace X]
     {f : X → ℝ → ℝ} {S : Set X} {T : Set ℝ}
@@ -490,77 +508,124 @@ lemma dist_lt_of_continuous' {X : Type*} [TopologicalSpace X]
     {x₀ : X} (hx₀ : x₀ ∈ S) {ε : ℝ} (hε : 0 < ε) :
     ∃ U ∈ nhds x₀, ∀ x ∈ U ∩ S, ∀ t ∈ T, ‖f x t - f x₀ t‖ < ε := by
   by_contra h_contra;
-  -- For each $t \in T$, by continuity at $(x₀, t)$, there exist neighborhoods $U_t$ of $x₀$ and $V_t$ of $t$ such that for all $x \in U_t \cap S$ and $t' \in V_t \cap T$, $|f(x, t') - f(x₀, t)| < \epsilon/2$.
-  have h_cont : ∀ t ∈ T, ∃ U_t ∈ nhds x₀, ∃ V_t ∈ nhds t, ∀ x ∈ U_t ∩ S, ∀ t' ∈ V_t ∩ T, ‖f x t' - f x₀ t‖ < ε / 2 := by
+  -- For each $t \in T$, by continuity at $(x₀, t)$, there exist neighborhoods $U_t$ of $x₀$ and
+  -- $V_t$ of $t$ such that for all $x \in U_t \cap S$ and $t' \in V_t \cap T$,
+  -- $|f(x, t') - f(x₀, t)| < \epsilon/2$.
+  have h_cont : ∀ t ∈ T, ∃ U_t ∈ nhds x₀, ∃ V_t ∈ nhds t, ∀ x ∈ U_t ∩ S, ∀ t' ∈ V_t ∩ T,
+      ‖f x t' - f x₀ t‖ < ε / 2 := by
     intro t ht
-    have h_cont_t : ∀ᶠ (p : X × ℝ) in nhds (x₀, t), p ∈ S ×ˢ T → ‖f p.1 p.2 - f x₀ t‖ < ε / 2 := by
+    have h_cont_t : ∀ᶠ (p : X × ℝ) in nhds (x₀, t),
+        p ∈ S ×ˢ T → ‖f p.1 p.2 - f x₀ t‖ < ε / 2 := by
       have := hf ( x₀, t ) ⟨ hx₀, ht ⟩;
       have := this.eventually ( Metric.ball_mem_nhds _ ( half_pos hε ) );
       rw [ eventually_nhdsWithin_iff ] at this; aesop;
     rcases mem_nhds_prod_iff.mp h_cont_t with ⟨ U, hU, V, hV, hUV ⟩;
-    exact ⟨ U, hU, V, hV, fun x hx t' ht' => hUV ( Set.mk_mem_prod hx.1 ht'.1 ) ⟨ hx.2, ht'.2 ⟩ ⟩;
+    exact ⟨ U, hU, V, hV,
+      fun x hx t' ht' => hUV ( Set.mk_mem_prod hx.1 ht'.1 ) ⟨ hx.2, ht'.2 ⟩ ⟩;
   choose! U hU V hV hUV using h_cont;
   -- Since $T$ is compact, cover it by finitely many $V_{t_i}$. Let $U = \bigcap U_{t_i}$.
-  obtain ⟨t_fin, ht_fin⟩ : ∃ t_fin : Finset ℝ, (∀ t ∈ t_fin, t ∈ T) ∧ T ⊆ ⋃ t ∈ t_fin, V t := by
+  obtain ⟨t_fin, ht_fin⟩ :
+      ∃ t_fin : Finset ℝ, (∀ t ∈ t_fin, t ∈ T) ∧ T ⊆ ⋃ t ∈ t_fin, V t := by
     have := hT.elim_nhds_subcover V fun t ht => hV t ht;
     tauto;
   refine h_contra ⟨⋂ t ∈ t_fin, U t, ?_, ?_⟩
-  · exact Filter.biInter_mem ( Finset.finite_toSet t_fin ) |>.2 fun t ht => hU t ( ht_fin.1 t ht );
+  · exact Filter.biInter_mem ( Finset.finite_toSet t_fin ) |>.2
+      fun t ht => hU t ( ht_fin.1 t ht );
   · intro x hx t ht
     obtain ⟨t', ht'_fin, ht'_t⟩ : ∃ t' ∈ t_fin, t ∈ V t' := by
       simpa using ht_fin.2 ht;
-    have := hUV t' ( ht_fin.1 t' ht'_fin ) x ⟨ Set.mem_iInter₂.1 hx.1 t' ht'_fin, hx.2 ⟩ t ⟨ ht'_t, ht ⟩;
-    have := hUV t' ( ht_fin.1 t' ht'_fin ) x₀ ⟨ mem_of_mem_nhds ( hU t' ( ht_fin.1 t' ht'_fin ) ), hx₀ ⟩ t ⟨ ht'_t, ht ⟩;
-    exact abs_lt.mpr ⟨ by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›, abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ], by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›, abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ] ⟩
+    have := hUV t' ( ht_fin.1 t' ht'_fin ) x ⟨ Set.mem_iInter₂.1 hx.1 t' ht'_fin, hx.2 ⟩ t
+      ⟨ ht'_t, ht ⟩;
+    have := hUV t' ( ht_fin.1 t' ht'_fin ) x₀
+      ⟨ mem_of_mem_nhds ( hU t' ( ht_fin.1 t' ht'_fin ) ), hx₀ ⟩ t ⟨ ht'_t, ht ⟩;
+    exact abs_lt.mpr ⟨ by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
+      abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ], by linarith [ abs_lt.mp ‹‖f x t - f x₀ t'‖ < ε / 2›,
+      abs_lt.mp ‹‖f x₀ t - f x₀ t'‖ < ε / 2› ] ⟩
 
 /--
 The functional calculus is continuous on matrices with spectrum in a compact set.
 -/
-lemma continuousOn_cfc_of_compact {K : Set ℝ} {g : ℝ → ℝ} (hK : IsCompact K) (hg : ContinuousOn g K) :
+lemma continuousOn_cfc_of_compact {K : Set ℝ} {g : ℝ → ℝ} (hK : IsCompact K)
+    (hg : ContinuousOn g K) :
     ContinuousOn (fun (A : HermitianMat d ℂ) ↦ A.cfc g) {A | spectrum ℝ A.mat ⊆ K} := by
   by_contra! h_contra;
-  -- By Stone-Weierstrass, there exists a sequence of polynomials `p_n` converging uniformly to `g` on `K`.
-  obtain ⟨p_n, hp_n⟩ : ∃ p_n : ℕ → Polynomial ℝ, (∀ n, ∀ x ∈ K, |(p_n n).eval x - g x| ≤ 1 / (n + 1)) := by
+  -- By Stone-Weierstrass, there exists a sequence of polynomials `p_n` converging uniformly to
+  -- `g` on `K`.
+  obtain ⟨p_n, hp_n⟩ :
+      ∃ p_n : ℕ → Polynomial ℝ, (∀ n, ∀ x ∈ K, |(p_n n).eval x - g x| ≤ 1 / (n + 1)) := by
     have h_stone_weierstrass : ∀ ε > 0, ∃ p : Polynomial ℝ, ∀ x ∈ K, |p.eval x - g x| < ε := by
       have := @exists_polynomial_near_of_continuousOn;
       obtain ⟨a, b, hab⟩ : ∃ a b : ℝ, K ⊆ Set.Icc a b := by
-        exact ⟨ hK.bddBelow.some, hK.bddAbove.some, fun x hx => ⟨ hK.bddBelow.choose_spec hx, hK.bddAbove.choose_spec hx ⟩ ⟩;
+        exact ⟨ hK.bddBelow.some, hK.bddAbove.some,
+          fun x hx => ⟨ hK.bddBelow.choose_spec hx, hK.bddAbove.choose_spec hx ⟩ ⟩;
       -- Extend $g$ to a continuous function on $[a, b]$.
       obtain ⟨f, hf⟩ : ∃ f : ℝ → ℝ, ContinuousOn f (Set.Icc a b) ∧ ∀ x ∈ K, f x = g x := by
         have := @ContinuousMap.exists_restrict_eq;
-        specialize this ( show IsClosed K from hK.isClosed ) ( ContinuousMap.mk ( fun x => g x ) <| by exact continuousOn_iff_continuous_restrict.mp hg );
-        exact ⟨ _, this.choose.continuous.continuousOn, fun x hx => by simpa using congr_arg ( fun f => f ⟨ x, hx ⟩ ) this.choose_spec ⟩;
-      exact fun ε εpos => by rcases this a b f hf.1 ε εpos with ⟨ p, hp ⟩ ; exact ⟨ p, fun x hx => by simpa only [ hf.2 x hx ] using hp x ( hab hx ) ⟩ ;
-    exact ⟨ fun n => Classical.choose ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ), fun n x hx => le_of_lt ( Classical.choose_spec ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ) x hx ) ⟩;
-  -- The sequence `A ↦ A.cfc (p_n)` converges uniformly to `A ↦ A.cfc g` on `{A | spectrum A ⊆ K}`.
-  have h_uniform : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, ∀ A : HermitianMat d ℂ, spectrum ℝ A.mat ⊆ K → ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ < ε := by
-    -- By the properties of the functional calculus, we have `‖A.cfc p_n - A.cfc g‖ ≤ sqrt(d) * ‖p_n - g‖_{∞, K}`.
-    have h_uniform_bound : ∀ n, ∀ A : HermitianMat d ℂ, spectrum ℝ A.mat ⊆ K → ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ ≤ Real.sqrt (Fintype.card d) * (1 / (n + 1)) := by
+        specialize this ( show IsClosed K from hK.isClosed )
+          ( ContinuousMap.mk ( fun x => g x ) <| by
+            exact continuousOn_iff_continuous_restrict.mp hg );
+        exact ⟨ _, this.choose.continuous.continuousOn,
+          fun x hx => by simpa using congr_arg ( fun f => f ⟨ x, hx ⟩ ) this.choose_spec ⟩;
+      exact fun ε εpos => by rcases this a b f hf.1 ε εpos with ⟨ p, hp ⟩ ;
+        exact ⟨ p, fun x hx => by simpa only [ hf.2 x hx ] using hp x ( hab hx ) ⟩ ;
+    exact ⟨ fun n => Classical.choose ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ),
+      fun n x hx => le_of_lt ( Classical.choose_spec
+        ( h_stone_weierstrass ( 1 / ( n + 1 ) ) ( by positivity ) ) x hx ) ⟩;
+  -- The sequence `A ↦ A.cfc (p_n)` converges uniformly to `A ↦ A.cfc g` on
+  -- `{A | spectrum A ⊆ K}`.
+  have h_uniform : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, ∀ A : HermitianMat d ℂ, spectrum ℝ A.mat ⊆ K →
+      ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ < ε := by
+    -- By the properties of the functional calculus, we have
+    -- `‖A.cfc p_n - A.cfc g‖ ≤ sqrt(d) * ‖p_n - g‖_{∞, K}`.
+    have h_uniform_bound : ∀ n, ∀ A : HermitianMat d ℂ, spectrum ℝ A.mat ⊆ K →
+        ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ ≤
+          Real.sqrt (Fintype.card d) * (1 / (n + 1)) := by
       intro n A hA
-      have h_uniform_bound : ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ ≤ Real.sqrt (Fintype.card d) * ⨆ x ∈ spectrum ℝ A.mat, |(p_n n).eval x - g x| := by
+      have h_uniform_bound : ‖A.cfc (fun x => (p_n n).eval x) - A.cfc g‖ ≤
+          Real.sqrt (Fintype.card d) * ⨆ x ∈ spectrum ℝ A.mat, |(p_n n).eval x - g x| := by
         exact norm_cfc_sub_cfc_le_sqrt_card;
-      refine' le_trans h_uniform_bound ( mul_le_mul_of_nonneg_left _ ( Real.sqrt_nonneg _ ) );
+      refine' le_trans h_uniform_bound
+        ( mul_le_mul_of_nonneg_left _ ( Real.sqrt_nonneg _ ) );
       refine' ciSup_le fun x => _;
       field_simp;
       by_cases hx : x ∈ spectrum ℝ A.mat <;> simp_all
-      exact le_trans ( mul_le_mul_of_nonneg_right ( hp_n n x ( hA hx ) ) ( by positivity ) ) ( by nlinarith [ mul_inv_cancel₀ ( by positivity : ( n : ℝ ) + 1 ≠ 0 ) ] );
-    exact fun ε εpos => ⟨ Nat.ceil ( ε⁻¹ * Real.sqrt ( Fintype.card d ) ), fun n hn A hA => lt_of_le_of_lt ( h_uniform_bound n A hA ) ( by rw [ mul_one_div, div_lt_iff₀ ] <;> nlinarith [ Nat.ceil_le.mp hn, inv_pos.mpr εpos, mul_inv_cancel₀ εpos.ne', Real.sqrt_nonneg ( Fintype.card d ), Real.sq_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ] ) ⟩;
+      exact le_trans ( mul_le_mul_of_nonneg_right ( hp_n n x ( hA hx ) ) ( by positivity ) )
+        ( by nlinarith [ mul_inv_cancel₀ ( by positivity : ( n : ℝ ) + 1 ≠ 0 ) ] );
+    exact fun ε εpos => ⟨ Nat.ceil ( ε⁻¹ * Real.sqrt ( Fintype.card d ) ),
+      fun n hn A hA => lt_of_le_of_lt ( h_uniform_bound n A hA )
+        ( by rw [ mul_one_div, div_lt_iff₀ ] <;>
+          nlinarith [ Nat.ceil_le.mp hn, inv_pos.mpr εpos, mul_inv_cancel₀ εpos.ne',
+            Real.sqrt_nonneg ( Fintype.card d ),
+            Real.sq_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ] ) ⟩;
   -- The uniform limit of continuous functions is continuous.
-  have h_cont : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc g) {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ K} := by
-    have h_seq_cont : ∀ n, ContinuousOn (fun A : HermitianMat d ℂ => A.cfc (fun x => (p_n n).eval x)) {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ K} := by
+  have h_cont : ContinuousOn (fun A : HermitianMat d ℂ => A.cfc g)
+      {A : HermitianMat d ℂ |
+        spectrum ℝ A.mat ⊆ K} := by
+    have h_seq_cont : ∀ n,
+        ContinuousOn (fun A : HermitianMat d ℂ => A.cfc (fun x => (p_n n).eval x))
+        {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ K} := by
       fun_prop
     refine' Metric.continuousOn_iff.mpr _;
     intro A hA ε εpos
     obtain ⟨N, hN⟩ := h_uniform (ε / 3) (by linarith)
-    obtain ⟨δ, δpos, hδ⟩ : ∃ δ > 0, ∀ a ∈ {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ K}, dist a A < δ → ‖a.cfc (fun x => (p_n N).eval x) - A.cfc (fun x => (p_n N).eval x)‖ < ε / 3 := by
+    obtain ⟨δ, δpos, hδ⟩ : ∃ δ > 0, ∀ a ∈ {A : HermitianMat d ℂ | spectrum ℝ A.mat ⊆ K},
+        dist a A < δ →
+          ‖a.cfc (fun x => (p_n N).eval x) - A.cfc (fun x => (p_n N).eval x)‖ < ε / 3 := by
       have := Metric.continuousOn_iff.mp ( h_seq_cont N ) A hA ( ε / 3 ) ( by linarith );
-      exact ⟨ this.choose, this.choose_spec.1, fun a ha ha' => by simpa only [ dist_eq_norm ] using this.choose_spec.2 a ha ha' ⟩;
+      exact ⟨ this.choose, this.choose_spec.1,
+        fun a ha ha' => by simpa only [ dist_eq_norm ] using this.choose_spec.2 a ha ha' ⟩;
     refine' ⟨ δ, δpos, fun a ha ha' => _ ⟩;
     have := hN N le_rfl a ha;
     have := hN N le_rfl A hA;
     rw [ dist_eq_norm ];
-    rw [ show a.cfc g - A.cfc g = ( a.cfc g - a.cfc ( fun x => Polynomial.eval x ( p_n N ) ) ) + ( a.cfc ( fun x => Polynomial.eval x ( p_n N ) ) - A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) ) + ( A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) - A.cfc g ) by abel1 ];
-    exact lt_of_le_of_lt ( norm_add₃_le .. ) ( by linarith [ norm_sub_rev ( a.cfc g ) ( a.cfc fun x => Polynomial.eval x ( p_n N ) ), norm_sub_rev ( A.cfc fun x => Polynomial.eval x ( p_n N ) ) ( A.cfc g ), hδ a ha ha' ] );
+    rw [ show a.cfc g - A.cfc g = ( a.cfc g - a.cfc ( fun x => Polynomial.eval x ( p_n N ) ) ) +
+        ( a.cfc ( fun x => Polynomial.eval x ( p_n N ) ) -
+          A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) ) +
+        ( A.cfc ( fun x => Polynomial.eval x ( p_n N ) ) - A.cfc g ) by abel1 ];
+    exact lt_of_le_of_lt ( norm_add₃_le .. )
+      ( by linarith [ norm_sub_rev ( a.cfc g ) ( a.cfc fun x => Polynomial.eval x ( p_n N ) ),
+        norm_sub_rev ( A.cfc fun x => Polynomial.eval x ( p_n N ) ) ( A.cfc g ),
+        hδ a ha ha' ] );
   contradiction
 
 end joint_continuity
@@ -580,8 +645,10 @@ theorem continuous_cfc_joint_compact {X d : Type*} [TopologicalSpace X] [Fintype
   rw [ ContinuousWithinAt ] at *;
   rw [ Metric.tendsto_nhds ] at *;
   intro ε ε_pos
-  obtain ⟨U, hU₁, hU₂⟩ : ∃ U ∈ nhds x, ∀ y ∈ U ∩ S, ‖(A y).cfc (f y) - (A y).cfc (f x)‖ ≤ Real.sqrt (Fintype.card d) * (ε / (2 * Real.sqrt (Fintype.card d) + 1)) := by
-    have h_eps_delta₁ : ∀ ε > 0, ∃ U ∈ nhds x, ∀ y ∈ U ∩ S, ‖(A y).cfc (f y) - (A y).cfc (f x)‖ ≤ Real.sqrt (Fintype.card d) * ε := by
+  obtain ⟨U, hU₁, hU₂⟩ : ∃ U ∈ nhds x, ∀ y ∈ U ∩ S, ‖(A y).cfc (f y) - (A y).cfc (f x)‖ ≤
+      Real.sqrt (Fintype.card d) * (ε / (2 * Real.sqrt (Fintype.card d) + 1)) := by
+    have h_eps_delta₁ : ∀ ε > 0, ∃ U ∈ nhds x, ∀ y ∈ U ∩ S,
+        ‖(A y).cfc (f y) - (A y).cfc (f x)‖ ≤ Real.sqrt (Fintype.card d) * ε := by
       intro ε ε_pos
       obtain ⟨U, hU₁, hU₂⟩ := dist_lt_of_continuous' (f := f) hT hf x_in_S ε_pos
       use U, hU₁
@@ -590,11 +657,13 @@ theorem continuous_cfc_joint_compact {X d : Type*} [TopologicalSpace X] [Fintype
       intro t ht
       exact le_of_lt (hU₂ y hy t ht)
     exact h_eps_delta₁ _ (by positivity)
-  filter_upwards [ h_eps_delta ( ε / 2 ) ( half_pos ε_pos ), self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds hU₁ ] with y hy₁ hy₂ hy₃
+  filter_upwards [ h_eps_delta ( ε / 2 ) ( half_pos ε_pos ), self_mem_nhdsWithin,
+    mem_nhdsWithin_of_mem_nhds hU₁ ] with y hy₁ hy₂ hy₃
   apply lt_of_le_of_lt (dist_triangle _ ((A y).cfc (f x)) _)
   nlinarith [hU₂ y ⟨ hy₃, hy₂ ⟩,
     Real.sqrt_nonneg ( Fintype.card d : ℝ ),
-    mul_div_cancel₀ ε ( show ( 2 * Real.sqrt ( Fintype.card d : ℝ ) + 1 ) ≠ 0 by positivity ),
+    mul_div_cancel₀ ε
+      ( show ( 2 * Real.sqrt ( Fintype.card d : ℝ ) + 1 ) ≠ 0 by positivity ),
     norm_nonneg ( ( A y ).cfc ( f y ) - ( A y ).cfc ( f x ) ),
     norm_nonneg ( ( A y ).cfc ( f x ) - ( A x ).cfc ( f x ) ),
     dist_eq_norm ( ( A y ).cfc ( f y ) ) ( ( A y ).cfc ( f x ) ),
@@ -605,14 +674,16 @@ open scoped Matrix.Norms.Frobenius
 PROBLEM
 Eigenvalues of a `HermitianMat` are bounded by its (Frobenius) norm.
 PROVIDED SOLUTION
-Use `norm_eq_sum_eigenvalues_sq` which gives `‖A‖² = Σᵢ (A.H.eigenvalues i)²`. Since `(A.H.eigenvalues i)² ≤ Σⱼ (A.H.eigenvalues j)² = ‖A‖²`, we get `|A.H.eigenvalues i| ≤ ‖A‖`.
+Use `norm_eq_sum_eigenvalues_sq` which gives `‖A‖² = Σᵢ (A.H.eigenvalues i)²`. Since
+`(A.H.eigenvalues i)² ≤ Σⱼ (A.H.eigenvalues j)² = ‖A‖²`, we get `|A.H.eigenvalues i| ≤ ‖A‖`.
 -/
 lemma eigenvalue_norm_le (A : HermitianMat d ℂ) (i : d) :
     |A.H.eigenvalues i| ≤ ‖A‖ := by
   have h_eigenvalue_bound : |A.H.eigenvalues i| ^ 2 ≤ ‖A‖ ^ 2 := by
     rw [ norm_eq_sum_eigenvalues_sq A ];
     simp [pow_two];
-    exact Finset.single_le_sum ( fun i _ => mul_self_nonneg ( A.H.eigenvalues i ) ) ( Finset.mem_univ i );
+    exact Finset.single_le_sum ( fun i _ => mul_self_nonneg ( A.H.eigenvalues i ) )
+      ( Finset.mem_univ i );
   nlinarith [ norm_nonneg A ]
 
 /--
@@ -630,34 +701,51 @@ in an open set `U`, then the spectrum of any Hermitian matrix sufficiently close
 contained in `U`. This follows from the openness of the set of invertible matrices and compactness.
 PROVIDED SOLUTION
 The proof uses the resolvent approach and compactness.
-1. Let M = ‖A₀‖ + 1. For B in a ball of radius 1 around A₀, ‖B‖ ≤ M, so spectrum ℝ B.mat ⊆ Metric.closedBall 0 M (by spectrum_subset_closedBall and the triangle inequality for norms).
-2. Let K = Metric.closedBall (0 : ℝ) M \ U. Then K is compact (closed and bounded minus open = closed and bounded in ℝ). And K ∩ spectrum ℝ A₀.mat = ∅ (since spectrum ℝ A₀.mat ⊆ U).
-3. For each t ∈ K: t ∉ spectrum ℝ A₀.mat. By the definition of spectrum, A₀.mat - algebraMap ℝ (Matrix d d ℂ) t is a unit. The set of units is open (Units.isOpen, since Matrix d d ℂ has HasSummableGeomSeries). The map B ↦ B.mat - algebraMap ℝ _ t is continuous. So there exist δ_t > 0 and ε_t > 0 such that for ‖B - A₀‖ < δ_t and |s - t| < ε_t, B.mat - algebraMap ℝ _ s is a unit, meaning s ∉ spectrum ℝ B.mat.
-4. By compactness of K (it's compact since it's a closed subset of the compact ball): finitely many ε-balls B(t_j, ε_{t_j}) cover K. Let δ = min(1, min_j δ_{t_j}).
-5. For B with ‖B - A₀‖ < δ: spectrum ℝ B.mat ⊆ Metric.closedBall 0 M (by step 1) and spectrum ℝ B.mat ∩ K = ∅ (by step 4). So spectrum ℝ B.mat ⊆ Metric.closedBall 0 M \ K ⊆ U.
-Note: we need to connect spectrum ℝ B.mat (the real spectrum) to IsUnit in the complex matrix ring. Use that for self-adjoint elements, t ∈ spectrum ℝ A.mat iff algebraMap ℝ (Matrix d d ℂ) t ∈ spectrum ℂ A.mat, and the resolvent set is open. We can use spectrum.isOpen_resolventSet or the characterization via IsUnit.
+1. Let M = ‖A₀‖ + 1. For B in a ball of radius 1 around A₀, ‖B‖ ≤ M, so spectrum ℝ B.mat ⊆
+Metric.closedBall 0 M (by spectrum_subset_closedBall and the triangle inequality for norms).
+2. Let K = Metric.closedBall (0 : ℝ) M \ U. Then K is compact (closed and bounded minus open =
+closed and bounded in ℝ). And K ∩ spectrum ℝ A₀.mat = ∅ (since spectrum ℝ A₀.mat ⊆ U).
+3. For each t ∈ K: t ∉ spectrum ℝ A₀.mat. By the definition of spectrum, A₀.mat - algebraMap ℝ
+(Matrix d d ℂ) t is a unit. The set of units is open (Units.isOpen, since Matrix d d ℂ has
+HasSummableGeomSeries). The map B ↦ B.mat - algebraMap ℝ _ t is continuous. So there exist δ_t > 0
+and ε_t > 0 such that for ‖B - A₀‖ < δ_t and |s - t| < ε_t, B.mat - algebraMap ℝ _ s is a unit,
+meaning s ∉ spectrum ℝ B.mat.
+4. By compactness of K (it's compact since it's a closed subset of the compact ball): finitely many
+ε-balls B(t_j, ε_{t_j}) cover K. Let δ = min(1, min_j δ_{t_j}).
+5. For B with ‖B - A₀‖ < δ: spectrum ℝ B.mat ⊆ Metric.closedBall 0 M (by step 1) and spectrum ℝ
+B.mat ∩ K = ∅ (by step 4). So spectrum ℝ B.mat ⊆ Metric.closedBall 0 M \ K ⊆ U.
+Note: we need to connect spectrum ℝ B.mat (the real spectrum) to IsUnit in the complex matrix ring.
+Use that for self-adjoint elements, t ∈ spectrum ℝ A.mat iff algebraMap ℝ (Matrix d d ℂ) t ∈
+spectrum ℂ A.mat, and the resolvent set is open. We can use spectrum.isOpen_resolventSet or the
+characterization via IsUnit.
 -/
 set_option maxHeartbeats 400000 in
 lemma spectrum_subset_of_isOpen (A₀ : HermitianMat d ℂ) (U : Set ℝ)
     (hU : IsOpen U) (hAU : spectrum ℝ A₀.mat ⊆ U) :
     ∀ᶠ B in nhds A₀, spectrum ℝ B.mat ⊆ U := by
-  -- Let $M = \|A₀\| + 1$. For $B$ in a ball of radius $1$ around $A₀$, $\|B\| \leq M$, so $\sigma(B) \subseteq \overline{B(0, M)}$.
-  obtain ⟨M, hM⟩ : ∃ M : ℝ, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < 1 → spectrum ℝ B.mat ⊆ Metric.closedBall 0 M := by
+  -- Let $M = \|A₀\| + 1$. For $B$ in a ball of radius $1$ around $A₀$, $\|B\| \leq M$, so
+  -- $\sigma(B) \subseteq \overline{B(0, M)}$.
+  obtain ⟨M, hM⟩ : ∃ M : ℝ, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < 1 →
+      spectrum ℝ B.mat ⊆ Metric.closedBall 0 M := by
     use ‖A₀‖ + 1
     intro B hB
     have h_norm : ‖B‖ ≤ ‖A₀‖ + 1 := by
       have := norm_sub_norm_le B A₀; linarith!;
-    generalize_proofs at *; (exact spectrum_subset_closedBall B |> fun h => h.trans <| Metric.closedBall_subset_closedBall h_norm)
+    generalize_proofs at *; (exact spectrum_subset_closedBall B |>
+      fun h => h.trans <| Metric.closedBall_subset_closedBall h_norm)
   generalize_proofs at *; (
-  -- Let $K = \overline{B(0, M)} \setminus U$. Then $K$ is compact and $K \cap \sigma(A₀) = \emptyset$.
+  -- Let $K = \overline{B(0, M)} \setminus U$. Then $K$ is compact and
+  -- $K \cap \sigma(A₀) = \emptyset$.
   set K : Set ℝ := Metric.closedBall 0 M \ U
   have hK_compact : IsCompact K := by
     exact IsCompact.diff ( ProperSpace.isCompact_closedBall _ _ ) hU
   have hK_disjoint : K ∩ spectrum ℝ A₀.mat = ∅ := by
     exact Set.eq_empty_of_forall_notMem fun x hx => hx.1.2 <| hAU hx.2
   generalize_proofs at *; (
-  -- For each $t \in K$, there exist $\delta_t > 0$ and $\epsilon_t > 0$ such that for $\|B - A₀\| < \delta_t$ and $|s - t| < \epsilon_t$, $B.mat - algebraMap ℝ _ s$ is a unit.
-  have h_unitary : ∀ t ∈ K, ∃ δ_t > 0, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ_t → ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
+  -- For each $t \in K$, there exist $\delta_t > 0$ and $\epsilon_t > 0$ such that for
+  -- $\|B - A₀\| < \delta_t$ and $|s - t| < \epsilon_t$, $B.mat - algebraMap ℝ _ s$ is a unit.
+  have h_unitary : ∀ t ∈ K, ∃ δ_t > 0, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ_t →
+      ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
     intro t ht
     have h_unitary : IsUnit (A₀.mat - algebraMap ℝ (Matrix d d ℂ) t) := by
       simp_all [ Set.ext_iff, spectrum.mem_iff ];
@@ -667,38 +755,52 @@ lemma spectrum_subset_of_isOpen (A₀ : HermitianMat d ℂ) (U : Set ℝ)
     have h_unitary_open : IsOpen {B : Matrix d d ℂ | IsUnit B} := by
       exact Units.isOpen
     generalize_proofs at *; (
-    have h_unitary_cont : Continuous (fun p : HermitianMat d ℂ × ℝ => p.1.mat - algebraMap ℝ (Matrix d d ℂ) p.2) := by
+    have h_unitary_cont : Continuous
+        (fun p : HermitianMat d ℂ × ℝ => p.1.mat - algebraMap ℝ (Matrix d d ℂ) p.2) := by
       refine' Continuous.sub _ _ <;> fun_prop (disch := solve_by_elim)
     generalize_proofs at *; (
-    have := Metric.isOpen_iff.mp ( h_unitary_open.preimage h_unitary_cont ) ( A₀, t ) h_unitary
+    have := Metric.isOpen_iff.mp ( h_unitary_open.preimage h_unitary_cont ) ( A₀, t )
+      h_unitary
     generalize_proofs at *; (
-    obtain ⟨ ε, ε_pos, hε ⟩ := this; exact ⟨ ε, ε_pos, ε, ε_pos, fun B hB s hs => hε ( show ( B, s ) ∈ Metric.ball ( A₀, t ) ε from by
+    obtain ⟨ ε, ε_pos, hε ⟩ := this; exact ⟨ ε, ε_pos, ε, ε_pos,
+      fun B hB s hs => hε ( show ( B, s ) ∈ Metric.ball ( A₀, t ) ε from by
       simp only [Metric.mem_ball, Prod.dist_eq,]
       refine max_lt ?_ ?_
       · simpa [dist_eq_norm] using hB
       · simpa [dist_eq_norm] using hs) ⟩ ;))))
   generalize_proofs at *; (
-  -- By compactness of $K$, finitely many $\epsilon$-balls cover $K$. Take $\delta = \min(1, \min_j \delta_j)$.
-  obtain ⟨δ, hδ_pos, hδ⟩ : ∃ δ > 0, ∀ t ∈ K, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ → ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
+  -- By compactness of $K$, finitely many $\epsilon$-balls cover $K$. Take
+  -- $\delta = \min(1, \min_j \delta_j)$.
+  obtain ⟨δ, hδ_pos, hδ⟩ : ∃ δ > 0, ∀ t ∈ K, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ →
+      ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
     choose! δ hδ ε hε h using h_unitary
     generalize_proofs at *; (
-    have := hK_compact.elim_nhds_subcover ( fun t => Metric.ball t ( ε t ) ) fun t ht => Metric.ball_mem_nhds t ( hε t ht ) ; simp_all [ Set.subset_def ] ; (
+    have := hK_compact.elim_nhds_subcover ( fun t => Metric.ball t ( ε t ) )
+      fun t ht => Metric.ball_mem_nhds t ( hε t ht ) ; simp_all [ Set.subset_def ] ; (
     obtain ⟨ t, ht₁, ht₂ ⟩ := this
     generalize_proofs at *; (
     -- Let $\delta = \min(1, \min_{i \in t} \delta_i)$.
     obtain ⟨δ_min, hδ_min_pos, hδ_min⟩ : ∃ δ_min > 0, ∀ i ∈ t, δ_min ≤ δ i := by
       by_cases ht : t.Nonempty <;> simp_all [ Finset.Nonempty ];
-      · exact ⟨ Finset.min' ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩, by have := Finset.min'_mem ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩ ; aesop, fun i hi => Finset.min'_le _ _ ( Finset.mem_image_of_mem δ hi ) ⟩;
+      · exact ⟨ Finset.min' ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩,
+          by have := Finset.min'_mem ( t.image δ )
+            ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩ ; aesop,
+          fun i hi => Finset.min'_le _ _ ( Finset.mem_image_of_mem δ hi ) ⟩;
       · exact ⟨ 1, zero_lt_one ⟩
     generalize_proofs at *; (
     refine' ⟨ Min.min δ_min 1, lt_min hδ_min_pos zero_lt_one, fun x hx => _ ⟩
     generalize_proofs at *; (
     obtain ⟨ i, hi, hi' ⟩ := ht₂ x hx
     generalize_proofs at *; (
-    exact ⟨ ε i - |x - i|, sub_pos.mpr ( by simpa [ abs_sub_comm ] using hi' ), fun B hB s hs => h i ( ht₁ i hi ) B ( lt_of_lt_of_le hB ( min_le_of_left_le ( hδ_min i hi ) ) ) s ( by rw [ abs_lt ] at *; constructor <;> linarith [ abs_le.mp ( show |x - i| ≤ |x - i| by rfl ) ] ) ⟩))))))
+    exact ⟨ ε i - |x - i|, sub_pos.mpr ( by simpa [ abs_sub_comm ] using hi' ),
+      fun B hB s hs => h i ( ht₁ i hi ) B
+        ( lt_of_lt_of_le hB ( min_le_of_left_le ( hδ_min i hi ) ) ) s
+        ( by rw [ abs_lt ] at *; constructor <;>
+          linarith [ abs_le.mp ( show |x - i| ≤ |x - i| by rfl ) ] ) ⟩))))))
   generalize_proofs at *; (
   -- For any $B$ with $\|B - A₀\| < \delta$, if $t \in \sigma(B)$, then $t \notin K$.
-  have h_not_in_K : ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ → ∀ t ∈ spectrum ℝ B.mat, t ∉ K := by
+  have h_not_in_K : ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ → ∀ t ∈ spectrum ℝ B.mat,
+      t ∉ K := by
     intro B hB t ht htK
     obtain ⟨ε_t, hε_t_pos, hε_t⟩ := hδ t htK
     have h_unit : IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) t) := by
@@ -706,10 +808,12 @@ lemma spectrum_subset_of_isOpen (A₀ : HermitianMat d ℂ) (U : Set ℝ)
     generalize_proofs at *; (
     exact ht ( by simpa [ sub_eq_iff_eq_add ] using h_unit.neg ))
   generalize_proofs at *; (
-  filter_upwards [ Metric.ball_mem_nhds A₀ ( show 0 < Min.min δ 1 by positivity ) ] with B hB using fun t ht =>
+  filter_upwards [ Metric.ball_mem_nhds A₀ ( show 0 < Min.min δ 1 by positivity ) ] with B hB using
+    fun t ht =>
       Classical.not_not.1 fun h => h_not_in_K B
       ( lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) ( min_le_left _ _ ) ) t ht
-      ⟨ hM B ( lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) ( min_le_right _ _ ) ) ht, h ⟩)))))
+      ⟨ hM B ( lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) ( min_le_right _ _ ) ) ht,
+        h ⟩)))))
 
 /-
 PROBLEM
@@ -720,19 +824,28 @@ compact version, and bounds the error using upper semicontinuity of the spectrum
 PROVIDED SOLUTION
 The proof uses Tietze extension and the compact version `continuousOn_cfc_of_compact`.
 Step 1: Extend g from the finite set spectrum(A₀) to all of ℝ via Tietze.
-The spectrum `Λ := spectrum ℝ A₀.mat` is finite (it equals `Set.range A₀.H.eigenvalues`), hence closed.
-The restriction of g to Λ is continuous (any function on a finite set is continuous in a T1 space, using `continuousOn_finite`).
-By `ContinuousMap.exists_restrict_eq`, there exists a continuous function `h : C(ℝ, ℝ)` with `h = g` on Λ.
+The spectrum `Λ := spectrum ℝ A₀.mat` is finite (it equals `Set.range A₀.H.eigenvalues`), hence
+closed.
+The restriction of g to Λ is continuous (any function on a finite set is continuous in a T1 space,
+using `continuousOn_finite`).
+By `ContinuousMap.exists_restrict_eq`, there exists a continuous function `h : C(ℝ, ℝ)` with `h = g`
+on Λ.
 Step 2: (A₀).cfc g = (A₀).cfc h, since g = h on spectrum(A₀) (by `cfc_congr`).
 Step 3: Show `B ↦ B.cfc h` is continuous at A₀.
-Let M = ‖A₀‖ + 1 and K = Set.Icc (-M) M. Since h is continuous on ℝ and hence on K, and K is compact, by `continuousOn_cfc_of_compact`, the map `B ↦ B.cfc h` is continuous on `{B | spectrum ℝ B.mat ⊆ K}`. Since `{B | spectrum ℝ B.mat ⊆ T} ∩ (Metric.ball A₀ 1) ⊆ {B | spectrum ℝ B.mat ⊆ K}` (because for B near A₀, ‖B‖ ≤ M, so spectrum B ⊆ [-M, M] = K by spectrum_subset_closedBall), the map is ContinuousWithinAt at A₀.
+Let M = ‖A₀‖ + 1 and K = Set.Icc (-M) M. Since h is continuous on ℝ and hence on K, and K is
+compact, by `continuousOn_cfc_of_compact`, the map `B ↦ B.cfc h` is continuous on
+`{B | spectrum ℝ B.mat ⊆ K}`. Since `{B | spectrum ℝ B.mat ⊆ T} ∩ (Metric.ball A₀ 1) ⊆
+{B | spectrum ℝ B.mat ⊆ K}` (because for B near A₀, ‖B‖ ≤ M, so spectrum B ⊆ [-M, M] = K by
+spectrum_subset_closedBall), the map is ContinuousWithinAt at A₀.
 Step 4: Show `‖B.cfc g - B.cfc h‖ → 0` as B → A₀ within `{B | σ(B) ⊆ T}`.
 The function `|g - h|` is 0 on Λ = spectrum(A₀). For each eigenvalue λᵢ ∈ Λ ⊆ T:
 - g is continuous on T at λᵢ
 - h is continuous everywhere
 So `|g(t) - h(t)| = |g(t) - g(λᵢ) + h(λᵢ) - h(t)|` is small for t near λᵢ with t ∈ T.
-Define U_ε = {t ∈ ℝ | ∀ λ ∈ Λ, if |t - λ| < some δ then |g(t) - h(t)| < ε for t ∈ T} ∪ (complement of a ball around Λ).
-Actually, more precisely: the set V_ε = {t : ℝ | t ∈ T → |g(t) - h(t)| < ε} is an open set containing Λ (since |g - h| = 0 on Λ and both are continuous at each point of Λ along T).
+Define U_ε = {t ∈ ℝ | ∀ λ ∈ Λ, if |t - λ| < some δ then |g(t) - h(t)| < ε for t ∈ T} ∪ (complement
+of a ball around Λ).
+Actually, more precisely: the set V_ε = {t : ℝ | t ∈ T → |g(t) - h(t)| < ε} is an open set
+containing Λ (since |g - h| = 0 on Λ and both are continuous at each point of Λ along T).
 By `spectrum_subset_of_isOpen`, for B near A₀, spectrum(B) ⊆ V_ε.
 Since spectrum(B) ⊆ T, for t ∈ spectrum(B), |g(t) - h(t)| < ε.
 So ‖B.cfc g - B.cfc h‖ ≤ sqrt(d) * ε by `norm_cfc_sub_le_of_sup_le`.
@@ -747,7 +860,8 @@ lemma continuousWithinAt_cfc_of_continuousOn {T : Set ℝ} {g : ℝ → ℝ}
     {A₀ : HermitianMat d ℂ}
     (hg : ContinuousOn g T) (hA₀ : spectrum ℝ A₀.mat ⊆ T) :
     ContinuousWithinAt (fun B ↦ B.cfc g) {B | spectrum ℝ B.mat ⊆ T} A₀ := by
-  have h_ext : ∃ h : ℝ → ℝ, Continuous h ∧ ∀ x ∈ spectrum ℝ A₀.mat, h x = g x := by
+  have h_ext : ∃ h : ℝ → ℝ, Continuous h ∧
+      ∀ x ∈ spectrum ℝ A₀.mat, h x = g x := by
     have h_finite : Set.Finite (spectrum ℝ A₀.mat) := by
       exact Set.toFinite _
     generalize_proofs at *; (
@@ -755,48 +869,76 @@ lemma continuousWithinAt_cfc_of_continuousOn {T : Set ℝ} {g : ℝ → ℝ}
       exact hg.mono hA₀
     generalize_proofs at *; (
     have := @ContinuousMap.exists_restrict_eq ℝ;
-    specialize this ( show IsClosed ( spectrum ℝ A₀.val ) from h_finite.isClosed ) ( ContinuousMap.mk ( fun x => g x ) <| by exact continuousOn_iff_continuous_restrict.mp h_cont ) ; rcases this with ⟨ h, hh ⟩ ; exact ⟨ h, h.continuous, fun x hx => by simpa using congr_arg ( fun f => f ⟨ x, hx ⟩ ) hh ⟩ ;));
+    specialize this ( show IsClosed ( spectrum ℝ A₀.val ) from h_finite.isClosed )
+      ( ContinuousMap.mk ( fun x => g x ) <| by
+        exact continuousOn_iff_continuous_restrict.mp h_cont );
+    rcases this with ⟨ h, hh ⟩ ;
+    exact ⟨ h, h.continuous, fun x hx => by simpa using congr_arg ( fun f => f ⟨ x, hx ⟩ ) hh ⟩ ;));
   obtain ⟨h, hh_cont, hh_eq⟩ := h_ext;
-  have h_cfc_cont : ContinuousWithinAt (fun B => B.cfc h) {B : HermitianMat d ℂ | spectrum ℝ B.mat ⊆ T} A₀ := by
+  have h_cfc_cont : ContinuousWithinAt (fun B => B.cfc h)
+      {B : HermitianMat d ℂ | spectrum ℝ B.mat ⊆ T} A₀ := by
     exact Continuous.continuousWithinAt (HermitianMat.cfc_continuous hh_cont)
-  have h_diff_small : ∀ ε > 0, ∃ U ∈ nhds A₀, ∀ B ∈ U ∩ {B : HermitianMat d ℂ | spectrum ℝ B.mat ⊆ T}, ‖B.cfc g - B.cfc h‖ < ε := by
+  have h_diff_small : ∀ ε > 0, ∃ U ∈ nhds A₀,
+      ∀ B ∈ U ∩ {B : HermitianMat d ℂ | spectrum ℝ B.mat ⊆ T}, ‖B.cfc g - B.cfc h‖ < ε := by
     intro ε ε_pos
-    obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ x ∈ T, ∀ y ∈ spectrum ℝ A₀.mat, |x - y| < δ → |g x - h x| < ε / (Real.sqrt (Fintype.card d) + 1) := by
-      have h_diff_small : ∀ y ∈ spectrum ℝ A₀.mat, ∃ δ > 0, ∀ x ∈ T, |x - y| < δ → |g x - h x| < ε / (Real.sqrt (Fintype.card d) + 1) := by
+    obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ x ∈ T, ∀ y ∈ spectrum ℝ A₀.mat, |x - y| < δ →
+        |g x - h x| < ε / (Real.sqrt (Fintype.card d) + 1) := by
+      have h_diff_small : ∀ y ∈ spectrum ℝ A₀.mat, ∃ δ > 0, ∀ x ∈ T, |x - y| < δ →
+          |g x - h x| < ε / (Real.sqrt (Fintype.card d) + 1) := by
         intro y hy
         have h_diff_small : Filter.Tendsto (fun x => |g x - h x|) (nhdsWithin y T) (nhds 0) := by
-          have h_diff_small : Filter.Tendsto (fun x => g x - h x) (nhdsWithin y T) (nhds (g y - h y)) := by
-            exact Filter.Tendsto.sub ( hg.continuousWithinAt ( hA₀ hy ) ) ( hh_cont.continuousWithinAt );
+          have h_diff_small : Filter.Tendsto (fun x => g x - h x) (nhdsWithin y T)
+              (nhds (g y - h y)) := by
+            exact Filter.Tendsto.sub ( hg.continuousWithinAt ( hA₀ hy ) )
+              ( hh_cont.continuousWithinAt );
           simpa [ hh_eq y hy ] using h_diff_small.abs;
-        have := Metric.tendsto_nhdsWithin_nhds.mp h_diff_small ( ε / ( Real.sqrt ( Fintype.card d ) + 1 ) ) ( div_pos ε_pos ( add_pos_of_nonneg_of_pos ( Real.sqrt_nonneg _ ) zero_lt_one ) ) ; aesop;
+        have := Metric.tendsto_nhdsWithin_nhds.mp h_diff_small
+          ( ε / ( Real.sqrt ( Fintype.card d ) + 1 ) )
+          ( div_pos ε_pos ( add_pos_of_nonneg_of_pos ( Real.sqrt_nonneg _ ) zero_lt_one ) ) ; aesop;
       choose! δ hδ_pos hδ using h_diff_small;
       have h_finite : Set.Finite (spectrum ℝ A₀.mat) := by
         exact Set.toFinite _;
-      obtain ⟨δ_min, hδ_min_pos, hδ_min⟩ : ∃ δ_min > 0, ∀ y ∈ spectrum ℝ A₀.mat, δ_min ≤ δ y := by
+      obtain ⟨δ_min, hδ_min_pos, hδ_min⟩ :
+          ∃ δ_min > 0, ∀ y ∈ spectrum ℝ A₀.mat, δ_min ≤ δ y := by
         by_cases h_empty : spectrum ℝ A₀.mat = ∅;
         · exact ⟨ 1, zero_lt_one, by simp [ h_empty ] ⟩;
         · have := h_finite.toFinset.exists_min_image δ;
-          exact Exists.elim ( this ( Finset.nonempty_of_ne_empty ( by simpa [ Set.ext_iff ] using h_empty ) ) ) fun x hx => ⟨ δ x, hδ_pos x ( by simpa using hx.1 ), fun y hy => hx.2 _ ( h_finite.mem_toFinset.mpr hy ) ⟩;
-      exact ⟨ δ_min, hδ_min_pos, fun x hx y hy hxy => hδ y hy x hx ( lt_of_lt_of_le hxy ( hδ_min y hy ) ) ⟩;
-    -- By the spectrum_subset_of_isOpen lemma, there exists a neighborhood U of A₀ such that the spectrum of B is within δ of the spectrum of A₀ for all B in U.
-    obtain ⟨U, hU⟩ : ∃ U ∈ nhds A₀, ∀ B ∈ U, spectrum ℝ B.mat ⊆ {x | ∃ y ∈ spectrum ℝ A₀.mat, |x - y| < δ} := by
-      have h_spectrum_subset : ∀ᶠ B in nhds A₀, spectrum ℝ B.mat ⊆ Metric.thickening δ (spectrum ℝ A₀.mat) := by
+          exact Exists.elim
+            ( this ( Finset.nonempty_of_ne_empty ( by simpa [ Set.ext_iff ] using h_empty ) ) )
+            fun x hx => ⟨ δ x, hδ_pos x ( by simpa using hx.1 ),
+              fun y hy => hx.2 _ ( h_finite.mem_toFinset.mpr hy ) ⟩;
+      exact ⟨ δ_min, hδ_min_pos,
+        fun x hx y hy hxy => hδ y hy x hx ( lt_of_lt_of_le hxy ( hδ_min y hy ) ) ⟩;
+    -- By the spectrum_subset_of_isOpen lemma, there exists a neighborhood U of A₀ such that the
+    -- spectrum of B is within δ of the spectrum of A₀ for all B in U.
+    obtain ⟨U, hU⟩ : ∃ U ∈ nhds A₀, ∀ B ∈ U,
+        spectrum ℝ B.mat ⊆ {x | ∃ y ∈ spectrum ℝ A₀.mat, |x - y| < δ} := by
+      have h_spectrum_subset : ∀ᶠ B in nhds A₀,
+          spectrum ℝ B.mat ⊆ Metric.thickening δ (spectrum ℝ A₀.mat) := by
         have h_open : IsOpen (Metric.thickening δ (spectrum ℝ A₀.mat)) := by
           exact Metric.isOpen_thickening
-        have := spectrum_subset_of_isOpen A₀ ( Metric.thickening δ ( spectrum ℝ A₀.mat ) ) h_open ( Metric.self_subset_thickening δ_pos _ ) ; aesop;
+        have := spectrum_subset_of_isOpen A₀ ( Metric.thickening δ ( spectrum ℝ A₀.mat ) ) h_open
+          ( Metric.self_subset_thickening δ_pos _ ) ; aesop;
       generalize_proofs at *; (
-      exact ⟨ _, h_spectrum_subset, fun B hB => fun x hx => by simpa [ dist_eq_norm ] using Metric.mem_thickening_iff.mp ( hB hx ) ⟩)
+      exact ⟨ _, h_spectrum_subset, fun B hB => fun x hx => by simpa [ dist_eq_norm ] using
+        Metric.mem_thickening_iff.mp ( hB hx ) ⟩)
     generalize_proofs at *; (
     refine' ⟨ U, hU.1, fun B hB => _ ⟩
-    have h_diff_small : ∀ x ∈ spectrum ℝ B.mat, |g x - h x| ≤ ε / (Real.sqrt (Fintype.card d) + 1) := by
-      exact fun x hx => le_of_lt ( hδ x ( hB.2 hx ) _ ( hU.2 B hB.1 hx |> Classical.choose_spec |> And.left ) ( hU.2 B hB.1 hx |> Classical.choose_spec |> And.right ) ) |> le_trans <| by norm_num;
+    have h_diff_small : ∀ x ∈ spectrum ℝ B.mat,
+        |g x - h x| ≤ ε / (Real.sqrt (Fintype.card d) + 1) := by
+      exact fun x hx => le_of_lt ( hδ x ( hB.2 hx ) _
+        ( hU.2 B hB.1 hx |> Classical.choose_spec |> And.left )
+        ( hU.2 B hB.1 hx |> Classical.choose_spec |> And.right ) ) |> le_trans <| by norm_num;
     generalize_proofs at *; (
-    have h_diff_small : ‖B.cfc g - B.cfc h‖ ≤ Real.sqrt (Fintype.card d) * (ε / (Real.sqrt (Fintype.card d) + 1)) := by
+    have h_diff_small : ‖B.cfc g - B.cfc h‖ ≤
+        Real.sqrt (Fintype.card d) * (ε / (Real.sqrt (Fintype.card d) + 1)) := by
       apply_rules [ norm_cfc_sub_le_of_sup_le ];
       · positivity;
       · exact fun x hx => hx
     generalize_proofs at *; (
-    exact h_diff_small.trans_lt ( by rw [ mul_div, div_lt_iff₀ ] <;> nlinarith [ Real.sqrt_nonneg ( Fintype.card d : ℝ ), Real.sq_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ] ))));
+    exact h_diff_small.trans_lt ( by rw [ mul_div, div_lt_iff₀ ] <;>
+      nlinarith [ Real.sqrt_nonneg ( Fintype.card d : ℝ ),
+        Real.sq_sqrt ( Nat.cast_nonneg ( Fintype.card d ) ) ] ))));
   rw [ Metric.continuousWithinAt_iff ] at *;
   intro ε hε
   obtain ⟨δ, hδ_pos, hδ⟩ := h_cfc_cont (ε / 2) (half_pos hε)
@@ -810,7 +952,8 @@ lemma continuousWithinAt_cfc_of_continuousOn {T : Set ℝ} {g : ℝ → ℝ}
     have hd1 := hδ hx hx'
     have hd2 := hU x ⟨(Metric.mem_nhds_iff.mp hU_nhds).choose_spec.2 hx'', hx⟩
     have h_eq : A₀.cfc g = A₀.cfc h := by
-      exact cfc_congr (show Set.EqOn g h (spectrum ℝ A₀.mat) from fun x hx => hh_eq x hx ▸ rfl) ▸ rfl
+      exact cfc_congr
+        (show Set.EqOn g h (spectrum ℝ A₀.mat) from fun x hx => hh_eq x hx ▸ rfl) ▸ rfl
     rw [dist_eq_norm, h_eq]
     calc ‖x.cfc g - A₀.cfc h‖
         = ‖(x.cfc g - x.cfc h) + (x.cfc h - A₀.cfc h)‖ := by congr 1; abel
@@ -828,22 +971,36 @@ This is the non-compact replacement for `dist_lt_of_continuous'`: instead of uni
 on a fixed compact set, we get uniform convergence on the (moving, finite) spectrum.
 PROVIDED SOLUTION
 Constructive proof. The key steps:
-Step 1: For each eigenvalue λᵢ := (A x₀).H.eigenvalues i (which is in T by hA₁), the function f is continuous at (x₀, λᵢ) within S ×ˢ T. So there exist open neighborhoods U_i of x₀ and V_i of λᵢ such that for all (y, t) ∈ (U_i ∩ S) × (V_i ∩ T), we have ‖f y t - f x₀ t‖ < ε. Here's how to get this:
+Step 1: For each eigenvalue λᵢ := (A x₀).H.eigenvalues i (which is in T by hA₁), the function f is
+continuous at (x₀, λᵢ) within S ×ˢ T. So there exist open neighborhoods U_i of x₀ and V_i of λᵢ such
+that for all (y, t) ∈ (U_i ∩ S) × (V_i ∩ T), we have ‖f y t - f x₀ t‖ < ε. Here's how to get this:
 - hf (x₀, λᵢ) gives ContinuousWithinAt at (x₀, λᵢ) within S ×ˢ T
-- Apply this to the ε-ball around f(x₀, λᵢ), use that f(x₀, λᵢ) - f(x₀, λᵢ) = 0 to get ‖f y t - f x₀ λᵢ‖ < ε/2
+- Apply this to the ε-ball around f(x₀, λᵢ), use that f(x₀, λᵢ) - f(x₀, λᵢ) = 0 to get
+‖f y t - f x₀ λᵢ‖ < ε/2
 - Similarly, hf at (x₀, λᵢ) restricted to {x₀} × T gives ‖f x₀ t - f x₀ λᵢ‖ < ε/2
 - Triangle inequality: ‖f y t - f x₀ t‖ < ε
 - Use `mem_nhds_prod_iff` to extract U_i and V_i from the product neighborhood
-Step 2: The open set W := ⋃ᵢ V_i contains spectrum(A x₀) (since each λᵢ ∈ V_i and spectrum = range of eigenvalues). W is open as a union of open sets. By `spectrum_subset_of_isOpen (A x₀) W`, we get ∀ᶠ B in nhds (A x₀), spectrum ℝ B.mat ⊆ W.
-Step 3: By ContinuousWithinAt of A at x₀ (from hA₂), and the filter from step 2, we get: ∀ᶠ y in nhdsWithin x₀ S, spectrum ℝ (A y).mat ⊆ W. Convert this to ∃ U' ∈ nhds x₀, ∀ y ∈ U' ∩ S, spectrum(A y) ⊆ W.
-Step 4: Take U = U' ∩ ⋂ᵢ U_i (finite intersection since d is Fintype). For y ∈ U ∩ S and t ∈ spectrum(A y):
+Step 2: The open set W := ⋃ᵢ V_i contains spectrum(A x₀) (since each λᵢ ∈ V_i and spectrum = range
+of eigenvalues). W is open as a union of open sets. By `spectrum_subset_of_isOpen (A x₀) W`, we get
+∀ᶠ B in nhds (A x₀), spectrum ℝ B.mat ⊆ W.
+Step 3: By ContinuousWithinAt of A at x₀ (from hA₂), and the filter from step 2, we get: ∀ᶠ y in
+nhdsWithin x₀ S, spectrum ℝ (A y).mat ⊆ W. Convert this to ∃ U' ∈ nhds x₀, ∀ y ∈ U' ∩ S,
+spectrum(A y) ⊆ W.
+Step 4: Take U = U' ∩ ⋂ᵢ U_i (finite intersection since d is Fintype). For y ∈ U ∩ S and
+t ∈ spectrum(A y):
 - t ∈ T (by hA₁)
 - spectrum(A y) ⊆ W (by step 3), so t ∈ V_i for some i
 - y ∈ U_i ∩ S
 - So ‖f y t - f x₀ t‖ < ε (by step 1)
-Use `by_contra` and arrive at contradiction, or construct the neighborhood directly using `Filter.inter_mem` and `Filter.iInter_mem` (since d is Fintype, the index set is finite).
-IMPORTANT: To get the open sets V_i, use `ContinuousWithinAt` of f at (x₀, λᵢ) which gives an eventually filter statement, then extract using `mem_nhdsWithin_iff_exists_mem_nhds_inter` and `mem_nhds_prod_iff`.
-For the continuity of A composed with spectrum_subset_of_isOpen: use `ContinuousWithinAt.eventually` or compose the filter. Specifically: `(hA₂ x₀ hx₀).eventually (spectrum_subset_of_isOpen (A x₀) W hW_open hW_contains)` gives `∀ᶠ y in nhdsWithin x₀ S, spectrum(A y) ⊆ W`. Then use `Filter.Eventually.exists_mem` to get U'.
+Use `by_contra` and arrive at contradiction, or construct the neighborhood directly using
+`Filter.inter_mem` and `Filter.iInter_mem` (since d is Fintype, the index set is finite).
+IMPORTANT: To get the open sets V_i, use `ContinuousWithinAt` of f at (x₀, λᵢ) which gives an
+eventually filter statement, then extract using `mem_nhdsWithin_iff_exists_mem_nhds_inter` and
+`mem_nhds_prod_iff`.
+For the continuity of A composed with spectrum_subset_of_isOpen: use `ContinuousWithinAt.eventually`
+or compose the filter. Specifically:
+`(hA₂ x₀ hx₀).eventually (spectrum_subset_of_isOpen (A x₀) W hW_open hW_contains)` gives
+`∀ᶠ y in nhdsWithin x₀ S, spectrum(A y) ⊆ W`. Then use `Filter.Eventually.exists_mem` to get U'.
 -/
 set_option maxHeartbeats 800000 in
 lemma dist_lt_of_continuous_spectrum {X : Type*} [TopologicalSpace X]
@@ -854,23 +1011,37 @@ lemma dist_lt_of_continuous_spectrum {X : Type*} [TopologicalSpace X]
     {x₀ : X} (hx₀ : x₀ ∈ S) {ε : ℝ} (hε : 0 < ε) :
     ∃ U ∈ nhds x₀, ∀ y ∈ U ∩ S, ∀ t ∈ spectrum ℝ (A y).mat, ‖f y t - f x₀ t‖ < ε := by
       by_contra h_contra;
-      -- For each eigenvalue λᵢ := (A x₀).H.eigenvalues i (which is in T by hA₁), the function f is continuous at (x₀, λᵢ) within S ×ˢ T. So there exist open neighborhoods U_i of x₀ and V_i of λᵢ such that for all (y, t) ∈ (U_i ∩ S) × (V_i ∩ T), we have ‖f y t - f x₀ t‖ < ε.
-      obtain ⟨U_i, V_i, hU_i, hV_i, h_cont⟩ : ∃ (U_i : d → Set X) (V_i : d → Set ℝ), (∀ i, IsOpen (U_i i)) ∧ (∀ i, IsOpen (V_i i)) ∧ (∀ i, x₀ ∈ U_i i) ∧ (∀ i, (A x₀).H.eigenvalues i ∈ V_i i) ∧ (∀ i, ∀ y ∈ U_i i ∩ S, ∀ t ∈ V_i i ∩ T, ‖f y t - f x₀ t‖ < ε) := by
-        have h_cont : ∀ i, ∃ (U_i : Set X) (V_i : Set ℝ), IsOpen U_i ∧ IsOpen V_i ∧ x₀ ∈ U_i ∧ (A x₀).H.eigenvalues i ∈ V_i ∧ ∀ y ∈ U_i ∩ S, ∀ t ∈ V_i ∩ T, ‖f y t - f x₀ t‖ < ε := by
+      -- For each eigenvalue λᵢ := (A x₀).H.eigenvalues i (which is in T by hA₁), the function f is
+      -- continuous at (x₀, λᵢ) within S ×ˢ T. So there exist open neighborhoods U_i of x₀ and V_i
+      -- of λᵢ such that for all (y, t) ∈ (U_i ∩ S) × (V_i ∩ T), we have ‖f y t - f x₀ t‖ < ε.
+      obtain ⟨U_i, V_i, hU_i, hV_i, h_cont⟩ : ∃ (U_i : d → Set X) (V_i : d → Set ℝ),
+          (∀ i, IsOpen (U_i i)) ∧ (∀ i, IsOpen (V_i i)) ∧ (∀ i, x₀ ∈ U_i i) ∧
+            (∀ i, (A x₀).H.eigenvalues i ∈ V_i i) ∧
+            (∀ i, ∀ y ∈ U_i i ∩ S, ∀ t ∈ V_i i ∩ T, ‖f y t - f x₀ t‖ < ε) := by
+        have h_cont : ∀ i, ∃ (U_i : Set X) (V_i : Set ℝ), IsOpen U_i ∧ IsOpen V_i ∧ x₀ ∈ U_i ∧
+            (A x₀).H.eigenvalues i ∈ V_i ∧
+            ∀ y ∈ U_i ∩ S, ∀ t ∈ V_i ∩ T, ‖f y t - f x₀ t‖ < ε := by
           intro i
           generalize_proofs at *; (
-          have h_cont : ContinuousWithinAt (fun p : X × ℝ => f p.1 p.2 - f x₀ p.2) (S ×ˢ T) (x₀, (A x₀).H.eigenvalues i) := by
+          have h_cont : ContinuousWithinAt (fun p : X × ℝ => f p.1 p.2 - f x₀ p.2) (S ×ˢ T)
+              (x₀, (A x₀).H.eigenvalues i) := by
             have := hf (x₀, (A x₀).H.eigenvalues i) ⟨hx₀, ?_⟩
             generalize_proofs at *;
-            · convert this.sub ( ContinuousWithinAt.comp ( show ContinuousWithinAt ( fun p : ℝ => f x₀ p ) T ( ( A x₀ ).H.eigenvalues i ) from ?_ ) ( continuousWithinAt_snd ) ?_ ) using 1 <;> norm_num +zetaDelta at *;
-              · have := hf ( x₀, ( A x₀ ).H.eigenvalues i ) ⟨ hx₀, hA₁ x₀ hx₀ ((A x₀).H.eigenvalues_mem_spectrum_real i) ⟩
+            · convert this.sub ( ContinuousWithinAt.comp
+                ( show ContinuousWithinAt ( fun p : ℝ => f x₀ p ) T ( ( A x₀ ).H.eigenvalues i )
+                  from ?_ ) ( continuousWithinAt_snd ) ?_ ) using 1 <;> norm_num +zetaDelta at *;
+              · have := hf ( x₀, ( A x₀ ).H.eigenvalues i )
+                  ⟨ hx₀, hA₁ x₀ hx₀ ((A x₀).H.eigenvalues_mem_spectrum_real i) ⟩
                 generalize_proofs at *; (
-                convert this.comp ( show ContinuousWithinAt ( fun p => ( x₀, p ) ) T ( ( A x₀ ).H.eigenvalues i ) from ?_ ) ?_ using 1 ;
+                convert this.comp
+                  ( show ContinuousWithinAt ( fun p => ( x₀, p ) ) T ( ( A x₀ ).H.eigenvalues i )
+                    from ?_ ) ?_ using 1 ;
                 generalize_proofs at *; (
                 exact ContinuousWithinAt.prodMk ( continuousWithinAt_const ) continuousWithinAt_id);
                 exact fun x hx => ⟨ hx₀, hx ⟩);
               · exact fun x hx => hx.2;
-            · exact hA₁ x₀ hx₀ ((A x₀).H.eigenvalues_mem_spectrum_real i) )
+            · exact hA₁ x₀ hx₀
+                ((A x₀).H.eigenvalues_mem_spectrum_real i) )
           generalize_proofs at *; (
           have := h_cont.eventually ( Metric.ball_mem_nhds _ hε )
           simp_all [ dist_eq_norm ]
@@ -879,10 +1050,16 @@ lemma dist_lt_of_continuous_spectrum {X : Type*} [TopologicalSpace X]
           generalize_proofs at *; (
           rcases mem_nhds_prod_iff.mp this with ⟨ U, V, hU, hV, h ⟩
           generalize_proofs at *; (
-          exact ⟨ interior U, isOpen_interior, interior hU, isOpen_interior, mem_interior_iff_mem_nhds.mpr V, mem_interior_iff_mem_nhds.mpr hV, fun y hy hyS t ht htT => h ( Set.mk_mem_prod ( interior_subset hy ) ( interior_subset ht ) ) ⟨ hyS, htT ⟩ ⟩))))
+          exact ⟨ interior U, isOpen_interior, interior hU, isOpen_interior,
+            mem_interior_iff_mem_nhds.mpr V, mem_interior_iff_mem_nhds.mpr hV,
+            fun y hy hyS t ht htT => h
+              ( Set.mk_mem_prod ( interior_subset hy ) ( interior_subset ht ) )
+              ⟨ hyS, htT ⟩ ⟩))))
         generalize_proofs at *; (
-        choose U_i V_i hU_i hV_i hx₀_i hV_i_i h_cont_i using h_cont; exact ⟨ U_i, V_i, hU_i, hV_i, hx₀_i, hV_i_i, h_cont_i ⟩ ;);
-      -- The open set W := ⋃ᵢ V_i contains spectrum(A x₀) (since each λᵢ ∈ V_i and spectrum = range of eigenvalues). W is open as a union of open sets.
+        choose U_i V_i hU_i hV_i hx₀_i hV_i_i h_cont_i using h_cont;
+        exact ⟨ U_i, V_i, hU_i, hV_i, hx₀_i, hV_i_i, h_cont_i ⟩ ;);
+      -- The open set W := ⋃ᵢ V_i contains spectrum(A x₀) (since each λᵢ ∈ V_i and spectrum = range
+      -- of eigenvalues). W is open as a union of open sets.
       set W := ⋃ i, V_i i with hW_def
       have hW_open : IsOpen W := by
         exact isOpen_iUnion hV_i
@@ -897,22 +1074,28 @@ lemma dist_lt_of_continuous_spectrum {X : Type*} [TopologicalSpace X]
       have hW_subset : ∀ᶠ B in nhds (A x₀), spectrum ℝ B.mat ⊆ W := by
         exact spectrum_subset_of_isOpen (A x₀) W hW_open hW_spectrum
       have hW_subset_S : ∀ᶠ y in nhdsWithin x₀ S, spectrum ℝ (A y).mat ⊆ W := by
-        exact Filter.mem_of_superset ( hA₂.continuousWithinAt hx₀ |> fun h => h.eventually ( hW_subset ) ) fun y hy => hy
+        exact Filter.mem_of_superset
+          ( hA₂.continuousWithinAt hx₀ |> fun h => h.eventually ( hW_subset ) ) fun y hy => hy
       obtain ⟨U', hU'⟩ : ∃ U' ∈ nhds x₀, ∀ y ∈ U' ∩ S, spectrum ℝ (A y).mat ⊆ W := by
-        obtain ⟨ U', hU' ⟩ := mem_nhdsWithin_iff_exists_mem_nhds_inter.mp hW_subset_S; use U'; aesop;
+        obtain ⟨ U', hU' ⟩ := mem_nhdsWithin_iff_exists_mem_nhds_inter.mp hW_subset_S; use U';
+        aesop;
       obtain ⟨U'', hU''⟩ : ∃ U'' ∈ nhds x₀, ∀ i, U'' ⊆ U_i i := by
-        exact ⟨ ⋂ i, U_i i, Filter.mem_of_superset ( Filter.iInter_mem.mpr fun i => IsOpen.mem_nhds ( hU_i i ) ( h_cont.1 i ) ) fun x hx => by aesop, fun i => Set.iInter_subset _ i ⟩
+        exact ⟨ ⋂ i, U_i i, Filter.mem_of_superset
+          ( Filter.iInter_mem.mpr fun i => IsOpen.mem_nhds ( hU_i i ) ( h_cont.1 i ) )
+          fun x hx => by aesop, fun i => Set.iInter_subset _ i ⟩
       set U := U' ∩ U'' with hU_def
       have hU_mem : U ∈ nhds x₀ := by
         exact Filter.inter_mem hU'.1 hU''.1
       have hU_subset : ∀ y ∈ U ∩ S, spectrum ℝ (A y).mat ⊆ W := by
         exact fun y hy => hU'.2 y ⟨ hy.1.1, hy.2 ⟩ |> Set.Subset.trans <| by simp [ hW_def ] ;
-      have hU_cont : ∀ y ∈ U ∩ S, ∀ t ∈ spectrum ℝ (A y).mat, ‖f y t - f x₀ t‖ < ε := by
+      have hU_cont : ∀ y ∈ U ∩ S, ∀ t ∈ spectrum ℝ (A y).mat,
+          ‖f y t - f x₀ t‖ < ε := by
         intro y hy t ht
         obtain ⟨i, hi⟩ : ∃ i, t ∈ V_i i := by
           exact Set.mem_iUnion.mp ( hU_subset y hy ht ) |> Exists.imp fun i => by tauto;
         have h_cont_i : ‖f y t - f x₀ t‖ < ε := by
-          exact h_cont.2.2 i y ⟨ hU''.2 i ( by aesop ), hy.2 ⟩ t ⟨ hi, hA₁ y hy.2 ht ⟩ |> fun h => by simpa using h;
+          exact h_cont.2.2 i y ⟨ hU''.2 i ( by aesop ), hy.2 ⟩ t ⟨ hi, hA₁ y hy.2 ht ⟩ |>
+            fun h => by simpa using h;
         exact h_cont_i
       exact h_contra ⟨U, hU_mem, hU_cont⟩
 
@@ -926,27 +1109,36 @@ the compact case locally: at each point `x₀ ∈ S`, the spectrum of `A x₀` i
 contained in a compact interval `K = [-M, M]`, and the compact version is applied with a
 continuous extension of `f x₀` from the finite spectrum to `K`.
 PROVIDED SOLUTION
-The proof follows the same structure as `continuous_cfc_joint_compact` but uses the non-compact helpers `dist_lt_of_continuous_spectrum` and `continuousWithinAt_cfc_of_continuousOn` instead of `dist_lt_of_continuous'` and `continuousOn_cfc_of_compact`.
+The proof follows the same structure as `continuous_cfc_joint_compact` but uses the non-compact
+helpers `dist_lt_of_continuous_spectrum` and `continuousWithinAt_cfc_of_continuousOn` instead of
+`dist_lt_of_continuous'` and `continuousOn_cfc_of_compact`.
 Fix x ∈ S. Show ContinuousWithinAt.
 Step 1: Show `ContinuousWithinAt (fun y => (A y).cfc (f x)) S x`.
-The function f x (i.e., f(x, ·)) is continuous on T: this follows from `hf.uncurry_left x x_in_S` which gives `ContinuousOn (f x) T`.
+The function f x (i.e., f(x, ·)) is continuous on T: this follows from `hf.uncurry_left x x_in_S`
+which gives `ContinuousOn (f x) T`.
 By `continuousWithinAt_cfc_of_continuousOn` with g = f x and T = T:
   `ContinuousWithinAt (fun B ↦ B.cfc (f x)) {B | spectrum ℝ B.mat ⊆ T} (A x)`.
 Compose with `hA₂.continuousWithinAt x_in_S` and `hA₁`:
   `ContinuousWithinAt (fun y => (A y).cfc (f x)) S x`.
-Note: We need that `fun y => A y` maps `S` into `{B | spectrum ℝ B.mat ⊆ T}`, which follows from `hA₁`.
+Note: We need that `fun y => A y` maps `S` into `{B | spectrum ℝ B.mat ⊆ T}`, which follows from
+`hA₁`.
 Step 2: Use the triangle inequality, exactly as in `continuous_cfc_joint_compact`:
 Decompose the goal using:
-  dist ((A y).cfc (f y)) ((A x).cfc (f x)) ≤ dist ((A y).cfc (f y)) ((A y).cfc (f x)) + dist ((A y).cfc (f x)) ((A x).cfc (f x))
+  dist ((A y).cfc (f y)) ((A x).cfc (f x)) ≤ dist ((A y).cfc (f y)) ((A y).cfc (f x)) +
+    dist ((A y).cfc (f x)) ((A x).cfc (f x))
 For the first term (f varies, A = A(y)):
-Use `dist_lt_of_continuous_spectrum` (our new helper) to get: for any ε > 0, there exists U ∈ nhds x such that for y ∈ U ∩ S and t ∈ spectrum(A y), ‖f y t - f x t‖ < ε.
+Use `dist_lt_of_continuous_spectrum` (our new helper) to get: for any ε > 0, there exists U ∈ nhds x
+such that for y ∈ U ∩ S and t ∈ spectrum(A y), ‖f y t - f x t‖ < ε.
 Then by `norm_cfc_sub_le_of_sup_le`, ‖(A y).cfc (f y) - (A y).cfc (f x)‖ ≤ sqrt(d) * ε.
 For the second term (A varies, f = f(x)):
 Use step 1 directly (ContinuousWithinAt of B ↦ B.cfc (f x)).
 Combine with the same nlinarith/ε-δ argument as in `continuous_cfc_joint_compact`.
 In code, the proof structure should mirror continuous_cfc_joint_compact closely, just replacing:
-- `dist_lt_of_continuous' hT hf x_in_S ε_pos` with `dist_lt_of_continuous_spectrum hf hA₁ hA₂ x_in_S ε_pos`
-- `continuousOn_cfc_of_compact hT (hf.uncurry_left x x_in_S)` with `continuousWithinAt_cfc_of_continuousOn (hf.uncurry_left x x_in_S) (hA₁ x x_in_S)` composed with hA₂ and hA₁.
+- `dist_lt_of_continuous' hT hf x_in_S ε_pos` with
+`dist_lt_of_continuous_spectrum hf hA₁ hA₂ x_in_S ε_pos`
+- `continuousOn_cfc_of_compact hT (hf.uncurry_left x x_in_S)` with
+`continuousWithinAt_cfc_of_continuousOn (hf.uncurry_left x x_in_S) (hA₁ x x_in_S)` composed with hA₂
+and hA₁.
 -/
 set_option backward.isDefEq.respectTransparency false in
 @[fun_prop]
@@ -961,35 +1153,52 @@ theorem continuous_cfc_joint {X d : Type*} [TopologicalSpace X] [Fintype d] [Dec
       have h_cont : ∀ x₀ ∈ S, ContinuousWithinAt (fun x => (A x).cfc (f x)) S x₀ := by
         intro x₀ hx₀
         have h_cont : ContinuousWithinAt (fun x => (A x).cfc (f x₀)) S x₀ := by
-          have h_cont : ContinuousWithinAt (fun B => B.cfc (f x₀)) {B | spectrum ℝ B.mat ⊆ T} (A x₀) := by
+          have h_cont : ContinuousWithinAt (fun B => B.cfc (f x₀)) {B | spectrum ℝ B.mat ⊆ T}
+              (A x₀) := by
             apply_rules [ continuousWithinAt_cfc_of_continuousOn, hf.uncurry_left x₀ hx₀ ]
           generalize_proofs at *; (
-          exact h_cont.comp ( hA₂.continuousWithinAt hx₀ ) ( by aesop ) |> ContinuousWithinAt.mono <| by aesop;)
+          exact h_cont.comp ( hA₂.continuousWithinAt hx₀ ) ( by aesop ) |>
+            ContinuousWithinAt.mono <| by aesop;)
         generalize_proofs at *; (
-        -- By the triangle inequality, we can bound the distance between $(A x).cfc (f x)$ and $(A x₀).cfc (f x₀)$.
-        have h_triangle : ∀ᶠ x in nhdsWithin x₀ S, ‖(A x).cfc (f x) - (A x).cfc (f x₀)‖ ≤ Real.sqrt (Fintype.card d) * (⨆ t ∈ spectrum ℝ (A x).mat, ‖f x t - f x₀ t‖) := by
+        -- By the triangle inequality, we can bound the distance between $(A x).cfc (f x)$ and
+        -- $(A x₀).cfc (f x₀)$.
+        have h_triangle : ∀ᶠ x in nhdsWithin x₀ S, ‖(A x).cfc (f x) - (A x).cfc (f x₀)‖ ≤
+            Real.sqrt (Fintype.card d) * (⨆ t ∈ spectrum ℝ (A x).mat, ‖f x t - f x₀ t‖) := by
           refine' Filter.Eventually.of_forall fun x => _;
           exact norm_cfc_sub_cfc_le_sqrt_card
         generalize_proofs at *; (
-        -- By the properties of the supremum, we can bound the distance between $(A x).cfc (f x)$ and $(A x₀).cfc (f x₀)$.
-        have h_sup : Filter.Tendsto (fun x => ⨆ t ∈ spectrum ℝ (A x).mat, ‖f x t - f x₀ t‖) (nhdsWithin x₀ S) (nhds 0) := by
-          have h_sup : ∀ ε > 0, ∃ U ∈ nhdsWithin x₀ S, ∀ x ∈ U, ∀ t ∈ spectrum ℝ (A x).mat, ‖f x t - f x₀ t‖ < ε := by
+        -- By the properties of the supremum, we can bound the distance between $(A x).cfc (f x)$
+        -- and $(A x₀).cfc (f x₀)$.
+        have h_sup : Filter.Tendsto (fun x => ⨆ t ∈ spectrum ℝ (A x).mat, ‖f x t - f x₀ t‖)
+            (nhdsWithin x₀ S) (nhds 0) := by
+          have h_sup : ∀ ε > 0, ∃ U ∈ nhdsWithin x₀ S, ∀ x ∈ U, ∀ t ∈ spectrum ℝ (A x).mat,
+              ‖f x t - f x₀ t‖ < ε := by
             intro ε ε_pos
             generalize_proofs at *; (
             have := dist_lt_of_continuous_spectrum hf hA₁ hA₂ hx₀ ε_pos
             generalize_proofs at *; (
-            obtain ⟨ U, hU₁, hU₂ ⟩ := this; exact ⟨ U ∩ S, mem_nhdsWithin_iff_exists_mem_nhds_inter.mpr ⟨ U, hU₁, by simp ⟩, fun x hx t ht => hU₂ x ⟨ hx.1, hx.2 ⟩ t ht ⟩ ;))
+            obtain ⟨ U, hU₁, hU₂ ⟩ := this;
+            exact ⟨ U ∩ S, mem_nhdsWithin_iff_exists_mem_nhds_inter.mpr ⟨ U, hU₁, by simp ⟩,
+              fun x hx t ht => hU₂ x ⟨ hx.1, hx.2 ⟩ t ht ⟩ ;))
           generalize_proofs at *; (
           refine' Metric.tendsto_nhds.mpr _;
-          intro ε ε_pos; rcases h_sup ( ε / 2 ) ( half_pos ε_pos ) with ⟨ U, hU₁, hU₂ ⟩ ; filter_upwards [ hU₁ ] with x hx; simp_all [ dist_eq_norm ] ; (
-          rw [ abs_of_nonneg ( Real.iSup_nonneg fun _ => Real.iSup_nonneg fun _ => abs_nonneg _ ) ] ; refine' lt_of_le_of_lt ( ciSup_le fun t => _ ) ( half_lt_self ε_pos ) ; by_cases ht : t ∈ spectrum ℝ ( A x |> HermitianMat.mat ) <;> simp_all [ abs_lt ] ;
+          intro ε ε_pos; rcases h_sup ( ε / 2 ) ( half_pos ε_pos ) with ⟨ U, hU₁, hU₂ ⟩ ;
+          filter_upwards [ hU₁ ] with x hx; simp_all [ dist_eq_norm ] ; (
+          rw [ abs_of_nonneg
+            ( Real.iSup_nonneg fun _ => Real.iSup_nonneg fun _ => abs_nonneg _ ) ] ;
+          refine' lt_of_le_of_lt ( ciSup_le fun t => _ ) ( half_lt_self ε_pos ) ;
+          by_cases ht : t ∈ spectrum ℝ ( A x |> HermitianMat.mat ) <;> simp_all [ abs_lt ] ;
           · exact abs_le.mpr ⟨ by linarith [ hU₂ x hx t ht ], by linarith [ hU₂ x hx t ht ] ⟩;
           · linarith [ ε_pos ]))
         generalize_proofs at *; (
-        have h_final : Filter.Tendsto (fun x => ‖(A x).cfc (f x) - (A x).cfc (f x₀)‖) (nhdsWithin x₀ S) (nhds 0) := by
-          exact squeeze_zero_norm' ( by filter_upwards [ h_triangle ] with x hx; simpa using hx ) ( by simpa using h_sup.const_mul _ ) |> fun h => h.trans ( by simp ) ;
+        have h_final : Filter.Tendsto (fun x => ‖(A x).cfc (f x) - (A x).cfc (f x₀)‖)
+            (nhdsWithin x₀ S) (nhds 0) := by
+          exact squeeze_zero_norm' ( by filter_upwards [ h_triangle ] with x hx; simpa using hx )
+            ( by simpa using h_sup.const_mul _ ) |> fun h => h.trans ( by simp ) ;
         generalize_proofs at *; (
-        convert h_cont.add ( show ContinuousWithinAt ( fun x => ( A x |> HermitianMat.cfc ) ( f x ) - ( A x |> HermitianMat.cfc ) ( f x₀ ) ) S x₀ from ?_ ) using 1 ; aesop
+        convert h_cont.add ( show ContinuousWithinAt
+          ( fun x => ( A x |> HermitianMat.cfc ) ( f x ) - ( A x |> HermitianMat.cfc ) ( f x₀ ) )
+          S x₀ from ?_ ) using 1 ; aesop
         generalize_proofs at *; (
         exact tendsto_zero_iff_norm_tendsto_zero.mpr h_final |> fun h => h.trans ( by simp) ;)))))
       generalize_proofs at *; (
@@ -1034,19 +1243,29 @@ lemma inv_cfc_eq_cfc_inv (hf : ∀ i, f (A.H.eigenvalues i) ≠ 0) :
   suffices (A.cfc f).mat⁻¹ = (A.cfc (fun u ↦ 1 / f u)).mat by
     ext1
     simpa using this
-  have h_def : (A.cfc f).mat = ∑ i, f (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
+  have h_def : (A.cfc f).mat = ∑ i, f (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val *
+      (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
     exact cfc_toMat_eq_sum_smul_proj A f;
-  have h_subst : (A.cfc (fun u ↦ 1 / f u)).mat = ∑ i, (1 / f (A.H.eigenvalues i)) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
+  have h_subst : (A.cfc (fun u ↦ 1 / f u)).mat = ∑ i, (1 / f (A.H.eigenvalues i)) •
+      (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+        A.H.eigenvectorUnitary.val.conjTranspose) := by
     exact cfc_toMat_eq_sum_smul_proj A fun u ↦ 1 / f u;
   have h_inv : (A.cfc f).mat * (A.cfc (fun u ↦ 1 / f u)).mat = 1 := by
-    -- Since the eigenvectorUnitary is unitary, we have that the product of the projections is the identity matrix.
+    -- Since the eigenvectorUnitary is unitary, we have that the product of the projections is the
+    -- identity matrix.
     have h_unitary : A.H.eigenvectorUnitary.val * A.H.eigenvectorUnitary.val.conjTranspose = 1 := by
       simp [ Matrix.IsHermitian.eigenvectorUnitary ];
-    have h_inv : ∀ i j, (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) * (A.H.eigenvectorUnitary.val * (Matrix.single j j 1) * A.H.eigenvectorUnitary.val.conjTranspose) = if i = j then A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose else 0 := by
+    have h_inv : ∀ i j, (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+        A.H.eigenvectorUnitary.val.conjTranspose) * (A.H.eigenvectorUnitary.val *
+          (Matrix.single j j 1) * A.H.eigenvectorUnitary.val.conjTranspose) =
+        if i = j then A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+          A.H.eigenvectorUnitary.val.conjTranspose else 0 := by
       simp [ ← Matrix.mul_assoc ];
       intro i j; split_ifs <;> simp_all [ Matrix.mul_assoc, mul_eq_one_comm.mp h_unitary ] ;
     simp_all [ Finset.sum_mul, Finset.mul_sum ];
-    have h_sum : ∑ i, (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) = A.H.eigenvectorUnitary.val * (∑ i, Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose := by
+    have h_sum : ∑ i, (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+        A.H.eigenvectorUnitary.val.conjTranspose) = A.H.eigenvectorUnitary.val *
+          (∑ i, Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose := by
       simp [ Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc ];
     simp_all [ Matrix.single ];
     convert h_unitary using 2;
@@ -1088,30 +1307,39 @@ set_option backward.isDefEq.respectTransparency false in
 A function to Hermitian matrices is integrable iff its matrix values are integrable.
 -/
 lemma intervalIntegrable_toMat_iff (A : ℝ → HermitianMat d 𝕜) (T₁ T₂ : ℝ) {μ : Measure ℝ} :
-    IntervalIntegrable (fun t ↦ (A t).mat) μ T₁ T₂ ↔ IntervalIntegrable A μ T₁ T₂ := by
+    IntervalIntegrable (fun t ↦ (A t).mat) μ T₁ T₂ ↔
+      IntervalIntegrable A μ T₁ T₂ := by
   --TODO Cleanup
   simp [ intervalIntegrable_iff ];
   constructor <;> intro h;
-  · -- Since `toMat` is a linear isometry, the integrability of `A.toMat` implies the integrability of `A`.
-    have h_toMat_integrable : IntegrableOn (fun t ↦ (A t).mat) (Set.uIoc T₁ T₂) μ → IntegrableOn A (Set.uIoc T₁ T₂) μ := by
+  · -- Since `toMat` is a linear isometry, the integrability of `A.toMat` implies the integrability
+    -- of `A`.
+    have h_toMat_integrable : IntegrableOn (fun t ↦ (A t).mat) (Set.uIoc T₁ T₂) μ →
+        IntegrableOn A (Set.uIoc T₁ T₂) μ := by
       intro h_toMat_integrable
-      have h_toMat_linear : ∃ (L : HermitianMat d 𝕜 →ₗ[ℝ] Matrix d d 𝕜), ∀ x, L x = x.mat := by
+      have h_toMat_linear : ∃ (L : HermitianMat d 𝕜 →ₗ[ℝ] Matrix d d 𝕜),
+          ∀ x, L x = x.mat := by
         refine' ⟨ _, _ ⟩;
         refine' { .. };
         exacts [ fun x ↦ x.mat, fun x y ↦ rfl, fun m x ↦ rfl, fun x ↦ rfl ];
       obtain ⟨L, hL⟩ := h_toMat_linear;
-      have h_toMat_linear : IntegrableOn (fun t ↦ L (A t)) (Set.uIoc T₁ T₂) μ → IntegrableOn A (Set.uIoc T₁ T₂) μ := by
+      have h_toMat_linear : IntegrableOn (fun t ↦ L (A t)) (Set.uIoc T₁ T₂) μ →
+          IntegrableOn A (Set.uIoc T₁ T₂) μ := by
         intro h_toMat_integrable
-        have h_toMat_linear : ∃ (L_inv : Matrix d d 𝕜 →ₗ[ℝ] HermitianMat d 𝕜), ∀ x, L_inv (L x) = x := by
+        have h_toMat_linear : ∃ (L_inv : Matrix d d 𝕜 →ₗ[ℝ] HermitianMat d 𝕜),
+            ∀ x, L_inv (L x) = x := by
           have h_toMat_linear : Function.Injective L := by
             intro x y hxy;
             simp_all only [HermitianMat.ext_iff]
-          have h_toMat_linear : ∃ (L_inv : Matrix d d 𝕜 →ₗ[ℝ] HermitianMat d 𝕜), L_inv.comp L = LinearMap.id := by
+          have h_toMat_linear : ∃ (L_inv : Matrix d d 𝕜 →ₗ[ℝ] HermitianMat d 𝕜),
+              L_inv.comp L = LinearMap.id := by
             exact IsSemisimpleModule.extension_property L h_toMat_linear LinearMap.id;
-          exact ⟨ h_toMat_linear.choose, fun x ↦ by simpa using LinearMap.congr_fun h_toMat_linear.choose_spec x ⟩;
+          exact ⟨ h_toMat_linear.choose,
+            fun x ↦ by simpa using LinearMap.congr_fun h_toMat_linear.choose_spec x ⟩;
         obtain ⟨ L_inv, hL_inv ⟩ := h_toMat_linear;
         have h_toMat_linear : IntegrableOn (fun t ↦ L_inv (L (A t))) (Set.uIoc T₁ T₂) μ := by
-          exact ContinuousLinearMap.integrable_comp ( L_inv.toContinuousLinearMap ) h_toMat_integrable;
+          exact ContinuousLinearMap.integrable_comp ( L_inv.toContinuousLinearMap )
+            h_toMat_integrable;
         aesop;
       aesop;
     exact h_toMat_integrable h;
@@ -1127,7 +1355,9 @@ The CFC of an integrable function family is integrable.
 lemma integrable_cfc (T₁ T₂ : ℝ) (f : ℝ → ℝ → ℝ) {μ : Measure ℝ}
     (hf : ∀ i, IntervalIntegrable (fun t ↦ f t (A.H.eigenvalues i)) μ T₁ T₂) :
     IntervalIntegrable (fun t ↦ A.cfc (f t)) μ T₁ T₂ := by
-  have h_expand : ∀ t, (A.cfc (f t)).mat = ∑ i, f t (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
+  have h_expand : ∀ t, (A.cfc (f t)).mat = ∑ i, f t (A.H.eigenvalues i) •
+      (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+        A.H.eigenvectorUnitary.val.conjTranspose) := by
     exact fun t ↦ cfc_toMat_eq_sum_smul_proj A (f t);
   rw [ ← intervalIntegrable_toMat_iff ];
   rw [ funext h_expand ];
@@ -1172,7 +1402,8 @@ theorem cfc_pos_of_pos {A : HermitianMat d 𝕜} {f : ℝ → ℝ} (hA : 0 < A)
   exact lt_of_le_of_ne h_f_nonneg h_f_nonzero.symm
 
 /-- If two matrices A and B commute, then they is a common matrix with which they are both CFCs of.
-This is a variant of the common theorem that "commuting matrices can be simultaneously diagonalized." -/
+This is a variant of the common theorem that "commuting matrices can be simultaneously
+diagonalized." -/
 theorem _root_.Commute.exists_HermitianMat_cfc (hAB : Commute A.mat B.mat) :
     ∃ C : HermitianMat d 𝕜, (∃ f : ℝ → ℝ, A = C.cfc f) ∧ (∃ g : ℝ → ℝ, B = C.cfc g) := by
   obtain ⟨C, ⟨g₁, hg₁⟩, ⟨g₂, hg₂⟩⟩ := hAB.exists_cfc A.H B.H
@@ -1200,9 +1431,9 @@ theorem cfc_le_cfc_of_PosDef (hfg : ∀ i, 0 < i → f i ≤ g i) (hA : A.mat.Po
 
 open ComplexOrder in
 variable {f} in
-/- TODO: Write a version of this that holds more broadly for some sets. Esp closed intervals of reals,
-which correspond nicely to closed intervals of matrices. Write the specialization to Set.univ (Monotone
-instead of MonotoneOn). Also a version that works for StrictMonoOn. -/
+/- TODO: Write a version of this that holds more broadly for some sets. Esp closed intervals of
+reals, which correspond nicely to closed intervals of matrices. Write the specialization to Set.univ
+(Monotone instead of MonotoneOn). Also a version that works for StrictMonoOn. -/
 theorem cfc_le_cfc_of_commute_monoOn (hf : MonotoneOn f (Set.Ioi 0))
   (hAB₁ : Commute A.mat B.mat) (hAB₂ : A ≤ B) (hA : A.mat.PosDef) (hB : B.mat.PosDef) :
     A.cfc f ≤ B.cfc f := by
@@ -1231,8 +1462,9 @@ theorem cfc_le_cfc_of_commute (hf : Monotone f) (hAB₁ : Commute A.mat B.mat) (
   apply hf
   simpa using hAB₂ i
 
---This is the more general version that requires operator concave functions but doesn't require the inputs
--- to commute. Requires the correct statement of operator convexity though, which we don't have right now.
+--This is the more general version that requires operator concave functions but doesn't require the
+-- inputs to commute. Requires the correct statement of operator convexity though, which we don't
+-- have right now.
 open ComplexOrder in
 theorem cfc_monoOn_pos_of_monoOn_posDef {d : Type*} [Fintype d] [DecidableEq d]
   {f : ℝ → ℝ} (hf_is_operator_convex : False) :
@@ -1256,16 +1488,21 @@ theorem inv_ge_one_of_le_one (hA : A.mat.PosDef) (h : A ≤ 1) : 1 ≤ A⁻¹ :=
             intro i
             have h_eigenvalue : A.mat.PosSemidef := by
               exact hA.posSemidef
-            have h_eigenvalue_le_one : ∀ x : d → 𝕜, x ≠ 0 → (star x ⬝ᵥ A.mat.mulVec x) / (star x ⬝ᵥ x) ≤ 1 := by
+            have h_eigenvalue_le_one : ∀ x : d → 𝕜, x ≠ 0 →
+                (star x ⬝ᵥ A.mat.mulVec x) / (star x ⬝ᵥ x) ≤ 1 := by
               intro x hx_ne_zero
               have h_eigenvalue_le_one : (star x ⬝ᵥ (1 - A.mat).mulVec x) ≥ 0 := by
                 exact Matrix.PosSemidef.dotProduct_mulVec_nonneg h x
               generalize_proofs at *; (
               rw [ div_le_iff₀ ] <;> simp_all [ Matrix.sub_mulVec, dotProduct_sub ])
             generalize_proofs at *; (
-            have := h_eigenvalue_le_one ( A.H.eigenvectorBasis i ) ?_ <;> simp_all [ div_le_iff₀,  ];
-            · have := Matrix.IsHermitian.mulVec_eigenvectorBasis ( show Matrix.IsHermitian ( A : Matrix d d _ ) from ‹_› ) i; simp_all [ dotProduct_comm ] ;
-              by_cases h : ( A.H.eigenvectorBasis i |> WithLp.ofLp ) ⬝ᵥ star ( A.H.eigenvectorBasis i |> WithLp.ofLp ) = 0 <;> simp_all [ div_le_iff₀ ] ; (
+            have := h_eigenvalue_le_one ( A.H.eigenvectorBasis i ) ?_ <;>
+              simp_all [ div_le_iff₀,  ];
+            · have := Matrix.IsHermitian.mulVec_eigenvectorBasis
+                ( show Matrix.IsHermitian ( A : Matrix d d _ ) from ‹_› ) i;
+                simp_all [ dotProduct_comm ] ;
+              by_cases h : ( A.H.eigenvectorBasis i |> WithLp.ofLp ) ⬝ᵥ
+                star ( A.H.eigenvectorBasis i |> WithLp.ofLp ) = 0 <;> simp_all [ div_le_iff₀ ] ; (
               exact absurd h ( by exact ne_of_apply_ne ( fun x => ‖x‖ ) ( by simp ) ));
             · exact fun h => by simpa [ h ] using ( A.H.eigenvectorBasis.orthonormal.ne_zero i ) ;)
           generalize_proofs at *; (
@@ -1304,13 +1541,16 @@ end uncategorized_cleanup
 lemma mulVec_eq_zero_iff_inner_eigenvector_zero
     (A : HermitianMat d ℂ) (x : EuclideanSpace ℂ d) :
     A.mat.mulVec x = 0 ↔ ∀ i, A.H.eigenvalues i ≠ 0 → inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
-  -- Since the eigenvectors form an orthonormal basis, we can express x as a linear combination of these eigenvectors.
+  -- Since the eigenvectors form an orthonormal basis, we can express x as a linear combination of
+  -- these eigenvectors.
   obtain ⟨c, hc⟩ : ∃ c : d → ℂ, x = ∑ i, c i • A.H.eigenvectorBasis i := by
     have := A.H.eigenvectorBasis.sum_repr x;
     exact ⟨ _, this.symm ⟩;
   -- By definition of $A$, we know that $A.mulVec (x.ofLp) = \sum_{i} c_i \lambda_i e_i$.
-  have h_mulVec : A.val.mulVec (x.ofLp) = ∑ i, c i • (A.H.eigenvalues i) • (A.H.eigenvectorBasis i) := by
-    have h_mulVec : ∀ i, A.val.mulVec (A.H.eigenvectorBasis i) = (A.H.eigenvalues i) • (A.H.eigenvectorBasis i) := by
+  have h_mulVec : A.val.mulVec (x.ofLp) =
+      ∑ i, c i • (A.H.eigenvalues i) • (A.H.eigenvectorBasis i) := by
+    have h_mulVec : ∀ i, A.val.mulVec (A.H.eigenvectorBasis i) =
+        (A.H.eigenvalues i) • (A.H.eigenvectorBasis i) := by
       intro i
       have := A.H.mulVec_eigenvectorBasis i
       aesop;
@@ -1323,31 +1563,42 @@ lemma mulVec_eq_zero_iff_inner_eigenvector_zero
     · ext i; simp [ Finset.sum_apply ] ;
   constructor;
   · intro h i hi
-    have h_inner : inner ℂ (A.H.eigenvectorBasis i) (∑ j, c j • (A.H.eigenvalues j) • (A.H.eigenvectorBasis j)) = 0 := by
-      convert congr_arg ( fun x => inner ℂ ( A.H.eigenvectorBasis i ) x ) ( show ( ∑ j, c j • A.H.eigenvalues j • A.H.eigenvectorBasis j ) = 0 from ?_ ) using 1;
+    have h_inner : inner ℂ (A.H.eigenvectorBasis i)
+        (∑ j, c j • (A.H.eigenvalues j) • (A.H.eigenvectorBasis j)) = 0 := by
+      convert congr_arg ( fun x => inner ℂ ( A.H.eigenvectorBasis i ) x )
+        ( show ( ∑ j, c j • A.H.eigenvalues j • A.H.eigenvectorBasis j ) = 0 from ?_ ) using 1;
       · simp [ inner_zero_right ];
       · ext j; replace h := congr_fun h j; aesop;
     simp_all
-    convert congr_arg ( fun x : ℂ => x / ( A.H.eigenvalues i ) ) h_inner using 1 <;> norm_num [ Finset.sum_div _ _ _, hi ];
-    refine' Finset.sum_congr rfl fun j _ => _ ; by_cases hj : A.H.eigenvalues j = 0 <;> simp_all [ mul_div_assoc ] ; ring_nf;
+    convert congr_arg ( fun x : ℂ => x / ( A.H.eigenvalues i ) ) h_inner using 1 <;>
+      norm_num [ Finset.sum_div _ _ _, hi ];
+    refine' Finset.sum_congr rfl fun j _ => _ ;
+    by_cases hj : A.H.eigenvalues j = 0 <;> simp_all [ mul_div_assoc ] ; ring_nf;
     · by_cases hij : i = j <;> simp_all [ ];
     · by_cases hij : i = j <;> simp_all [  inner_self_eq_norm_sq_to_K ];
   · intro h
     have h_zero_coeffs : ∀ i, A.H.eigenvalues i ≠ 0 → c i = 0 := by
       intro i hi; specialize h i hi; simp_all
-      rw [ Finset.sum_eq_single i ] at h <;> simp_all [ orthonormal_iff_ite.mp ( A.H.eigenvectorBasis.orthonormal ) ];
+      rw [ Finset.sum_eq_single i ] at h <;>
+        simp_all [ orthonormal_iff_ite.mp ( A.H.eigenvectorBasis.orthonormal ) ];
       aesop;
     simp_all
-    exact Finset.sum_eq_zero fun i _ => by by_cases hi : A.H.eigenvalues i = 0 <;> simp [ hi, h_zero_coeffs i ] ;
+    exact Finset.sum_eq_zero fun i _ => by
+      by_cases hi : A.H.eigenvalues i = 0 <;> simp [ hi, h_zero_coeffs i ] ;
 
 open InnerProductSpace in
 lemma cfc_mulVec_expansion (A : HermitianMat d ℂ) (f : ℝ → ℝ) (x : EuclideanSpace ℂ d) :
-    (A.cfc f).mat.mulVec x = ∑ i, (f (A.H.eigenvalues i) : ℂ) • inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i := by
+    (A.cfc f).mat.mulVec x = ∑ i, (f (A.H.eigenvalues i) : ℂ) •
+      inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i := by
   ext i; simp [ Matrix.mulVec, dotProduct ] ; ring_nf
-  -- By definition of $cfc$, we know that $(A.cfc f).i j = \sum_k f(\lambda_k) \langle e_k, e_i \rangle \langle e_j, e_k \rangle$.
-  have h_cfc_def : (A.cfc f).mat i = ∑ k, f (A.H.eigenvalues k) • (A.H.eigenvectorBasis k).ofLp i • star (A.H.eigenvectorBasis k).ofLp := by
-    -- By definition of $cfc$, we know that $(A.cfc f).i j = \sum_k f(\lambda_k) \langle e_k, e_i \rangle \langle e_j, e_k \rangle$ follows directly from the definition of $cfc$.
-    have h_cfc_def : (A.cfc f).mat = ∑ k, f (A.H.eigenvalues k) • (A.H.eigenvectorUnitary.val * (Matrix.single k k 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
+  -- By definition of $cfc$, we know that $(A.cfc f).i j = \sum_k f(\lambda_k) \langle e_k, e_i
+  -- \rangle \langle e_j, e_k \rangle$.
+  have h_cfc_def : (A.cfc f).mat i = ∑ k, f (A.H.eigenvalues k) • (A.H.eigenvectorBasis k).ofLp i •
+      star (A.H.eigenvectorBasis k).ofLp := by
+    -- By definition of $cfc$, we know that $(A.cfc f).i j = \sum_k f(\lambda_k) \langle e_k, e_i
+    -- \rangle \langle e_j, e_k \rangle$ follows directly from the definition of $cfc$.
+    have h_cfc_def : (A.cfc f).mat = ∑ k, f (A.H.eigenvalues k) • (A.H.eigenvectorUnitary.val *
+        (Matrix.single k k 1) * A.H.eigenvectorUnitary.val.conjTranspose) := by
       convert cfc_toMat_eq_sum_smul_proj A f using 1;
     convert congr_fun h_cfc_def i using 1;
     simp [ funext_iff, Matrix.single ];
@@ -1376,23 +1627,31 @@ lemma ker_cfc_le_ker_on_set
   have h_inner : ∀ i, A.H.eigenvalues i ≠ 0 → inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
     have h_inner_zero : (A.cfc f).mat.mulVec x = 0 := by
       exact (mem_ker_iff_mulVec_zero (A.cfc f) x).mp hx
-    have h_inner_zero_expansion : ∑ i, (f (A.H.eigenvalues i) : ℂ) • inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i = 0 := by
+    have h_inner_zero_expansion : ∑ i, (f (A.H.eigenvalues i) : ℂ) •
+        inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i = 0 := by
       convert h_inner_zero using 1;
       rw [ cfc_mulVec_expansion ];
       exact Iff.symm (WithLp.ofLp_eq_zero 2)
-    have h_inner_zero_coeff : ∀ i, f (A.H.eigenvalues i) • inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
+    have h_inner_zero_coeff : ∀ i,
+        f (A.H.eigenvalues i) • inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
       intro i
-      have h_inner_zero_coeff_i : f (A.H.eigenvalues i) • inner ℂ (A.H.eigenvectorBasis i) x = inner ℂ (A.H.eigenvectorBasis i) (∑ j, (f (A.H.eigenvalues j) : ℂ) • inner ℂ (A.H.eigenvectorBasis j) x • A.H.eigenvectorBasis j) := by
+      have h_inner_zero_coeff_i : f (A.H.eigenvalues i) • inner ℂ (A.H.eigenvectorBasis i) x =
+          inner ℂ (A.H.eigenvectorBasis i) (∑ j, (f (A.H.eigenvalues j) : ℂ) •
+            inner ℂ (A.H.eigenvectorBasis j) x • A.H.eigenvectorBasis j) := by
         simp [  orthonormal_iff_ite.mp ( A.H.eigenvectorBasis.orthonormal ) ]
       rw [h_inner_zero_coeff_i, h_inner_zero_expansion]
-      simp [inner_zero_right] -- This line is just to prevent the proof from being completed prematurely. In a real proof, this line would be replaced with the actual proof steps.
-    have h_inner_zero_final : ∀ i, A.H.eigenvalues i ≠ 0 → inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
+      simp [inner_zero_right] -- This line is just to prevent the proof from being completed
+      -- prematurely. In a real proof, this line would be replaced with the actual proof steps.
+    have h_inner_zero_final : ∀ i, A.H.eigenvalues i ≠ 0 →
+        inner ℂ (A.H.eigenvectorBasis i) x = 0 := by
       -- Since $A.H.eigenvalues i \neq 0$, by hypothesis $h$, we have $f(A.H.eigenvalues i) \neq 0$.
       have h_f_nonzero : ∀ i, A.H.eigenvalues i ≠ 0 → f (A.H.eigenvalues i) ≠ 0 := by
         intro i hi; specialize h ( A.H.eigenvalues i ) ( hs <| by
           exact Matrix.IsHermitian.eigenvalues_mem_spectrum_real (H A) i ) ; contrapose! hi; aesop;
       generalize_proofs at *; (
-      exact fun i hi => by simpa [ h_f_nonzero i hi ] using h_inner_zero_coeff i;) -- This line is just to prevent the proof from being completed prematurely. In a real proof, this line would be replaced with the actual proof steps.
+      exact fun i hi => by simpa [ h_f_nonzero i hi ] using h_inner_zero_coeff i;)
+      -- This line is just to prevent the proof from being completed prematurely. In a real proof,
+      -- this line would be replaced with the actual proof steps.
     exact h_inner_zero_final;
   convert mulVec_eq_zero_iff_inner_eigenvector_zero A x |>.2 h_inner using 1;
   exact mem_ker_iff_mulVec_zero A x
@@ -1414,7 +1673,8 @@ lemma ker_le_ker_cfc_on_set (hs : spectrum ℝ A.mat ⊆ s) (h : ∀ i ∈ s, i 
     have h_inner_zero : A.mat.mulVec x = 0 := by
       exact (mem_ker_iff_mulVec_zero A x).mp hx;
     have := mulVec_eq_zero_iff_inner_eigenvector_zero A x; aesop;
-  have h_mulVec_zero : (A.cfc f).mat.mulVec x = ∑ i, (f (A.H.eigenvalues i) : ℂ) • inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i := by
+  have h_mulVec_zero : (A.cfc f).mat.mulVec x = ∑ i, (f (A.H.eigenvalues i) : ℂ) •
+      inner ℂ (A.H.eigenvectorBasis i) x • A.H.eigenvectorBasis i := by
     convert cfc_mulVec_expansion A f x using 1;
   convert h_mulVec_zero using 1
   simp_all [ funext_iff] ;

--- a/QuantumInfo/ForMathlib/HermitianMat/Inner.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Inner.lean
@@ -11,18 +11,21 @@ public import Mathlib.Topology.Instances.Real.Lemmas
 
 /-! # Inner product of Hermitian Matrices
 
-For general matrices there are multiple reasonable notions of "inner product" (Hilbert–Schmidt inner product,
-Frobenius inner product), and so Mathlib avoids giving a canonical `InnerProductSpace` instance. But for the
-particular case of Hermitian matrices, these all coincide, so we can put a canonical `InnerProductSpace`
+For general matrices there are multiple reasonable notions of "inner product" (Hilbert–Schmidt
+inner product, Frobenius inner product), and so Mathlib avoids giving a canonical
+`InnerProductSpace` instance. But for the
+particular case of Hermitian matrices, these all coincide, so we can put a canonical
+`InnerProductSpace`
 instance.
 
-This _does_ however induce a `Norm` on `HermitianMat` as well, the Frobenius norm, and this is less obviously
-a uniquely correct choice. It is something that one essentially has to live with, with the way that Mathlib
-currently structures the instances. (Thankfully, all norms induce the same _topology and bornology_ on
-finite-dimensional matrices.)
+This _does_ however induce a `Norm` on `HermitianMat` as well, the Frobenius norm, and this is less
+obviously a uniquely correct choice. It is something that one essentially has to live with, with the
+way that Mathlib
+currently structures the instances. (Thankfully, all norms induce the same _topology and bornology_
+on finite-dimensional matrices.)
 
-Some care to be taken so that the topology induced by the InnerProductSpace is defeq with the Subtype
-topology that HermitianMat inherits from the topology on Matrix. This can be done via
+Some care to be taken so that the topology induced by the InnerProductSpace is defeq with the
+Subtype topology that HermitianMat inherits from the topology on Matrix. This can be done via
 `InnerProductSpace.ofCoreOfTopology`.
 
 -/
@@ -115,7 +118,8 @@ protected def innerₗ : LinearMap.BilinForm R (HermitianMat n α) where
 end ring
 section starring
 
-variable [CommSemiring R] [Ring α] [StarRing α] [Algebra R α] [IsMaximalSelfAdjoint R α] [DecidableEq n]
+variable [CommSemiring R] [Ring α] [StarRing α] [Algebra R α] [IsMaximalSelfAdjoint R α]
+  [DecidableEq n]
 variable (A B : HermitianMat n α)
 
 @[simp]
@@ -190,7 +194,8 @@ theorem inner_ge_zero (hA : 0 ≤ A) (hB : 0 ≤ B) : 0 ≤ ⟪A, B⟫ := by
   rw [zero_le_iff] at hB
   open MatrixOrder in
   open Classical in
-  rw [inner_eq_re_trace, ← CFC.sqrt_mul_sqrt_self A.mat hA, Matrix.trace_mul_cycle, Matrix.trace_mul_cycle]
+  rw [inner_eq_re_trace, ← CFC.sqrt_mul_sqrt_self A.mat hA, Matrix.trace_mul_cycle,
+    Matrix.trace_mul_cycle]
   nth_rewrite 1 [← (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A.mat)).left]
   exact (RCLike.nonneg_iff.mp (hB.conjTranspose_mul_mul_same _).trace_nonneg).left
 
@@ -210,24 +215,32 @@ theorem inner_le_mul_trace (hA : 0 ≤ A) (hB : 0 ≤ B) : ⟪A, B⟫ ≤ A.trac
   simp [mul_comm]
 
 --TODO cleanup
-private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemidef) (hB₁ : B.mat.PosSemidef) :
+private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemidef)
+  (hB₁ : B.mat.PosSemidef) :
   RCLike.re (A.val * B.val).trace = 0 ↔
     LinearMap.range (Matrix.toEuclideanLin A.val) ≤
       LinearMap.ker (Matrix.toEuclideanLin B.val) := by
   open MatrixOrder in
   --Thanks Aristotle
   have h_trace_zero : (RCLike.re ((A.val * B.val).trace)) = 0 ↔ (A.val * B.val) = 0 := by
-    -- Since $A$ and $B$ are positive semidefinite, we can write them as $A = C^* C$ and $B = D^* D$ for some matrices $C$ and $D$.
+    -- Since $A$ and $B$ are positive semidefinite, we can write them as $A = C^* C$ and
+    -- $B = D^* D$ for some matrices $C$ and $D$.
     obtain ⟨C, hC⟩ : ∃ C : Matrix n n 𝕜, A.val = C.conjTranspose * C := by
       rw [← Matrix.nonneg_iff_posSemidef] at hA₁
       exact CStarAlgebra.nonneg_iff_eq_star_mul_self.mp hA₁
     obtain ⟨D, hD⟩ : ∃ D : Matrix n n 𝕜, B.val = D.conjTranspose * D := by
       erw [← Matrix.nonneg_iff_posSemidef] at hB₁
       exact CStarAlgebra.nonneg_iff_eq_star_mul_self.mp hB₁
-    have h_trace_zero_iff : (RCLike.re ((A.val * B.val).trace)) = 0 ↔ (D * C.conjTranspose) = 0 := by
-      -- Since $\operatorname{Tr}((DC)^* DC) = \sum_{i,j} |(DC)_{ij}|^2$, and this sum is zero if and only if each term is zero, we have $\operatorname{Tr}((DC)^* DC) = 0$ if and only if $DC = 0$.
-      have h_trace_zero_iff : (RCLike.re ((D * C.conjTranspose).conjTranspose * (D * C.conjTranspose)).trace) = 0 ↔ (D * C.conjTranspose) = 0 := by
-        have h_trace_zero_iff : ∀ (M : Matrix n n 𝕜), (RCLike.re (M.conjTranspose * M).trace) = 0 ↔ M = 0 := by
+    have h_trace_zero_iff :
+        (RCLike.re ((A.val * B.val).trace)) = 0 ↔ (D * C.conjTranspose) = 0 := by
+      -- Since $\operatorname{Tr}((DC)^* DC) = \sum_{i,j} |(DC)_{ij}|^2$, and this sum is zero if
+      -- and only if each term is zero, we have $\operatorname{Tr}((DC)^* DC) = 0$ if and only if
+      -- $DC = 0$.
+      have h_trace_zero_iff :
+          (RCLike.re ((D * C.conjTranspose).conjTranspose * (D * C.conjTranspose)).trace) = 0 ↔
+            (D * C.conjTranspose) = 0 := by
+        have h_trace_zero_iff :
+            ∀ (M : Matrix n n 𝕜), (RCLike.re (M.conjTranspose * M).trace) = 0 ↔ M = 0 := by
           simp [ Matrix.trace, Matrix.mul_apply ];
           intro M
           -- simp_all only
@@ -236,12 +249,15 @@ private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemid
           subst hD hC
           apply Iff.intro
           · intro a
-            rw [ Finset.sum_eq_zero_iff_of_nonneg fun i _ => Finset.sum_nonneg fun j _ => add_nonneg ( mul_self_nonneg _ ) ( mul_self_nonneg _ )] at a
+            rw [ Finset.sum_eq_zero_iff_of_nonneg fun i _ => Finset.sum_nonneg fun j _ =>
+              add_nonneg ( mul_self_nonneg _ ) ( mul_self_nonneg _ )] at a
             ext i j
             specialize a j
-            rw [ Finset.sum_eq_zero_iff_of_nonneg fun _ _ => add_nonneg ( mul_self_nonneg _ ) ( mul_self_nonneg _ ) ] at a
+            rw [ Finset.sum_eq_zero_iff_of_nonneg fun _ _ =>
+              add_nonneg ( mul_self_nonneg _ ) ( mul_self_nonneg _ ) ] at a
             simp_all only [Finset.mem_univ, forall_const, Matrix.zero_apply]
-            exact RCLike.ext ( by norm_num; nlinarith only [ a i ] ) ( by norm_num; nlinarith only [ a i ] );
+            exact RCLike.ext ( by norm_num; nlinarith only [ a i ] )
+              ( by norm_num; nlinarith only [ a i ] );
           · intro a
             subst a
             simp_all only [Matrix.zero_apply, map_zero, mul_zero, add_zero, Finset.sum_const_zero]
@@ -249,7 +265,8 @@ private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemid
       convert h_trace_zero_iff using 3
       simp [ Matrix.mul_assoc ];
       rw [ ← Matrix.trace_mul_comm ]
-      have h_trace_cyclic : Matrix.trace (D.conjTranspose * D * C.conjTranspose * C) = Matrix.trace (C * D.conjTranspose * D * C.conjTranspose) := by
+      have h_trace_cyclic : Matrix.trace (D.conjTranspose * D * C.conjTranspose * C) =
+          Matrix.trace (C * D.conjTranspose * D * C.conjTranspose) := by
         rw [ ← Matrix.trace_mul_comm ]
         simp [ Matrix.mul_assoc ] ;
       simp_all [ Matrix.mul_assoc ]
@@ -263,7 +280,8 @@ private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemid
       simp [ ← Matrix.mul_assoc, ← Matrix.conjTranspose_inj, a ];
     · intro a
       simp_all only [Matrix.trace_zero, map_zero, true_iff]
-  have h_range_ker : (LinearMap.range (Matrix.toEuclideanLin A.val)) ≤ (LinearMap.ker (Matrix.toEuclideanLin B.val)) → (A.val * B.val) = 0 := by
+  have h_range_ker : (LinearMap.range (Matrix.toEuclideanLin A.val)) ≤
+      (LinearMap.ker (Matrix.toEuclideanLin B.val)) → (A.val * B.val) = 0 := by
     intro h_range_ker
     have hAB_zero : ∀ v, (Matrix.toEuclideanLin B.val) ((Matrix.toEuclideanLin A.val) v) = 0 := by
       exact fun v => h_range_ker ( LinearMap.mem_range_self _ v )
@@ -294,8 +312,8 @@ private theorem inner_zero_iff_aux_lemma [DecidableEq n] (hA₁ : A.mat.PosSemid
     simp [Matrix.toEuclideanLin, Matrix.toLpLin_apply, Matrix.mulVec_mulVec, h_comm]
   · exact h_range_ker
 
-/-- The inner product of two PSD matrices is zero iff they have disjoint support, i.e., each lives entirely
-in the other's kernel. -/
+/-- The inner product of two PSD matrices is zero iff they have disjoint support, i.e., each lives
+entirely in the other's kernel. -/
 theorem inner_zero_iff [DecidableEq n] (hA₁ : 0 ≤ A) (hB₁ : 0 ≤ B)
     : ⟪A, B⟫ = 0 ↔ A.support ≤ B.ker := by
   rw [zero_le_iff] at hA₁ hB₁
@@ -318,7 +336,8 @@ end RCLike
 
 section topology
 /-!
-Theorems about `HermitianMat`s that have to do with the topological structure. Pretty much everything here will
+Theorems about `HermitianMat`s that have to do with the topological structure. Pretty much
+everything here will
 assume these are matrices over ℂ, but changes to upgrade this to other types are welcome.
 -/
 open ComplexOrder
@@ -335,7 +354,8 @@ theorem inner_continuous : Continuous (Inner.inner ℝ (E := HermitianMat d 𝕜
   fun_prop
 
 @[fun_prop] --fun_prop can actually prove this, should I leave this on or not?
-theorem inner_bilinForm_Continuous (A : HermitianMat d 𝕜) : Continuous ⇑(HermitianMat.innerₗ A) :=
+theorem inner_bilinForm_Continuous (A : HermitianMat d 𝕜) :
+    Continuous ⇑(HermitianMat.innerₗ A) :=
   LinearMap.continuous_of_finiteDimensional _
 
 end topology
@@ -344,9 +364,12 @@ section innerproductspace
 
 variable {d d₂ : Type*} [Fintype d] [Fintype d₂] {𝕜 : Type*} [RCLike 𝕜]
 
-/-- We define the Hermitian inner product as our "canonical" inner product, which does induce a norm.
-This disagrees slightly with Mathlib convention on the `Matrix` type, which avoids asserting one norm
-as there are several reasonable ones; for Hermitian matrices, though, this seem to be the right choice. -/
+/-- We define the Hermitian inner product as our "canonical" inner product, which does induce a
+norm.
+This disagrees slightly with Mathlib convention on the `Matrix` type, which avoids asserting one
+norm
+as there are several reasonable ones; for Hermitian matrices, though, this seem to be the right
+choice. -/
 @[reducible]
 noncomputable def InnerProductCore : InnerProductSpace.Core ℝ (HermitianMat d 𝕜) :=
    {
@@ -370,7 +393,8 @@ noncomputable def InnerProductCore : InnerProductSpace.Core ℝ (HermitianMat d 
       rw [Pi.zero_apply, Fintype.sum_eq_zero_iff_of_nonneg (fun i ↦ by positivity)] at h
       replace h := congrFun h i
       rw [Pi.zero_apply] at h
-      rw [add_eq_zero_iff_of_nonneg (by positivity) (by positivity), sq_eq_zero_iff, sq_eq_zero_iff] at h
+      rw [add_eq_zero_iff_of_nonneg (by positivity) (by positivity), sq_eq_zero_iff,
+        sq_eq_zero_iff] at h
       apply RCLike.ext (h.left.trans RCLike.zero_re.symm) (h.right.trans (map_zero _).symm)
   }
 
@@ -453,10 +477,12 @@ theorem Matrix.IsHermitian_isClosed : IsClosed { A : Matrix n n 𝕜 | A.IsHermi
 open ComplexOrder
 
 theorem Matrix.PosSemiDef_isClosed : IsClosed { A : Matrix n n 𝕜 | A.PosSemidef } := by
-  rw [show { A : Matrix n n 𝕜 | A.PosSemidef } = { A | A.IsHermitian } ∩ { A | ∀ x : n → 𝕜, 0 ≤ star x ⬝ᵥ A.mulVec x } from by
+  rw [show { A : Matrix n n 𝕜 | A.PosSemidef } =
+      { A | A.IsHermitian } ∩ { A | ∀ x : n → 𝕜, 0 ≤ star x ⬝ᵥ A.mulVec x } from by
     ext A; simp [Matrix.posSemidef_iff_dotProduct_mulVec]]
   refine IsHermitian_isClosed.inter ?_
-  suffices IsClosed (⋂ x : n → 𝕜, { A : Matrix n n 𝕜 | 0 ≤ star x ⬝ᵥ A.mulVec x }) by
+  suffices
+      IsClosed (⋂ x : n → 𝕜, { A : Matrix n n 𝕜 | 0 ≤ star x ⬝ᵥ A.mulVec x }) by
     rwa [← Set.setOf_forall] at this
   exact isClosed_iInter fun _ ↦ (isClosed_Ici (a := 0)).preimage (by fun_prop)
 
@@ -464,7 +490,8 @@ theorem isClosed_nonneg : IsClosed { A : HermitianMat n 𝕜 | 0 ≤ A } := by
   simp_rw [zero_le_iff]
   exact Matrix.PosSemiDef_isClosed.preimage_val
 
---TODO: The PosDef matrices are open *within* the HermitianMat space (not in the ambient space of matrices.)
+--TODO: The PosDef matrices are open *within* the HermitianMat space (not in the ambient space of
+-- matrices.)
 
 instance : OrderClosedTopology (HermitianMat d 𝕜) where
   isClosed_le' := by
@@ -475,7 +502,8 @@ instance : OrderClosedTopology (HermitianMat d 𝕜) where
     simp only [Set.mem_setOf_eq, Set.mem_preimage, ← sub_nonneg (b := x)]
 
 set_option backward.isDefEq.respectTransparency false in
-/-- Equivalently: the matrices `X` such that `X - A` is PSD and `B - X` is PSD, form a compact set. -/
+/-- Equivalently: the matrices `X` such that `X - A` is PSD and `B - X` is PSD, form a compact
+set. -/
 instance : CompactIccSpace (HermitianMat d 𝕜) where
   isCompact_Icc := by
     intros A B
@@ -489,9 +517,12 @@ instance : CompactIccSpace (HermitianMat d 𝕜) where
 
 variable [DecidableEq d]
 
-/-- The PSD matrices that are `≤ 1` are a compact set. More generally, this is true of any closed interval,
-but stating that is a bit different because of how numerals are treated. The `0` and `1` here are already
-directly matrices, putting in an `(a : ℝ) • 1 ≤ m ∧ m ≤ (b : ℝ) • 1` involves casts. But that theorem should follow
+/-- The PSD matrices that are `≤ 1` are a compact set. More generally, this is true of any closed
+interval,
+but stating that is a bit different because of how numerals are treated. The `0` and `1` here are
+already
+directly matrices, putting in an `(a : ℝ) • 1 ≤ m ∧ m ≤ (b : ℝ) • 1` involves casts.
+But that theorem should follow
 easily from this. More generally `A ≤ m ∧ m ≤ B` is compact.
 -/
 theorem unitInterval_IsCompact : IsCompact {m : HermitianMat d 𝕜 | 0 ≤ m ∧ m ≤ 1} :=
@@ -504,9 +535,12 @@ theorem norm_one : ‖(1 : HermitianMat d 𝕜)‖ = √(Fintype.card d : ℝ) :
   simp [-inner_self_eq_norm_sq_to_K, inner_def]
 
 theorem norm_eq_trace_sq : ‖A‖ ^ 2 = (A.mat ^ 2).trace := by
-  rw [norm_eq_frobenius, ← RCLike.ofReal_pow, ← Real.rpow_two, ← Real.rpow_mul (by positivity)]
-  simp only [one_div, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, inv_mul_cancel₀, Real.rpow_one]
-  simp only [sq A.mat, map_sum, map_pow, Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, mat_apply]
+  rw [norm_eq_frobenius, ← RCLike.ofReal_pow, ← Real.rpow_two,
+    ← Real.rpow_mul (by positivity)]
+  simp only [one_div, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, inv_mul_cancel₀,
+    Real.rpow_one]
+  simp only [sq A.mat, map_sum, map_pow, Matrix.trace, Matrix.diag_apply, Matrix.mul_apply,
+    mat_apply]
   congr! with i _ j _
   rw [← star_star (A j i), ← A.mat_apply (i := j)]
   rw [← A.mat.conjTranspose_apply j i, A.H, eq_comm]
@@ -524,32 +558,67 @@ lemma inner_eq_doubly_stochastic_sum {d : Type*} [Fintype d] [DecidableEq d]
     let C := A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val
     ⟪A, B⟫_ℝ = ∑ i, ∑ j,
       A.H.eigenvalues i * B.H.eigenvalues j * (‖C i j‖^2) := by
-  -- By the properties of the trace and diagonalization, we can rewrite the trace of AB as the sum of the products of the eigenvalues of A and B, multiplied by the squared norms of the entries of the product of their eigenvector matrices.
-  have h_trace_diag : Matrix.trace (A.mat * B.mat) = Matrix.trace ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ) * ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ))) := by
-    have h_trace_diag : Matrix.trace (A.mat * B.mat) = Matrix.trace ((A.H.eigenvectorUnitary : Matrix d d ℂ) * ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ)) * ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ)) * (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose) := by
+  -- By the properties of the trace and diagonalization, we can rewrite the trace of AB as the sum
+  -- of the products of the eigenvalues of A and B, multiplied by the squared norms of the entries
+  -- of the product of their eigenvector matrices.
+  have h_trace_diag : Matrix.trace (A.mat * B.mat) =
+      Matrix.trace ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat *
+        (A.H.eigenvectorUnitary : Matrix d d ℂ) *
+        ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat *
+          (A.H.eigenvectorUnitary : Matrix d d ℂ))) := by
+    have h_trace_diag : Matrix.trace (A.mat * B.mat) =
+        Matrix.trace ((A.H.eigenvectorUnitary : Matrix d d ℂ) *
+          ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat *
+            (A.H.eigenvectorUnitary : Matrix d d ℂ)) *
+          ((A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat *
+            (A.H.eigenvectorUnitary : Matrix d d ℂ)) *
+          (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose) := by
       simp [ Matrix.mul_assoc ];
       simp [ ← Matrix.mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ];
     rw [ h_trace_diag, Matrix.trace_mul_comm ];
     simp [ ← mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ];
-  -- Since $A$ is Hermitian, its eigenvector matrix is unitary, and thus $(A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ)$ is diagonal with the eigenvalues of $A$ on the diagonal.
-  have h_diag_A : (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ) = Matrix.diagonal (fun i => A.H.eigenvalues i : d → ℂ) := by
+  -- Since $A$ is Hermitian, its eigenvector matrix is unitary, and thus
+  -- $(A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat *
+  -- (A.H.eigenvectorUnitary : Matrix d d ℂ)$ is diagonal with the eigenvalues of $A$ on the
+  -- diagonal.
+  have h_diag_A : (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * A.mat *
+      (A.H.eigenvectorUnitary : Matrix d d ℂ) =
+      Matrix.diagonal (fun i => A.H.eigenvalues i : d → ℂ) := by
     have := A.H.spectral_theorem;
-    convert congr_arg ( fun x : Matrix d d ℂ => ( A.H.eigenvectorUnitary : Matrix d d ℂ ).conjTranspose * x * ( A.H.eigenvectorUnitary : Matrix d d ℂ ) ) this using 1 ; simp [ Matrix.mul_assoc ];
+    convert congr_arg ( fun x : Matrix d d ℂ =>
+      ( A.H.eigenvectorUnitary : Matrix d d ℂ ).conjTranspose * x *
+        ( A.H.eigenvectorUnitary : Matrix d d ℂ ) ) this using 1 ;
+    simp [ Matrix.mul_assoc ];
     simp [ ← Matrix.mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ];
-  -- Since $B$ is Hermitian, its eigenvector matrix is unitary, and thus $(A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ)$ is diagonal with the eigenvalues of $B$ on the diagonal.
-  have h_diag_B : (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat * (A.H.eigenvectorUnitary : Matrix d d ℂ) = (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * (B.H.eigenvectorUnitary : Matrix d d ℂ) * Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) * (B.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * (A.H.eigenvectorUnitary : Matrix d d ℂ) := by
-    have h_diag_B : B.mat = (B.H.eigenvectorUnitary : Matrix d d ℂ) * Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) * (B.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose := by
+  -- Since $B$ is Hermitian, its eigenvector matrix is unitary, and thus
+  -- $(A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat *
+  -- (A.H.eigenvectorUnitary : Matrix d d ℂ)$ is diagonal with the eigenvalues of $B$ on the
+  -- diagonal.
+  have h_diag_B : (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * B.mat *
+      (A.H.eigenvectorUnitary : Matrix d d ℂ) =
+      (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose *
+        (B.H.eigenvectorUnitary : Matrix d d ℂ) *
+        Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) *
+        (B.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose *
+        (A.H.eigenvectorUnitary : Matrix d d ℂ) := by
+    have h_diag_B : B.mat = (B.H.eigenvectorUnitary : Matrix d d ℂ) *
+        Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) *
+        (B.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose := by
       convert B.H.spectral_theorem using 1;
     grind;
-  -- Since $C = U_A^* U_B$ is unitary, we have $C_{ij} = \langle u_i, v_j \rangle$ where $u_i$ and $v_j$ are the eigenvectors of $A$ and $B$, respectively.
-  set C : Matrix d d ℂ := (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose * (B.H.eigenvectorUnitary : Matrix d d ℂ)
+  -- Since $C = U_A^* U_B$ is unitary, we have $C_{ij} = \langle u_i, v_j \rangle$ where $u_i$ and
+  -- $v_j$ are the eigenvectors of $A$ and $B$, respectively.
+  set C : Matrix d d ℂ := (A.H.eigenvectorUnitary : Matrix d d ℂ).conjTranspose *
+    (B.H.eigenvectorUnitary : Matrix d d ℂ)
   have hC_unitary : C * C.conjTranspose = 1 := by
     simp +zetaDelta at *;
     simp [ Matrix.mul_assoc ];
     simp [ ← Matrix.mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ]
   have hC_norm : ∀ i j, ‖C i j‖ ^ 2 = (C i j) * (star (C i j)) := by
     simp [ Complex.mul_conj, Complex.normSq_eq_norm_sq ]
-  have hC_trace : Matrix.trace (Matrix.diagonal (fun i => A.H.eigenvalues i : d → ℂ) * C * Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) * C.conjTranspose) = ∑ i, ∑ j, A.H.eigenvalues i * B.H.eigenvalues j * ‖C i j‖ ^ 2 := by
+  have hC_trace : Matrix.trace (Matrix.diagonal (fun i => A.H.eigenvalues i : d → ℂ) * C *
+      Matrix.diagonal (fun i => B.H.eigenvalues i : d → ℂ) * C.conjTranspose) =
+      ∑ i, ∑ j, A.H.eigenvalues i * B.H.eigenvalues j * ‖C i j‖ ^ 2 := by
     simp [ Matrix.trace, Matrix.mul_apply, hC_norm ];
     simp [ Matrix.diagonal, Finset.sum_ite_eq ];
     exact Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring;

--- a/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
@@ -25,8 +25,10 @@ variable {A B : HermitianMat d 𝕜} {x : ℝ}
 
 noncomputable section
 
-theorem Matrix.IsHermitian.log_smul_of_ne_zero {A : Matrix d d 𝕜} (hA : A.IsHermitian) (hx : x ≠ 0) :
-    cfc Real.log (x • A) = (Real.log x) • cfc (if · = 0 then (0 : ℝ) else 1) A + cfc Real.log A := by
+theorem Matrix.IsHermitian.log_smul_of_ne_zero {A : Matrix d d 𝕜} (hA : A.IsHermitian)
+    (hx : x ≠ 0) :
+    cfc Real.log (x • A) =
+      (Real.log x) • cfc (if · = 0 then (0 : ℝ) else 1) A + cfc Real.log A := by
   have hCFC : cfc (Real.log ∘ (x * ·)) A = cfc Real.log (x • A) := by
     exact cfc_comp_smul x Real.log _ (by fun_prop) hA
   rw [← hCFC, ← cfc_smul, ← cfc_add]
@@ -147,11 +149,19 @@ theorem inv_antitone (hA : A.mat.PosDef) (h : A ≤ B) : B⁻¹ ≤ A⁻¹ := by
   -- Using the fact that $B = A + C^*C$, we can write $B^{-1}$ as $(A + C^*C)^{-1}$.
   have h_inv_posDef : (1 + C * A.mat⁻¹ * C.conjTranspose).PosDef := by
     exact Matrix.PosDef.one.add_posSemidef (hA.inv.posSemidef.mul_mul_conjTranspose_same C)
-  have hB_inv : B.mat⁻¹ = A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹ := by
-    have hB_inv : (A.mat + C.conjTranspose * C)⁻¹ = A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹ := by
-      have hB_inv : (A.mat + C.conjTranspose * C) * (A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹) = 1 := by
-        have h_inv : (1 + C * A.mat⁻¹ * C.conjTranspose) * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ = 1 := by
-          exact Matrix.mul_nonsing_inv _ ( show IsUnit _ from by simpa [ Matrix.isUnit_iff_isUnit_det ] using h_inv_posDef.det_pos.ne' );
+  have hB_inv : B.mat⁻¹ =
+      A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C
+        * A.mat⁻¹ := by
+    have hB_inv : (A.mat + C.conjTranspose * C)⁻¹ =
+        A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C
+          * A.mat⁻¹ := by
+      have hB_inv : (A.mat + C.conjTranspose * C)
+          * (A.mat⁻¹ - A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C
+            * A.mat⁻¹) = 1 := by
+        have h_inv : (1 + C * A.mat⁻¹ * C.conjTranspose)
+            * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ = 1 := by
+          exact Matrix.mul_nonsing_inv _ ( show IsUnit _ from by
+            simpa [ Matrix.isUnit_iff_isUnit_det ] using h_inv_posDef.det_pos.ne' );
         simp only [mul_assoc, Matrix.mul_sub] at *
         simp only [← Matrix.mul_assoc, add_mul, one_mul] at *
         simp only [isUnit_iff_ne_zero, ne_eq, hA.det_pos.ne', not_false_eq_true,
@@ -161,9 +171,13 @@ theorem inv_antitone (hA : A.mat.PosDef) (h : A ≤ B) : B⁻¹ ≤ A⁻¹ := by
         grind only [cases eager Subtype]
       rw [ Matrix.inv_eq_right_inv hB_inv ];
     rw [ ← hB_inv, ← hC, add_sub_cancel ];
-  -- Since $(1 + C * A⁻¹ * C.conjTranspose)$ is positive definite, its inverse is also positive definite.
-  have h_inv_pos : (A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹).PosSemidef := by
-    have h_inv_pos : (C * A.mat⁻¹).conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * (C * A.mat⁻¹) = A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹ := by
+  -- Since $(1 + C * A⁻¹ * C.conjTranspose)$ is positive definite, its inverse is also positive
+  -- definite.
+  have h_inv_pos : (A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C
+      * A.mat⁻¹).PosSemidef := by
+    have h_inv_pos : (C * A.mat⁻¹).conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹
+        * (C * A.mat⁻¹) =
+        A.mat⁻¹ * C.conjTranspose * (1 + C * A.mat⁻¹ * C.conjTranspose)⁻¹ * C * A.mat⁻¹ := by
       simp [ Matrix.mul_assoc, Matrix.conjTranspose_mul ];
       rw [ Matrix.conjTranspose_nonsing_inv, A.H ];
     rw [ ← h_inv_pos ];
@@ -177,30 +191,51 @@ The integral of $1/(1+t) - 1/(x+t)$ from 0 to T is $\log x + \log((1+T)/(x+T))$.
 -/
 lemma Real.integral_inv_sub_inv_finite (x T : ℝ) (hx : 0 < x) (hT : 0 < T) :
     ∫ t in (0)..T, (1 / (1 + t) - 1 / (x + t)) = Real.log x + Real.log ((1 + T) / (x + T)) := by
-  rw [ intervalIntegral.integral_sub, intervalIntegral.integral_comp_add_left, intervalIntegral.integral_comp_add_left ];
+  rw [ intervalIntegral.integral_sub, intervalIntegral.integral_comp_add_left,
+    intervalIntegral.integral_comp_add_left ];
   · rw [ ← Real.log_mul, intervalIntegral.integral_deriv_eq_sub' ];
     field_simp;
     rw [ intervalIntegral.integral_deriv_eq_sub' ];
-    any_goals intro t ht; exact Real.differentiableAt_log ( by cases Set.mem_uIcc.mp ht <;> linarith );
+    any_goals intro t ht;
+      exact Real.differentiableAt_log ( by cases Set.mem_uIcc.mp ht <;> linarith );
     any_goals positivity;
-    · rw [ Real.log_div ( by positivity ) ( by positivity ), Real.log_mul ( by positivity ) ( by positivity ) ] ; norm_num;
+    · rw [ Real.log_div ( by positivity ) ( by positivity ),
+        Real.log_mul ( by positivity ) ( by positivity ) ] ; norm_num;
       ring;
     · exact funext fun x => by simp [ div_eq_inv_mul ] ;
-    · exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.div continuousAt_const continuousAt_id ( by cases Set.mem_uIcc.mp ht <;> linarith );
+    · exact continuousOn_of_forall_continuousAt fun t ht =>
+        ContinuousAt.div continuousAt_const continuousAt_id
+          ( by cases Set.mem_uIcc.mp ht <;> linarith );
     · exact funext fun x => by simp [ div_eq_inv_mul ] ;
-    · exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.div continuousAt_const continuousAt_id <| by cases Set.mem_uIcc.mp ht <;> linarith;
-  · exact ContinuousOn.intervalIntegrable ( by exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.div continuousAt_const ( continuousAt_const.add continuousAt_id ) ( by linarith [ Set.mem_Icc.mp ( by simpa [ hT.le ] using ht ) ] ) );
-  · exact ContinuousOn.intervalIntegrable ( by exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.div continuousAt_const ( continuousAt_const.add continuousAt_id ) ( by linarith [ Set.mem_Icc.mp ( by simpa [ hT.le ] using ht ) ] ) )
+    · exact continuousOn_of_forall_continuousAt fun t ht =>
+        ContinuousAt.div continuousAt_const continuousAt_id <| by
+          cases Set.mem_uIcc.mp ht <;> linarith;
+  · exact ContinuousOn.intervalIntegrable ( by
+      exact continuousOn_of_forall_continuousAt fun t ht =>
+        ContinuousAt.div continuousAt_const ( continuousAt_const.add continuousAt_id )
+          ( by linarith [ Set.mem_Icc.mp ( by simpa [ hT.le ] using ht ) ] ) );
+  · exact ContinuousOn.intervalIntegrable ( by
+      exact continuousOn_of_forall_continuousAt fun t ht =>
+        ContinuousAt.div continuousAt_const ( continuousAt_const.add continuousAt_id )
+          ( by linarith [ Set.mem_Icc.mp ( by simpa [ hT.le ] using ht ) ] ) )
 
 /--
 The limit of $\log((1+T)/(x+T))$ as $T \to \infty$ is 0, for $x > 0$.
 -/
 lemma Real.tendsto_log_div_add_atTop (x : ℝ) :
     Filter.Tendsto (fun T => Real.log ((1 + T) / (x + T))) .atTop (nhds 0) := by
-  -- We can divide the numerator and the denominator by $b$ and then take the limit as $b$ approaches infinity.
-  suffices h_div : Filter.Tendsto (fun b => Real.log ((1 / b + 1) / (x / b + 1))) Filter.atTop (nhds 0) by
-    refine h_div.congr' ( by filter_upwards [ Filter.eventually_gt_atTop 0 ] with b hb using by rw [ show ( 1 + b ) / ( x + b ) = ( 1 / b + 1 ) / ( x / b + 1 ) by rw [ div_add_one, div_add_one, div_div_div_cancel_right₀ ] <;> positivity ] );
-  exact le_trans ( Filter.Tendsto.log ( Filter.Tendsto.div ( Filter.Tendsto.add ( tendsto_const_nhds.div_atTop Filter.tendsto_id ) tendsto_const_nhds ) ( Filter.Tendsto.add ( tendsto_const_nhds.div_atTop Filter.tendsto_id ) tendsto_const_nhds ) ( by positivity ) ) ( by positivity ) ) ( by norm_num )
+  -- We can divide the numerator and the denominator by $b$ and then take the limit as $b$
+  -- approaches infinity.
+  suffices h_div :
+      Filter.Tendsto (fun b => Real.log ((1 / b + 1) / (x / b + 1))) Filter.atTop (nhds 0) by
+    refine h_div.congr' ( by
+      filter_upwards [ Filter.eventually_gt_atTop 0 ] with b hb using by
+        rw [ show ( 1 + b ) / ( x + b ) = ( 1 / b + 1 ) / ( x / b + 1 ) by
+          rw [ div_add_one, div_add_one, div_div_div_cancel_right₀ ] <;> positivity ] );
+  exact le_trans ( Filter.Tendsto.log ( Filter.Tendsto.div
+    ( Filter.Tendsto.add ( tendsto_const_nhds.div_atTop Filter.tendsto_id ) tendsto_const_nhds )
+    ( Filter.Tendsto.add ( tendsto_const_nhds.div_atTop Filter.tendsto_id ) tendsto_const_nhds )
+    ( by positivity ) ) ( by positivity ) ) ( by norm_num )
 
 set_option maxHeartbeats 1000000 in
 set_option backward.isDefEq.respectTransparency false in
@@ -213,9 +248,13 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
     ∫ t in (0)..T, ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (x + t • 1)⁻¹) ≤
     ∫ t in (0)..T, ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (y + t • 1)⁻¹) := by
   -- By the properties of the integral, we can bring the limit inside, so we have:
-  have h_integrable : ContinuousOn (fun t : ℝ => (1 + t)⁻¹ • (1 : HermitianMat d 𝕜)) (Set.Icc 0 T) ∧ ContinuousOn (fun t : ℝ => (x + t • 1)⁻¹) (Set.Icc 0 T) ∧ ContinuousOn (fun t : ℝ => (y + t • 1)⁻¹) (Set.Icc 0 T) := by
-    refine' ⟨ ContinuousOn.smul ( ContinuousOn.inv₀ ( continuousOn_const.add continuousOn_id ) fun t ht => by linarith [ ht.1 ] ) continuousOn_const, _, _ ⟩;
-    · refine' ContinuousOn.comp ( show ContinuousOn ( fun m : HermitianMat d 𝕜 => m⁻¹ ) ( { m : HermitianMat d 𝕜 | m.mat.PosDef } ) from _ ) _ _;
+  have h_integrable : ContinuousOn (fun t : ℝ => (1 + t)⁻¹ • (1 : HermitianMat d 𝕜)) (Set.Icc 0 T)
+      ∧ ContinuousOn (fun t : ℝ => (x + t • 1)⁻¹) (Set.Icc 0 T)
+      ∧ ContinuousOn (fun t : ℝ => (y + t • 1)⁻¹) (Set.Icc 0 T) := by
+    refine' ⟨ ContinuousOn.smul ( ContinuousOn.inv₀ ( continuousOn_const.add continuousOn_id )
+      fun t ht => by linarith [ ht.1 ] ) continuousOn_const, _, _ ⟩;
+    · refine' ContinuousOn.comp ( show ContinuousOn ( fun m : HermitianMat d 𝕜 => m⁻¹ )
+        ( { m : HermitianMat d 𝕜 | m.mat.PosDef } ) from _ ) _ _;
       · intro m hm;
         refine' ContinuousAt.continuousWithinAt _;
         have h_inv_cont : ContinuousAt (fun m : Matrix d d 𝕜 => m⁻¹) m.mat := by
@@ -225,7 +264,8 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
             have h_adj_cont : ContinuousAt (fun m : Matrix d d 𝕜 => m.adjugate) m.mat := by
               exact Continuous.continuousAt ( continuous_id.matrix_adjugate )
             simp_all [ Matrix.inv_def ];
-            exact ContinuousAt.smul ( h_det_cont.inv₀ ( by simpa using hm.det_pos.ne' ) ) h_adj_cont;
+            exact ContinuousAt.smul ( h_det_cont.inv₀ ( by simpa using hm.det_pos.ne' ) )
+              h_adj_cont;
           exact h_inv_cont;
         rw [ ContinuousAt ] at *;
         rw [ tendsto_subtype_rng ] at *;
@@ -237,10 +277,12 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
         refine' ⟨ _, _ ⟩;
         · exact H ((fun t => x + t • 1) t);
         · intro v hv_ne_zero
-          have h_pos : 0 < star v ⬝ᵥ x.mat.mulVec v + t * star v ⬝ᵥ (1 : Matrix d d 𝕜).mulVec v := by
+          have h_pos :
+              0 < star v ⬝ᵥ x.mat.mulVec v + t * star v ⬝ᵥ (1 : Matrix d d 𝕜).mulVec v := by
             have := hx.2 hv_ne_zero;
             refine' add_pos_of_pos_of_nonneg this _;
-            exact mul_nonneg ( mod_cast ht.1 ) ( Finset.sum_nonneg fun i _ => by simp [ mul_comm, RCLike.mul_conj ] );
+            exact mul_nonneg ( mod_cast ht.1 )
+              ( Finset.sum_nonneg fun i _ => by simp [ mul_comm, RCLike.mul_conj ] );
           simp_all [ Matrix.add_mulVec ];
           simp_all [ Matrix.mulVec, dotProduct ];
           simp_all [ Matrix.one_apply, Finset.mul_sum, mul_left_comm,];
@@ -256,17 +298,21 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
             · intro x hx_ne_zero
               have h_pos : 0 < star x ⬝ᵥ y.mat.mulVec x + t * star x ⬝ᵥ x := by
                 have := hy.2 hx_ne_zero;
-                exact add_pos_of_pos_of_nonneg this ( mul_nonneg ( mod_cast ht.1 ) ( by simp [ dotProduct_comm ] ) );
+                exact add_pos_of_pos_of_nonneg this
+                  ( mul_nonneg ( mod_cast ht.1 ) ( by simp [ dotProduct_comm ] ) );
               simp_all [ Matrix.add_mulVec ]
               simp_all [ Matrix.mulVec, dotProduct ]
               simp_all [ Matrix.one_apply, Finset.mul_sum, mul_left_comm ]
               convert h_pos using 1;
               simp [ mul_assoc, mul_comm, mul_left_comm, Algebra.smul_def ];
           exact ne_of_gt ( h_det_pos t ht |> fun h => h.det_pos )
-        have h_cont_inv : ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜)⁻¹) (Set.Icc 0 T) := by
-          have h_cont_det : ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜).det) (Set.Icc 0 T) := by
+        have h_cont_inv :
+            ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜)⁻¹) (Set.Icc 0 T) := by
+          have h_cont_det :
+              ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜).det) (Set.Icc 0 T) := by
             fun_prop
-          have h_cont_adj : ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜).adjugate) (Set.Icc 0 T) := by
+          have h_cont_adj :
+              ContinuousOn (fun t : ℝ => (y + t • 1 : Matrix d d 𝕜).adjugate) (Set.Icc 0 T) := by
             fun_prop;
           simp_all [ Matrix.inv_def ];
           exact ContinuousOn.smul ( h_cont_det.inv₀ fun t ht => h_inv t ht.1 ht.2 ) h_cont_adj;
@@ -275,8 +321,10 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
       exact continuous_induced_rng.mpr h_cont
   rw [ intervalIntegral.integral_of_le hT.le, intervalIntegral.integral_of_le hT.le ];
   apply_rules [ MeasureTheory.integral_mono_ae ];
-  · exact ContinuousOn.integrableOn_Icc (ContinuousOn.sub h_integrable.1 h_integrable.2.1) |> fun h => h.mono_set (Set.Ioc_subset_Icc_self);
-  · exact ContinuousOn.integrableOn_Icc (ContinuousOn.sub h_integrable.1 h_integrable.2.2) |> fun h => h.mono_set (Set.Ioc_subset_Icc_self);
+  · exact ContinuousOn.integrableOn_Icc (ContinuousOn.sub h_integrable.1 h_integrable.2.1)
+      |> fun h => h.mono_set (Set.Ioc_subset_Icc_self);
+  · exact ContinuousOn.integrableOn_Icc (ContinuousOn.sub h_integrable.1 h_integrable.2.2)
+      |> fun h => h.mono_set (Set.Ioc_subset_Icc_self);
   have h_integral_limit : ∀ t ∈ Set.Icc (0 : ℝ) T, (y + t • 1)⁻¹ ≤ (x + t • 1)⁻¹ := by
     intro t ht;
     apply inv_antitone;
@@ -286,13 +334,15 @@ theorem logApprox_mono {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.m
       · intro v hv_ne_zero
         have h_pos : 0 < star v ⬝ᵥ x.mat.mulVec v + t * star v ⬝ᵥ v := by
           have := hx.2 hv_ne_zero
-          exact add_pos_of_pos_of_nonneg this ( mul_nonneg ( mod_cast ht.1 ) ( dotProduct_star_self_nonneg v ) );
+          exact add_pos_of_pos_of_nonneg this
+            ( mul_nonneg ( mod_cast ht.1 ) ( dotProduct_star_self_nonneg v ) );
         simp_all [ Matrix.add_mulVec ];
         convert h_pos using 2 ; simp [ Matrix.mulVec, dotProduct ];
         simp [ Matrix.one_apply, Finset.mul_sum, mul_left_comm ];
         simp [ mul_left_comm, Algebra.smul_def ];
     · exact add_le_add_left hxy _;
-  have h_integral_limit : ∀ t ∈ Set.Ioc 0 T, (1 + t)⁻¹ • 1 - (x + t • 1)⁻¹ ≤ (1 + t)⁻¹ • 1 - (y + t • 1)⁻¹ := by
+  have h_integral_limit : ∀ t ∈ Set.Ioc 0 T,
+      (1 + t)⁻¹ • 1 - (x + t • 1)⁻¹ ≤ (1 + t)⁻¹ • 1 - (y + t • 1)⁻¹ := by
     exact fun t ht => sub_le_sub_left ( h_integral_limit t <| Set.Ioc_subset_Icc_self ht ) _;
   filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioc] with t ht
   exact h_integral_limit t ht
@@ -321,7 +371,8 @@ The integrand in the log approximation is the CFC of the scalar integrand.
 -/
 private lemma integrand_eq
     (x : HermitianMat d 𝕜) (hx : x.mat.PosDef) (t : ℝ) (ht : 0 ≤ t) :
-    ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (x + t • 1)⁻¹) = x.cfc (fun u => (1 + t)⁻¹ - (u + t)⁻¹) := by
+    ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (x + t • 1)⁻¹) =
+      x.cfc (fun u => (1 + t)⁻¹ - (u + t)⁻¹) := by
   have h_cfc_add : x.cfc (fun u => u + t) = x.cfc (fun u => u) + x.cfc (fun u => t) :=
     x.cfc_add id _
   have h_cfc_sub : (x + t • 1)⁻¹ = x.cfc (fun u => (u + t)⁻¹) := by
@@ -349,7 +400,8 @@ theorem logApprox_eq_cfc_scalar
     · exact fun x hx => by cases Set.mem_uIcc.mp hx <;> linarith;
     · fun_prop;
     · have := hx.eigenvalues_pos i;
-      exact fun t ht => ne_of_gt ( add_pos_of_pos_of_nonneg this ( by cases Set.mem_uIcc.mp ht <;> linarith ) );
+      exact fun t ht => ne_of_gt
+        ( add_pos_of_pos_of_nonneg this ( by cases Set.mem_uIcc.mp ht <;> linarith ) );
   · apply integrand_eq x hx t
     cases Set.mem_uIcc.mp ht <;> linarith
 
@@ -360,11 +412,14 @@ The log approximation is the log plus an error term.
 theorem logApprox_eq_log_add_error
     (x : HermitianMat d 𝕜) (hx : x.mat.PosDef) (T : ℝ) (hT : 0 < T) :
     logApprox x T = x.log + x.cfc (fun u => Real.log ((1 + T) / (u + T))) := by
-  have h_logApprox : ∫ t in (0)..T, ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (x + t • 1)⁻¹) = x.cfc (fun u => Real.log u + Real.log ((1 + T) / (u + T))) := by
+  have h_logApprox :
+      ∫ t in (0)..T, ((1 + t)⁻¹ • (1 : HermitianMat d 𝕜) - (x + t • 1)⁻¹) =
+        x.cfc (fun u => Real.log u + Real.log ((1 + T) / (u + T))) := by
     convert logApprox_eq_cfc_scalar x hx T hT using 1;
     apply cfc_congr_of_posDef hx;
     exact fun u hu => Eq.symm ( scalarLogApprox_eq u T hu.out hT );
-  have h_cfc_add : x.cfc (fun u => Real.log u + Real.log ((1 + T) / (u + T))) = x.cfc Real.log + x.cfc (fun u => Real.log ((1 + T) / (u + T))) := by
+  have h_cfc_add : x.cfc (fun u => Real.log u + Real.log ((1 + T) / (u + T))) =
+      x.cfc Real.log + x.cfc (fun u => Real.log ((1 + T) / (u + T))) := by
     apply cfc_add;
   exact h_logApprox.trans h_cfc_add
 
@@ -377,12 +432,19 @@ The error term in the log approximation tends to 0 as T goes to infinity.
 lemma tendsto_cfc_log_div_add_atTop (x : HermitianMat d 𝕜) :
     Tendsto (fun T => x.cfc (fun u => Real.log ((1 + T) / (u + T)))) atTop (nhds 0) := by
   -- Expand `(cfc x ...).mat` using `cfc_toMat_eq_sum_smul_proj`.
-  have h_expand : ∀ T : ℝ, (x.cfc (fun u => Real.log ((1 + T) / (u + T)))).mat = ∑ i, Real.log ((1 + T) / (x.H.eigenvalues i + T)) • (x.H.eigenvectorUnitary.val * (Matrix.single i i 1) * x.H.eigenvectorUnitary.val.conjTranspose) := by
+  have h_expand : ∀ T : ℝ, (x.cfc (fun u => Real.log ((1 + T) / (u + T)))).mat =
+      ∑ i, Real.log ((1 + T) / (x.H.eigenvalues i + T)) • (x.H.eigenvectorUnitary.val
+        * (Matrix.single i i 1) * x.H.eigenvectorUnitary.val.conjTranspose) := by
     exact fun T => cfc_toMat_eq_sum_smul_proj x fun u => Real.log ((1 + T) / (u + T));
   -- The limit of a sum is the sum of the limits.
-  have h_sum : Filter.Tendsto (fun T : ℝ => ∑ i, Real.log ((1 + T) / (x.H.eigenvalues i + T)) • (x.H.eigenvectorUnitary.val * (Matrix.single i i 1) * x.H.eigenvectorUnitary.val.conjTranspose)) Filter.atTop (nhds (∑ i, 0 • (x.H.eigenvectorUnitary.val * (Matrix.single i i 1) * x.H.eigenvectorUnitary.val.conjTranspose))) := by
+  have h_sum : Filter.Tendsto (fun T : ℝ => ∑ i, Real.log ((1 + T) / (x.H.eigenvalues i + T))
+        • (x.H.eigenvectorUnitary.val * (Matrix.single i i 1)
+          * x.H.eigenvectorUnitary.val.conjTranspose)) Filter.atTop
+      (nhds (∑ i, 0 • (x.H.eigenvectorUnitary.val * (Matrix.single i i 1)
+        * x.H.eigenvectorUnitary.val.conjTranspose))) := by
     refine' tendsto_finsetSum _ fun i _ => _;
-    convert Filter.Tendsto.smul_const ( Real.tendsto_log_div_add_atTop ( x.H.eigenvalues i ) ) _ using 1;
+    convert Filter.Tendsto.smul_const ( Real.tendsto_log_div_add_atTop ( x.H.eigenvalues i ) ) _
+      using 1;
     all_goals try infer_instance;
     norm_num +zetaDelta at *
   rw [ tendsto_iff_norm_sub_tendsto_zero ] at *;
@@ -395,8 +457,10 @@ The log approximation converges to the matrix logarithm.
 -/
 lemma tendsto_logApprox {x : HermitianMat d 𝕜} (hx : x.mat.PosDef) :
   Tendsto (fun T => logApprox x T) atTop (nhds x.log) := by
-    have h_log_approx_eq : ∀ᶠ T in Filter.atTop, x.logApprox T = x.log + x.cfc (fun u => Real.log ((1 + T) / (u + T))) := by
-      filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using logApprox_eq_log_add_error x hx T hT;
+    have h_log_approx_eq : ∀ᶠ T in Filter.atTop,
+        x.logApprox T = x.log + x.cfc (fun u => Real.log ((1 + T) / (u + T))) := by
+      filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using
+        logApprox_eq_log_add_error x hx T hT;
     rw [ Filter.tendsto_congr' h_log_approx_eq ];
     simpa using tendsto_const_nhds.add ( tendsto_cfc_log_div_add_atTop x )
 
@@ -438,23 +502,37 @@ The inverse function is operator convex on positive definite matrices.
 lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.PosDef)
     ⦃a b : ℝ⦄ (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) :
     (a • x + b • y)⁻¹ ≤ a • x⁻¹ + b • y⁻¹ := by
-  -- Using the fact that the set of positive semidefinite matrices is a convex cone, we can show that the matrix
-  -- $\begin{pmatrix} a \bullet x + b \bullet y & I \\ I & a \bullet x^{-1} + b \bullet y^{-1} \end{pmatrix}$
+  -- Using the fact that the set of positive semidefinite matrices is a convex cone, we can show
+  -- that the matrix
+  -- $\begin{pmatrix} a \bullet x + b \bullet y & I \\ I & a \bullet x^{-1} + b \bullet y^{-1}
+  -- \end{pmatrix}$
   -- is positive semidefinite.
   have h_pos_semidef :
-    (Matrix.fromBlocks (a • x.mat + b • y.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (a • (x.mat)⁻¹ + b • (y.mat)⁻¹)).PosSemidef := by
-      -- Since $a + b = 1$, we can use the fact that the block matrix $\begin{pmatrix} A & I \\ I & A^{-1} \end{pmatrix}$ is positive semidefinite for any positive definite $A$.
-      have h_block_pos : ∀ A : Matrix d d 𝕜, A.PosDef → (Matrix.fromBlocks A 1 1 A⁻¹).PosSemidef := by
+    (Matrix.fromBlocks (a • x.mat + b • y.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜)
+      (a • (x.mat)⁻¹ + b • (y.mat)⁻¹)).PosSemidef := by
+      -- Since $a + b = 1$, we can use the fact that the block matrix $\begin{pmatrix} A & I \\ I &
+      -- A^{-1} \end{pmatrix}$ is positive semidefinite for any positive definite $A$.
+      have h_block_pos :
+          ∀ A : Matrix d d 𝕜, A.PosDef → (Matrix.fromBlocks A 1 1 A⁻¹).PosSemidef := by
         intro A hA
-        have h_block_pos : (Matrix.fromBlocks A (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (A⁻¹)).PosSemidef := by
+        have h_block_pos :
+            (Matrix.fromBlocks A (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (A⁻¹)).PosSemidef := by
           have h_inv_pos : A⁻¹.PosSemidef := by
             exact hA.inv.posSemidef
-          have h_block_pos : (Matrix.fromBlocks A (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (A⁻¹)) = (Matrix.fromBlocks 1 0 A⁻¹ 1) * (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * A * A⁻¹)) * (Matrix.fromBlocks 1 A⁻¹ 0 1) := by
+          have h_block_pos :
+              (Matrix.fromBlocks A (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (A⁻¹)) =
+                (Matrix.fromBlocks 1 0 A⁻¹ 1)
+                  * (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * A * A⁻¹))
+                  * (Matrix.fromBlocks 1 A⁻¹ 0 1) := by
             simp [ Matrix.fromBlocks_multiply ];
             have := hA.det_pos;
-            exact ⟨ by rw [ Matrix.mul_nonsing_inv _ ( show IsUnit A.det from isUnit_iff_ne_zero.mpr this.ne' ) ], by rw [ Matrix.nonsing_inv_mul _ ( show IsUnit A.det from isUnit_iff_ne_zero.mpr this.ne' ) ] ⟩;
+            exact ⟨ by rw [ Matrix.mul_nonsing_inv _
+              ( show IsUnit A.det from isUnit_iff_ne_zero.mpr this.ne' ) ],
+              by rw [ Matrix.nonsing_inv_mul _
+                ( show IsUnit A.det from isUnit_iff_ne_zero.mpr this.ne' ) ] ⟩;
           have h_block_pos : (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * A * A⁻¹)).PosSemidef := by
-            have h_block_pos : (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * A * A⁻¹)) = (Matrix.fromBlocks A 0 0 0) := by
+            have h_block_pos : (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * A * A⁻¹)) =
+                (Matrix.fromBlocks A 0 0 0) := by
               have h_inv : A⁻¹ * A = 1 := by
                 rw [ Matrix.nonsing_inv_mul _ ];
                 exact isUnit_iff_ne_zero.mpr hA.det_pos.ne';
@@ -479,7 +557,10 @@ lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.Pos
           · simp [Matrix.fromBlocks_conjTranspose, h_inv_pos.1 ];
           · intro x
             set y : d ⊕ d → 𝕜 := (Matrix.fromBlocks 1 A⁻¹ 0 1).mulVec x
-            have h_y : star x ⬝ᵥ (Matrix.fromBlocks 1 0 A⁻¹ 1 * (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * (A * A⁻¹)) * Matrix.fromBlocks 1 A⁻¹ 0 1)).mulVec x = star y ⬝ᵥ (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * (A * A⁻¹))).mulVec y := by
+            have h_y : star x ⬝ᵥ (Matrix.fromBlocks 1 0 A⁻¹ 1
+                  * (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * (A * A⁻¹))
+                    * Matrix.fromBlocks 1 A⁻¹ 0 1)).mulVec x =
+                star y ⬝ᵥ (Matrix.fromBlocks A 0 0 (A⁻¹ - A⁻¹ * (A * A⁻¹))).mulVec y := by
               simp +zetaDelta at *;
               simp [Matrix.dotProduct_mulVec ];
               simp [ Matrix.star_mulVec ];
@@ -490,8 +571,13 @@ lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.Pos
               · rw [ ← Matrix.ext_iff ] at * ; aesop;
             exact h_y.symm ▸ h_block_pos.2 y;
         exact h_block_pos;
-      -- Since $a + b = 1$, we can use the fact that the block matrix $\begin{pmatrix} a \bullet x + b \bullet y & I \\ I & a \bullet x^{-1} + b \bullet y^{-1} \end{pmatrix}$ is positive semidefinite.
-      have h_convex : Matrix.PosSemidef ((a • Matrix.fromBlocks (x.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (x.mat)⁻¹) + (b • Matrix.fromBlocks (y.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (y.mat)⁻¹)) := by
+      -- Since $a + b = 1$, we can use the fact that the block matrix $\begin{pmatrix} a \bullet x +
+      -- b \bullet y & I \\ I & a \bullet x^{-1} + b \bullet y^{-1} \end{pmatrix}$ is positive
+      -- semidefinite.
+      have h_convex : Matrix.PosSemidef
+          ((a • Matrix.fromBlocks (x.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜) (x.mat)⁻¹)
+            + (b • Matrix.fromBlocks (y.mat) (1 : Matrix d d 𝕜) (1 : Matrix d d 𝕜)
+              (y.mat)⁻¹)) := by
         apply_rules [ Matrix.PosSemidef.add, Matrix.PosSemidef.smul ];
       convert h_convex using 1;
       ext i j ; simp [ Matrix.fromBlocks ];
@@ -499,7 +585,8 @@ lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.Pos
       · split_ifs <;> simp_all [ ← add_smul ];
       · split_ifs <;> simp_all [ ← add_smul ];
   have h_schur : (a • x.mat + b • y.mat).PosDef := by
-    by_cases ha' : a = 0 <;> by_cases hb' : b = 0 <;> simp_all [ Matrix.posSemidef_iff_dotProduct_mulVec ];
+    by_cases ha' : a = 0 <;> by_cases hb' : b = 0 <;>
+      simp_all [ Matrix.posSemidef_iff_dotProduct_mulVec ];
     rw [Matrix.posDef_iff_dotProduct_mulVec] at hx hy ⊢
     constructor;
     · simp_all [ Matrix.IsHermitian, Matrix.conjTranspose_add, Matrix.conjTranspose_smul ];
@@ -508,7 +595,8 @@ lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.Pos
         have := hx.2 hv_ne_zero; have := hy.2 hv_ne_zero
         clear hx hy
         simp_all [ Matrix.mulVec, dotProduct ] ;
-        exact add_pos_of_nonneg_of_pos ( mul_nonneg ( mod_cast ha ) ( le_of_lt ‹_› ) ) ( mul_pos ( mod_cast lt_of_le_of_ne hb ( Ne.symm hb' ) ) ( mod_cast this ) );
+        exact add_pos_of_nonneg_of_pos ( mul_nonneg ( mod_cast ha ) ( le_of_lt ‹_› ) )
+          ( mul_pos ( mod_cast lt_of_le_of_ne hb ( Ne.symm hb' ) ) ( mod_cast this ) );
       convert h_pos using 1 ; simp [ Matrix.add_mulVec]
       ring_nf
       simp [ Matrix.mulVec, dotProduct, Finset.mul_sum, mul_left_comm];
@@ -520,7 +608,8 @@ lemma inv_convex {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.Pos
   · have := h_pos_semidef.2;
     specialize this (Sum.elim (- (a • x.mat + b • y.mat)⁻¹.mulVec v) v);
     simp_all [ Matrix.fromBlocks_mulVec ];
-    simp_all [ Matrix.mul_nonsing_inv _ ( show IsUnit (a • x.mat + b • y.mat).det from isUnit_iff_ne_zero.mpr <| h_schur.det_pos.ne' ), Matrix.mulVec_neg];
+    simp_all [ Matrix.mul_nonsing_inv _ ( show IsUnit (a • x.mat + b • y.mat).det from
+      isUnit_iff_ne_zero.mpr <| h_schur.det_pos.ne' ), Matrix.mulVec_neg];
     simp_all [ dotProduct, Matrix.sub_mulVec ];
     refine this.trans_eq (Finset.sum_congr rfl fun _ _ => by ring );
 
@@ -545,7 +634,8 @@ Definition of the approximation of the matrix logarithm.
 -/
 lemma integrable_inv_shift {A : HermitianMat d 𝕜} (hA : A.mat.PosDef) (b : ℝ) (hb : 0 ≤ b) :
     IntervalIntegrable (fun t => (A + t • 1)⁻¹) volume 0 b := by
-  -- Since A is positive definite, for any t ≥ 0, A + t • 1 is also positive definite, hence invertible.
+  -- Since A is positive definite, for any t ≥ 0, A + t • 1 is also positive definite, hence
+  -- invertible.
   have h_inv : ∀ t : ℝ, 0 ≤ t → IsUnit (A + t • 1).mat := by
     intro t ht
     have h_pos_def : (A + t • 1).mat.PosDef := by
@@ -567,7 +657,8 @@ lemma integrable_inv_shift {A : HermitianMat d 𝕜} (hA : A.mat.PosDef) (b : �
       have h_adj_cont : ContinuousAt (fun t : ℝ => (A + t • 1).mat.adjugate) t := by
         exact Continuous.continuousAt ( by exact Continuous.matrix_adjugate <| by continuity )
       simp_all [ Matrix.inv_def ];
-      exact ContinuousAt.smul ( h_det_cont.inv₀ <| by simpa [ Matrix.isUnit_iff_isUnit_det ] using h_inv t ht.1 ) h_adj_cont
+      exact ContinuousAt.smul ( h_det_cont.inv₀ <| by
+        simpa [ Matrix.isUnit_iff_isUnit_det ] using h_inv t ht.1 ) h_adj_cont
     exact h_inv_cont.continuousWithinAt
   have h_inv_cont : ContinuousOn (fun t : ℝ => (A + t • 1)⁻¹) (Set.Icc 0 b) := by
     exact (continuousOn_iff_coe fun t => (A + t • 1)⁻¹).mpr h_inv_cont
@@ -582,29 +673,51 @@ theorem logApprox_concave {n 𝕜 : Type*} [Fintype n] [DecidableEq n] [RCLike �
     {x y : HermitianMat n 𝕜} (hx : x.mat.PosDef) (hy : y.mat.PosDef)
     ⦃a b : ℝ⦄ (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) (T : ℝ) (hT : 0 ≤ T) :
     a • x.logApprox T + b • y.logApprox T ≤ (a • x + b • y).logApprox T := by
-  have h_integrable {z : HermitianMat n 𝕜} : z.mat.PosDef → IntervalIntegrable (fun t => (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (z + t • 1)⁻¹) MeasureTheory.volume 0 T := by
+  have h_integrable {z : HermitianMat n 𝕜} : z.mat.PosDef → IntervalIntegrable
+      (fun t => (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (z + t • 1)⁻¹) MeasureTheory.volume 0 T := by
     intro hz
     have h_integrable := integrable_inv_shift hz T hT
     rw [ intervalIntegrable_iff_integrableOn_Ioc_of_le hT ] at *
     refine MeasureTheory.Integrable.sub ?_ h_integrable
-    exact ContinuousOn.integrableOn_Icc ( by exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.smul ( ContinuousAt.inv₀ ( continuousAt_const.add continuousAt_id ) ( by linarith [ ht.1 ] ) ) continuousAt_const ) |> fun h => h.mono_set ( Set.Ioc_subset_Icc_self );
-  have h_int2 : IntervalIntegrable (fun t => (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹) MeasureTheory.volume 0 T := by
+    exact ContinuousOn.integrableOn_Icc ( by
+      exact continuousOn_of_forall_continuousAt fun t ht =>
+        ContinuousAt.smul ( ContinuousAt.inv₀ ( continuousAt_const.add continuousAt_id )
+          ( by linarith [ ht.1 ] ) ) continuousAt_const )
+      |> fun h => h.mono_set ( Set.Ioc_subset_Icc_self );
+  have h_int2 : IntervalIntegrable
+      (fun t => (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹)
+      MeasureTheory.volume 0 T := by
     exact h_integrable (Matrix.PosDef.Convex hx hy ha hb hab)
-  have h_integral_mono : ∫ t in (0)..T, a • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (x + t • 1)⁻¹) + b • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (y + t • 1)⁻¹) ≤ ∫ t in (0)..T, (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹ := by
-    have h_integral_mono : ∀ t ∈ Set.Icc 0 T, a • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (x + t • 1)⁻¹) + b • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (y + t • 1)⁻¹) ≤ (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹ := by
+  have h_integral_mono :
+      ∫ t in (0)..T, a • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (x + t • 1)⁻¹)
+          + b • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (y + t • 1)⁻¹) ≤
+        ∫ t in (0)..T, (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹ := by
+    have h_integral_mono : ∀ t ∈ Set.Icc 0 T,
+        a • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (x + t • 1)⁻¹)
+            + b • ((1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - (y + t • 1)⁻¹) ≤
+          (1 + t)⁻¹ • (1 : HermitianMat n 𝕜) - ((a • x + b • y) + t • 1)⁻¹ := by
       intros t ht
-      have h_inv_shift_convex : ((a • x + b • y) + t • 1)⁻¹ ≤ a • (x + t • 1)⁻¹ + b • (y + t • 1)⁻¹ := by
+      have h_inv_shift_convex :
+          ((a • x + b • y) + t • 1)⁻¹ ≤ a • (x + t • 1)⁻¹ + b • (y + t • 1)⁻¹ := by
         convert inv_shift_convex hx hy ha hb hab t ht.1 using 1;
       simp_all [smul_sub, ← smul_assoc ];
-      rw [ show ( 1 + t ) ⁻¹ • ( 1 : HermitianMat n 𝕜 ) = ( a * ( 1 + t ) ⁻¹ ) • ( 1 : HermitianMat n 𝕜 ) + ( b * ( 1 + t ) ⁻¹ ) • ( 1 : HermitianMat n 𝕜 ) by rw [ ← add_smul, ← add_mul, hab, one_mul ] ];
+      rw [ show ( 1 + t ) ⁻¹ • ( 1 : HermitianMat n 𝕜 ) =
+        ( a * ( 1 + t ) ⁻¹ ) • ( 1 : HermitianMat n 𝕜 )
+          + ( b * ( 1 + t ) ⁻¹ ) • ( 1 : HermitianMat n 𝕜 ) by
+        rw [ ← add_smul, ← add_mul, hab, one_mul ] ];
       convert sub_le_sub_left h_inv_shift_convex _ using 1 ; abel_nf;
     rw [ intervalIntegral.integral_of_le hT, intervalIntegral.integral_of_le hT ];
     apply MeasureTheory.integral_mono_ae
-    · exact ( (h_integrable hx).1.smul a |> fun h => h.add ( (h_integrable hy).1.smul b ) ) |> fun h => h.mono_measure ( MeasureTheory.Measure.restrict_mono ( Set.Ioc_subset_Ioc le_rfl le_rfl ) le_rfl );
+    · exact ( (h_integrable hx).1.smul a |> fun h => h.add ( (h_integrable hy).1.smul b ) )
+        |> fun h => h.mono_measure ( MeasureTheory.Measure.restrict_mono
+          ( Set.Ioc_subset_Ioc le_rfl le_rfl ) le_rfl );
     · exact h_int2.1.mono_set (Set.Ioc_subset_Ioc le_rfl le_rfl)
-    · filter_upwards [ MeasureTheory.ae_restrict_mem measurableSet_Ioc ] with t ht using h_integral_mono t <| Set.Ioc_subset_Icc_self ht;
+    · filter_upwards [ MeasureTheory.ae_restrict_mem measurableSet_Ioc ] with t ht using
+        h_integral_mono t <| Set.Ioc_subset_Icc_self ht;
   convert h_integral_mono using 1;
-  rw [ intervalIntegral.integral_add ( by exact (h_integrable hx).smul a ) ( by exact (h_integrable hy).smul b ), intervalIntegral.integral_smul, intervalIntegral.integral_smul ]
+  rw [ intervalIntegral.integral_add ( by exact (h_integrable hx).smul a )
+    ( by exact (h_integrable hy).smul b ), intervalIntegral.integral_smul,
+    intervalIntegral.integral_smul ]
   rw [logApprox, logApprox]
 
 open ComplexOrder in
@@ -614,31 +727,38 @@ The matrix logarithm is operator concave.
 theorem log_concave {x y : HermitianMat d 𝕜} (hx : x.mat.PosDef) (hy : y.mat.PosDef)
     ⦃a b : ℝ⦄ (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) :
     a • x.log + b • y.log ≤ (a • x + b • y).log := by
-  apply le_of_tendsto_of_tendsto (b := .atTop) (f := fun T => a • x.logApprox T + b • y.logApprox T) (g := (a • x + b • y).logApprox)
-  · exact ((tendsto_const_nhds.smul (tendsto_logApprox hx)).add (tendsto_const_nhds.smul (y.tendsto_logApprox hy)))
+  apply le_of_tendsto_of_tendsto (b := .atTop)
+    (f := fun T => a • x.logApprox T + b • y.logApprox T) (g := (a • x + b • y).logApprox)
+  · exact ((tendsto_const_nhds.smul (tendsto_logApprox hx)).add
+      (tendsto_const_nhds.smul (y.tendsto_logApprox hy)))
   · apply tendsto_logApprox
     exact Matrix.PosDef.Convex hx hy ha hb hab
   · rw [Filter.EventuallyLE, Filter.eventually_atTop]
     exact ⟨0, logApprox_concave hx hy ha hb hab⟩
 
 /-
-The logarithm of the Kronecker product of two diagonal Hermitian matrices is the sum of the Kronecker products of their logarithms with the identity matrix.
+The logarithm of the Kronecker product of two diagonal Hermitian matrices is the sum of the
+Kronecker products of their logarithms with the identity matrix.
 -/
-lemma log_kron_diagonal {m n 𝕜 : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n] [RCLike 𝕜]
+lemma log_kron_diagonal {m n 𝕜 : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+    [RCLike 𝕜]
     {d₁ : m → ℝ} {d₂ : n → ℝ} (h₁ : ∀ i, 0 < d₁ i) (h₂ : ∀ j, 0 < d₂ j) :
     (diagonal 𝕜 d₁ ⊗ₖ diagonal 𝕜 d₂).log =
     (diagonal 𝕜 d₁).log ⊗ₖ 1 + 1 ⊗ₖ (diagonal 𝕜 d₂).log := by
-  have h_eq : (diagonal 𝕜 d₁ ⊗ₖ diagonal 𝕜 d₂) = (diagonal 𝕜 (fun (i : m × n) => d₁ i.1 * d₂ i.2)) := by
+  have h_eq : (diagonal 𝕜 d₁ ⊗ₖ diagonal 𝕜 d₂) =
+      (diagonal 𝕜 (fun (i : m × n) => d₁ i.1 * d₂ i.2)) := by
     exact kronecker_diagonal d₁ d₂
   convert congr_arg _ h_eq using 1;
   -- By definition of logarithm, we can rewrite the right-hand side.
   have h_rhs : (diagonal 𝕜 (fun (i : m × n) => d₁ i.1 * d₂ i.2)).log =
     (diagonal 𝕜 (fun (i : m × n) => Real.log (d₁ i.1) + Real.log (d₂ i.2))) := by
       rw [log, cfc_diagonal ];
-      exact congr_arg _ ( funext fun i => Real.log_mul ( ne_of_gt ( h₁ i.1 ) ) ( ne_of_gt ( h₂ i.2 ) ) );
+      exact congr_arg _
+        ( funext fun i => Real.log_mul ( ne_of_gt ( h₁ i.1 ) ) ( ne_of_gt ( h₂ i.2 ) ) );
   rw [ h_rhs ];
   have h_rhs : (diagonal 𝕜 (fun (i : m × n) => Real.log (d₁ i.1) + Real.log (d₂ i.2))) =
-    (diagonal 𝕜 (fun (i : m × n) => Real.log (d₁ i.1))) + (diagonal 𝕜 (fun (i : m × n) => Real.log (d₂ i.2))) := by
+    (diagonal 𝕜 (fun (i : m × n) => Real.log (d₁ i.1)))
+      + (diagonal 𝕜 (fun (i : m × n) => Real.log (d₂ i.2))) := by
       ext1
       simp [ diagonal ]
   rw [ h_rhs ];
@@ -656,7 +776,8 @@ lemma log_kron_diagonal {m n 𝕜 : Type*} [Fintype m] [DecidableEq m] [Fintype 
     · simp
 
 /--
-The logarithm of a Hermitian matrix conjugated by a unitary matrix is the conjugate of the logarithm.
+The logarithm of a Hermitian matrix conjugated by a unitary matrix is the conjugate of the
+logarithm.
 -/
 lemma log_conj_unitary (A : HermitianMat d 𝕜) (U : Matrix.unitaryGroup d 𝕜) :
     (A.conj U.val).log = A.log.conj U.val :=
@@ -673,7 +794,8 @@ lemma log_kron_diagonal_with_proj {f : d → ℝ} {g : d₂ → ℝ}  :
     (diagonal 𝕜 f ⊗ₖ diagonal 𝕜 g).log =
     (diagonal 𝕜 f).log ⊗ₖ (diagonal 𝕜 g).supportProj +
     (diagonal 𝕜 f).supportProj ⊗ₖ (diagonal 𝕜 g).log := by
-  have h_diag_kron : (diagonal 𝕜 f ⊗ₖ diagonal 𝕜 g).log = diagonal 𝕜 (fun i ↦ Real.log (f i.1 * g i.2)) := by
+  have h_diag_kron : (diagonal 𝕜 f ⊗ₖ diagonal 𝕜 g).log =
+      diagonal 𝕜 (fun i ↦ Real.log (f i.1 * g i.2)) := by
     rw [kronecker_diagonal, log]
     exact cfc_diagonal _ _
   simp_all [ HermitianMat.ext_iff, cfc_diagonal, log, supportProj_eq_cfc ];
@@ -698,7 +820,8 @@ lemma log_kron_with_proj : (A ⊗ₖ B).log = A.log ⊗ₖ B.supportProj + A.sup
   rw [← kronecker_conj, log_conj_unitary _ ⟨_, Matrix.kronecker_mem_unitary UA.2 UB.2⟩]
   rw [log_kron_diagonal_with_proj, map_add (conj _)]
   congr 1
-  <;> rw [supportProj_eq_cfc, supportProj_eq_cfc, cfc_conj_unitary, log_conj_unitary, kronecker_conj]
+  <;> rw [supportProj_eq_cfc, supportProj_eq_cfc, cfc_conj_unitary, log_conj_unitary,
+    kronecker_conj]
 
 /--
 The matrix logarithm of the Kronecker product of two nonsingular Hermitian matrices is

--- a/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean
@@ -196,8 +196,9 @@ lemma Real.integral_inv_sub_inv_finite (x T : ℝ) (hx : 0 < x) (hT : 0 < T) :
   · rw [ ← Real.log_mul, intervalIntegral.integral_deriv_eq_sub' ];
     field_simp;
     rw [ intervalIntegral.integral_deriv_eq_sub' ];
-    any_goals intro t ht;
-      exact Real.differentiableAt_log ( by cases Set.mem_uIcc.mp ht <;> linarith );
+    any_goals
+      intro t ht
+      exact Real.differentiableAt_log ( by cases Set.mem_uIcc.mp ht <;> linarith )
     any_goals positivity;
     · rw [ Real.log_div ( by positivity ) ( by positivity ),
         Real.log_mul ( by positivity ) ( by positivity ) ] ; norm_num;

--- a/QuantumInfo/ForMathlib/HermitianMat/Order.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Order.lean
@@ -119,7 +119,8 @@ theorem le_trace_smul_one [DecidableEq n] (hA : 0 ≤ A) : A ≤ A.trace • 1 :
   exact Finset.single_le_sum (fun j _ ↦ hA'.eigenvalues_nonneg j) (Finset.mem_univ i)
 
 /-- The Kronecker product of two nonnegative Hermitian matrices is nonnegative. -/
-theorem kronecker_nonneg {A : HermitianMat m 𝕜} (hA : 0 ≤ A) (hB : 0 ≤ B) : 0 ≤ A ⊗ₖ B := by
+theorem kronecker_nonneg {A : HermitianMat m 𝕜} (hA : 0 ≤ A) (hB : 0 ≤ B) :
+    0 ≤ A ⊗ₖ B := by
   rw [zero_le_iff, kronecker_mat]
   classical exact (zero_le_iff.mp hA).PosSemidef_kronecker (zero_le_iff.mp hB)
 
@@ -193,8 +194,10 @@ meta partial def findMatrixPSDInExpr (e : Expr) (p : Expr) (ty : Expr) :
         let nonemptyType ← mkAppM ``Nonempty #[nType]
         match ← try? (synthInstance nonemptyType) with
         | some nonemptyInst =>
-          -- posDef_to_pos : {𝕜} → [RCLike 𝕜] → {n} → [Fintype n] → {A} → (hA : A.PosDef) → [Nonempty n] → 0 < A
-          let pf ← mkAppOptM ``HermitianMat.posDef_to_pos #[none, none, none, none, none, p, nonemptyInst]
+          -- posDef_to_pos : {𝕜} → [RCLike 𝕜] → {n} → [Fintype n] → {A} → (hA : A.PosDef) →
+          -- [Nonempty n] → 0 < A
+          let pf ← mkAppOptM ``HermitianMat.posDef_to_pos
+            #[none, none, none, none, none, p, nonemptyInst]
           return some (true, pf)
         | none =>
           let pSemidef ← mkAppM ``Matrix.PosDef.posSemidef #[p]
@@ -271,8 +274,10 @@ meta partial def findHermitianMatPSDInExpr (e : Expr) (p : Expr) (ty : Expr) :
             let nonemptyType ← mkAppM ``Nonempty #[nType]
             match ← try? (synthInstance nonemptyType) with
             | some nonemptyInst =>
-              -- mat_posDef_to_pos : {𝕜} → [RCLike 𝕜] → {n} → [Fintype n] → {A} → [Nonempty n] → (hA : A.mat.PosDef) → 0 < A
-              let pf ← mkAppOptM ``HermitianMat.mat_posDef_to_pos #[none, none, none, none, none, nonemptyInst, p]
+              -- mat_posDef_to_pos : {𝕜} → [RCLike 𝕜] → {n} → [Fintype n] → {A} → [Nonempty n] →
+              -- (hA : A.mat.PosDef) → 0 < A
+              let pf ← mkAppOptM ``HermitianMat.mat_posDef_to_pos
+                #[none, none, none, none, none, nonemptyInst, p]
               return some (true, pf)
             | none =>
               let pSemidef ← mkAppM ``Matrix.PosDef.posSemidef #[p]
@@ -307,7 +312,8 @@ meta def evalHermitianMatPSD : PositivityExt where eval {_u _α} _zα _pα e := 
       else
         best := .nonnegative pf
   match best with
-  | .none => throwError "evalHermitianMatPSD: no A.mat.PosSemidef or A.mat.PosDef hypothesis found for {e}"
+  | .none => throwError "evalHermitianMatPSD: no A.mat.PosSemidef or A.mat.PosDef hypothesis \
+      found for {e}"
   | other => return other
 
 open Lean Meta Mathlib.Meta.Positivity in
@@ -370,7 +376,8 @@ example (A B : HermitianMat n ℂ) (hA : 0 < A) (hB : 0 < B) :
   positivity
 
 omit [Fintype n] in
-theorem convex_cone (hA : 0 ≤ A) (hB : 0 ≤ B) {c₁ c₂ : ℝ} (hc₁ : 0 ≤ c₁) (hc₂ : 0 ≤ c₂) :
+theorem convex_cone (hA : 0 ≤ A) (hB : 0 ≤ B) {c₁ c₂ : ℝ} (hc₁ : 0 ≤ c₁)
+    (hc₂ : 0 ≤ c₂) :
     0 ≤ (c₁ • A + c₂ • B) := by
   rw [zero_le_iff] at hA hB ⊢
   exact (hA.smul hc₁).add (hB.smul hc₂)
@@ -483,20 +490,23 @@ theorem ker_conj [DecidableEq n] (hA : 0 ≤ A) (B : Matrix n n 𝕜) :
 
   ext v; simp [HermitianMat.conj];
   constructor <;> intro h;
-  · have := Matrix.PosSemidef.dotProduct_mulVec_zero_iff ( show Matrix.PosSemidef A.mat from zero_le_iff.mp hA );
+  · have := Matrix.PosSemidef.dotProduct_mulVec_zero_iff
+      ( show Matrix.PosSemidef A.mat from zero_le_iff.mp hA );
     convert this ( Bᴴ.mulVec v ) |>.1 _ using 1;
     · rw [ mem_ker_iff_mulVec_zero ];
       congr! 2;
     · convert congr_arg ( fun x : EuclideanSpace _ _ => star v.ofLp ⬝ᵥ x ) h using 1
       simp [Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec]
-      · simp [Matrix.mul_assoc, Matrix.dotProduct_mulVec, Matrix.mulVec_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose, lin]
+      · simp [Matrix.mul_assoc, Matrix.dotProduct_mulVec, Matrix.mulVec_mulVec,
+          Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose, lin]
       · simp [dotProduct]
   · simp only [ker, Matrix.mul_assoc, LinearMap.mem_ker]
     convert congr_arg B.toEuclideanLin h using 1
     · simp [HermitianMat.lin, Matrix.toEuclideanLin]
     · exact Eq.symm (LinearMap.map_zero (Matrix.toEuclideanLin B))
 
-theorem ker_le_of_le_smul {α : ℝ} [DecidableEq n] (hα : α ≠ 0) (hA : 0 ≤ A) (hAB : A ≤ α • B) : B.ker ≤ A.ker := by
+theorem ker_le_of_le_smul {α : ℝ} [DecidableEq n] (hα : α ≠ 0) (hA : 0 ≤ A) (hAB : A ≤ α • B) :
+    B.ker ≤ A.ker := by
   rw [← ker_pos_smul B hα]
   exact ker_antitone hA hAB
 
@@ -578,7 +588,8 @@ theorem subtype_mk_pos {M : Matrix m m 𝕜} (h : 0 < M) :
   h
 
 open MatrixOrder in
-private theorem _root_.Matrix.eigenvalues_nonneg [DecidableEq n] {M : Matrix n n 𝕜} (h : 0 ≤ M) (i : n) :
+private theorem _root_.Matrix.eigenvalues_nonneg [DecidableEq n] {M : Matrix n n 𝕜} (h : 0 ≤ M)
+    (i : n) :
     0 ≤ (Matrix.LE.le.posSemidef h).isHermitian.eigenvalues i :=
   (Matrix.LE.le.posSemidef h).eigenvalues_nonneg i
 
@@ -668,12 +679,14 @@ example (M : Matrix n m ℂ) : 0 ≤ M * M.conjTranspose := by positivity
 
 -- Test: ⟨Mᴴ * M, _⟩ nonneg as HermitianMat
 example (M : Matrix m n ℂ) :
-    (0 : HermitianMat n ℂ) ≤ ⟨M.conjTranspose * M, Matrix.isHermitian_conjTranspose_mul_self M⟩ := by
+    (0 : HermitianMat n ℂ) ≤
+      ⟨M.conjTranspose * M, Matrix.isHermitian_conjTranspose_mul_self M⟩ := by
   positivity
 
 -- Test: ⟨M * Mᴴ, _⟩ nonneg as HermitianMat
 example (M : Matrix n m ℝ) :
-    (0 : HermitianMat n ℝ) ≤ ⟨M * M.conjTranspose, Matrix.isHermitian_mul_conjTranspose_self M⟩ := by
+    (0 : HermitianMat n ℝ) ≤
+      ⟨M * M.conjTranspose, Matrix.isHermitian_mul_conjTranspose_self M⟩ := by
   positivity
 
 example (M : Matrix n n ℂ) (i : n) (A : HermitianMat n ℂ) (hA : 0 ≤ A) :

--- a/QuantumInfo/ForMathlib/HermitianMat/Peierls.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Peierls.lean
@@ -34,7 +34,8 @@ Peierls inequality: for a convex function g, the sum of g applied to the
 diagonal entries of a Hermitian matrix is at most the trace of g(A).
 This follows from Jensen's inequality applied to the spectral decomposition.
 -/
-theorem peierls_inequality (A : HermitianMat d ℂ) (g : ℝ → ℝ) (hg : ConvexOn ℝ Set.univ g) :
+theorem peierls_inequality (A : HermitianMat d ℂ) (g : ℝ → ℝ)
+    (hg : ConvexOn ℝ Set.univ g) :
     ∑ i, g ((A.mat i i).re) ≤ (A.cfc g).trace := by
   -- By the properties of the trace and the convexity of $g$, we have:
   have h_trace_le : ∑ i, g ((A.mat i i).re) ≤ ∑ j, g (A.H.eigenvalues j) *
@@ -66,7 +67,8 @@ theorem peierls_inequality (A : HermitianMat d ℂ) (g : ℝ → ℝ) (hg : Conv
     exact fun j => Matrix.unitaryGroup_row_norm (H A).eigenvectorUnitary j
   simp_all [trace_cfc_eq]
 
-theorem peierls_inequality_ici (A : HermitianMat d ℂ) (g : ℝ → ℝ) (hg : ConvexOn ℝ (Set.Ici 0) g)
+theorem peierls_inequality_ici (A : HermitianMat d ℂ) (g : ℝ → ℝ)
+  (hg : ConvexOn ℝ (Set.Ici 0) g)
   (hA : 0 ≤ A) :
     ∑ i, g ((A.mat i i).re) ≤ (A.cfc g).trace := by
   -- By the properties of the trace and the convexity of $g$, we have:
@@ -146,13 +148,15 @@ theorem trace_function_convex_univ (g : ℝ → ℝ) (hg : ConvexOn ℝ Set.univ
       rw [h_eigenvalue]
       exact hg.2 trivial trivial ha hb hab
     simpa only [Finset.mul_sum, Finset.sum_add_distrib] using Finset.sum_le_sum fun i _ => h_sum i
-  have hAtr : ∑ i, g ((A.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤ (A.cfc g).trace := by
+  have hAtr : ∑ i, g ((A.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤
+      (A.cfc g).trace := by
     convert peierls_inequality _ _ hg using 1
     convert trace_cfc_conj_unitary _ _ _ using 1
     rotate_right
     exact C.H.eigenvectorUnitary
     simp [conj_conj]
-  have hBtr : ∑ i, g ((B.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤ (B.cfc g).trace := by
+  have hBtr : ∑ i, g ((B.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤
+      (B.cfc g).trace := by
     convert peierls_inequality _ _ hg using 1
     convert trace_cfc_conj_unitary _ _ _
     rotate_right
@@ -208,7 +212,8 @@ theorem trace_function_convex_ici {g : ℝ → ℝ} (hg : ConvexOn ℝ (Set.Ici 
         exact (Complex.le_def.mp (((zero_le_iff.mp (conj_nonneg _ hB)).diag_nonneg (i := i)))).1
     simpa only [Finset.mul_sum, Finset.sum_add_distrib] using Finset.sum_le_sum fun i _ => h_sum i
   -- With convexity of g, we have ∑_i g(A_ii) ≤ Tr(g(A)) and ∑_i g(B_ii) ≤ Tr(g(B))
-  have hAtr : ∑ i, g ((A.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤ (A.cfc g).trace := by
+  have hAtr : ∑ i, g ((A.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤
+      (A.cfc g).trace := by
     have hA' : 0 ≤ A.conj (star C.H.eigenvectorUnitary.val) := A.conj_nonneg _ hA
     calc ∑ i, g ((A.conj (star C.H.eigenvectorUnitary.val)).mat i i |> Complex.re)
         ≤ ((A.conj (star C.H.eigenvectorUnitary.val)).cfc g).trace :=
@@ -216,7 +221,8 @@ theorem trace_function_convex_ici {g : ℝ → ℝ} (hg : ConvexOn ℝ (Set.Ici 
       _ = (A.cfc g).trace :=
           trace_cfc_conj_unitary A g ⟨star C.H.eigenvectorUnitary.val, by
             rw [Matrix.mem_unitaryGroup_iff, star_star]; exact C.H.eigenvectorUnitary.prop.1⟩
-  have hBtr : ∑ i, g ((B.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤ (B.cfc g).trace := by
+  have hBtr : ∑ i, g ((B.conj (star C.H.eigenvectorUnitary.val)).mat i i).re ≤
+      (B.cfc g).trace := by
     have hB' : 0 ≤ B.conj (star C.H.eigenvectorUnitary.val) := B.conj_nonneg _ hB
     calc ∑ i, g ((B.conj (star C.H.eigenvectorUnitary.val)).mat i i |> Complex.re)
         ≤ ((B.conj (star C.H.eigenvectorUnitary.val)).cfc g).trace :=

--- a/QuantumInfo/ForMathlib/HermitianMat/Proj.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Proj.lean
@@ -47,10 +47,12 @@ in the orthogonal complement of that submodule.
 -/
 noncomputable def projector (S : Submodule 𝕜 (EuclideanSpace 𝕜 n)) : HermitianMat n 𝕜 :=
   let P := S.subtypeL.comp S.orthogonalProjection
-  ⟨P.toMatrix (EuclideanSpace.basisFun n 𝕜).toBasis (EuclideanSpace.basisFun n 𝕜).toBasis, by
+  ⟨P.toMatrix (EuclideanSpace.basisFun n 𝕜).toBasis
+      (EuclideanSpace.basisFun n 𝕜).toBasis, by
     ext i j
     simpa [EuclideanSpace.inner_single_right, EuclideanSpace.inner_single_left] using
-      S.inner_starProjection_left_eq_right (EuclideanSpace.single i 1) (EuclideanSpace.single j 1)⟩
+      S.inner_starProjection_left_eq_right (EuclideanSpace.single i 1)
+        (EuclideanSpace.single j 1)⟩
 
 theorem projector_add_orthogonal : projector S + projector Sᗮ = 1 := by
   unfold projector;
@@ -79,11 +81,17 @@ theorem projector_ker : (projector S).ker = Sᗮ := by
 
 @[simp]
 theorem trace_projector : (projector S).trace = (Module.finrank 𝕜 S : ℝ) := by
-  suffices h_trace : ((S.subtype ∘ₗ S.orthogonalProjection).toMatrix (EuclideanSpace.basisFun n 𝕜).toBasis (EuclideanSpace.basisFun n 𝕜).toBasis).trace = Module.finrank 𝕜 S by
+  suffices h_trace : ((S.subtype ∘ₗ S.orthogonalProjection).toMatrix
+      (EuclideanSpace.basisFun n 𝕜).toBasis
+      (EuclideanSpace.basisFun n 𝕜).toBasis).trace = Module.finrank 𝕜 S by
     simp [projector, trace_eq_re_trace, h_trace]
-  suffices h_trace : ((S.subtype ∘ₗ S.orthogonalProjection).toMatrix (EuclideanSpace.basisFun n 𝕜).toBasis (EuclideanSpace.basisFun n 𝕜).toBasis).trace = (LinearMap.id.toMatrix (Module.finBasis 𝕜 S) (Module.finBasis 𝕜 S)).trace by
+  suffices h_trace : ((S.subtype ∘ₗ S.orthogonalProjection).toMatrix
+      (EuclideanSpace.basisFun n 𝕜).toBasis
+      (EuclideanSpace.basisFun n 𝕜).toBasis).trace
+      = (LinearMap.id.toMatrix (Module.finBasis 𝕜 S) (Module.finBasis 𝕜 S)).trace by
     simp [h_trace]
-  rw [LinearMap.toMatrix_comp _ (Module.finBasis 𝕜 ↥S), Matrix.trace_mul_comm, ← LinearMap.toMatrix_comp]
+  rw [LinearMap.toMatrix_comp _ (Module.finBasis 𝕜 ↥S), Matrix.trace_mul_comm,
+    ← LinearMap.toMatrix_comp]
   congr 2
   ext1
   simp [Submodule.orthogonalProjection_mem_subspace_eq_self]
@@ -120,7 +128,8 @@ theorem supportProj_of_nonSingular [NonSingular A] : A.supportProj = 1 := by
   simpa using A.kerProj_add_supportProj
 
 /--
-The projector onto a submodule S is the sum of the outer products of the vectors in an orthonormal basis of S.
+The projector onto a submodule S is the sum of the outer products of the vectors in an
+orthonormal basis of S.
 -/
 theorem projector_eq_sum_rankOne (b : OrthonormalBasis ι 𝕜 S) :
     (projector S).mat = ∑ i, Matrix.vecMulVec (S.subtype (b i)) (star (S.subtype (b i))) := by
@@ -128,10 +137,13 @@ theorem projector_eq_sum_rankOne (b : OrthonormalBasis ι 𝕜 S) :
   ext i j;
   field_simp;
   simp [Matrix.vecMulVec]
-  -- By definition of orthogonal projection, we can write the projection of $e_j$ onto $S$ as $\sum_{k} \langle e_j, b_k \rangle b_k$.
-  have h_proj : ∀ j : n, S.orthogonalProjection (EuclideanSpace.single j 1) = ∑ k, (star (b k |>.1 j)) • (b k |>.1) := by
+  -- By definition of orthogonal projection, we can write the projection of $e_j$ onto $S$ as
+  -- $\sum_{k} \langle e_j, b_k \rangle b_k$.
+  have h_proj : ∀ j : n, S.orthogonalProjection (EuclideanSpace.single j 1)
+      = ∑ k, (star (b k |>.1 j)) • (b k |>.1) := by
     intro j
-    have h_proj : S.orthogonalProjection (EuclideanSpace.single j 1) = ∑ k, (inner 𝕜 (b k |>.1) (EuclideanSpace.single j 1)) • (b k |>.1) := by
+    have h_proj : S.orthogonalProjection (EuclideanSpace.single j 1)
+        = ∑ k, (inner 𝕜 (b k |>.1) (EuclideanSpace.single j 1)) • (b k |>.1) := by
       convert b.sum_repr ( S.orthogonalProjection ( EuclideanSpace.single j 1 ) ) using 1;
       constructor <;> intro h <;> simp_all [ Subtype.ext_iff, b.repr_apply_apply ];
     convert h_proj using 3
@@ -141,49 +153,65 @@ theorem projector_eq_sum_rankOne (b : OrthonormalBasis ι 𝕜 S) :
 
 set_option backward.isDefEq.respectTransparency false in
 /--
-The projector onto the support of A is the sum of the projections onto the eigenvectors with non-zero eigenvalues.
+The projector onto the support of A is the sum of the projections onto the eigenvectors with
+non-zero eigenvalues.
 -/
 lemma projector_support_eq_sum : A.supportProj.mat =
     ∑ i, (if A.H.eigenvalues i = 0 then 0 else 1) •
       Matrix.vecMulVec (A.H.eigenvectorBasis i) (star (A.H.eigenvectorBasis i)) := by
-  have h_support : A.support = Submodule.span (𝕜) (Set.image (fun i => A.H.eigenvectorBasis i) { i | A.H.eigenvalues i ≠ 0 }) := by
+  have h_support : A.support = Submodule.span (𝕜)
+      (Set.image (fun i => A.H.eigenvectorBasis i) { i | A.H.eigenvalues i ≠ 0 }) := by
     refine' le_antisymm _ _;
     · intro x hx;
-      -- By definition of $A.support$, we know that $x$ is in the orthogonal complement of the kernel of $A$.
-      have h_orthogonal_complement : x ∈ (A.ker : Submodule (𝕜) (EuclideanSpace (𝕜) n))ᗮ := by
+      -- By definition of $A.support$, we know that $x$ is in the orthogonal complement of the
+      -- kernel of $A$.
+      have h_orthogonal_complement :
+          x ∈ (A.ker : Submodule (𝕜) (EuclideanSpace (𝕜) n))ᗮ := by
         convert hx using 1;
         exact ker_orthogonal_eq_support A;
-      -- By definition of $A.ker$, we know that $x$ is orthogonal to all eigenvectors with zero eigenvalues.
-      have h_orthogonal_zero_eigenvalues : ∀ i, A.H.eigenvalues i = 0 → inner (𝕜) (A.H.eigenvectorBasis i) x = 0 := by
+      -- By definition of $A.ker$, we know that $x$ is orthogonal to all eigenvectors with zero
+      -- eigenvalues.
+      have h_orthogonal_zero_eigenvalues :
+          ∀ i, A.H.eigenvalues i = 0 → inner (𝕜) (A.H.eigenvectorBasis i) x = 0 := by
         intro i hi
         have h_eigenvector_zero : A.mat.mulVec (A.H.eigenvectorBasis i) = 0 := by
           have := A.H.mulVec_eigenvectorBasis i; aesop;
         convert h_orthogonal_complement ( A.H.eigenvectorBasis i ) _ using 1;
         exact (mem_ker_iff_mulVec_zero A ((H A).eigenvectorBasis i)).mpr h_eigenvector_zero;
-      -- By definition of $A.ker$, we know that $x$ can be written as a linear combination of eigenvectors with non-zero eigenvalues.
-      have h_decomp : x = ∑ i, (inner (𝕜) (A.H.eigenvectorBasis i) x) • A.H.eigenvectorBasis i := by
+      -- By definition of $A.ker$, we know that $x$ can be written as a linear combination of
+      -- eigenvectors with non-zero eigenvalues.
+      have h_decomp :
+          x = ∑ i, (inner (𝕜) (A.H.eigenvectorBasis i) x) • A.H.eigenvectorBasis i := by
         exact Eq.symm (OrthonormalBasis.sum_repr' (H A).eigenvectorBasis x);
       rw [ h_decomp ];
-      exact Submodule.sum_mem _ fun i _ => if hi : A.H.eigenvalues i = 0 then by simp [h_orthogonal_zero_eigenvalues i hi ] else Submodule.smul_mem _ _ ( Submodule.subset_span ⟨ i, hi, rfl ⟩ );
+      exact Submodule.sum_mem _ fun i _ =>
+        if hi : A.H.eigenvalues i = 0 then by simp [h_orthogonal_zero_eigenvalues i hi ]
+        else Submodule.smul_mem _ _ ( Submodule.subset_span ⟨ i, hi, rfl ⟩ );
     · rw [ Submodule.span_le, Set.image_subset_iff ];
       intro i hi;
       simp_all [ HermitianMat.support ];
       use (1 / A.H.eigenvalues i) • A.H.eigenvectorBasis i;
-      convert congr_arg ( fun x => ( 1 / A.H.eigenvalues i ) • x ) ( A.H.mulVec_eigenvectorBasis i ) using 1
+      convert congr_arg ( fun x => ( 1 / A.H.eigenvalues i ) • x )
+        ( A.H.mulVec_eigenvectorBasis i ) using 1
       simp [hi]
       simp [ funext_iff, Matrix.mulVec, dotProduct ];
       exact PiLp.ext_iff;
-  have h_orthonormal_basis : ∃ b : OrthonormalBasis {i : n | A.H.eigenvalues i ≠ 0} (𝕜) (Submodule.span (𝕜) (Set.image (fun i => A.H.eigenvectorBasis i) {i | A.H.eigenvalues i ≠ 0})), ∀ i, b i = A.H.eigenvectorBasis i := by
+  have h_orthonormal_basis : ∃ b : OrthonormalBasis {i : n | A.H.eigenvalues i ≠ 0} (𝕜)
+      (Submodule.span (𝕜)
+        (Set.image (fun i => A.H.eigenvectorBasis i) {i | A.H.eigenvalues i ≠ 0})),
+      ∀ i, b i = A.H.eigenvectorBasis i := by
     refine' ⟨ _, _ ⟩;
     refine' OrthonormalBasis.mk _ _;
-    use fun i => ⟨ A.H.eigenvectorBasis i, Submodule.subset_span ( Set.mem_image_of_mem _ i.2 ) ⟩;
+    use fun i =>
+      ⟨ A.H.eigenvectorBasis i, Submodule.subset_span ( Set.mem_image_of_mem _ i.2 ) ⟩;
     all_goals simp [ Orthonormal ];
     · intro i j hij; have := A.H.eigenvectorBasis.orthonormal; simp_all [ orthonormal_iff_ite ] ;
       exact fun h => hij <| Subtype.ext h;
     · rw [ Submodule.eq_top_iff' ];
       rintro ⟨ x, hx ⟩;
       rw [ Submodule.mem_span ] at hx ⊢;
-      intro p hp; specialize hx ( Submodule.map ( Submodule.subtype _ ) p ) ; simp_all [ Set.range_subset_iff ] ;
+      intro p hp; specialize hx ( Submodule.map ( Submodule.subtype _ ) p ) ;
+      simp_all [ Set.range_subset_iff ] ;
       exact hx fun i hi => ⟨ _, hp i hi, rfl ⟩;
   obtain ⟨ b, hb ⟩ := h_orthonormal_basis
   have h_sum_rankOne : (projector A.support).mat = ∑ i, Matrix.vecMulVec (b i) (star (b i)) := by
@@ -192,7 +220,8 @@ lemma projector_support_eq_sum : A.supportProj.mat =
   simp_all [ Finset.sum_ite ];
   convert h_sum_rankOne using 1;
   · exact h_support ▸ rfl;
-  · refine' Finset.sum_bij ( fun i hi => ⟨ i, by simpa using hi ⟩ ) _ _ _ _ <;> simp [ Finset.mem_filter ]
+  · refine' Finset.sum_bij ( fun i hi => ⟨ i, by simpa using hi ⟩ ) _ _ _ _ <;>
+      simp [ Finset.mem_filter ]
 
 /-
 `HermitianMat.supportProj` as a cfc.

--- a/QuantumInfo/ForMathlib/HermitianMat/Reindex.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Reindex.lean
@@ -88,7 +88,8 @@ theorem conj_submatrix (B : Matrix d₂ d₄ 𝕜) (e : d₃ ≃ d₂) (f : d �
   ext1
   simp [conj_apply, ← Matrix.submatrix_mul_equiv (e₂ := .refl d)]
 
-theorem reindex_eq_conj [DecidableEq d] (e : d ≃ d₂) : A.reindex e = A.conj (Matrix.reindex e (.refl d) 1) := by
+theorem reindex_eq_conj [DecidableEq d] (e : d ≃ d₂) :
+    A.reindex e = A.conj (Matrix.reindex e (.refl d) 1) := by
   ext : 3
   simp [-mat_apply, reindex, conj_apply, Matrix.submatrix,
     Matrix.mul_apply, Matrix.one_apply]

--- a/QuantumInfo/ForMathlib/HermitianMat/Rpow.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Rpow.lean
@@ -64,7 +64,8 @@ theorem diagonal_pow (f : d → ℝ) :
   rfl
 
 @[fun_prop]
-theorem rpow_const_continuous {r : ℝ} (hr : 0 ≤ r) : Continuous (fun A : HermitianMat d ℂ ↦ A ^ r) := by
+theorem rpow_const_continuous {r : ℝ} (hr : 0 ≤ r) :
+    Continuous (fun A : HermitianMat d ℂ ↦ A ^ r) := by
   exact HermitianMat.cfc_continuous (Real.continuous_rpow_const hr)
 
 @[fun_prop]
@@ -78,7 +79,8 @@ theorem const_rpow_continuous [NonSingular A] : Continuous (fun r : ℝ ↦ A ^ 
 For a fixed Hermitian matrix A, the function x ↦ A^x is continuous for x > 0.
 -/
 @[fun_prop]
-theorem continuousOn_rpow_pos (A : HermitianMat d ℂ) : ContinuousOn (fun x : ℝ ↦ A ^ x) (Set.Ioi 0) := by
+theorem continuousOn_rpow_pos (A : HermitianMat d ℂ) :
+    ContinuousOn (fun x : ℝ ↦ A ^ x) (Set.Ioi 0) := by
   apply A.continuousOn_cfc_fun (hA := subset_rfl)
   intro i _ x hx
   exact (Real.continuousAt_const_rpow' hx.ne').continuousWithinAt
@@ -87,7 +89,8 @@ theorem continuousOn_rpow_pos (A : HermitianMat d ℂ) : ContinuousOn (fun x : �
 For a fixed Hermitian matrix A, the function x ↦ A^x is continuous for x < 0.
 -/
 @[fun_prop]
-theorem continuousOn_rpow_neg (A : HermitianMat d ℂ) : ContinuousOn (fun x : ℝ ↦ A ^ x) (Set.Iio 0) := by
+theorem continuousOn_rpow_neg (A : HermitianMat d ℂ) :
+    ContinuousOn (fun x : ℝ ↦ A ^ x) (Set.Iio 0) := by
   apply A.continuousOn_cfc_fun (hA := subset_rfl)
   intro i _ x hx
   exact (Real.continuousAt_const_rpow' hx.ne).continuousWithinAt
@@ -168,7 +171,8 @@ theorem inv_eq_rpow_neg_one (hA : A.mat.PosDef) : A⁻¹ = A ^ (-1 : ℝ) := by
 open ComplexOrder in
 theorem sandwich_self (hB : B.mat.PosDef) :
     (B.conj (B ^ (-1/2 : ℝ)).mat) = 1 := by
-  have hB_inv_sqrt : (B ^ (-1 / 2 : ℝ)).mat * (B ^ (-1 / 2 : ℝ)).mat = (B ^ (-1 : ℝ)).mat := by
+  have hB_inv_sqrt :
+      (B ^ (-1 / 2 : ℝ)).mat * (B ^ (-1 / 2 : ℝ)).mat = (B ^ (-1 : ℝ)).mat := by
     rw [ ← mat_rpow_add ] <;> norm_num
     rw [zero_le_iff]
     exact hB.posSemidef
@@ -200,7 +204,8 @@ lemma rpow_inv_eq_neg_rpow (hA : A.mat.PosDef) (p : ℝ) : (A ^ p)⁻¹ = A ^ (-
         exact fun x hx => by simp [ ← Real.rpow_add hx ] ;
       rw [ h_inv, cfc_const ] ; norm_num;
     exact h_inv;
-  -- By definition of matrix inverse, if $(A^p) * (A^{-p}) = 1$, then $(A^{-p})$ is the inverse of $(A^p)$.
+  -- By definition of matrix inverse, if $(A^p) * (A^{-p}) = 1$, then $(A^{-p})$ is the inverse
+  -- of $(A^p)$.
   have h_inv_def : (A ^ p).mat⁻¹ = (A ^ (-p)).mat := by
     exact Matrix.inv_eq_right_inv h_inv;
   convert congr_fun ( congr_fun h_inv_def i ) j using 1
@@ -223,7 +228,8 @@ lemma rpow_neg_mul_rpow_self (hA : A.mat.PosDef) (p : ℝ) :
         exact fun i => Real.rpow_pos_of_pos ( by exact Matrix.PosDef.eigenvalues_pos hA i ) _;
       have h_eigenvalues_pos : (A ^ p).mat.PosDef ↔ ∀ i, 0 < (A ^ p).H.eigenvalues i := by
         exact Matrix.IsHermitian.posDef_iff_eigenvalues_pos (H (A ^ p));
-      have h_eigenvalues_pos : ∃ e : d ≃ d, (A ^ p).H.eigenvalues = fun i => (A.H.eigenvalues (e i)) ^ p := by
+      have h_eigenvalues_pos :
+          ∃ e : d ≃ d, (A ^ p).H.eigenvalues = fun i => (A.H.eigenvalues (e i)) ^ p := by
         exact Matrix.IsHermitian.cfc_eigenvalues (H A) fun x => x.rpow p;
       aesop;
     exact h_pos_def p hA;
@@ -272,7 +278,8 @@ private lemma rpow_kron_diagonal
 open scoped Kronecker in
 omit [DecidableEq d] [DecidableEq d₂] in
 lemma conj_kron
-  (A : Matrix d d 𝕜) (B : Matrix d₂ d₂ 𝕜) (C : HermitianMat d 𝕜) (D : HermitianMat d₂ 𝕜) :
+  (A : Matrix d d 𝕜) (B : Matrix d₂ d₂ 𝕜) (C : HermitianMat d 𝕜)
+    (D : HermitianMat d₂ 𝕜) :
     conj (A ⊗ₖ B) (C ⊗ₖ D) = conj A C ⊗ₖ conj B D := by
   ext1
   simp [conj, Matrix.mul_kronecker_mul, Matrix.conjTranspose_kronecker]
@@ -280,18 +287,23 @@ lemma conj_kron
 lemma rpow_kron
     {A : HermitianMat d ℂ} {B : HermitianMat d₂ ℂ} (r : ℝ) (hA : 0 ≤ A) (hB : 0 ≤ B) :
     (A ⊗ₖ B) ^ r = (A ^ r) ⊗ₖ (B ^ r) := by
-  obtain ⟨U, a, ha, hA⟩ : ∃ U : 𝐔[d], ∃ a : d → ℝ, (∀ i, 0 ≤ a i) ∧ A = conj U.val (diagonal ℂ a) := by
+  obtain ⟨U, a, ha, hA⟩ :
+      ∃ U : 𝐔[d], ∃ a : d → ℝ, (∀ i, 0 ≤ a i) ∧ A = conj U.val (diagonal ℂ a) := by
     rw [zero_le_iff] at hA
     exact ⟨_, _, hA.eigenvalues_nonneg, eq_conj_diagonal A⟩
-  obtain ⟨V, b, hb, hB⟩ : ∃ V : 𝐔[d₂], ∃ b : d₂ → ℝ, (∀ j, 0 ≤ b j) ∧ B = conj V.val (diagonal ℂ b) := by
+  obtain ⟨V, b, hb, hB⟩ :
+      ∃ V : 𝐔[d₂], ∃ b : d₂ → ℝ, (∀ j, 0 ≤ b j) ∧ B = conj V.val (diagonal ℂ b) := by
     rw [zero_le_iff] at hB
     exact ⟨_, _, hB.eigenvalues_nonneg, eq_conj_diagonal B⟩
-  have h_kron_r_pow : (A ⊗ₖ B) ^ r = conj (Matrix.unitary_kron U V).val ((diagonal ℂ a ⊗ₖ diagonal ℂ b) ^ r) := by
+  have h_kron_r_pow :
+      (A ⊗ₖ B) ^ r =
+        conj (Matrix.unitary_kron U V).val ((diagonal ℂ a ⊗ₖ diagonal ℂ b) ^ r) := by
     subst hB hA
     rw [← rpow_conj_unitary, Matrix.unitary_kron, conj_kron]
   rw [h_kron_r_pow]
   subst A B
-  have h_kron_r_pow_diag : (diagonal ℂ a ⊗ₖ diagonal ℂ b) ^ r = ((diagonal ℂ a) ^ r) ⊗ₖ ((diagonal ℂ b) ^ r) := by
+  have h_kron_r_pow_diag :
+      (diagonal ℂ a ⊗ₖ diagonal ℂ b) ^ r = ((diagonal ℂ a) ^ r) ⊗ₖ ((diagonal ℂ b) ^ r) := by
     exact rpow_kron_diagonal a b r ha hb
   rw [h_kron_r_pow_diag, Matrix.unitary_kron]
   rw [rpow_conj_unitary, rpow_conj_unitary, ← conj_kron]
@@ -306,7 +318,8 @@ lemma continuousOn_rpow_uniform {K : Set ℝ} (hK : IsCompact K) :
   simp only [Set.mem_singleton_iff, UniformOnFun.toFun_ofFun, Metric.tendstoUniformlyOn_iff,
     Function.comp_apply, forall_eq]
   intro ε hεpos;
-  have h_unif_cont : UniformContinuousOn (fun (p : ℝ × ℝ) => p.1 ^ p.2) (K ×ˢ Set.Icc (r / 2) (r * 2)) := by
+  have h_unif_cont :
+      UniformContinuousOn (fun (p : ℝ × ℝ) => p.1 ^ p.2) (K ×ˢ Set.Icc (r / 2) (r * 2)) := by
     apply IsCompact.uniformContinuousOn_of_continuous
     · exact hK.prod CompactIccSpace.isCompact_Icc
     · refine continuousOn_of_forall_continuousAt fun p ⟨hp₁, ⟨hp₂₁, hp₂₂⟩⟩ ↦ ?_
@@ -314,7 +327,9 @@ lemma continuousOn_rpow_uniform {K : Set ℝ} (hK : IsCompact K) :
       fun_prop (disch := assumption)
   rw [Metric.uniformContinuousOn_iff] at h_unif_cont
   obtain ⟨δ, hδpos, H⟩ := h_unif_cont ε hεpos
-  filter_upwards [Ioo_mem_nhds (show r / 2 < r by linarith) (show r < r * 2 by linarith), Ioo_mem_nhds (show r - δ < r by linarith) (show r < r + δ by linarith)] with n ⟨_, _⟩ ⟨_, _⟩ x hx
+  filter_upwards [Ioo_mem_nhds (show r / 2 < r by linarith) (show r < r * 2 by linarith),
+      Ioo_mem_nhds (show r - δ < r by linarith) (show r < r + δ by linarith)]
+    with n ⟨_, _⟩ ⟨_, _⟩ x hx
   refine H (x, r) ⟨hx, ?_⟩ (x, n) ⟨hx, ?_⟩ ?_
   · constructor <;> linarith
   · constructor <;> linarith
@@ -348,11 +363,14 @@ matrices, the same identity should hold for all real `p`. -/
 theorem cfc_sq_rpow_eq_cfc_rpow
     (A : HermitianMat d 𝕜) (hA : 0 ≤ A) (p : ℝ) (hp : 0 ≤ p) :
     (A ^ 2).cfc (fun x => x ^ (p/2)) = A.cfc (fun x => x ^ p) := by
-  have h_sqrt : (A ^ 2).cfc (fun x => x ^ (p / 2)) = (A.cfc (fun x => x ^ 2)).cfc (fun x => x ^ (p / 2)) := by
+  have h_sqrt :
+      (A ^ 2).cfc (fun x => x ^ (p / 2)) =
+        (A.cfc (fun x => x ^ 2)).cfc (fun x => x ^ (p / 2)) := by
     convert rfl;
     exact cfc_pow A;
   rw [ h_sqrt ];
-  have h_sqrt : ∀ (f g : ℝ → ℝ), Continuous f → Continuous g → ∀ (A : HermitianMat d 𝕜), (A.cfc f).cfc g = A.cfc (fun x => g (f x)) := by
+  have h_sqrt : ∀ (f g : ℝ → ℝ), Continuous f → Continuous g → ∀ (A : HermitianMat d 𝕜),
+      (A.cfc f).cfc g = A.cfc (fun x => g (f x)) := by
     exact fun f g a a A => Eq.symm (cfc_comp_apply A f g);
   rw [ h_sqrt ];
   · have h_sqrt : ∀ x : ℝ, 0 ≤ x → (x ^ 2) ^ (p / 2) = x ^ p := by
@@ -393,13 +411,16 @@ theorem rpowApprox_mono {A B : HermitianMat d ℂ} (hA : A.mat.PosDef) (hB : B.m
     (hAB : A ≤ B) (hq : 0 ≤ q) (T : ℝ) (hT : 0 < T) :
     rpowApprox A q T ≤ rpowApprox B q T := by
   unfold HermitianMat.rpowApprox
-  have h_integral_mono : ∀ᵐ t ∂Measure.restrict volume (Set.Ioc 0 T), t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) ≤ t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (B + t • 1)⁻¹) := by
+  have h_integral_mono : ∀ᵐ t ∂Measure.restrict volume (Set.Ioc 0 T),
+      t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) ≤
+        t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (B + t • 1)⁻¹) := by
     filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
     have h_inv_antitone : (B + t • 1)⁻¹ ≤ (A + t • 1)⁻¹ := by
       apply inv_antitone
       · exact hA.add_posSemidef ( Matrix.PosSemidef.smul ( Matrix.PosSemidef.one ) ht.1.le )
       · exact add_le_add_left hAB _
-    exact smul_le_smul_of_nonneg_left (sub_le_sub_left h_inv_antitone _) (Real.rpow_nonneg ht.1.le q)
+    exact smul_le_smul_of_nonneg_left (sub_le_sub_left h_inv_antitone _)
+      (Real.rpow_nonneg ht.1.le q)
   have h_cont_tq : ContinuousOn (fun t : ℝ => t ^ q) (Set.Icc 0 T) := by
     exact continuousOn_id.rpow_const fun _ _ => Or.inr hq
   have h_cont_const :
@@ -436,15 +457,20 @@ open MeasureTheory ComplexOrder in
 theorem rpowApprox_eq_cfc_scalar (A : HermitianMat d ℂ) (hA : A.mat.PosDef) (q T : ℝ)
     (hq : 0 ≤ q) (hT : 0 < T) :
     rpowApprox A q T = A.cfc (scalarRpowApprox q T) := by
-  have rpowApprox_eq_cfc_scalar : ∀ t ∈ Set.Ioc 0 T, t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) = A.cfc (fun u => t ^ q * (1 / (1 + t) - 1 / (u + t))) := by
+  have rpowApprox_eq_cfc_scalar : ∀ t ∈ Set.Ioc 0 T,
+      t ^ q • ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) =
+        A.cfc (fun u => t ^ q * (1 / (1 + t) - 1 / (u + t))) := by
     intro t ht
-    have h_integrand : ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) = A.cfc (fun u => (1 + t)⁻¹ - (u + t)⁻¹) := by
+    have h_integrand :
+        ((1 + t)⁻¹ • (1 : HermitianMat d ℂ) - (A + t • 1)⁻¹) =
+          A.cfc (fun u => (1 + t)⁻¹ - (u + t)⁻¹) := by
       have h_integrand : (A + t • 1)⁻¹ = A.cfc (fun u => (u + t)⁻¹) := by
         have h_inv : (A + t • 1)⁻¹ = A.cfc (fun u => (u + t)⁻¹) := by
           have h_inv_def : (A + t • 1)⁻¹ = (A.cfc (fun u => u + t))⁻¹ := by
             rw [ show ( fun u => u + t ) = ( fun u => u ) + fun u => t from rfl, cfc_add ] ; aesop;
           have h_inv_comp : (A.cfc (fun u => u + t))⁻¹ = A.cfc (fun u => (u + t)⁻¹) := by
-            have h_inv_smul : ∀ {f : ℝ → ℝ} (hf : ∀ i, f (A.H.eigenvalues i) ≠ 0), (A.cfc f)⁻¹ = A.cfc (fun u => (f u)⁻¹) := by
+            have h_inv_smul : ∀ {f : ℝ → ℝ} (hf : ∀ i, f (A.H.eigenvalues i) ≠ 0),
+                (A.cfc f)⁻¹ = A.cfc (fun u => (f u)⁻¹) := by
               exact fun {f} hf => inv_cfc_eq_cfc_inv f hf
             apply h_inv_smul
             intro i
@@ -458,17 +484,31 @@ theorem rpowApprox_eq_cfc_scalar (A : HermitianMat d ℂ) (hA : A.mat.PosDef) (q
       rfl;
     aesop;
   -- Apply the fact that the integral of a CFC is the CFC of the integral.
-  have rpowApprox_integral_eq : ∫ t in (0)..T, A.cfc (fun u => t ^ q * (1 / (1 + t) - 1 / (u + t))) = A.cfc (fun u => ∫ t in (0)..T, t ^ q * (1 / (1 + t) - 1 / (u + t))) := by
-    have h_integrable : ∀ u : d, IntervalIntegrable (fun t : ℝ => t ^ q * (1 / (1 + t) - 1 / (A.H.eigenvalues u + t))) volume 0 T := by
+  have rpowApprox_integral_eq :
+      ∫ t in (0)..T, A.cfc (fun u => t ^ q * (1 / (1 + t) - 1 / (u + t))) =
+        A.cfc (fun u => ∫ t in (0)..T, t ^ q * (1 / (1 + t) - 1 / (u + t))) := by
+    have h_integrable : ∀ u : d,
+        IntervalIntegrable
+          (fun t : ℝ => t ^ q * (1 / (1 + t) - 1 / (A.H.eigenvalues u + t))) volume 0 T := by
       intro u
-      have h_integrable : IntervalIntegrable (fun t : ℝ => t ^ q * (1 / (1 + t) - 1 / (A.H.eigenvalues u + t))) volume 0 T := by
+      have h_integrable :
+          IntervalIntegrable
+            (fun t : ℝ => t ^ q * (1 / (1 + t) - 1 / (A.H.eigenvalues u + t))) volume 0 T := by
         have h_pos : 0 < A.H.eigenvalues u := by
           exact Matrix.PosDef.eigenvalues_pos hA u
-        exact ContinuousOn.intervalIntegrable ( by exact ContinuousOn.mul ( continuousOn_id.rpow_const fun x hx => Or.inr <| by linarith ) <| ContinuousOn.sub ( continuousOn_const.div ( continuousOn_const.add continuousOn_id ) fun x hx => by linarith [ Set.mem_Icc.mp <| by simpa [ hT.le ] using hx ] ) ( continuousOn_const.div ( continuousOn_const.add continuousOn_id ) fun x hx => by linarith [ Set.mem_Icc.mp <| by simpa [ hT.le ] using hx ] ) ) ..;
+        exact ContinuousOn.intervalIntegrable ( by
+          exact ContinuousOn.mul
+            ( continuousOn_id.rpow_const fun x hx => Or.inr <| by linarith ) <|
+          ContinuousOn.sub
+            ( continuousOn_const.div ( continuousOn_const.add continuousOn_id )
+              fun x hx => by linarith [ Set.mem_Icc.mp <| by simpa [ hT.le ] using hx ] )
+            ( continuousOn_const.div ( continuousOn_const.add continuousOn_id )
+              fun x hx => by linarith [ Set.mem_Icc.mp <| by simpa [ hT.le ] using hx ] ) ) ..;
       exact h_integrable
     exact integral_cfc_eq_cfc_integral _ _ _ h_integrable
   unfold HermitianMat.rpowApprox scalarRpowApprox; simp_all +singlePass;
-  rw [ ← rpowApprox_integral_eq, intervalIntegral.integral_of_le hT.le, integral_Ioc_eq_integral_Ioo ] at *
+  rw [ ← rpowApprox_integral_eq, intervalIntegral.integral_of_le hT.le,
+    integral_Ioc_eq_integral_Ioo ] at *
   rw [ setIntegral_congr_fun measurableSet_Ioo fun t ht => rpowApprox_eq_cfc_scalar t ht.1 ht.2.le ]
   simp [ ← integral_Ioc_eq_integral_Ioo, intervalIntegral.integral_of_le hT.le ]
 
@@ -490,7 +530,8 @@ lemma rpowConst_integrableOn (hq : 0 < q) (hq1 : q < 1) :
     · apply Measurable.aestronglyMeasurable
       fun_prop
     · filter_upwards [ae_restrict_mem measurableSet_Ioc ] with x hx
-      rw [ Real.norm_of_nonneg ( div_nonneg ( Real.rpow_nonneg hx.1.le _ ) ( by linarith [ hx.1 ] ) ) ]
+      rw [ Real.norm_of_nonneg
+        ( div_nonneg ( Real.rpow_nonneg hx.1.le _ ) ( by linarith [ hx.1 ] ) ) ]
       exact div_le_self ( Real.rpow_nonneg hx.1.le _ ) ( by linarith [ hx.1 ] ) ;
   · have h_bound : ∀ u : ℝ, 1 ≤ u → u ^ (q - 1) / (1 + u) ≤ u ^ (q - 2) := by
       intro u hu
@@ -516,12 +557,18 @@ open MeasureTheory in
 lemma rpowConst_pos (hq : 0 < q) (hq1 : q < 1) : 0 < rpowConst q := by
   unfold rpowConst;
   have h_nonzero : 0 < ∫ u in Set.Ioi (0 : ℝ), u ^ (q - 1) / (1 + u) := by
-    have h_integrable : IntegrableOn (fun u : ℝ => u ^ (q - 1) / (1 + u)) (Set.Ioi (0 : ℝ)) := by
+    have h_integrable :
+        IntegrableOn (fun u : ℝ => u ^ (q - 1) / (1 + u)) (Set.Ioi (0 : ℝ)) := by
       exact rpowConst_integrableOn hq hq1
     rw [ integral_pos_iff_support_of_nonneg_ae ];
     · simp [Function.support]
-      exact lt_of_lt_of_le ( by norm_num ) ( measure_mono <| show Set.Ioi ( 0 : ℝ ) ⊆ { x : ℝ | ¬x ^ ( q - 1 ) = 0 ∧ ¬1 + x = 0 } ∩ Set.Ioi 0 from fun x hx => ⟨ ⟨ ne_of_gt <| Real.rpow_pos_of_pos hx _, ne_of_gt <| add_pos zero_lt_one hx ⟩, hx ⟩ );
-    · filter_upwards [ ae_restrict_mem measurableSet_Ioi ] with u hu using div_nonneg ( Real.rpow_nonneg hu.out.le _ ) ( add_nonneg zero_le_one hu.out.le );
+      exact lt_of_lt_of_le ( by norm_num )
+        ( measure_mono <| show Set.Ioi ( 0 : ℝ ) ⊆
+              { x : ℝ | ¬x ^ ( q - 1 ) = 0 ∧ ¬1 + x = 0 } ∩ Set.Ioi 0 from
+            fun x hx => ⟨ ⟨ ne_of_gt <| Real.rpow_pos_of_pos hx _,
+              ne_of_gt <| add_pos zero_lt_one hx ⟩, hx ⟩ );
+    · filter_upwards [ ae_restrict_mem measurableSet_Ioi ] with u hu using
+        div_nonneg ( Real.rpow_nonneg hu.out.le _ ) ( add_nonneg zero_le_one hu.out.le );
     · exact h_integrable;
   linarith
 
@@ -530,42 +577,66 @@ open MeasureTheory Filter in
     `scalarRpowApprox q T x → rpowConst q * (x^q - 1)` as `T → ∞`. -/
 lemma scalarRpowApprox_tendsto {x : ℝ} (hx : 0 < x) (hq : 0 < q) (hq1 : q < 1) :
     Filter.Tendsto (fun T => scalarRpowApprox q T x) atTop (nhds (rpowConst q * (x ^ q - 1))) := by
-  have h_def : ∀ T > 0, scalarRpowApprox q T x = x * (∫ t in (0)..T, t ^ (q - 1) / (x + t)) - (∫ t in (0)..T, t ^ (q - 1) / (1 + t)) := by
+  have h_def : ∀ T > 0, scalarRpowApprox q T x =
+      x * (∫ t in (0)..T, t ^ (q - 1) / (x + t)) -
+        (∫ t in (0)..T, t ^ (q - 1) / (1 + t)) := by
     intro T hT
-    have : ∀ t ∈ Set.Ioc (0 : ℝ) T, t ^ q * (1 / (1 + t) - 1 / (x + t)) = x * (t ^ (q - 1) / (x + t)) - (t ^ (q - 1) / (1 + t)) := by
+    have : ∀ t ∈ Set.Ioc (0 : ℝ) T,
+        t ^ q * (1 / (1 + t) - 1 / (x + t)) =
+          x * (t ^ (q - 1) / (x + t)) - (t ^ (q - 1) / (1 + t)) := by
       intro t ht; rw [ Real.rpow_sub_one ht.1.ne' ]
       grind
     rw [ intervalIntegral.integral_of_le hT.le, intervalIntegral.integral_of_le hT.le ];
     rw [ ← integral_const_mul, ← integral_sub ];
-    · exact Eq.trans ( intervalIntegral.integral_of_le hT.le ) ( setIntegral_congr_fun measurableSet_Ioc this );
+    · exact Eq.trans ( intervalIntegral.integral_of_le hT.le )
+        ( setIntegral_congr_fun measurableSet_Ioc this );
     · apply Integrable.const_mul _ _;
       apply Integrable.mono' (g := fun t => t ^ ( q - 1 ) / x)
       · exact ( intervalIntegral.intervalIntegrable_rpow' ( by linarith ) ).1.div_const _;
       · apply Measurable.aestronglyMeasurable
         fun_prop
-      · filter_upwards [ ae_restrict_mem measurableSet_Ioc ] with t ht using by rw [ Real.norm_of_nonneg ( div_nonneg ( Real.rpow_nonneg ht.1.le _ ) ( by linarith [ ht.1 ] ) ) ] ; exact div_le_div_of_nonneg_left ( Real.rpow_nonneg ht.1.le _ ) ( by linarith [ ht.1 ] ) ( by linarith [ ht.1 ] ) ;
+      · filter_upwards [ ae_restrict_mem measurableSet_Ioc ] with t ht using by
+          rw [ Real.norm_of_nonneg
+            ( div_nonneg ( Real.rpow_nonneg ht.1.le _ ) ( by linarith [ ht.1 ] ) ) ] ;
+          exact div_le_div_of_nonneg_left ( Real.rpow_nonneg ht.1.le _ )
+            ( by linarith [ ht.1 ] ) ( by linarith [ ht.1 ] ) ;
     · apply Integrable.mono' (g := fun t => t ^ ( q - 1 ) / ( 1 + 0 ))
       · exact ( intervalIntegral.intervalIntegrable_rpow' ( by linarith ) ).1.div_const _;
       · apply Measurable.aestronglyMeasurable
         fun_prop
-      · filter_upwards [ ae_restrict_mem measurableSet_Ioc ] with t ht using by rw [ Real.norm_of_nonneg ( div_nonneg ( Real.rpow_nonneg ( by linarith [ ht.1 ] ) _ ) ( by linarith [ ht.1 ] ) ) ] ; exact div_le_div_of_nonneg_left ( Real.rpow_nonneg ( by linarith [ ht.1 ] ) _ ) ( by linarith [ ht.1 ] ) ( by linarith [ ht.1 ] ) ;
-  have h_int_1 : Filter.Tendsto (fun T => ∫ t in (0)..T, t ^ (q - 1) / (1 + t)) Filter.atTop (nhds (rpowConst q)) := by
+      · filter_upwards [ ae_restrict_mem measurableSet_Ioc ] with t ht using by
+          rw [ Real.norm_of_nonneg
+            ( div_nonneg ( Real.rpow_nonneg ( by linarith [ ht.1 ] ) _ )
+              ( by linarith [ ht.1 ] ) ) ] ;
+          exact div_le_div_of_nonneg_left ( Real.rpow_nonneg ( by linarith [ ht.1 ] ) _ )
+            ( by linarith [ ht.1 ] ) ( by linarith [ ht.1 ] ) ;
+  have h_int_1 : Filter.Tendsto (fun T => ∫ t in (0)..T, t ^ (q - 1) / (1 + t)) Filter.atTop
+      (nhds (rpowConst q)) := by
     apply intervalIntegral_tendsto_integral_Ioi
     · exact rpowConst_integrableOn hq hq1
     · exact Filter.tendsto_id
-  have h_int_x : Filter.Tendsto (fun T => ∫ t in (0)..T, t ^ (q - 1) / (x + t)) Filter.atTop (nhds (rpowConst q * x ^ (q - 1))) := by
-    have h_subst : ∀ T > 0, ∫ t in (0)..T, t ^ (q - 1) / (x + t) = x ^ (q - 1) * ∫ u in (0)..T / x, u ^ (q - 1) / (1 + u) := by
+  have h_int_x : Filter.Tendsto (fun T => ∫ t in (0)..T, t ^ (q - 1) / (x + t)) Filter.atTop
+      (nhds (rpowConst q * x ^ (q - 1))) := by
+    have h_subst : ∀ T > 0, ∫ t in (0)..T, t ^ (q - 1) / (x + t) =
+        x ^ (q - 1) * ∫ u in (0)..T / x, u ^ (q - 1) / (1 + u) := by
       intro T hT
-      have h_subst : ∫ t in (0)..T, t ^ (q - 1) / (x + t) = ∫ u in (0)..T / x, (x * u) ^ (q - 1) / (x + x * u) * x := by
-        simp [ mul_comm x, intervalIntegral.integral_comp_mul_right ( fun u => u ^ ( q - 1 ) / ( x + u ) ), hx.ne' ];
+      have h_subst : ∫ t in (0)..T, t ^ (q - 1) / (x + t) =
+          ∫ u in (0)..T / x, (x * u) ^ (q - 1) / (x + x * u) * x := by
+        simp [ mul_comm x,
+          intervalIntegral.integral_comp_mul_right ( fun u => u ^ ( q - 1 ) / ( x + u ) ),
+          hx.ne' ];
         rw [ inv_mul_eq_div, div_mul_cancel₀ _ hx.ne' ];
       rw [ h_subst, ← intervalIntegral.integral_const_mul ];
       refine intervalIntegral.integral_congr fun u hu ↦ ?_
-      rw [ Real.mul_rpow ( by positivity ) ( by cases Set.mem_uIcc.mp hu <;> nlinarith [ div_mul_cancel₀ T hx.ne' ] ) ]
+      rw [ Real.mul_rpow ( by positivity )
+        ( by cases Set.mem_uIcc.mp hu <;> nlinarith [ div_mul_cancel₀ T hx.ne' ] ) ]
       field_simp
-    rw [ Filter.tendsto_congr' ( by filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using h_subst T hT ) ]
-    simpa [ mul_comm ] using h_int_1.comp ( Filter.tendsto_id.atTop_div_const hx ) |> Filter.Tendsto.const_mul ( x ^ ( q - 1 ) ) ;
-  rw [ Filter.tendsto_congr' ( by filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using h_def T hT ) ]
+    rw [ Filter.tendsto_congr'
+      ( by filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using h_subst T hT ) ]
+    simpa [ mul_comm ] using h_int_1.comp ( Filter.tendsto_id.atTop_div_const hx ) |>
+      Filter.Tendsto.const_mul ( x ^ ( q - 1 ) ) ;
+  rw [ Filter.tendsto_congr'
+    ( by filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using h_def T hT ) ]
   convert Filter.Tendsto.sub ( h_int_x.const_mul x ) h_int_1 using 2
   ring_nf
   rw [ mul_assoc, ← Real.rpow_one_add' hx.le ]
@@ -578,7 +649,8 @@ set_option backward.isDefEq.respectTransparency false in
 lemma tendsto_rpowApprox (hA : A.mat.PosDef) (hq : 0 < q) (hq1 : q < 1) :
     Tendsto (rpowApprox A q) atTop (nhds (rpowConst q • (A ^ q - 1))) := by
   have h_target : rpowConst q • (A ^ q - 1) = A.cfc (fun x => rpowConst q * (x ^ q - 1)) := by
-    have h2 : A.cfc (fun x => rpowConst q * (x ^ q - 1)) = rpowConst q • A.cfc (fun x => x ^ q - 1) :=
+    have h2 : A.cfc (fun x => rpowConst q * (x ^ q - 1)) =
+        rpowConst q • A.cfc (fun x => x ^ q - 1) :=
       HermitianMat.cfc_const_mul A (fun x => x ^ q - 1) (rpowConst q)
     have h3 : A.cfc (fun x => x ^ q - 1) = A.cfc (· ^ q) - 1 := by
       conv_rhs => rw [show (1 : HermitianMat d ℂ) = A.cfc (fun _ => (1 : ℝ)) by simp]
@@ -588,11 +660,22 @@ lemma tendsto_rpowApprox (hA : A.mat.PosDef) (hq : 0 < q) (hq1 : q < 1) :
     filter_upwards [Filter.eventually_gt_atTop 0] with T hT
     exact rpowApprox_eq_cfc_scalar A hA q T hq.le hT
   rw [Filter.tendsto_congr' h_eq, h_target]
-  have h_expand_src : ∀ T, (A.cfc (scalarRpowApprox q T)).mat = ∑ i, scalarRpowApprox q T (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) :=
+  have h_expand_src : ∀ T, (A.cfc (scalarRpowApprox q T)).mat =
+      ∑ i, scalarRpowApprox q T (A.H.eigenvalues i) •
+        (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+          A.H.eigenvectorUnitary.val.conjTranspose) :=
     fun T => cfc_toMat_eq_sum_smul_proj A (scalarRpowApprox q T)
-  have h_expand_tgt : (A.cfc (fun x => rpowConst q * (x ^ q - 1))).mat = ∑ i, (rpowConst q * (A.H.eigenvalues i ^ q - 1)) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose) :=
+  have h_expand_tgt : (A.cfc (fun x => rpowConst q * (x ^ q - 1))).mat =
+      ∑ i, (rpowConst q * (A.H.eigenvalues i ^ q - 1)) •
+        (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+          A.H.eigenvectorUnitary.val.conjTranspose) :=
     cfc_toMat_eq_sum_smul_proj A (fun x => rpowConst q * (x ^ q - 1))
-  have h_sum : Tendsto (fun T : ℝ => ∑ i, scalarRpowApprox q T (A.H.eigenvalues i) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose)) atTop (nhds (∑ i, (rpowConst q * (A.H.eigenvalues i ^ q - 1)) • (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) * A.H.eigenvectorUnitary.val.conjTranspose))) := by
+  have h_sum : Tendsto (fun T : ℝ => ∑ i, scalarRpowApprox q T (A.H.eigenvalues i) •
+        (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+          A.H.eigenvectorUnitary.val.conjTranspose)) atTop
+      (nhds (∑ i, (rpowConst q * (A.H.eigenvalues i ^ q - 1)) •
+        (A.H.eigenvectorUnitary.val * (Matrix.single i i 1) *
+          A.H.eigenvectorUnitary.val.conjTranspose))) := by
     refine tendsto_finsetSum _ fun i _ => ?_
     have := scalarRpowApprox_tendsto (hA.eigenvalues_pos i) hq hq1
     exact Filter.Tendsto.smul_const (Complex.continuous_ofReal.continuousAt.tendsto.comp this) _
@@ -612,9 +695,14 @@ theorem rpow_le_rpow_of_posDef (hA : A.mat.PosDef) (hAB : A ≤ B)
   by_cases hq_eq_one : q = 1;
   · aesop;
   · have h_rpow : rpowConst q • (A ^ q - 1) ≤ rpowConst q • (B ^ q - 1) := by
-      convert le_of_tendsto_of_tendsto ( tendsto_rpowApprox hA hq ( lt_of_le_of_ne hq1 hq_eq_one ) ) ( tendsto_rpowApprox ( posDef_of_posDef_le hA hAB ) hq ( lt_of_le_of_ne hq1 hq_eq_one ) ) _ using 1
+      convert le_of_tendsto_of_tendsto
+        ( tendsto_rpowApprox hA hq ( lt_of_le_of_ne hq1 hq_eq_one ) )
+        ( tendsto_rpowApprox ( posDef_of_posDef_le hA hAB ) hq
+          ( lt_of_le_of_ne hq1 hq_eq_one ) ) _ using 1
       generalize_proofs at *; (
-      filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using rpowApprox_mono hA ( posDef_of_posDef_le hA hAB ) hAB hq.le T hT |> le_trans <| by aesop;);
+      filter_upwards [ Filter.eventually_gt_atTop 0 ] with T hT using
+        rpowApprox_mono hA ( posDef_of_posDef_le hA hAB ) hAB hq.le T hT |>
+          le_trans <| by aesop;);
     have h_rpow_pos : 0 < rpowConst q := by
       exact rpowConst_pos hq ( lt_of_le_of_ne hq1 hq_eq_one );
     simp_all
@@ -635,7 +723,8 @@ theorem rpow_le_rpow_of_le (hA : 0 ≤ A) (hAB : A ≤ B)
       constructor <;> norm_num [ hε_pos, hA, hAB ];
       · exact H (Aε ε)
       · intro x hx_nonzero
-        have h_inner : star x ⬝ᵥ (Aε ε).mat.mulVec x = star x ⬝ᵥ A.mat.mulVec x + ε * star x ⬝ᵥ x := by
+        have h_inner :
+            star x ⬝ᵥ (Aε ε).mat.mulVec x = star x ⬝ᵥ A.mat.mulVec x + ε * star x ⬝ᵥ x := by
           simp [ Aε, Matrix.add_mulVec]
           ring_nf
           simp [ Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _, mul_assoc, mul_left_comm];
@@ -644,23 +733,34 @@ theorem rpow_le_rpow_of_le (hA : 0 ≤ A) (hAB : A ≤ B)
           exact inner_mulVec_nonneg hA x
         have h_inner_pos : 0 < star x ⬝ᵥ x := by
           simp_all
-        exact h_inner.symm ▸ add_pos_of_nonneg_of_pos h_inner_nonneg ( mul_pos ( mod_cast hε_pos ) ( mod_cast h_inner_pos ) ) |> lt_of_lt_of_le <| le_rfl;
+        exact h_inner.symm ▸ add_pos_of_nonneg_of_pos h_inner_nonneg
+          ( mul_pos ( mod_cast hε_pos ) ( mod_cast h_inner_pos ) ) |> lt_of_lt_of_le <| le_rfl;
     have h_pos_def_Bε : (Bε ε).mat.PosDef := by
       convert posDef_of_posDef_le h_pos_def_Aε _ using 1
       exact add_le_add_left hAB _ |> le_trans ( by simp [ Aε ] ) ;
     have h_le_Aε_Bε : Aε ε ≤ Bε ε := by
       exact add_le_add_left hAB _ |> le_trans <| by simp [ Bε ] ;
     exact ⟨h_pos_def_Aε, h_pos_def_Bε, h_le_Aε_Bε⟩
-  -- By the continuity of the function $M \mapsto M^q$, we have $(Aε ε)^q \to A^q$ and $(Bε ε)^q \to B^q$ as $\epsilon \to 0^+$.
-  have h_cont : Filter.Tendsto (fun ε => (Aε ε) ^ q) (nhdsWithin 0 (Set.Ioi 0)) (nhds (A ^ q)) ∧ Filter.Tendsto (fun ε => (Bε ε) ^ q) (nhdsWithin 0 (Set.Ioi 0)) (nhds (B ^ q)) := by
-    have h_cont : ContinuousOn (fun M : HermitianMat d ℂ => M ^ q) (Set.univ : Set (HermitianMat d ℂ)) := by
+  -- By the continuity of the function $M \mapsto M^q$, we have $(Aε ε)^q \to A^q$ and
+  -- $(Bε ε)^q \to B^q$ as $\epsilon \to 0^+$.
+  have h_cont : Filter.Tendsto (fun ε => (Aε ε) ^ q) (nhdsWithin 0 (Set.Ioi 0)) (nhds (A ^ q)) ∧
+      Filter.Tendsto (fun ε => (Bε ε) ^ q) (nhdsWithin 0 (Set.Ioi 0)) (nhds (B ^ q)) := by
+    have h_cont :
+        ContinuousOn (fun M : HermitianMat d ℂ => M ^ q) (Set.univ : Set (HermitianMat d ℂ)) := by
       -- Apply the continuity of the function $M \mapsto M^q$ on the set of all Hermitian matrices.
       apply rpow_const_continuous hq.le |> Continuous.continuousOn
-    refine' ⟨ h_cont.continuousAt ( by simp ) |> fun h => h.tendsto.comp ( tendsto_nhdsWithin_of_tendsto_nhds <| Continuous.tendsto' _ _ _ _ ), h_cont.continuousAt ( by simp ) |> fun h => h.tendsto.comp ( tendsto_nhdsWithin_of_tendsto_nhds <| Continuous.tendsto' _ _ _ _ ) ⟩ <;> continuity;
-  -- By the continuity of the function $M \mapsto M^q$, we have $(Aε ε)^q \leq (Bε ε)^q$ for all $\epsilon > 0$.
+    refine' ⟨ h_cont.continuousAt ( by simp ) |> fun h => h.tendsto.comp
+        ( tendsto_nhdsWithin_of_tendsto_nhds <| Continuous.tendsto' _ _ _ _ ),
+      h_cont.continuousAt ( by simp ) |> fun h => h.tendsto.comp
+        ( tendsto_nhdsWithin_of_tendsto_nhds <| Continuous.tendsto' _ _ _ _ ) ⟩ <;> continuity;
+  -- By the continuity of the function $M \mapsto M^q$, we have $(Aε ε)^q \leq (Bε ε)^q$ for all
+  -- $\epsilon > 0$.
   have h_le : ∀ ε > 0, (Aε ε) ^ q ≤ (Bε ε) ^ q := by
-    exact fun ε hε => rpow_le_rpow_of_posDef ( h_pos_def ε hε |>.1 ) ( h_pos_def ε hε |>.2.2 ) hq hq1 |> le_trans <| by simp [ * ] ;
-  exact le_of_tendsto_of_tendsto h_cont.1 h_cont.2 ( Filter.eventually_of_mem self_mem_nhdsWithin fun ε hε => h_le ε hε ) |> fun h => by simpa using h;
+    exact fun ε hε => rpow_le_rpow_of_posDef ( h_pos_def ε hε |>.1 ) ( h_pos_def ε hε |>.2.2 )
+      hq hq1 |> le_trans <| by simp [ * ] ;
+  exact le_of_tendsto_of_tendsto h_cont.1 h_cont.2
+    ( Filter.eventually_of_mem self_mem_nhdsWithin fun ε hε => h_le ε hε ) |>
+    fun h => by simpa using h;
 
 end LoewnerHeinz
 
@@ -742,9 +842,11 @@ private lemma conj_rpow_le_one_of_conj_le_one_posDef
         · linarith [hr0.ne']
       _ = 1 := by
         have hInv : (B ^ (-r : ℝ)).mat = (B ^ r).mat⁻¹ := by
-          simpa [HermitianMat.mat_inv] using congrArg HermitianMat.mat (rpow_inv_eq_neg_rpow hB r).symm
+          simpa [HermitianMat.mat_inv] using
+            congrArg HermitianMat.mat (rpow_inv_eq_neg_rpow hB r).symm
         rw [hInv]
-        exact Matrix.mul_nonsing_inv _ (((B ^ r).mat).isUnit_iff_isUnit_det.mp (isUnit_rpow_toMat hB r))
+        exact Matrix.mul_nonsing_inv _
+          (((B ^ r).mat).isUnit_iff_isUnit_det.mp (isUnit_rpow_toMat hB r))
   exact le_trans hconj hright.le
 
 private lemma conj_smul_right (A B : HermitianMat d ℂ) (c : ℝ) :
@@ -759,7 +861,8 @@ private lemma conjTranspose_half_mul_eq_conj
       = (A.conj B.mat).mat := by
   have := HermitianMat.pow_half_mul hA
   simp only [Matrix.conjTranspose_mul, HermitianMat.conjTranspose_mat, Matrix.mul_assoc]
-  simpa [HermitianMat.conj_apply_mat, Matrix.mul_assoc] using congrArg (fun M => B.mat * M * B.mat) this
+  simpa [HermitianMat.conj_apply_mat, Matrix.mul_assoc] using
+    congrArg (fun M => B.mat * M * B.mat) this
 
 private lemma top_singular_le_of_self_mul_le_smul_one
     {e : Type*} [Fintype e] [DecidableEq e] (X : Matrix e e ℂ)
@@ -781,8 +884,10 @@ private lemma compound_top_singular_le_posDef
     {A B : HermitianMat d ℂ} (hA : 0 ≤ A) (hB : B.mat.PosDef)
     {r : ℝ} (hr0 : 0 < r) (hr1 : r ≤ 1)
     (k : ℕ) (hk : k ≤ Fintype.card d) :
-    singularValuesSorted (compoundMatrix ((A ^ (r / 2 : ℝ)).mat * (B ^ r).mat) k) (compoundZero k hk) ≤
-      singularValuesSorted (compoundMatrix ((A ^ (1 / 2 : ℝ)).mat * B.mat) k) (compoundZero k hk) ^ r := by
+    singularValuesSorted (compoundMatrix ((A ^ (r / 2 : ℝ)).mat * (B ^ r).mat) k)
+        (compoundZero k hk) ≤
+      singularValuesSorted (compoundMatrix ((A ^ (1 / 2 : ℝ)).mat * B.mat) k)
+        (compoundZero k hk) ^ r := by
   let Ak : HermitianMat {S : Finset d // S.card = k} ℂ := compoundHermitian A k
   let Bk : HermitianMat {S : Finset d // S.card = k} ℂ := compoundHermitian B k
   let Mk : Matrix {S : Finset d // S.card = k} {S : Finset d // S.card = k} ℂ :=
@@ -821,7 +926,8 @@ private lemma compound_top_singular_le_posDef
         (((compoundHermitian A k) ^ r).conj ((compoundHermitian B k) ^ r).mat).mat
     rw [compoundHermitian_rpow A hA k (r / 2 : ℝ),
       compoundHermitian_rpow B (zero_le_iff.mpr hB.posSemidef) k r]
-    rw [show (compoundHermitian A k) ^ (r / 2 : ℝ) = ((compoundHermitian A k) ^ r) ^ (1 / 2 : ℝ) from by
+    rw [show (compoundHermitian A k) ^ (r / 2 : ℝ) =
+        ((compoundHermitian A k) ^ r) ^ (1 / 2 : ℝ) from by
       change Ak ^ (r / 2 : ℝ) = (Ak ^ r) ^ (1 / 2 : ℝ)
       rw [← HermitianMat.rpow_mul hAk]; ring_nf]
     exact conjTranspose_half_mul_eq_conj
@@ -990,7 +1096,8 @@ private lemma lieb_thirring_le_one_posDef
   have hleft :
       ((A ^ r).conj (B ^ r).mat).trace =
         ∑ i : Fin (Fintype.card d), singularValuesSorted N i ^ 2 := by
-    have := trace_conj_rpow_eq_sum_singularValuesSorted (A := A ^ r) (B := B ^ r) (hA := rpow_nonneg hA) (α := 1)
+    have := trace_conj_rpow_eq_sum_singularValuesSorted (A := A ^ r) (B := B ^ r)
+      (hA := rpow_nonneg hA) (α := 1)
     rw [show ((A ^ r) ^ (1 / 2 : ℝ)) = A ^ (r / 2 : ℝ) from by
       rw [← HermitianMat.rpow_mul hA]; ring_nf] at this
     simpa [N] using this
@@ -999,7 +1106,8 @@ private lemma lieb_thirring_le_one_posDef
         ∑ i : Fin (Fintype.card d), (singularValuesSorted M i ^ r) ^ 2 := by
     calc ((A.conj B.mat) ^ r).trace
         = ∑ i : Fin (Fintype.card d), singularValuesSorted M i ^ (2 * r) := by
-            simpa [M] using trace_conj_rpow_eq_sum_singularValuesSorted (A := A) (B := B) (hA := hA) (α := r)
+            simpa [M] using trace_conj_rpow_eq_sum_singularValuesSorted (A := A) (B := B)
+              (hA := hA) (α := r)
       _ = ∑ i, (singularValuesSorted M i ^ r) ^ 2 := Finset.sum_congr rfl fun i _ => by
             have hn := singularValuesSorted_nonneg M i
             rw [← Real.rpow_natCast _ 2, ← Real.rpow_mul hn]; push_cast; ring_nf
@@ -1025,7 +1133,8 @@ lemma lieb_thirring_le_one
       Filter.Tendsto (fun ε => (f ε).trace) (nhdsWithin 0 (Set.Ioi 0)) (nhds target.trace) := by
     rw [← h0]
     simp only [HermitianMat.trace_eq_re_trace]
-    exact (RCLike.continuous_re.comp (HermitianMat.continuous_mat.comp hf).matrix_trace).continuousWithinAt.tendsto
+    exact (RCLike.continuous_re.comp
+      (HermitianMat.continuous_mat.comp hf).matrix_trace).continuousWithinAt.tendsto
   have hleft_tendsto :
       Filter.Tendsto
         (fun ε => ((A ^ r).conj ((Bε ε) ^ r).mat).trace)
@@ -1217,7 +1326,8 @@ private lemma trace_mul_inv_shift_eq_sum_div {A : HermitianMat d ℂ} (hA : 0 �
           refine Finset.sum_congr rfl ?_
           intro i hi
           have hpos : 0 < A.H.eigenvalues i + t := by
-            exact add_pos_of_nonneg_of_pos (by simpa using (zero_le_iff.mp hA).eigenvalues_nonneg i) ht
+            exact add_pos_of_nonneg_of_pos
+              (by simpa using (zero_le_iff.mp hA).eigenvalues_nonneg i) ht
           rw [show ((↑(A.H.eigenvalues i) + ↑t : ℂ)) = ↑(A.H.eigenvalues i + t) by simp,
             Complex.normSq_ofReal]
           field_simp [hpos.ne', div_eq_mul_inv]

--- a/QuantumInfo/ForMathlib/HermitianMat/Schatten.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Schatten.lean
@@ -24,7 +24,8 @@ noncomputable section
 The Schatten p-norm of a matrix A is (Tr[(A*A)^(p/2)])^(1/p).
 -/
 noncomputable def schattenNorm (A : Matrix d d ℂ) (p : ℝ) : ℝ :=
-  RCLike.re ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).cfc (· ^ (p/2))).trace ^ (1/p)
+  RCLike.re ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).cfc (· ^ (p/2))).trace ^
+    (1/p)
 
 /-
 For a positive Hermitian matrix A, ||A||_p = (Tr(A^p))^(1/p).
@@ -45,10 +46,15 @@ theorem schattenNorm_hermitian_pow {A : HermitianMat d ℂ} (hA : 0 ≤ A) {p : 
 lemma schattenNorm_nonneg (A : Matrix d d ℂ) (p : ℝ) :
     0 ≤ schattenNorm A p := by
   by_cases hp : p = 0 <;> simp [ *, schattenNorm ];
-  by_cases h₁ : 0 ≤ RCLike.re ( Matrix.trace ( Matrix.IsHermitian.cfc ( Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose ) fun x => x ^ ( p / 2 ) ) ) <;> simp_all [ Real.rpow_nonneg ];
-  contrapose! h₁; simp_all [Matrix.trace ] ; ring_nf; norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
-  refine' Finset.sum_nonneg fun i _ => _ ; norm_num [ Matrix.IsHermitian.cfc ] ; ring_nf ; norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
-  simp [ Matrix.mul_apply, Matrix.diagonal ] ; ring_nf ; norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
+  by_cases h₁ : 0 ≤ RCLike.re ( Matrix.trace ( Matrix.IsHermitian.cfc
+      ( Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose ) fun x => x ^ ( p / 2 ) ) ) <;>
+    simp_all [ Real.rpow_nonneg ];
+  contrapose! h₁; simp_all [Matrix.trace ] ; ring_nf;
+  norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
+  refine' Finset.sum_nonneg fun i _ => _ ; norm_num [ Matrix.IsHermitian.cfc ] ; ring_nf ;
+  norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
+  simp [ Matrix.mul_apply, Matrix.diagonal ] ; ring_nf ;
+  norm_num [ Real.exp_nonneg, Real.log_nonneg ] ; (
   --TODO: If we import Order, the whole line is just `positivity`.
   exact Finset.sum_nonneg fun _ _ => add_nonneg ( mul_nonneg ( sq_nonneg _ ) ( Real.rpow_nonneg (
     (Matrix.eigenvalues_conjTranspose_mul_self_nonneg A _) ) _ ) ) ( mul_nonneg ( Real.rpow_nonneg (
@@ -61,7 +67,8 @@ lemma schattenNorm_pow_eq
   · rw [ ← Real.rpow_mul ] <;> ring_nf <;> norm_num [ hp.ne', hk.ne' ];
     · rw [ mul_comm, ← HermitianMat.rpow_mul ];
       exact hA;
-    · -- Since $A$ is positive, $A^{k*p}$ is also positive, and the trace of a positive matrix is non-negative.
+    · -- Since $A$ is positive, $A^{k*p}$ is also positive, and the trace of a positive matrix is
+      -- non-negative.
       have h_pos : 0 ≤ A ^ (k * p) := by
         exact HermitianMat.rpow_nonneg hA;
       exact HermitianMat.trace_nonneg h_pos;
@@ -79,7 +86,8 @@ lemma trace_eq_schattenNorm_rpow
 /- The trace of cfc(A†A, t ↦ t^{p/2}) expressed as a sum of eigenvalues. -/
 lemma schattenNorm_trace_as_eigenvalue_sum (A : Matrix d d ℂ) (p : ℝ) :
     RCLike.re ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).cfc (· ^ (p/2))).trace =
-    ∑ i : d, ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i) ^ (p/2) := by
+    ∑ i : d,
+      ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i) ^ (p/2) := by
   rw [ Matrix.IsHermitian.cfc ];
   simp [ Matrix.trace_mul_comm, Matrix.mul_assoc ]
 
@@ -97,8 +105,10 @@ lemma schattenNorm_rpow_eq_sum_singularValues (A : Matrix d d ℂ) {p : ℝ} (hp
     ring_nf
     simp +zetaDelta at *;
     exact Matrix.eigenvalues_conjTranspose_mul_self_nonneg A i;
-  · have h_nonneg : ∀ i : d, 0 ≤ ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i) ^ (p / 2) := by
-      exact fun i => Real.rpow_nonneg ( by have := Matrix.eigenvalues_conjTranspose_mul_self_nonneg A; aesop ) _;
+  · have h_nonneg : ∀ i : d, 0 ≤
+        ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i) ^ (p / 2) := by
+      exact fun i => Real.rpow_nonneg
+        ( by have := Matrix.eigenvalues_conjTranspose_mul_self_nonneg A; aesop ) _;
     convert Finset.sum_nonneg fun i _ => h_nonneg i using 1;
     convert schattenNorm_trace_as_eigenvalue_sum A p using 1
 
@@ -114,7 +124,8 @@ lemma schattenNorm_eq_sum_singularValues_rpow (A : Matrix d d ℂ) {p : ℝ} (hp
     simp [ Matrix.mul_apply, Matrix.diagonal ];
     field_simp;
     exact Finset.sum_nonneg fun _ _ => mul_nonneg ( Real.rpow_nonneg ( by
-      exact Matrix.eigenvalues_conjTranspose_mul_self_nonneg A _ ) _ ) ( add_nonneg ( sq_nonneg _ ) ( sq_nonneg _ ) ) ) _ ), mul_one_div_cancel hp.ne', Real.rpow_one ]
+      exact Matrix.eigenvalues_conjTranspose_mul_self_nonneg A _ ) _ ) ( add_nonneg ( sq_nonneg _ )
+        ( sq_nonneg _ ) ) ) _ ), mul_one_div_cancel hp.ne', Real.rpow_one ]
 
 /-- `‖A‖_p^p` equals the same sum over sorted singular values. -/
 lemma schattenNorm_rpow_eq_sum_sorted (A : Matrix d d ℂ) {p : ℝ} (hp : 0 < p) :
@@ -133,9 +144,11 @@ lemma HermitianMat.trace_young
     (p q : ℝ) (hp : 1 < p) (hpq : 1/p + 1/q = 1) :
     ⟪A, B⟫_ℝ ≤ (A ^ p).trace / p + (B ^ q).trace / q := by
   --TODO Cleanup
-  have h_schatten : ∀ (i j : d), (A.H.eigenvalues i) * (B.H.eigenvalues j) ≤ (A.H.eigenvalues i)^p / p + (B.H.eigenvalues j)^q / q := by
+  have h_schatten : ∀ (i j : d), (A.H.eigenvalues i) * (B.H.eigenvalues j) ≤
+      (A.H.eigenvalues i)^p / p + (B.H.eigenvalues j)^q / q := by
     intro i j
-    have h_young : ∀ (a b : ℝ), 0 ≤ a → 0 ≤ b → (1 < p → 1 / p + 1 / q = 1 → a * b ≤ (a^p) / p + (b^q) / q) := by
+    have h_young : ∀ (a b : ℝ), 0 ≤ a → 0 ≤ b →
+        (1 < p → 1 / p + 1 / q = 1 → a * b ≤ (a^p) / p + (b^q) / q) := by
       intro a b ha hb hp hpq
       have h_young : a * b ≤ (a^p) / p + (b^q) / q := by
         have h_conj : 1 / p + 1 / q = 1 := hpq
@@ -145,24 +158,34 @@ lemma HermitianMat.trace_young
           rw [ div_eq_mul_inv, div_eq_mul_inv ] at h_conj
           nlinarith [inv_nonpos.2 h, inv_mul_cancel₀ (by linarith : p ≠ 0)]
         have := @Real.geom_mean_le_arith_mean
-        specialize this { 0, 1 } ( fun i => if i = 0 then p⁻¹ else q⁻¹ ) ( fun i => if i = 0 then a ^ p else b ^ q ) ; simp_all [ ne_of_gt ];
-        simpa only [ div_eq_inv_mul ] using this h_pos.1.le h_pos.2.le ( Real.rpow_nonneg ha _ ) ( Real.rpow_nonneg hb _ )
+        specialize this { 0, 1 } ( fun i => if i = 0 then p⁻¹ else q⁻¹ )
+          ( fun i => if i = 0 then a ^ p else b ^ q ) ;
+        simp_all [ ne_of_gt ];
+        simpa only [ div_eq_inv_mul ] using
+          this h_pos.1.le h_pos.2.le ( Real.rpow_nonneg ha _ ) ( Real.rpow_nonneg hb _ )
       exact h_young
     refine h_young _ _ ?_ ?_ hp hpq
     · exact (zero_le_iff.mp hA).eigenvalues_nonneg _
     · exact (zero_le_iff.mp hB).eigenvalues_nonneg _
-  convert Finset.sum_le_sum fun i _ => Finset.sum_le_sum fun j _ => mul_le_mul_of_nonneg_right ( h_schatten i j ) ( show 0 ≤ ‖(A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val) i j‖ ^ 2 by positivity ) using 1;
+  convert Finset.sum_le_sum fun i _ => Finset.sum_le_sum fun j _ =>
+    mul_le_mul_of_nonneg_right ( h_schatten i j )
+      ( show 0 ≤ ‖(A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val) i j‖ ^ 2
+        by positivity ) using 1;
   convert HermitianMat.inner_eq_doubly_stochastic_sum A B using 1;
-  simp [ Finset.sum_add_distrib, add_mul, Finset.mul_sum, div_eq_mul_inv, mul_assoc, mul_comm, HermitianMat.trace_rpow_eq_sum ];
+  simp [ Finset.sum_add_distrib, add_mul, Finset.mul_sum, div_eq_mul_inv, mul_assoc, mul_comm,
+    HermitianMat.trace_rpow_eq_sum ];
   simp [ ← Finset.mul_sum, ← Finset.sum_comm, ];
   congr! 2;
   · refine Finset.sum_congr rfl fun i _ => ?_
-    have := Matrix.unitary_row_sum_norm_sq ( A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val ) ?_ i;
+    have := Matrix.unitary_row_sum_norm_sq
+        ( A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val ) ?_ i;
     · rw [ this, mul_one ];
     · simp [ Matrix.mul_assoc ];
       simp [ ← Matrix.mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ];
   · refine' Finset.sum_congr rfl fun i _ => _;
-    have := Matrix.unitary_col_sum_norm_sq ( A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val ) ?_ i <;> simp_all [ Matrix.mul_assoc, Matrix.conjTranspose_mul ];
+    have := Matrix.unitary_col_sum_norm_sq
+        ( A.H.eigenvectorUnitary.val.conjTranspose * B.H.eigenvectorUnitary.val ) ?_ i <;>
+      simp_all [ Matrix.mul_assoc, Matrix.conjTranspose_mul ];
     simp [ ← Matrix.mul_assoc, Matrix.IsHermitian.eigenvectorUnitary ]
 
 /-- For PSD `A` and Hermitian `B`, the product
@@ -179,7 +202,8 @@ lemma schattenNorm_half_mul_rpow_eq_trace_conj
     {α : ℝ} (hα : 0 < α) :
     (schattenNorm ((A ^ (1/2 : ℝ)).mat * B.mat) (2 * α)) ^ (2 * α) =
     ((A.conj B.mat) ^ α).trace := by
-  have h_conj : ((A ^ (1 / 2 : ℝ)).mat * B.mat).conjTranspose * ((A ^ (1 / 2 : ℝ)).mat * B.mat) = (A.conj B.mat).mat := by
+  have h_conj : ((A ^ (1 / 2 : ℝ)).mat * B.mat).conjTranspose * ((A ^ (1 / 2 : ℝ)).mat * B.mat) =
+      (A.conj B.mat).mat := by
     exact conjTranspose_half_mul_eq_conj hA;
   unfold schattenNorm;
   rw [ ← Real.rpow_mul ] <;> norm_num [ hα.ne' ];
@@ -187,7 +211,8 @@ lemma schattenNorm_half_mul_rpow_eq_trace_conj
     rw [ ← Matrix.IsHermitian.cfc_eq ];
     rw [ Matrix.conjTranspose_conjTranspose ];
     exact congrArg Complex.re (congrArg Matrix.trace (congrArg (cfc fun x => x ^ α) h_conj));
-  · have h_eigenvalues_nonneg : ∀ i, 0 ≤ (Matrix.isHermitian_mul_conjTranspose_self ((A ^ (1 / 2 : ℝ)).mat * B.mat).conjTranspose).eigenvalues i := by
+  · have h_eigenvalues_nonneg : ∀ i, 0 ≤ (Matrix.isHermitian_mul_conjTranspose_self
+        ((A ^ (1 / 2 : ℝ)).mat * B.mat).conjTranspose).eigenvalues i := by
       intro i
       simpa only [one_div, HermitianMat.conjTranspose_mat, HermitianMat.conj_apply_mat,
         Matrix.conjTranspose_mul] using
@@ -251,7 +276,8 @@ lemma schattenNorm_mul_le (A B : Matrix d d ℂ) {r p q : ℝ}
   --   ∑ σ↓ᵢ(A)^r · σ↓ᵢ(B)^r ≤ (∑ σ↓ᵢ(A)^p)^{r/p} · (∑ σ↓ᵢ(B)^q)^{r/q}
   have h_holder := holder_step_for_singularValues A B hr hp hq hpqr
   -- Step 3: Combine and take 1/r-th power
-  -- Need: (∑ σ↓ᵢ(AB)^r)^{1/r} ≤ ((∑ σ↓ᵢ(A)^p)^{r/p} · (∑ σ↓ᵢ(B)^q)^{r/q})^{1/r}
+  -- Need: (∑ σ↓ᵢ(AB)^r)^{1/r} ≤
+  -- ((∑ σ↓ᵢ(A)^p)^{r/p} · (∑ σ↓ᵢ(B)^q)^{r/q})^{1/r}
   --      = (∑ σ↓ᵢ(A)^p)^{1/p} · (∑ σ↓ᵢ(B)^q)^{1/q}
   have h_combined : ∑ i, singularValuesSorted (A * B) i ^ r ≤
       (∑ i, singularValuesSorted A i ^ p) ^ (r / p) *
@@ -293,8 +319,10 @@ lemma HermitianMat.trace_rpow_conj_le
     ((A.conj B.mat) ^ α).trace ≤
     (((A ^ (p / 2)).trace) ^ (1 / p) * ((B ^ q).trace) ^ (1 / q)) ^ (2 * α) := by
   -- Raise both sides of the inequality to the power of $2\alpha$.
-  have h_exp : ((A.conj B.mat) ^ α).trace ≤ (schattenNorm (A ^ (1 / 2 : ℝ)).mat p * schattenNorm B.mat q) ^ (2 * α) := by
-    have h_exp : (schattenNorm ((A ^ (1 / 2 : ℝ)).mat * B.mat) (2 * α)) ^ (2 * α) = ((A.conj B.mat) ^ α).trace := by
+  have h_exp : ((A.conj B.mat) ^ α).trace ≤
+      (schattenNorm (A ^ (1 / 2 : ℝ)).mat p * schattenNorm B.mat q) ^ (2 * α) := by
+    have h_exp : (schattenNorm ((A ^ (1 / 2 : ℝ)).mat * B.mat) (2 * α)) ^ (2 * α) =
+        ((A.conj B.mat) ^ α).trace := by
       exact schattenNorm_half_mul_rpow_eq_trace_conj hA hα
     rw [← h_exp]
     -- Apply the Schatten-Hölder inequality to the matrices $A^{1/2} * B$.

--- a/QuantumInfo/ForMathlib/HermitianMat/Schatten.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Schatten.lean
@@ -24,8 +24,8 @@ noncomputable section
 The Schatten p-norm of a matrix A is (Tr[(A*A)^(p/2)])^(1/p).
 -/
 noncomputable def schattenNorm (A : Matrix d d ℂ) (p : ℝ) : ℝ :=
-  RCLike.re ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).cfc (· ^ (p/2))).trace ^
-    (1/p)
+  RCLike.re ((Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose).cfc
+    (· ^ (p/2))).trace ^ (1/p)
 
 /-
 For a positive Hermitian matrix A, ||A||_p = (Tr(A^p))^(1/p).
@@ -117,7 +117,8 @@ lemma schattenNorm_rpow_eq_sum_singularValues (A : Matrix d d ℂ) {p : ℝ} (hp
 lemma schattenNorm_eq_sum_singularValues_rpow (A : Matrix d d ℂ) {p : ℝ} (hp : 0 < p) :
     schattenNorm A p = (∑ i : d, singularValues A i ^ p) ^ (1/p) := by
   rw [ ←schattenNorm_rpow_eq_sum_singularValues A hp ];
-  rw [ ← Real.rpow_mul ( by exact Real.rpow_nonneg ( by
+  rw [ ← Real.rpow_mul , mul_one_div_cancel hp.ne', Real.rpow_one ]
+  exact Real.rpow_nonneg ( by
     simp [ Matrix.trace ];
     refine' Finset.sum_nonneg fun i _ => _;
     rw [ Matrix.IsHermitian.cfc ];
@@ -125,7 +126,7 @@ lemma schattenNorm_eq_sum_singularValues_rpow (A : Matrix d d ℂ) {p : ℝ} (hp
     field_simp;
     exact Finset.sum_nonneg fun _ _ => mul_nonneg ( Real.rpow_nonneg ( by
       exact Matrix.eigenvalues_conjTranspose_mul_self_nonneg A _ ) _ ) ( add_nonneg ( sq_nonneg _ )
-        ( sq_nonneg _ ) ) ) _ ), mul_one_div_cancel hp.ne', Real.rpow_one ]
+        ( sq_nonneg _ ) ) ) _
 
 /-- `‖A‖_p^p` equals the same sum over sorted singular values. -/
 lemma schattenNorm_rpow_eq_sum_sorted (A : Matrix d d ℂ) {p : ℝ} (hp : 0 < p) :

--- a/QuantumInfo/ForMathlib/HermitianMat/Trace.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Trace.lean
@@ -10,8 +10,8 @@ public import QuantumInfo.ForMathlib.HermitianMat.Reindex
 /-! # Trace of Hermitian Matrices
 
 While the trace of a Hermitian matrix is, in informal math, typically just "the same as" a trace of
-a matrix that happens to be Hermitian - it is a real number, not a complex number. Or more generally,
-it is a self-adjoint element of the base `StarAddMonoid`.
+a matrix that happens to be Hermitian - it is a real number, not a complex number. Or more
+generally, it is a self-adjoint element of the base `StarAddMonoid`.
 
 Working directly with `Matrix.trace` then means that there would be constant casts between rings,
 chasing imaginary parts and inequalities and so on. By defining `HermitianMat.trace` as its own
@@ -29,12 +29,13 @@ namespace HermitianMat
 variable {R n m α : Type*} [Star R] [TrivialStar R] [Fintype n] [Fintype m]
 
 section star
-variable [AddGroup α] [StarAddMonoid α] [CommSemiring R] [Semiring α] [Algebra R α] [IsMaximalSelfAdjoint R α]
+variable [AddGroup α] [StarAddMonoid α] [CommSemiring R] [Semiring α] [Algebra R α]
+  [IsMaximalSelfAdjoint R α]
 
 /-- The trace of the matrix. This requires a `IsMaximalSelfAdjoint R α` instance, and then maps from
-  `HermitianMat n α` to `R`. This means that the trace of (say) a `HermitianMat n ℤ` gives values in ℤ,
-  but that the trace of a `HermitianMat n ℂ` gives values in ℝ. The fact that traces are "automatically"
-  real reduces coercions down the line. -/
+  `HermitianMat n α` to `R`. This means that the trace of (say) a `HermitianMat n ℤ` gives values in
+  ℤ, but that the trace of a `HermitianMat n ℂ` gives values in ℝ. The fact that traces are
+  "automatically" real reduces coercions down the line. -/
 def trace (A : HermitianMat n α) : R :=
   IsMaximalSelfAdjoint.selfadjMap (A.mat.trace)
 

--- a/QuantumInfo/ForMathlib/HermitianMat/Unitary.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/Unitary.lean
@@ -26,7 +26,8 @@ theorem neg_unitary_val (u : 𝐔[α]) : (-u).val = -u := by
 omit [DecidableEq α] [Fintype α] [DecidableEq β] [Fintype β] in
 open Kronecker in
 @[simp]
-theorem star_kron (a : Matrix α α ℂ) (b : Matrix β β ℂ) : star (a ⊗ₖ b) = (star a) ⊗ₖ (star b) := by
+theorem star_kron (a : Matrix α α ℂ) (b : Matrix β β ℂ) :
+    star (a ⊗ₖ b) = (star a) ⊗ₖ (star b) := by
   ext _ _
   simp
 

--- a/QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean
+++ b/QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean
@@ -9,8 +9,9 @@ public import Mathlib.Analysis.Matrix.Normed
 
 @[expose] public section
 
-/- We want to have `HermitianMat.trace` give 𝕜 when 𝕜 is already a TrivialStar field, but give the "clean" type
-otherwise -- for instance, ℝ when the input field is ℂ. This typeclass lets us do so. -/
+/- We want to have `HermitianMat.trace` give 𝕜 when 𝕜 is already a TrivialStar field, but give the
+"clean" type otherwise -- for instance, ℝ when the input field is ℂ. This typeclass lets us do
+so. -/
 class IsMaximalSelfAdjoint (R : outParam Type*) (α : Type*) [Star α] [Star R] [CommSemiring R]
     [Semiring α] [TrivialStar R] [Algebra R α] where
   selfadjMap : α →+ R
@@ -18,7 +19,8 @@ class IsMaximalSelfAdjoint (R : outParam Type*) (α : Type*) [Star α] [Star R] 
   selfadj_algebra : ∀ {a : α}, IsSelfAdjoint a → algebraMap _ _ (selfadjMap a) = a
 
 /-- Every `TrivialStar` `CommSemiring` is its own maximal self adjoints. -/
-instance instTrivialStar_IsMaximalSelfAdjoint {R} [Star R] [TrivialStar R] [CommSemiring R] : IsMaximalSelfAdjoint R R where
+instance instTrivialStar_IsMaximalSelfAdjoint {R} [Star R] [TrivialStar R] [CommSemiring R] :
+    IsMaximalSelfAdjoint R R where
   selfadjMap := AddMonoidHom.id R
   selfadj_smul _ __ := rfl
   selfadj_algebra {_} _ := rfl
@@ -36,7 +38,8 @@ namespace IsMaximalSelfAdjoint
 -- take care of proving that anyway.
 
 @[simp]
-theorem trivial_selfadjMap {R} [Star R] [TrivialStar R] [CommSemiring R] : (selfadjMap : R →+ R) = .id R := by
+theorem trivial_selfadjMap {R} [Star R] [TrivialStar R] [CommSemiring R] :
+    (selfadjMap : R →+ R) = .id R := by
   rfl
 
 @[simp]

--- a/QuantumInfo/ForMathlib/Isometry.lean
+++ b/QuantumInfo/ForMathlib/Isometry.lean
@@ -29,17 +29,23 @@ def Matrix.Isometry (A : Matrix d d₂ R) : Prop :=
   Aᴴ * A = 1
 
 omit [Fintype d₃] [DecidableEq d₂] in
-theorem Matrix.submatrix_one_isometry {e : d₂ → d} {f : d₃ → d} (he : e.Bijective) (hf : f.Injective) :
+theorem Matrix.submatrix_one_isometry {e : d₂ → d} {f : d₃ → d} (he : e.Bijective)
+    (hf : f.Injective) :
     (submatrix (α := R) 1 e f).Isometry := by
-  -- Since $e$ is injective and $f$ is bijective, the submatrix of the identity matrix formed by $e$ and $f$ is a permutation matrix.
-  have h_perm : ∀ i j, (Matrix.submatrix (1 : Matrix d d R) e f) i j = if e i = f j then 1 else 0 := by
-    -- By definition of the identity matrix, the entry (i, j) in the submatrix is 1 if e i = f j and 0 otherwise.
+  -- Since $e$ is injective and $f$ is bijective, the submatrix of the identity matrix formed by
+  -- $e$ and $f$ is a permutation matrix.
+  have h_perm : ∀ i j, (Matrix.submatrix (1 : Matrix d d R) e f) i j = if e i = f j then 1 else 0
+      := by
+    -- By definition of the identity matrix, the entry (i, j) in the submatrix is 1 if e i = f j
+    -- and 0 otherwise.
     simp [Matrix.submatrix, Matrix.one_apply]
   ext i j
-  -- Since $e$ is injective and $f$ is bijective, the product $A * Aᴴ$ will have 1s on the diagonal and 0s elsewhere, which is the identity matrix.
+  -- Since $e$ is injective and $f$ is bijective, the product $A * Aᴴ$ will have 1s on the diagonal
+  -- and 0s elsewhere, which is the identity matrix.
   change ∑ k, (Matrix.conjTranspose (Matrix.submatrix (1 : Matrix d d R) e f)) i k *
     (Matrix.submatrix (1 : Matrix d d R) e f) k j = if i = j then 1 else 0
-  simp_all only [Multiset.bijective_iff_map_univ_eq_univ, submatrix_apply, conjTranspose_apply, one_apply]
+  simp_all only [Multiset.bijective_iff_map_univ_eq_univ, submatrix_apply, conjTranspose_apply,
+    one_apply]
   symm; split <;> symm
   next h =>
     subst h
@@ -48,15 +54,20 @@ theorem Matrix.submatrix_one_isometry {e : d₂ → d} {f : d₃ → d} (he : e.
     have h_unique : ∀ i, ∃! x, e x = f i := by
       intro i
       obtain ⟨x, hx⟩ : ∃ x, e x = f i := by
-        replace he := congr_arg Multiset.toFinset he; rw [Finset.ext_iff] at he; specialize he ( f i ) ; aesop;
+        replace he := congr_arg Multiset.toFinset he; rw [Finset.ext_iff] at he;
+          specialize he ( f i ) ; aesop;
       use x
       simp_all only [true_and]
       intro y a
       have := Fintype.bijective_iff_injective_and_card e
       aesop
     obtain ⟨ x, hx ⟩ := h_unique i;
-    rw [show ( Finset.univ.filter fun y => e y = f i ) = { x } from Finset.eq_singleton_iff_unique_mem.2 ⟨ by aesop, fun y hy => hx.2 y <| Eq.symm <| Finset.mem_filter.1 hy |>.2.symm ⟩] ; simp ;
-  next h => -- Since $e$ is injective and $e i \neq e j$, there is no $x$ such that $e i = f x$ and $e j = f x$.
+    rw [show ( Finset.univ.filter fun y => e y = f i ) = { x } from
+      Finset.eq_singleton_iff_unique_mem.2
+        ⟨ by aesop, fun y hy => hx.2 y <| Eq.symm <| Finset.mem_filter.1 hy |>.2.symm ⟩] ; simp ;
+  next h =>
+    -- Since $e$ is injective and $e i \neq e j$, there is no $x$ such that $e i = f x$ and
+    -- $e j = f x$.
     have h_no_x : ∀ x : d₂, ¬(e x = f i ∧ e x = f j) := by
       exact fun x hx => h ( hf ( hx.1.symm.trans hx.2 ) );
     exact Finset.sum_eq_zero fun x hx => by specialize h_no_x x; aesop
@@ -78,12 +89,14 @@ theorem Matrix.mem_unitaryGroup_iff_isometry (A : Matrix d d R) :
 
 theorem Equiv.Perm.permMatrix_mem_unitaryGroup (e : Perm d) :
     e.permMatrix R ∈ Matrix.unitaryGroup d R := by
-  -- Since $e$ is a permutation, its permutation matrix $P_e$ is orthogonal, meaning $P_e * P_e^T = I$.
+  -- Since $e$ is a permutation, its permutation matrix $P_e$ is orthogonal, meaning
+  -- $P_e * P_e^T = I$.
   have h_perm_ortho : (Equiv.Perm.permMatrix R e) * (Equiv.Perm.permMatrix R e)ᵀ = 1 := by
     ext i j; rw [Matrix.mul_apply] ; aesop;
   constructor
   · simp_all only [Matrix.transpose_permMatrix]
-    -- Since the conjugate transpose of a permutation matrix is the permutation matrix of the inverse permutation, we have:
+    -- Since the conjugate transpose of a permutation matrix is the permutation matrix of the
+    -- inverse permutation, we have:
     have h_conj_transpose : star (Equiv.Perm.permMatrix R e) = (Equiv.Perm.permMatrix R e)ᵀ := by
       ext i j; simp [Equiv.Perm.permMatrix] ; aesop;
     simp_all [mul_eq_one_comm]
@@ -94,7 +107,8 @@ theorem Equiv.Perm.permMatrix_mem_unitaryGroup (e : Perm d) :
 omit [Fintype d₃] [DecidableEq d₂] in
 theorem Matrix.reindex_one_isometry (e : d ≃ d₂) (f : d ≃ d₃) :
     (reindex (α := R) e f 1).Isometry := by
-  -- Since $e$ and $f$ are bijections, the reindexing of the identity matrix by $e$ and $f$ is a permutation matrix, which is unitary.
+  -- Since $e$ and $f$ are bijections, the reindexing of the identity matrix by $e$ and $f$ is a
+  -- permutation matrix, which is unitary.
   have h_perm : ∀ (e : d ≃ d₂) (f : d ≃ d₃), (Matrix.reindex e f (1 : Matrix d d R)).Isometry := by
     intro e f
     simp [Matrix.Isometry]
@@ -105,7 +119,8 @@ theorem Matrix.reindex_one_mem_unitaryGroup (e : d ≃ d₂)  :
     reindex (α := R) e e 1 ∈ unitaryGroup d₂ R := by
   -- The reindex of the identity matrix under an equivalence e is just the identity matrix on d₂.
   have h_reindex_id : Matrix.reindex e e (1 : Matrix d d R) = 1 := by
-    -- By definition of reindex, the entry at (i, j) in the reindexed matrix is 1 if i = j and 0 otherwise.
+    -- By definition of reindex, the entry at (i, j) in the reindexed matrix is 1 if i = j and 0
+    -- otherwise.
     ext i j
     simp [Matrix.reindex, Matrix.one_apply]
   simp only [h_reindex_id, one_mem]
@@ -118,7 +133,8 @@ theorem Matrix.reindex_eq_conj (A : Matrix d d R) (e : d ≃ d₂) : reindex e e
   simp [Matrix.one_apply]
 
 theorem Matrix.reindex_eq_conj_unitaryGroup' (A : Matrix d d R) (e : Equiv.Perm d) : reindex e e A =
-    (⟨_, e⁻¹.permMatrix_mem_unitaryGroup⟩ : unitaryGroup d R) * A * (⟨_, e.permMatrix_mem_unitaryGroup⟩ : unitaryGroup d R) := by
+    (⟨_, e⁻¹.permMatrix_mem_unitaryGroup⟩ : unitaryGroup d R) * A *
+      (⟨_, e.permMatrix_mem_unitaryGroup⟩ : unitaryGroup d R) := by
   ext i j;
   simp [Matrix.mul_apply]
   rw [Finset.sum_eq_single ( e.symm j )] <;> aesop
@@ -126,13 +142,19 @@ theorem Matrix.reindex_eq_conj_unitaryGroup' (A : Matrix d d R) (e : Equiv.Perm 
 theorem Matrix.IsHermitian.eigenvalue_ext (hA : A.IsHermitian)
   (h : ∀ (v : d → 𝕜) (lam : 𝕜), A *ᵥ v = lam • v → B *ᵥ v = lam • v) :
     A = B := by
-  -- Since A is Hermitian, it is diagonalizable, and its eigenvectors form a complete basis. Therefore, for any vector v, we have Av = Bv.
+  -- Since A is Hermitian, it is diagonalizable, and its eigenvectors form a complete basis.
+  -- Therefore, for any vector v, we have Av = Bv.
   have h_diag : ∀ v : d → 𝕜, (A *ᵥ v) = (B *ᵥ v) := by
-    -- Since A is Hermitian, it is diagonalizable, and its eigenvectors form a complete basis. Therefore, for any vector v, we can express it as a linear combination of eigenvectors.
-    have h_diag : ∀ v : d → 𝕜, ∃ (c : d → 𝕜) (lam : d → 𝕜), v = ∑ i, c i • (Matrix.IsHermitian.eigenvectorBasis hA i) ∧ ∀ i, A *ᵥ (Matrix.IsHermitian.eigenvectorBasis hA i) = lam i • (Matrix.IsHermitian.eigenvectorBasis hA i) := by
+    -- Since A is Hermitian, it is diagonalizable, and its eigenvectors form a complete basis.
+    -- Therefore, for any vector v, we can express it as a linear combination of eigenvectors.
+    have h_diag : ∀ v : d → 𝕜, ∃ (c : d → 𝕜) (lam : d → 𝕜),
+        v = ∑ i, c i • (Matrix.IsHermitian.eigenvectorBasis hA i) ∧
+        ∀ i, A *ᵥ (Matrix.IsHermitian.eigenvectorBasis hA i) =
+          lam i • (Matrix.IsHermitian.eigenvectorBasis hA i) := by
       intro v
       obtain ⟨c, hc⟩ : ∃ c : d → 𝕜, v = ∑ i, c i • (hA.eigenvectorBasis i) := by
-        have h_diag : ∀ v : EuclideanSpace 𝕜 d, ∃ c : d → 𝕜, v = ∑ i, c i • (hA.eigenvectorBasis i) := by
+        have h_diag : ∀ v : EuclideanSpace 𝕜 d,
+            ∃ c : d → 𝕜, v = ∑ i, c i • (hA.eigenvectorBasis i) := by
           intro v
           set c := fun i => innerₛₗ 𝕜 (hA.eigenvectorBasis i) v
           have hv : v = ∑ i, c i • (hA.eigenvectorBasis i) := by
@@ -152,10 +174,12 @@ theorem Matrix.IsHermitian.eigenvalue_ext (hA : A.IsHermitian)
     obtain ⟨c, lam, hv, hlam⟩ := h_diag v
     have hA_v : A *ᵥ v = ∑ i, c i • lam i • (hA.eigenvectorBasis i) := by
       -- By linearity of matrix multiplication, we can distribute A over the sum.
-      have hA_v : A *ᵥ (∑ i, c i • (hA.eigenvectorBasis i)) = ∑ i, c i • A *ᵥ (hA.eigenvectorBasis i) := by
+      have hA_v : A *ᵥ (∑ i, c i • (hA.eigenvectorBasis i)) =
+          ∑ i, c i • A *ᵥ (hA.eigenvectorBasis i) := by
         simp [funext_iff]
         simp [Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _]
-        exact fun _ => Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+        exact fun _ => Finset.sum_comm.trans
+          ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
       aesop
     have hB_v : B *ᵥ v = ∑ i, c i • lam i • (hA.eigenvectorBasis i) := by
       have hBv : B *ᵥ v = ∑ i, c i • (B *ᵥ (hA.eigenvectorBasis i)) := by
@@ -165,7 +189,8 @@ theorem Matrix.IsHermitian.eigenvalue_ext (hA : A.IsHermitian)
           simp only [WithLp.ofLp_sum, WithLp.ofLp_smul]
         simp [hBv, funext_iff]
         simp [Matrix.mulVec, dotProduct, Finset.mul_sum _ _ _]
-        exact fun _ => Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+        exact fun _ => Finset.sum_comm.trans
+          ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
       refine hBv.trans ?_
       conv => enter [1, 2, i]; rw [h _ _ ( hlam i )]
       simp only [WithLp.ofLp_sum, WithLp.ofLp_smul]
@@ -174,9 +199,9 @@ theorem Matrix.IsHermitian.eigenvalue_ext (hA : A.IsHermitian)
   apply Matrix.ext; intro i j; exact (by
   simpa using congr_fun ( h_diag ( Pi.single j 1 ) ) i)
 
-/-- Generalizes `Matrix.IsHermitian.cfc.eq_1`, which gives a definition for the matrix CFC in terms of
-`Matrix.IsHermitian.eigenvalues` and `Matrix.IsHermitian.eigenvectorUnitary`, to show that the CFC works
-similarly for _any_ diagonalization by a two-sided isometry.
+/-- Generalizes `Matrix.IsHermitian.cfc.eq_1`, which gives a definition for the matrix CFC in
+terms of `Matrix.IsHermitian.eigenvalues` and `Matrix.IsHermitian.eigenvectorUnitary`, to show
+that the CFC works similarly for _any_ diagonalization by a two-sided isometry.
 -/
 theorem Matrix.IsHermitian.cfc_eq_any_isometry {n m 𝕜 : Type*} [RCLike 𝕜]
   [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
@@ -193,26 +218,31 @@ theorem Matrix.IsHermitian.cfc_eq_any_isometry {n m 𝕜 : Type*} [RCLike 𝕜]
   simp only [Unitary.conjStarAlgAut_apply] at hUV ⊢
   clear hV hD
   subst A; clear hA
-  have h_diag_eq : diagonal (RCLike.ofReal ∘ D) * (Uᴴ * V) = (Uᴴ * V) * diagonal (RCLike.ofReal ∘ D2) := by
-    have h_mul : (Uᴴ * U * diagonal (RCLike.ofReal ∘ D) * Uᴴ : Matrix m n 𝕜) * V = Uᴴ * V * (diagonal (RCLike.ofReal ∘ D2) * star V * V) := by
+  have h_diag_eq : diagonal (RCLike.ofReal ∘ D) * (Uᴴ * V) =
+      (Uᴴ * V) * diagonal (RCLike.ofReal ∘ D2) := by
+    have h_mul : (Uᴴ * U * diagonal (RCLike.ofReal ∘ D) * Uᴴ : Matrix m n 𝕜) * V =
+        Uᴴ * V * (diagonal (RCLike.ofReal ∘ D2) * star V * V) := by
       simp only [Matrix.mul_assoc, hUV]
     simp_all [ Matrix.mul_assoc ];
-  have h_diag_eq_f : diagonal (RCLike.ofReal ∘ f ∘ D) * (Uᴴ * V) = (Uᴴ * V) * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
+  have h_diag_eq_f : diagonal (RCLike.ofReal ∘ f ∘ D) * (Uᴴ * V) =
+      (Uᴴ * V) * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
     ext i j
     simp_all only [diagonal_mul, Function.comp_apply, mul_diagonal]
     replace h_diag_eq := congr_fun ( congr_fun h_diag_eq i ) j
     by_cases hi : D i = D2 j <;> simp_all [ mul_comm ] ;
-  have h_final : U * diagonal (RCLike.ofReal ∘ f ∘ D) * Uᴴ * V = V * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
-    have h_final : U * diagonal (RCLike.ofReal ∘ f ∘ D) * (Uᴴ * V) = U * (Uᴴ * V) * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
+  have h_final : U * diagonal (RCLike.ofReal ∘ f ∘ D) * Uᴴ * V =
+      V * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
+    have h_final : U * diagonal (RCLike.ofReal ∘ f ∘ D) * (Uᴴ * V) =
+        U * (Uᴴ * V) * diagonal (RCLike.ofReal ∘ f ∘ D2) := by
       rw [ Matrix.mul_assoc, h_diag_eq_f, Matrix.mul_assoc ];
       rw [ Matrix.mul_assoc, Matrix.mul_assoc ];
     simp_all +decide [ ← Matrix.mul_assoc ];
   rw [ ← h_final, Matrix.mul_assoc ];
   rw [hV₂, mul_one ]
 
-/-- Generalizes `Matrix.IsHermitian.cfc.eq_1`, which gives a definition for the matrix CFC in terms of
-`Matrix.IsHermitian.eigenvalues` and `Matrix.IsHermitian.eigenvectorUnitary`, to show that the CFC works
-similarly for _any_ diagonalization.
+/-- Generalizes `Matrix.IsHermitian.cfc.eq_1`, which gives a definition for the matrix CFC in
+terms of `Matrix.IsHermitian.eigenvalues` and `Matrix.IsHermitian.eigenvectorUnitary`, to show
+that the CFC works similarly for _any_ diagonalization.
 -/
 theorem Matrix.IsHermitian.cfc_eq_any_unitary {n 𝕜 : Type*} [RCLike 𝕜] [Fintype n] [DecidableEq n]
   {A : Matrix n n 𝕜} (hA : A.IsHermitian) {U : unitaryGroup n 𝕜} {D : n → ℝ}
@@ -274,7 +304,8 @@ theorem Matrix.cfc_conj_unitary' (f : ℝ → ℝ) (u : unitaryGroup d 𝕜) :
 theorem Matrix.cfc_reindex (f : ℝ → ℝ) (e : d ≃ d₂) :
     cfc f (reindex e e A) = reindex e e (cfc f A) := by
   rw [reindex_eq_conj, reindex_eq_conj]
-  convert Matrix.cfc_conj_isometry f (u := (Matrix.reindex e (Equiv.refl d) : Matrix d d 𝕜 → Matrix d₂ d 𝕜) 1) ?_ ?_
+  convert Matrix.cfc_conj_isometry f
+    (u := (Matrix.reindex e (Equiv.refl d) : Matrix d d 𝕜 → Matrix d₂ d 𝕜) 1) ?_ ?_
   · simp
   · simp
   · apply reindex_one_isometry
@@ -298,9 +329,9 @@ open Module.End
 --  of projectors that all pairwise commute, and we want to simultaneously diagonalize all
 --  of them.
 
-/-- Similar to `LinearMap.IsSymmetric.orthogonalFamily_eigenspace_inf_eigenspace`, but here the direct sum
-is indexed by only the pairs of eigenvalues, as opposed to all pairs of `𝕜` values, giving a finite
-decomposition. -/
+/-- Similar to `LinearMap.IsSymmetric.orthogonalFamily_eigenspace_inf_eigenspace`, but here the
+direct sum is indexed by only the pairs of eigenvalues, as opposed to all pairs of `𝕜` values,
+giving a finite decomposition. -/
 theorem LinearMap.IsSymmetric.orthogonalFamily_eigenspace_inf_eigenspace' {𝕜 E : Type*} [RCLike 𝕜]
   [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {A B : E →ₗ[𝕜] E}
   (hA : A.IsSymmetric) (hB : B.IsSymmetric) :
@@ -360,9 +391,12 @@ theorem LinearMap.IsSymmetric.directSum_isInternal_of_commute' {𝕜 E : Type*} 
   have h := LinearMap.IsSymmetric.directSum_isInternal_of_commute hA hB hAB
   constructor
   · intro x y hxy
-    -- Since the subspaces are orthogonal, the only way their sum can be zero is if each component is zero. Hence, x - y = 0, which implies x = y.
+    -- Since the subspaces are orthogonal, the only way their sum can be zero is if each component
+    -- is zero. Hence, x - y = 0, which implies x = y.
     rw [← sub_eq_zero]
-    suffices h_diff_zero : ∀ (x : DirectSum (Eigenvalues A × Eigenvalues B) fun μ₁₂ ↦ ↥(eigenspace A μ₁₂.1 ⊓ eigenspace B μ₁₂.2)), x.coeAddMonoidHom _ = 0 → x = 0 from
+    suffices h_diff_zero : ∀ (x : DirectSum (Eigenvalues A × Eigenvalues B)
+        fun μ₁₂ ↦ ↥(eigenspace A μ₁₂.1 ⊓ eigenspace B μ₁₂.2)),
+        x.coeAddMonoidHom _ = 0 → x = 0 from
       h_diff_zero (x - y) (by simp [hxy])
     clear x y hxy; intro x hx;
     ext μ₁₂
@@ -373,14 +407,17 @@ theorem LinearMap.IsSymmetric.directSum_isInternal_of_commute' {𝕜 E : Type*} 
     rw [← h_inner_zero]
     simp only [DirectSum.coeAddMonoidHom_eq_dfinsuppSum, ZeroMemClass.coe_zero, implies_true,
       DFinsupp.sum_eq_sum_fintype, DFinsupp.equivFunOnFintype_apply]
-    -- Since the decomposition is orthogonal, the inner product of x μ₁₂ with any other component is zero. Therefore, the sum simplifies to just the inner product of x μ₁₂ with itself.
+    -- Since the decomposition is orthogonal, the inner product of x μ₁₂ with any other component
+    -- is zero. Therefore, the sum simplifies to just the inner product of x μ₁₂ with itself.
     rw [inner_sum, Finset.sum_eq_add_sum_diff_singleton _ _ (by simp)]
     rw [Finset.sdiff_singleton_eq_erase, left_eq_add]
     apply Finset.sum_eq_zero
     intro μ hμ
     exact orthogonalFamily_eigenspace_inf_eigenspace' hA hB (Finset.ne_of_mem_erase hμ).symm _ _
-  · -- Since the decomposition is orthogonal, the direct sum of the intersections is isomorphic to their sum. Therefore, the isomorphism implies that the sum is equal to E.
-    have h_sum : ⨆ (μ₁₂ : Eigenvalues A × Eigenvalues B), eigenspace A μ₁₂.1 ⊓ eigenspace B μ₁₂.2 = ⊤ := by
+  · -- Since the decomposition is orthogonal, the direct sum of the intersections is isomorphic to
+    -- their sum. Therefore, the isomorphism implies that the sum is equal to E.
+    have h_sum : ⨆ (μ₁₂ : Eigenvalues A × Eigenvalues B),
+        eigenspace A μ₁₂.1 ⊓ eigenspace B μ₁₂.2 = ⊤ := by
       rw [eq_top_iff]
       intro x hx
       obtain ⟨y, rfl⟩ := h.2 x
@@ -389,7 +426,8 @@ theorem LinearMap.IsSymmetric.directSum_isInternal_of_commute' {𝕜 E : Type*} 
       have hyi := Submodule.coe_mem (y i)
       simp only [Submodule.mem_inf, mem_genEigenspace_one] at hyi
       refine Submodule.mem_iSup_of_mem ⟨⟨i.2, ?_⟩, ⟨i.1, ?_⟩⟩ (by simp)
-      <;> simp only [HasUnifEigenvalue, ne_eq, Submodule.eq_bot_iff, mem_genEigenspace_one, not_forall]
+      <;> simp only [HasUnifEigenvalue, ne_eq, Submodule.eq_bot_iff, mem_genEigenspace_one,
+        not_forall]
       <;> refine ⟨y i, by tauto, by simpa using hi⟩
     intro x
     rw [Submodule.eq_top_iff'] at h_sum
@@ -407,23 +445,28 @@ noncomputable def LinearMap.sharedEigenbasis {A B : EuclideanSpace 𝕜 d →ₗ
 
 noncomputable def LinearMap.sharedEigenvaluesA {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
     (hA : A.IsSymmetric) (hB : B.IsSymmetric) (hAB : Commute A B) : d → ℝ :=
-  fun i => RCLike.re (inner 𝕜 (LinearMap.sharedEigenbasis hA hB hAB i) (A (LinearMap.sharedEigenbasis hA hB hAB i)))
+  fun i => RCLike.re (inner 𝕜 (LinearMap.sharedEigenbasis hA hB hAB i)
+    (A (LinearMap.sharedEigenbasis hA hB hAB i)))
 
 noncomputable def LinearMap.sharedEigenvaluesB {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
     (hA : A.IsSymmetric) (hB : B.IsSymmetric) (hAB : Commute A B) : d → ℝ :=
-  fun i => RCLike.re (inner 𝕜 (LinearMap.sharedEigenbasis hA hB hAB i) (B (LinearMap.sharedEigenbasis hA hB hAB i)))
+  fun i => RCLike.re (inner 𝕜 (LinearMap.sharedEigenbasis hA hB hAB i)
+    (B (LinearMap.sharedEigenbasis hA hB hAB i)))
 
 omit [DecidableEq d] in
-theorem LinearMap.mem_eigenspace_inf_of_sharedEigenbasis {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
+theorem LinearMap.mem_eigenspace_inf_of_sharedEigenbasis
+    {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
     (hA : A.IsSymmetric) (hB : B.IsSymmetric) (hAB : Commute A B) (i : d) :
     ∃ (μ : Module.End.Eigenvalues A) (ν : Module.End.Eigenvalues B),
-      LinearMap.sharedEigenbasis hA hB hAB i ∈ Module.End.eigenspace A μ ⊓ Module.End.eigenspace B ν := by
+      LinearMap.sharedEigenbasis hA hB hAB i ∈
+        Module.End.eigenspace A μ ⊓ Module.End.eigenspace B ν := by
   rw [LinearMap.sharedEigenbasis]
   rw [OrthonormalBasis.reindex_apply]
   let hV := hA.directSum_isInternal_of_commute' hB hAB
   let hV' := hA.orthogonalFamily_eigenspace_inf_eigenspace' hB
   let hn : Module.finrank 𝕜 (EuclideanSpace 𝕜 d) = Module.finrank 𝕜 (EuclideanSpace 𝕜 d) := rfl
-  let e := Fintype.equivOfCardEq (show Fintype.card (Fin (Module.finrank 𝕜 (EuclideanSpace 𝕜 d))) = Fintype.card d by simp)
+  let e := Fintype.equivOfCardEq
+    (show Fintype.card (Fin (Module.finrank 𝕜 (EuclideanSpace 𝕜 d))) = Fintype.card d by simp)
   let j := e.symm i
   let idx := hV.subordinateOrthonormalBasisIndex hn j hV'
   exists idx.1, idx.2
@@ -432,7 +475,8 @@ theorem LinearMap.mem_eigenspace_inf_of_sharedEigenbasis {A B : EuclideanSpace �
 omit [DecidableEq d] in
 theorem LinearMap.apply_A_sharedEigenbasis {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
     (hA : A.IsSymmetric) (hB : B.IsSymmetric) (hAB : Commute A B) (i : d) :
-    A (sharedEigenbasis hA hB hAB i) = (sharedEigenvaluesA hA hB hAB i : 𝕜) • (sharedEigenbasis hA hB hAB i) := by
+    A (sharedEigenbasis hA hB hAB i) =
+      (sharedEigenvaluesA hA hB hAB i : 𝕜) • (sharedEigenbasis hA hB hAB i) := by
   obtain ⟨μ, ν, h⟩ := mem_eigenspace_inf_of_sharedEigenbasis hA hB hAB i
   have h₂ := Module.End.mem_eigenspace_iff.mp h.1
   rw [h₂]
@@ -448,7 +492,8 @@ theorem LinearMap.apply_A_sharedEigenbasis {A B : EuclideanSpace 𝕜 d →ₗ[�
 omit [DecidableEq d] in
 theorem LinearMap.apply_B_sharedEigenbasis {A B : EuclideanSpace 𝕜 d →ₗ[𝕜] EuclideanSpace 𝕜 d}
     (hA : A.IsSymmetric) (hB : B.IsSymmetric) (hAB : Commute A B) (i : d) :
-    B (sharedEigenbasis hA hB hAB i) = (sharedEigenvaluesB hA hB hAB i : 𝕜) • (sharedEigenbasis hA hB hAB i) := by
+    B (sharedEigenbasis hA hB hAB i) =
+      (sharedEigenvaluesB hA hB hAB i : 𝕜) • (sharedEigenbasis hA hB hAB i) := by
   obtain ⟨μ, ν, h⟩ := mem_eigenspace_inf_of_sharedEigenbasis hA hB hAB i
   have h₂ := Module.End.mem_eigenspace_iff.mp h.2
   rw [h₂]
@@ -470,7 +515,8 @@ noncomputable def Matrix.sharedEigenbasis
 noncomputable def Matrix.sharedEigenvectorUnitary (hA : A.IsHermitian) (hB : B.IsHermitian)
     (hAB : Commute A B) : Matrix.unitaryGroup d 𝕜 :=
   ⟨(EuclideanSpace.basisFun d 𝕜).toBasis.toMatrix (sharedEigenbasis hA hB hAB).toBasis,
-    (EuclideanSpace.basisFun d 𝕜).toMatrix_orthonormalBasis_mem_unitary (sharedEigenbasis hA hB hAB)⟩
+    (EuclideanSpace.basisFun d 𝕜).toMatrix_orthonormalBasis_mem_unitary
+      (sharedEigenbasis hA hB hAB)⟩
 
 namespace Matrix.SharedEigenbasis
 
@@ -517,7 +563,12 @@ theorem mulVec_sharedEigenbasisB (j : d) :
 
 /-
 PROVIDED SOLUTION
-This is exactly analogous to star_shared_mul_B_mul_IsDiag (which is proved below in this file), but for A instead of B. Use the same proof structure: rw isDiag_iff_diagonal_diag, apply toEuclideanLin.injective, ext with basis, simp, then use mulVec_sharedEigenbasisA (instead of mulVec_sharedEigenbasisB), sharedEigenvectorUnitary_mulVec, h_simp2 (orthogonality/unit property), and by_cases on index equality, simplifying with simp +decide. Reference the B version's proof approach for the exact tactic sequence.
+This is exactly analogous to star_shared_mul_B_mul_IsDiag (which is proved below in this file), but
+for A instead of B. Use the same proof structure: rw isDiag_iff_diagonal_diag, apply
+toEuclideanLin.injective, ext with basis, simp, then use mulVec_sharedEigenbasisA (instead of
+mulVec_sharedEigenbasisB), sharedEigenvectorUnitary_mulVec, h_simp2 (orthogonality/unit property),
+and by_cases on index equality, simplifying with simp +decide. Reference the B version's proof
+approach for the exact tactic sequence.
 -/
 set_option maxHeartbeats 0 in
 
@@ -553,17 +604,25 @@ theorem star_shared_mul_B_mul_IsDiag : IsDiag
   apply PiLp.ext
   intro j
 
-  have h_simp : (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec (B.mulVec (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i))) =
-    (sharedEigenvalueB hA hB hAB i) • (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i)) := by
-      convert congr_arg ( fun x => ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 ) ᴴ *ᵥ x ) ( mulVec_sharedEigenbasisB hA hB hAB i) using 1;
+  have h_simp : (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec
+      (B.mulVec (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i))) =
+    (sharedEigenvalueB hA hB hAB i) •
+      (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec
+        (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i)) := by
+      convert congr_arg
+        ( fun x => ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 ) ᴴ *ᵥ x )
+        ( mulVec_sharedEigenbasisB hA hB hAB i) using 1;
       symm
       exact (mulVec_smul ((sharedEigenvectorUnitary hA hB hAB).val)ᴴ (sharedEigenvalueB hA hB hAB i)
       (WithLp.ofLp ((sharedEigenbasis hA hB hAB) i)))
-  have h_simp2 : (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i)) = Pi.single i 1 := by
+  have h_simp2 : (Matrix.sharedEigenvectorUnitary hA hB hAB).val.conjTranspose.mulVec
+      (WithLp.ofLp (Matrix.sharedEigenbasis hA hB hAB i)) = Pi.single i 1 := by
     rw [ ← sharedEigenvectorUnitary_mulVec hA hB hAB i ];
     simp
     ext j
-    have := mul_eq_one_comm.mp ( show ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 ) * ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 )ᴴ = 1 from ?_ );
+    have := mul_eq_one_comm.mp
+      ( show ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 ) *
+          ( Matrix.sharedEigenvectorUnitary hA hB hAB : Matrix d d 𝕜 )ᴴ = 1 from ?_ );
     · convert congr_fun ( congr_fun this j ) i using 1;
       simp [ Pi.single_apply, Matrix.one_apply ];
     · exact Matrix.mem_unitaryGroup_iff.mp ( Matrix.sharedEigenvectorUnitary hA hB hAB ).2;

--- a/QuantumInfo/ForMathlib/LimSupInf.lean
+++ b/QuantumInfo/ForMathlib/LimSupInf.lean
@@ -31,15 +31,20 @@ Several 'bespoke' facts about limsup and liminf on ENNReal / NNReal needed in St
 -/
 
 /-
-There exists a strictly increasing sequence of indices $n_k$ such that $f(1/(k+1), n_k) \le y + 1/(k+1)$.
+There exists a strictly increasing sequence of indices $n_k$ such that
+$f(1/(k+1), n_k) \le y + 1/(k+1)$.
 -/
-lemma exists_strictMono_seq_le (y : ℝ≥0) (f : ℝ≥0 → ℕ → ℝ≥0∞) (hf : ∀ x > 0, Filter.atTop.liminf (f x) ≤ y) :
-    ∃ n : ℕ → ℕ, StrictMono n ∧ ∀ k : ℕ, f ((k : ℝ≥0) + 1)⁻¹ (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
-  -- Since the liminf is ≤ y, for any ε > 0 and index n, there frequently exists an m > n satisfying the bound.
+lemma exists_strictMono_seq_le (y : ℝ≥0) (f : ℝ≥0 → ℕ → ℝ≥0∞)
+    (hf : ∀ x > 0, Filter.atTop.liminf (f x) ≤ y) :
+    ∃ n : ℕ → ℕ, StrictMono n ∧
+      ∀ k : ℕ, f ((k : ℝ≥0) + 1)⁻¹ (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
+  -- Since the liminf is ≤ y, for any ε > 0 and index n, there frequently exists an m > n
+  -- satisfying the bound.
   have h_freq (k n : ℕ) : ∃ m > n, f ((k + 1 : ℝ≥0)⁻¹) m ≤ y + (k + 1 : ℝ≥0)⁻¹ := by
     specialize hf ((k + 1 : ℝ≥0)⁻¹) (by positivity)
     rw [Filter.liminf_eq] at hf
-    simp only [Filter.eventually_atTop, ge_iff_le, sSup_le_iff, Set.mem_setOf_eq, forall_exists_index] at hf
+    simp only [Filter.eventually_atTop, ge_iff_le, sSup_le_iff, Set.mem_setOf_eq,
+      forall_exists_index] at hf
     contrapose! hf
     refine ⟨_, n + 1, fun m hm ↦ (hf m hm).le, ENNReal.lt_add_right (by norm_num) (by norm_num)⟩
   refine ⟨fun k ↦ k.recOn (Classical.choose (h_freq 0 0))
@@ -49,9 +54,11 @@ lemma exists_strictMono_seq_le (y : ℝ≥0) (f : ℝ≥0 → ℕ → ℝ≥0∞
     · exact (Classical.choose_spec (h_freq 0 _)).2
     · exact (Nat.find_spec (h_freq (k + 1) _)).2
 /-
-There exists a strictly increasing sequence M such that for all k, and all n ≥ M k, f (1/(k+1)) n is close to y.
+There exists a strictly increasing sequence M such that for all k, and all n ≥ M k,
+f (1/(k+1)) n is close to y.
 -/
-lemma exists_seq_bound (y : ℝ≥0) (f : ℝ≥0 → ℕ → ℝ≥0∞) (hf : ∀ x > 0, Filter.atTop.limsup (f x) ≤ y) :
+lemma exists_seq_bound (y : ℝ≥0) (f : ℝ≥0 → ℕ → ℝ≥0∞)
+    (hf : ∀ x > 0, Filter.atTop.limsup (f x) ≤ y) :
     ∃ M : ℕ → ℕ, StrictMono M ∧ ∀ k, ∀ n ≥ M k, f ((k + 1 : ℝ≥0)⁻¹) n ≤ y + (k + 1 : ℝ≥0∞)⁻¹ := by
   have h_M (k : ℕ) : ∃ M_k, ∀ n ≥ M_k, f (k + 1)⁻¹ n ≤ y + (k + 1 : ℝ≥0∞)⁻¹ := by
     specialize hf (k + 1)⁻¹ (by positivity)
@@ -92,9 +99,12 @@ lemma exists_liminf_zero_of_forall_liminf_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
   by_contra h_contra;
   -- By definition of negation, if $\neg P$ holds, then $P$ does not hold.
   push Not at h_contra;
-  -- Apply `exists_strictMono_seq_le` to obtain a strictly increasing sequence `n_k` such that `f (1/(k+1)) (n_k) ≤ y + 1/(k+1)`.
-  obtain ⟨n, hn_mono, hn_le⟩ : ∃ n : ℕ → ℕ, StrictMono n ∧ ∀ k : ℕ, f ((k : ℝ≥0) + 1)⁻¹ (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
-    -- Apply `exists_strictMono_seq_le` to obtain a strictly increasing sequence `n_k` such that `f (1/(k+1)) (n_k) ≤ y + 1/(k+1)` for all `k`.
+  -- Apply `exists_strictMono_seq_le` to obtain a strictly increasing sequence `n_k` such that
+  -- `f (1/(k+1)) (n_k) ≤ y + 1/(k+1)`.
+  obtain ⟨n, hn_mono, hn_le⟩ : ∃ n : ℕ → ℕ, StrictMono n ∧
+      ∀ k : ℕ, f ((k : ℝ≥0) + 1)⁻¹ (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
+    -- Apply `exists_strictMono_seq_le` to obtain a strictly increasing sequence `n_k` such that
+    -- `f (1/(k+1)) (n_k) ≤ y + 1/(k+1)` for all `k`.
     apply exists_strictMono_seq_le y f; intro x hx_pos; (
     refine' le_of_forall_gt_imp_ge_of_dense fun z hz => _;
     refine' csSup_le _ _ <;> norm_num;
@@ -103,33 +113,41 @@ lemma exists_liminf_zero_of_forall_liminf_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
       simp_all only [gt_iff_lt, Filter.eventually_atTop, ge_iff_le]
       obtain ⟨w, h⟩ := this
       exact le_trans ( hn _ ( le_of_lt ( h _ le_rfl ) ) ) ( le_of_lt ( hc₂ _ hx_pos _ hz _ ) ));
-  -- Define $g(m) = 1/(k(m)+1)$ where $k(m)$ is the index such that $n_{k(m)} \leq m < n_{k(m)+1}$.
+  -- Define $g(m) = 1/(k(m)+1)$ where $k(m)$ is the index such that
+  -- $n_{k(m)} \leq m < n_{k(m)+1}$.
   set g : ℕ → ℝ≥0 := fun m => (Nat.findGreatest (fun k => m ≥ n k) m + 1 : ℝ≥0)⁻¹;
   have hg_pos : ∀ m, g m > 0 := by
     exact fun m => by positivity;;
   have hg_tendsto_zero : Filter.Tendsto g Filter.atTop (𝓝 0) := by
-    -- Since $n$ is strictly monotone, $Nat.findGreatest (fun k => m ≥ n k) m$ tends to infinity as $m$ tends to infinity.
-    have h_find_greatest_inf : Filter.Tendsto (fun m => Nat.findGreatest (fun k => m ≥ n k) m) Filter.atTop Filter.atTop := by
+    -- Since $n$ is strictly monotone, $Nat.findGreatest (fun k => m ≥ n k) m$ tends to infinity
+    -- as $m$ tends to infinity.
+    have h_find_greatest_inf : Filter.Tendsto (fun m => Nat.findGreatest (fun k => m ≥ n k) m)
+        Filter.atTop Filter.atTop := by
       refine' Filter.tendsto_atTop_atTop.mpr fun x => _;
       use n x; intro a ha
       refine' Nat.le_findGreatest _ ha
-      simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true,
-        ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, ge_iff_le, inv_pos, add_pos_iff,
-        Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true, implies_true, g]
+      simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+        not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one,
+        ge_iff_le, inv_pos, add_pos_iff, Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true,
+        implies_true, g]
       exact le_trans ( hn_mono.id_le _ ) ha;
     rw [ tendsto_order ] at *
-    simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true,
-      ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, ge_iff_le, inv_pos, add_pos_iff,
-      Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true, implies_true, not_lt_zero, Filter.eventually_atTop,
-      not_isEmpty_of_nonempty, IsEmpty.forall_iff, IsEmpty.exists_iff, true_and, g]
+    simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+      not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one,
+      ge_iff_le, inv_pos, add_pos_iff, Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true,
+      implies_true, not_lt_zero, Filter.eventually_atTop, not_isEmpty_of_nonempty,
+      IsEmpty.forall_iff, IsEmpty.exists_iff, true_and, g]
     intro a' a
-    exact Filter.eventually_atTop.mp ( h_find_greatest_inf.eventually_gt_atTop ⌈ ( a' : ℝ≥0 ) ⁻¹⌉₊ ) |> fun ⟨ M, hM ⟩ ↦ ⟨ M, fun m hm ↦ by simpa using inv_lt_of_inv_lt₀ a <| by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| hM m hm ) <| mod_cast Nat.le_succ _ ⟩;
+    exact Filter.eventually_atTop.mp ( h_find_greatest_inf.eventually_gt_atTop ⌈ ( a' : ℝ≥0 ) ⁻¹⌉₊ )
+      |> fun ⟨ M, hM ⟩ ↦ ⟨ M, fun m hm ↦ by simpa using inv_lt_of_inv_lt₀ a <|
+        by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| hM m hm ) <| mod_cast Nat.le_succ _ ⟩;
   have hg_le : ∀ k, f (g (n k)) (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
     intro k
     specialize hn_le k
-    simp_all only [gt_iff_lt, ge_iff_le, inv_pos, add_pos_iff, Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one,
-      or_true, implies_true, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true,
-      ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, g]
+    simp_all only [gt_iff_lt, ge_iff_le, inv_pos, add_pos_iff, Nat.cast_pos, Nat.findGreatest_pos,
+      zero_lt_one, or_true, implies_true, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+      and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+      ENNReal.coe_one, g]
     rw [ show Nat.findGreatest ( fun k_1 => n k_1 ≤ n k ) ( n k ) = k from _ ]
     simp_all only
     rw [ Nat.findGreatest_eq_iff ]
@@ -142,30 +160,34 @@ lemma exists_liminf_zero_of_forall_liminf_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
     refine' csSup_le _ _ <;> norm_num;
     · exact ⟨ 0, ⟨ 0, fun _ _ => zero_le ⟩ ⟩;
     · intro b x hx; contrapose! hx
-      simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true,
-        ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, ge_iff_le, inv_pos, add_pos_iff,
-        Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true, implies_true, g]
+      simp_all only [gt_iff_lt, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+        not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one,
+        ge_iff_le, inv_pos, add_pos_iff, Nat.cast_pos, Nat.findGreatest_pos, zero_lt_one, or_true,
+        implies_true, g]
       -- Choose $k$ such that $y + 1/(k+1) < b$.
       obtain ⟨k, hk⟩ : ∃ k : ℕ, y + ((k : ℝ≥0) + 1)⁻¹ < b := by
         rcases ENNReal.lt_iff_exists_nnreal_btwn.mp hx with ⟨z, hz⟩
-        simp_all only [ENNReal.coe_lt_coe, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-          not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
+        simp_all only [ENNReal.coe_lt_coe, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+          and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+          ENNReal.coe_one]
         obtain ⟨left, right⟩ := hz
-        obtain ⟨k, hk⟩ := exists_nat_one_div_lt ( show 0 < ( z : ℝ ) - y from sub_pos.mpr <| mod_cast left )
+        obtain ⟨k, hk⟩ := exists_nat_one_div_lt
+          ( show 0 < ( z : ℝ ) - y from sub_pos.mpr <| mod_cast left )
         use k
         norm_num at *;
         refine' lt_of_le_of_lt _ right;
-        convert add_le_add_left ( ENNReal.ofReal_le_ofReal hk.le ) ( y : ℝ≥0∞ ) using 1 ; norm_num [ ENNReal.ofReal ];
+        convert add_le_add_left ( ENNReal.ofReal_le_ofReal hk.le ) ( y : ℝ≥0∞ ) using 1 ;
+        norm_num [ ENNReal.ofReal ];
         · norm_num [ Real.toNNReal_inv ];
           rw [add_comm]
         · rw [ENNReal.ofReal_sub _ (by positivity)]
           simp [tsub_add_cancel_of_le, left.le]
       refine' ⟨ n ( Max.max x k ), _, _ ⟩
-      · simp_all only [ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true, ENNReal.coe_inv,
-          ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
+      · simp_all only [ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+          not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
         exact le_trans ( le_max_left _ _ ) ( hn_mono.id_le _ );
-      · simp_all only [ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true, ENNReal.coe_inv,
-          ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
+      · simp_all only [ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+          not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
         refine' lt_of_le_of_lt ( hg_le _ ) _;
         refine' lt_of_le_of_lt _ hk
         gcongr
@@ -196,30 +218,37 @@ lemma exists_limsup_zero_of_forall_limsup_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
     ∃ g : ℕ → ℝ≥0, (∀ x, g x > 0) ∧ (Filter.atTop.Tendsto g (𝓝 0)) ∧
       (Filter.atTop.limsup (fun n ↦ f (g n) n) ≤ y) := by
     -- Let's choose a sequence M such that for all k, and all n ≥ M k, f (1/(k+1)) n is close to y.
-  obtain ⟨M, hM⟩ : ∃ M : ℕ → ℕ, StrictMono M ∧ ∀ k, ∀ n ≥ M k, f ((k + 1 : ℝ≥0)⁻¹) n ≤ y + (k + 1 : ℝ≥0∞)⁻¹ := by
+  obtain ⟨M, hM⟩ : ∃ M : ℕ → ℕ, StrictMono M ∧
+      ∀ k, ∀ n ≥ M k, f ((k + 1 : ℝ≥0)⁻¹) n ≤ y + (k + 1 : ℝ≥0∞)⁻¹ := by
     -- Apply the hypothesis `exists_seq_bound` to obtain the sequence $M$.
     apply exists_seq_bound y f hf;
   use fun n => 1 / ( Nat.findGreatest ( fun k => M k ≤ n ) n + 1 );
   refine ⟨?_, ?_, ?_⟩
   · aesop;
-  · -- We'll use that Nat.findGreatest (fun k => M k ≤ n) n tends to infinity as n tends to infinity.
-    have h_find_greatest : Filter.Tendsto (fun n => Nat.findGreatest (fun k => M k ≤ n) n) Filter.atTop Filter.atTop := by
+  · -- We'll use that Nat.findGreatest (fun k => M k ≤ n) n tends to infinity as n tends to
+    -- infinity.
+    have h_find_greatest : Filter.Tendsto (fun n => Nat.findGreatest (fun k => M k ≤ n) n)
+        Filter.atTop Filter.atTop := by
       refine' Filter.tendsto_atTop_atTop.mpr fun k => _;
       use M k; intro a ha; refine' Nat.le_findGreatest _ ha
       simp_all only [gt_iff_lt, ge_iff_le]
       obtain ⟨left, right⟩ := hM
       exact le_trans ( left.id_le _ ) ha;
     rw [ tendsto_order ]
-    simp_all only [gt_iff_lt, ge_iff_le, not_lt_zero, one_div, Filter.eventually_atTop, not_isEmpty_of_nonempty,
-      IsEmpty.forall_iff, IsEmpty.exists_iff, implies_true, true_and]
+    simp_all only [gt_iff_lt, ge_iff_le, not_lt_zero, one_div, Filter.eventually_atTop,
+      not_isEmpty_of_nonempty, IsEmpty.forall_iff, IsEmpty.exists_iff, implies_true, true_and]
     intro a' a
     obtain ⟨left, right⟩ := hM
     have := h_find_greatest.eventually_gt_atTop ⌈a'⁻¹⌉₊
     simp_all only [Filter.eventually_atTop, ge_iff_le]
     obtain ⟨w, h⟩ := this
-    exact ⟨ w, fun n hn => inv_lt_of_inv_lt₀ a <| by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| h n hn ) <| mod_cast Nat.le_succ _ ⟩;
-  · -- For any ε > 0, choose K such that 1/(K+1) < ε. For n ≥ M K, we have g n = 1/(k+1) with k ≥ K. Also n ≥ M k (since k is the smallest such that n < M (k+1)). Thus f (g n) n ≤ y + 1/(k+1) < y + ε.
-    have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N, f (1 / (Nat.findGreatest (fun k => M k ≤ n) n + 1)) n ≤ y + ε := by
+    exact ⟨ w, fun n hn => inv_lt_of_inv_lt₀ a <|
+      by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| h n hn ) <| mod_cast Nat.le_succ _ ⟩;
+  · -- For any ε > 0, choose K such that 1/(K+1) < ε. For n ≥ M K, we have g n = 1/(k+1) with
+    -- k ≥ K. Also n ≥ M k (since k is the smallest such that n < M (k+1)).
+    -- Thus f (g n) n ≤ y + 1/(k+1) < y + ε.
+    have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N,
+        f (1 / (Nat.findGreatest (fun k => M k ≤ n) n + 1)) n ≤ y + ε := by
       intro ε hε_pos
       obtain ⟨K, hK⟩ : ∃ K : ℕ, (K + 1 : ℝ≥0∞)⁻¹ < ε := by
         rcases ENNReal.exists_inv_nat_lt hε_pos.ne' with ⟨ K, hK ⟩
@@ -240,7 +269,8 @@ lemma exists_limsup_zero_of_forall_limsup_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
         refine le_trans this ( add_le_add_right ( le_trans ( by gcongr ) hK.le ) _ );
       · simp_all only [gt_iff_lt, ge_iff_le]
         obtain ⟨left, right⟩ := hM
-        have := Nat.findGreatest_eq_iff.mp ( by aesop : Nat.findGreatest ( fun k => M k ≤ n ) n = Nat.findGreatest ( fun k => M k ≤ n ) n )
+        have := Nat.findGreatest_eq_iff.mp ( by aesop :
+          Nat.findGreatest ( fun k => M k ≤ n ) n = Nat.findGreatest ( fun k => M k ≤ n ) n )
         by_cases h : Nat.findGreatest ( fun k => M k ≤ n ) n = 0
         · simp_all
         · simp_all
@@ -250,10 +280,12 @@ lemma exists_limsup_zero_of_forall_limsup_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
     · aesop
 
 /-
-If x_k tends to L and g(n) = x_k for n in [T_k, T_{k+1}) where T is strictly increasing, then g(n) tends to L.
+If x_k tends to L and g(n) = x_k for n in [T_k, T_{k+1}) where T is strictly increasing,
+then g(n) tends to L.
 -/
 lemma tendsto_of_block_sequence {α : Type*} [TopologicalSpace α] {x : ℕ → α} {T : ℕ → ℕ}
-    (hT : StrictMono T) {L : α} (hx : Filter.atTop.Tendsto x (𝓝 L)) (g : ℕ → α) (hg : ∀ k, ∀ n ∈ Set.Ico (T k) (T (k + 1)), g n = x k) :
+    (hT : StrictMono T) {L : α} (hx : Filter.atTop.Tendsto x (𝓝 L)) (g : ℕ → α)
+    (hg : ∀ k, ∀ n ∈ Set.Ico (T k) (T (k + 1)), g n = x k) :
       Filter.atTop.Tendsto g (𝓝 L) := by
   rw [Filter.tendsto_atTop'] at hx ⊢
   intro s hs
@@ -277,24 +309,34 @@ lemma tendsto_of_block_sequence {α : Type*} [TopologicalSpace α] {x : ℕ → 
   exact ha k (le_of_not_gt fun hk' ↦ by linarith [hT.monotone hk'])
 
 /-
-Given a lower bound sequence M and a property P that can always be satisfied eventually, there exists a strictly increasing sequence T bounded by M such that each interval [T_k, T_{k+1}) contains a witness for P.
+Given a lower bound sequence M and a property P that can always be satisfied eventually, there
+exists a strictly increasing sequence T bounded by M such that each interval [T_k, T_{k+1})
+contains a witness for P.
 -/
-lemma exists_increasing_sequence_with_property (M : ℕ → ℕ) (P : ℕ → ℕ → Prop) (hP : ∀ k L, ∃ n ≥ L, P k n) :
-    ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ M k) ∧ (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), P k n) := by
+lemma exists_increasing_sequence_with_property (M : ℕ → ℕ) (P : ℕ → ℕ → Prop)
+    (hP : ∀ k L, ∃ n ≥ L, P k n) :
+    ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ M k) ∧
+      (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), P k n) := by
   -- We construct $T_k$ by induction.
-  have hT_ind : ∀ k : ℕ, ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ M k) ∧ (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), P k n) ∧ T (k + 1) > T k := by
+  have hT_ind : ∀ k : ℕ, ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ M k) ∧
+      (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), P k n) ∧ T (k + 1) > T k := by
     intro k
     induction k
     · choose! n hn using hP;
-      use fun k => Nat.recOn k ( M 0 ) fun k ih => Max.max ( ih + 1 ) ( Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) )
-      simp_all only [ge_iff_le, le_sup_iff, add_le_add_iff_right, or_true, sup_of_le_right, Set.mem_Ico, lt_sup_iff,
-        Nat.rec_zero, zero_add]
+      use fun k => Nat.recOn k ( M 0 )
+        fun k ih => Max.max ( ih + 1 ) ( Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) )
+      simp_all only [ge_iff_le, le_sup_iff, add_le_add_iff_right, or_true, sup_of_le_right,
+        Set.mem_Ico, lt_sup_iff, Nat.rec_zero, zero_add]
       refine ⟨?_, ?_, ?_, ?_⟩
-      · exact strictMono_nat_of_lt_succ fun k => by cases max_cases ( M ( k + 1 ) ) ( n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) + 1 ) <;> linarith [ hn k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) ] ;
+      · exact strictMono_nat_of_lt_succ fun k => by cases max_cases ( M ( k + 1 ) )
+          ( n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) + 1 )
+          <;> linarith
+          [ hn k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) ] ;
       · intro k
         induction k <;> aesop;
       · intro k
-        exact ⟨ n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ), ⟨ hn _ _ |>.1, Or.inr ( Nat.lt_succ_self _ ) ⟩, hn _ _ |>.2 ⟩;
+        exact ⟨ n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ),
+          ⟨ hn _ _ |>.1, Or.inr ( Nat.lt_succ_self _ ) ⟩, hn _ _ |>.2 ⟩;
       · exact Or.inr ( by linarith [ hn 0 ( M 0 ) ] );
     · rename_i ih
       obtain ⟨ T, hT₁, hT₂, hT₃, hT₄ ⟩ := ih
@@ -303,7 +345,8 @@ lemma exists_increasing_sequence_with_property (M : ℕ → ℕ) (P : ℕ → �
   exact Exists.elim ( hT_ind 0 ) fun T hT => ⟨ T, hT.1, hT.2.1, hT.2.2.1 ⟩
 
 /-
-If g is a block sequence constructed from x and T, and each block contains a witness where f is bounded by y + 1/(k+1), then liminf f(g) <= y.
+If g is a block sequence constructed from x and T, and each block contains a witness where f is
+bounded by y + 1/(k+1), then liminf f(g) <= y.
 -/
 lemma liminf_le_of_block_sequence_witnesses {α : Type*} (y : ℝ≥0) (f : α → ℕ → ℝ≥0∞)
     (T : ℕ → ℕ) (hT : StrictMono T) (x : ℕ → α) (g : ℕ → α)
@@ -311,9 +354,10 @@ lemma liminf_le_of_block_sequence_witnesses {α : Type*} (y : ℝ≥0) (f : α �
     (hwit : ∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), f (x k) n ≤ (y : ℝ≥0∞) + (k + 1 : ℝ≥0)⁻¹) :
     Filter.atTop.liminf (fun n ↦ f (g n) n) ≤ y := by
   rw [ Filter.liminf_eq ];
-  simp_all only [Set.mem_Ico, and_imp, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-    not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one,
-    Filter.eventually_atTop, ge_iff_le, sSup_le_iff, Set.mem_setOf_eq, forall_exists_index]
+  simp_all only [Set.mem_Ico, and_imp, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+    and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+    ENNReal.coe_one, Filter.eventually_atTop, ge_iff_le, sSup_le_iff, Set.mem_setOf_eq,
+    forall_exists_index]
   intro b x_1 h
   -- Fix an arbitrary $k \geq x_1$.
   suffices h_suff : ∀ k ≥ x_1, ∃ n ≥ k, f (g n) n ≤ y + 1 / (k + 1) by
@@ -327,13 +371,16 @@ lemma liminf_le_of_block_sequence_witnesses {α : Type*} (y : ℝ≥0) (f : α �
         exact ⟨ N, fun n hn => le_trans ( by gcongr ; norm_cast ; linarith ) hN.le ⟩;
       simpa using tendsto_const_nhds.add h_lim;
     refine' le_of_tendsto_of_tendsto tendsto_const_nhds h_lim _;
-    filter_upwards [ Filter.eventually_ge_atTop x_1 ] with k hk using by obtain ⟨ n, hn₁, hn₂ ⟩ := h_suff k hk; exact le_trans ( h n ( by linarith ) ) hn₂;
+    filter_upwards [ Filter.eventually_ge_atTop x_1 ] with k hk using by
+      obtain ⟨ n, hn₁, hn₂ ⟩ := h_suff k hk; exact le_trans ( h n ( by linarith ) ) hn₂;
   intro k hk
   obtain ⟨n, hn₁, hn₂⟩ := hwit k;
-  exact ⟨ n, le_trans ( show k ≤ T k from hT.id_le _ ) hn₁.1, by rw [ hg k n hn₁.1 hn₁.2 ] ; simpa using hn₂ ⟩
+  exact ⟨ n, le_trans ( show k ≤ T k from hT.id_le _ ) hn₁.1,
+    by rw [ hg k n hn₁.1 hn₁.2 ] ; simpa using hn₂ ⟩
 
 /-
-If g is a block sequence constructed from x and T, and f is bounded by y + 1/(k+1) on each block, then limsup f(g) <= y.
+If g is a block sequence constructed from x and T, and f is bounded by y + 1/(k+1) on each block,
+then limsup f(g) <= y.
 -/
 lemma limsup_le_of_block_sequence_bound {α : Type*} (y : ℝ≥0) (f : α → ℕ → ℝ≥0∞)
   (T : ℕ → ℕ) (hT : StrictMono T) (x : ℕ → α) (g : ℕ → α)
@@ -343,14 +390,15 @@ lemma limsup_le_of_block_sequence_bound {α : Type*} (y : ℝ≥0) (f : α → �
     refine' le_of_forall_pos_le_add fun ε hε => _;
     refine' csInf_le _ _
     · aesop
-    simp_all only [Set.mem_Ico, and_imp, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-      not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one,
-      Filter.eventually_map, Filter.eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
+    simp_all only [Set.mem_Ico, and_imp, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+      and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+      ENNReal.coe_one, Filter.eventually_map, Filter.eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
     -- Choose $K$ such that for all $k \ge K$, we have $1/(k+1) \le \epsilon$.
     obtain ⟨K, hK⟩ : ∃ K : ℕ, ∀ k ≥ K, (k + 1 : ℝ≥0)⁻¹ ≤ ε := by
       rcases ENNReal.lt_iff_exists_nnreal_btwn.mp hε with ⟨ δ, hδ, hδε ⟩
-      simp_all only [ENNReal.coe_pos, ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-        not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
+      simp_all only [ENNReal.coe_pos, ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+        and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+        ENNReal.coe_one]
       refine' ⟨ ⌈δ⁻¹⌉₊, fun k hk => le_trans _ hδε.le ⟩
       norm_cast
       rw [ ENNReal.inv_le_iff_le_mul ] <;> norm_cast
@@ -361,20 +409,26 @@ lemma limsup_le_of_block_sequence_bound {α : Type*} (y : ℝ≥0) (f : α → �
       · aesop
     use T K
     intro b a
-    simp_all only [ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false, not_false_eq_true,
-      ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
+    simp_all only [ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
+      not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one]
     -- Let $k$ be such that $b \in [T_k, T_{k+1})$.
     obtain ⟨k, hk⟩ : ∃ k, T k ≤ b ∧ b < T (k + 1) := by
-      -- Since $T$ is strictly increasing and unbounded, the set $\{n \mid T n \leq b\}$ is finite and non-empty.
+      -- Since $T$ is strictly increasing and unbounded, the set $\{n \mid T n \leq b\}$ is finite
+      -- and non-empty.
       have h_finite : Set.Finite {n | T n ≤ b} := by
         exact Set.finite_iff_bddAbove.2 ⟨ b, fun n hn => le_trans ( hT.id_le _ ) hn ⟩;
-      exact ⟨ Finset.max' ( h_finite.toFinset ) ⟨ K, h_finite.mem_toFinset.mpr a ⟩, h_finite.mem_toFinset.mp ( Finset.max'_mem _ _ ), not_le.mp fun h => not_lt_of_ge ( Finset.le_max' _ _ ( h_finite.mem_toFinset.mpr h ) ) ( Nat.lt_succ_self _ ) ⟩;
+      exact ⟨ Finset.max' ( h_finite.toFinset ) ⟨ K, h_finite.mem_toFinset.mpr a ⟩,
+        h_finite.mem_toFinset.mp ( Finset.max'_mem _ _ ),
+        not_le.mp fun h => not_lt_of_ge ( Finset.le_max' _ _ ( h_finite.mem_toFinset.mpr h ) )
+          ( Nat.lt_succ_self _ ) ⟩;
     rw [ hg k b hk.1 hk.2 ];
-    exact le_trans ( hbound k b hk.1 hk.2 ) ( add_le_add_right ( hK k ( le_of_not_gt fun hk' => by linarith [ hT.monotone hk'.nat_succ_le ] ) ) _ )
+    exact le_trans ( hbound k b hk.1 hk.2 ) ( add_le_add_right ( hK k
+      ( le_of_not_gt fun hk' => by linarith [ hT.monotone hk'.nat_succ_le ] ) ) _ )
 
 /- Version of `exists_liminf_zero_of_forall_liminf_le_with_UB` that lets you stipulate it for
 two different functions simultaneously, one with liminf and one with limsup. -/
-lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0) (f₁ f₂ : ℝ≥0 → ℕ → ℝ≥0∞)
+lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0)
+    (f₁ f₂ : ℝ≥0 → ℕ → ℝ≥0∞)
     {z : ℝ≥0} (hz : 0 < z)
     (hf₁ : ∀ x > 0, Filter.atTop.liminf (f₁ x) ≤ y₁)
     (hf₂ : ∀ x > 0, Filter.atTop.limsup (f₂ x) ≤ y₂) :
@@ -383,16 +437,20 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
         Filter.atTop.liminf (fun n ↦ f₁ (g n) n) ≤ y₁ ∧
       Filter.atTop.limsup (fun n ↦ f₂ (g n) n) ≤ y₂ := by
   -- Fix some sequences of positive real numbers $x_k$ and $N_0(k)$.
-  obtain ⟨x, hx⟩ : ∃ x : ℕ → ℝ≥0, (∀ k, 0 < x k) ∧ (∀ k, x k ≤ z / 2) ∧ (∀ k, x k ≤ 1 / (k + 1)) ∧ Filter.Tendsto x Filter.atTop (𝓝 0) := by
+  obtain ⟨x, hx⟩ : ∃ x : ℕ → ℝ≥0, (∀ k, 0 < x k) ∧ (∀ k, x k ≤ z / 2) ∧
+      (∀ k, x k ≤ 1 / (k + 1)) ∧ Filter.Tendsto x Filter.atTop (𝓝 0) := by
     use fun k => Min.min ( z / 2 ) ( 1 / ( k + 1 ) )
-    simp_all only [gt_iff_lt, one_div, lt_inf_iff, div_pos_iff_of_pos_left, Nat.ofNat_pos, inv_pos, add_pos_iff,
-      Nat.cast_pos, zero_lt_one, or_true, and_self, implies_true, inf_le_left, inf_le_right, true_and]
+    simp_all only [gt_iff_lt, one_div, lt_inf_iff, div_pos_iff_of_pos_left, Nat.ofNat_pos, inv_pos,
+      add_pos_iff, Nat.cast_pos, zero_lt_one, or_true, and_self, implies_true, inf_le_left,
+      inf_le_right, true_and]
     rw [ Filter.tendsto_congr' ];
-    any_goals filter_upwards [ Filter.eventually_gt_atTop ⌈ ( z / 2 ) ⁻¹⌉₊ ] with k hk; rw [ min_eq_right ];
+    any_goals filter_upwards [ Filter.eventually_gt_atTop ⌈ ( z / 2 ) ⁻¹⌉₊ ] with k hk;
+      rw [ min_eq_right ];
     · refine' tendsto_order.2 ⟨ fun x => _, fun x hx => _ ⟩
       · aesop
       · simp_all only [gt_iff_lt, Filter.eventually_atTop, ge_iff_le]
-        exact ⟨ ⌈x⁻¹⌉₊, fun n hn => inv_lt_of_inv_lt₀ hx <| lt_of_le_of_lt ( Nat.le_ceil _ ) <| mod_cast Nat.lt_succ_of_le hn ⟩;
+        exact ⟨ ⌈x⁻¹⌉₊, fun n hn => inv_lt_of_inv_lt₀ hx <|
+          lt_of_le_of_lt ( Nat.le_ceil _ ) <| mod_cast Nat.lt_succ_of_le hn ⟩;
     · rw [ inv_le_comm₀ ] <;> norm_cast
       · simp_all only [inv_div, Nat.cast_add, Nat.cast_one]
         exact le_trans ( Nat.le_ceil _ ) ( mod_cast by linarith )
@@ -405,9 +463,15 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
       intro k ε hε_pos
       have h_limsup_le : Filter.limsup (f₂ (x k)) Filter.atTop ≤ y₂ := h_limsup k;
       rw [ Filter.limsup_eq ] at h_limsup_le;
-      have := exists_lt_of_csInf_lt ( show { a : ℝ≥0∞ | ∀ᶠ n in Filter.atTop, f₂ ( x k ) n ≤ a }.Nonempty from ⟨ _, Filter.Eventually.of_forall fun n => le_top ⟩ ) ( show InfSet.sInf { a : ℝ≥0∞ | ∀ᶠ n in Filter.atTop, f₂ ( x k ) n ≤ a } < ( y₂ : ℝ≥0∞ ) + ε from lt_of_le_of_lt h_limsup_le <| ENNReal.lt_add_right ( by aesop ) <| by aesop )
-      simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-        not_false_eq_true, NNReal.le_inv_iff_mul_le, implies_true, Filter.eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
+      have := exists_lt_of_csInf_lt
+        ( show { a : ℝ≥0∞ | ∀ᶠ n in Filter.atTop, f₂ ( x k ) n ≤ a }.Nonempty from
+          ⟨ _, Filter.Eventually.of_forall fun n => le_top ⟩ )
+        ( show InfSet.sInf { a : ℝ≥0∞ | ∀ᶠ n in Filter.atTop, f₂ ( x k ) n ≤ a } <
+          ( y₂ : ℝ≥0∞ ) + ε from
+          lt_of_le_of_lt h_limsup_le <| ENNReal.lt_add_right ( by aesop ) <| by aesop )
+      simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+        and_false, not_false_eq_true, NNReal.le_inv_iff_mul_le, implies_true,
+        Filter.eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
       obtain ⟨left, right⟩ := hx
       obtain ⟨w, h⟩ := this
       obtain ⟨left_1, right⟩ := right
@@ -415,22 +479,28 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
       obtain ⟨left_3, right⟩ := right
       obtain ⟨w_1, h⟩ := left_2
       exact ⟨ w_1, fun n hn => le_trans ( h n hn ) right_1.le ⟩;
-    exact ⟨ fun k => Classical.choose ( h_limsup_le k _ <| by positivity ), fun k n hn => Classical.choose_spec ( h_limsup_le k _ <| by positivity ) n hn ⟩;
-  -- Define the sequence $T_k$ such that $T_k \geq N_0(k)$ and each interval $[T_k, T_{k+1})$ contains some $n_k$ with $P(k, n_k)$.
-  obtain ⟨T, hT_mono, hT_bound, hT_wit⟩ : ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ N0 k) ∧ (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), f₁ (x k) n ≤ y₁ + (k + 1 : ℝ≥0)⁻¹) := by
+    exact ⟨ fun k => Classical.choose ( h_limsup_le k _ <| by positivity ),
+      fun k n hn => Classical.choose_spec ( h_limsup_le k _ <| by positivity ) n hn ⟩;
+  -- Define the sequence $T_k$ such that $T_k \geq N_0(k)$ and each interval $[T_k, T_{k+1})$
+  -- contains some $n_k$ with $P(k, n_k)$.
+  obtain ⟨T, hT_mono, hT_bound, hT_wit⟩ : ∃ T : ℕ → ℕ, StrictMono T ∧ (∀ k, T k ≥ N0 k) ∧
+      (∀ k, ∃ n ∈ Set.Ico (T k) (T (k + 1)), f₁ (x k) n ≤ y₁ + (k + 1 : ℝ≥0)⁻¹) := by
     have hP : ∀ k L, ∃ n ≥ L, f₁ (x k) n ≤ y₁ + (k + 1 : ℝ≥0)⁻¹ := by
-      intro k L; specialize hf₁ ( x k ) ( hx.1 k ) ; rw [ Filter.liminf_eq ] at hf₁; simp_all +decide [ Filter.limsup_eq ] ;
+      intro k L; specialize hf₁ ( x k ) ( hx.1 k ) ; rw [ Filter.liminf_eq ] at hf₁;
+      simp_all +decide [ Filter.limsup_eq ] ;
       contrapose! hf₁;
-      exact ⟨ y₁ + ( k + 1 : ℝ≥0∞ ) ⁻¹, L, fun n hn => le_of_lt ( hf₁ n hn ), ENNReal.lt_add_right ( by aesop ) ( by aesop ) ⟩;
-    have := exists_increasing_sequence_with_property ( fun k => N0 k ) ( fun k n => f₁ ( x k ) n ≤ y₁ + ( k + 1 : ℝ≥0 ) ⁻¹ ) hP; aesop;
+      exact ⟨ y₁ + ( k + 1 : ℝ≥0∞ ) ⁻¹, L, fun n hn => le_of_lt ( hf₁ n hn ),
+        ENNReal.lt_add_right ( by aesop ) ( by aesop ) ⟩;
+    have := exists_increasing_sequence_with_property ( fun k => N0 k )
+      ( fun k n => f₁ ( x k ) n ≤ y₁ + ( k + 1 : ℝ≥0 ) ⁻¹ ) hP; aesop;
   refine' ⟨ fun n => x ( Nat.find ( show ∃ k, n < T ( k + 1 ) from _ ) ), _, _, _, _, _ ⟩;
   exact ⟨ n, hT_mono.id_le _ ⟩;
   · exact fun n => hx.1 _;
   · intro n
     specialize hx
-    simp_all only [gt_iff_lt, ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-      not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, Set.mem_Ico, one_div,
-      NNReal.le_inv_iff_mul_le]
+    simp_all only [gt_iff_lt, ge_iff_le, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+      and_false, not_false_eq_true, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
+      ENNReal.coe_one, Set.mem_Ico, one_div, NNReal.le_inv_iff_mul_le]
     obtain ⟨left, right⟩ := hx
     obtain ⟨left_1, right⟩ := right
     obtain ⟨left_2, right⟩ := right
@@ -438,9 +508,9 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
   · refine' hx.2.2.2.comp _;
     refine' Filter.tendsto_atTop_atTop.mpr _;
     intro b; use T b; intro a ha; contrapose! ha
-    simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-      not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
-      ENNReal.coe_one, Set.mem_Ico, Nat.find_lt_iff]
+    simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+      and_false, not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv,
+      ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, Set.mem_Ico, Nat.find_lt_iff]
     obtain ⟨left, right⟩ := hx
     obtain ⟨w, h⟩ := ha
     obtain ⟨left_1, right⟩ := right
@@ -450,9 +520,9 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
   · refine liminf_le_of_block_sequence_witnesses y₁ f₁ T hT_mono x _ ?_ hT_wit
     intro k n hn
     congr
-    simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-      not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
-      ENNReal.coe_one, Set.mem_Ico]
+    simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+      and_false, not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv,
+      ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, Set.mem_Ico]
     obtain ⟨left, right⟩ := hx
     obtain ⟨left_1, right_1⟩ := hn
     obtain ⟨left_2, right⟩ := right
@@ -467,9 +537,9 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
     · intro k n hn
       congr! 1;
       rw [ Nat.find_eq_iff ]
-      simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero, and_false,
-        not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv, ENNReal.coe_add, ENNReal.coe_natCast,
-        ENNReal.coe_one, Set.mem_Ico, not_lt, true_and]
+      simp_all only [gt_iff_lt, one_div, ne_eq, add_eq_zero, Nat.cast_eq_zero, one_ne_zero,
+        and_false, not_false_eq_true, NNReal.le_inv_iff_mul_le, ge_iff_le, ENNReal.coe_inv,
+        ENNReal.coe_add, ENNReal.coe_natCast, ENNReal.coe_one, Set.mem_Ico, not_lt, true_and]
       intro n_1 a
       obtain ⟨left, right⟩ := hx
       obtain ⟨left_1, right_1⟩ := hn
@@ -480,9 +550,11 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
 
 
 --PULLOUT.
---PR? This is "not specific to our repo", but might be a bit too specialized to be in Mathlib. Not sure.
+--PR? This is "not specific to our repo", but might be a bit too specialized to be in Mathlib.
+--Not sure.
 --Definitely would need to clean up the proof first
-theorem extracted_limsup_inequality (z : ℝ≥0∞) (hz : z ≠ ⊤) (y x : ℕ → ℝ≥0∞) (h_lem5 : ∀ (n : ℕ), x n ≤ y n + z)
+theorem extracted_limsup_inequality (z : ℝ≥0∞) (hz : z ≠ ⊤) (y x : ℕ → ℝ≥0∞)
+    (h_lem5 : ∀ (n : ℕ), x n ≤ y n + z)
     : Filter.atTop.limsup (fun n ↦ x n / n) ≤ Filter.atTop.limsup (fun n ↦ y n / n) := by
   --Thanks Aristotle!
   simp? [Filter.limsup_eq] says simp only [Filter.limsup_eq, Filter.eventually_atTop,
@@ -508,7 +580,8 @@ theorem extracted_limsup_inequality (z : ℝ≥0∞) (hz : z ≠ ⊤) (y x : ℕ
       grw [ha.le, ← ENNReal.ofReal_natCast, ← ENNReal.ofReal_mul (by positivity)]
       gcongr
       nlinarith [Nat.ceil_le.mp hn, mul_div_cancel₀ a hε₂.1.ne']
-    -- Since z ≤ b * ε' for all b ≥ k, dividing both sides by b (which is positive) gives z / b ≤ ε'.
+    -- Since z ≤ b * ε' for all b ≥ k, dividing both sides by b (which is positive) gives
+    -- z / b ≤ ε'.
     rw [Filter.eventually_atTop]
     use k + 1
     intros b _
@@ -530,10 +603,11 @@ theorem _root_.Filter.tendsto_sub_atTop_iff_nat {α : Type*} {f : ℕ → α} {l
 
 --PULLOUT and PR
 open ENNReal Filter in
-/-- Sort of dual to `ENNReal.tendsto_const_sub_nhds_zero_iff`. Takes a substantially different form though, since
-we don't actually have equality of the limits, or even the fact that the other one converges, which is why we
-need to use `limsup`. -/
-theorem _root_.ENNReal.tendsto_sub_const_nhds_zero_iff {α : Type*} {l : Filter α} {f : α → ℝ≥0∞} {a : ℝ≥0∞}
+/-- Sort of dual to `ENNReal.tendsto_const_sub_nhds_zero_iff`. Takes a substantially different form
+though, since we don't actually have equality of the limits, or even the fact that the other one
+converges, which is why we need to use `limsup`. -/
+theorem _root_.ENNReal.tendsto_sub_const_nhds_zero_iff {α : Type*} {l : Filter α} {f : α → ℝ≥0∞}
+    {a : ℝ≥0∞}
     : Tendsto (f · - a) l (𝓝 0) ↔ limsup f l ≤ a := by
   rcases eq_or_ne a ⊤ with rfl | ha
   · simp [tendsto_const_nhds]

--- a/QuantumInfo/ForMathlib/LimSupInf.lean
+++ b/QuantumInfo/ForMathlib/LimSupInf.lean
@@ -140,7 +140,7 @@ lemma exists_liminf_zero_of_forall_liminf_le (y : ℝ≥0) (f : ℝ≥0 → ℕ 
     intro a' a
     exact Filter.eventually_atTop.mp ( h_find_greatest_inf.eventually_gt_atTop ⌈ ( a' : ℝ≥0 ) ⁻¹⌉₊ )
       |> fun ⟨ M, hM ⟩ ↦ ⟨ M, fun m hm ↦ by simpa using inv_lt_of_inv_lt₀ a <|
-        by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| hM m hm ) <| mod_cast Nat.le_succ _ ⟩;
+        (by exact lt_of_lt_of_le ( Nat.lt_of_ceil_lt <| hM m hm ) <| mod_cast Nat.le_succ _) ⟩;
   have hg_le : ∀ k, f (g (n k)) (n k) ≤ (y : ℝ≥0∞) + ((k : ℝ≥0) + 1)⁻¹ := by
     intro k
     specialize hn_le k
@@ -328,8 +328,9 @@ lemma exists_increasing_sequence_with_property (M : ℕ → ℕ) (P : ℕ → �
       simp_all only [ge_iff_le, le_sup_iff, add_le_add_iff_right, or_true, sup_of_le_right,
         Set.mem_Ico, lt_sup_iff, Nat.rec_zero, zero_add]
       refine ⟨?_, ?_, ?_, ?_⟩
-      · exact strictMono_nat_of_lt_succ fun k => by cases max_cases ( M ( k + 1 ) )
-          ( n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) + 1 )
+      · exact strictMono_nat_of_lt_succ fun k => by
+          cases max_cases ( M ( k + 1 ) )
+            ( n k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) + 1 )
           <;> linarith
           [ hn k ( Nat.rec ( M 0 ) ( fun k ih => Max.max ( M ( k + 1 ) ) ( n k ih + 1 ) ) k ) ] ;
       · intro k
@@ -444,8 +445,9 @@ lemma exists_liminf_zero_of_forall_liminf_limsup_le_with_UB (y₁ y₂ : ℝ≥0
       add_pos_iff, Nat.cast_pos, zero_lt_one, or_true, and_self, implies_true, inf_le_left,
       inf_le_right, true_and]
     rw [ Filter.tendsto_congr' ];
-    any_goals filter_upwards [ Filter.eventually_gt_atTop ⌈ ( z / 2 ) ⁻¹⌉₊ ] with k hk;
-      rw [ min_eq_right ];
+    any_goals
+      filter_upwards [ Filter.eventually_gt_atTop ⌈ ( z / 2 ) ⁻¹⌉₊ ] with k hk
+      rw [ min_eq_right ]
     · refine' tendsto_order.2 ⟨ fun x => _, fun x hx => _ ⟩
       · aesop
       · simp_all only [gt_iff_lt, Filter.eventually_atTop, ge_iff_le]

--- a/QuantumInfo/ForMathlib/LinearEquiv.lean
+++ b/QuantumInfo/ForMathlib/LinearEquiv.lean
@@ -25,7 +25,8 @@ variable (e : d ≃ d₂)
 
 variable (𝕜) in
 @[simps!]
-def euclidean_of_relabel (e : d ≃ d₂) : EuclideanSpace 𝕜 d₂ ≃ₗ[𝕜] EuclideanSpace 𝕜 d :=
+def euclidean_of_relabel (e : d ≃ d₂) :
+    EuclideanSpace 𝕜 d₂ ≃ₗ[𝕜] EuclideanSpace 𝕜 d :=
   (WithLp.linearEquiv 2 𝕜 _).trans ((of_relabel _ e).trans (WithLp.linearEquiv 2 𝕜 _).symm)
 
 @[simp]

--- a/QuantumInfo/ForMathlib/Majorization.lean
+++ b/QuantumInfo/ForMathlib/Majorization.lean
@@ -1147,8 +1147,8 @@ lemma sum_mul_log_nonneg_of_weak_log_maj {n : ℕ}
             (Nat.le_refl _)⟩
     simp +zetaDelta at *
     rw [← Real.log_prod fun i hi => ne_of_gt (div_pos (hy_pos i) (hx_pos i))];
-      exact Real.log_nonneg (by rw [Finset.prod_div_distrib]; exact by
-        rw [le_div_iff₀ (Finset.prod_pos fun i hi => hx_pos i)]; linarith)
+      exact Real.log_nonneg (by rw [Finset.prod_div_distrib]; exact
+        (by rw [le_div_iff₀ (Finset.prod_pos fun i hi => hx_pos i)]; linarith))
   exact h_neg <| h_abel.symm ▸ add_nonneg
     (mul_nonneg (le_of_lt (hx_pos _)) (h_nonneg _))
     (Finset.sum_nonneg fun i hi =>

--- a/QuantumInfo/ForMathlib/Majorization.lean
+++ b/QuantumInfo/ForMathlib/Majorization.lean
@@ -36,7 +36,8 @@ roots of the eigenvalues of `A†A`. These are indexed by `d` without a
 particular ordering.
 
 Note: We use `A.conjTranspose` as the argument to `isHermitian_mul_conjTranspose_self`
-so that the underlying Hermitian matrix is `A† * A` (matching the convention in `schattenNorm`). -/
+so that the underlying Hermitian matrix is `A† * A` (matching the convention in
+`schattenNorm`). -/
 def singularValues (A : Matrix d d ℂ) : d → ℝ :=
   fun i => Real.sqrt ((isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i)
 
@@ -54,14 +55,18 @@ noncomputable def singularValuesSorted (A : Matrix d d ℂ) :
   fun i =>
     let vals : Multiset ℝ := Finset.univ.val.map (singularValues A)
     let sorted := vals.sort (· ≥ ·)
-    sorted.get ⟨i.val, by rw [Multiset.length_sort]; show i.val < (Multiset.map (singularValues A) univ.val).card; rw [Multiset.card_map]; simp [Finset.card_univ]⟩
+    sorted.get ⟨i.val, by
+      rw [Multiset.length_sort];
+      show i.val < (Multiset.map (singularValues A) univ.val).card;
+      rw [Multiset.card_map]; simp [Finset.card_univ]⟩
 
 /-- Sorted singular values are nonneg. -/
 lemma singularValuesSorted_nonneg (A : Matrix d d ℂ) (i : Fin (Fintype.card d)) :
     0 ≤ singularValuesSorted A i := by
   have h_nonneg : ∀ i, 0 ≤ (singularValues A i) := by
     exact singularValues_nonneg A
-  have h_sorted_nonneg : ∀ {l : List ℝ}, (∀ x ∈ l, 0 ≤ x) → ∀ i < l.length, 0 ≤ l[i]! := by
+  have h_sorted_nonneg : ∀ {l : List ℝ}, (∀ x ∈ l, 0 ≤ x) → ∀ i < l.length,
+      0 ≤ l[i]! := by
     aesop
   contrapose! h_sorted_nonneg
   use Multiset.sort (Finset.univ.val.map (singularValues A)) (· ≥ ·)
@@ -75,12 +80,18 @@ lemma singularValuesSorted_nonneg (A : Matrix d d ℂ) (i : Fin (Fintype.card d)
 lemma sum_singularValues_rpow_eq_sum_sorted (A : Matrix d d ℂ) (p : ℝ) :
     ∑ i : d, singularValues A i ^ p =
     ∑ i : Fin (Fintype.card d), singularValuesSorted A i ^ p := by
-  have h_perm : Multiset.map (fun i => singularValues A i) Finset.univ.val = Multiset.map (fun i => singularValuesSorted A i) Finset.univ.val := by
-    have h_multiset : Multiset.map (fun i => singularValues A i) Finset.univ.val = Multiset.sort (Multiset.map (fun i => singularValues A i) Finset.univ.val) (· ≥ ·) := by
+  have h_perm : Multiset.map (fun i => singularValues A i) Finset.univ.val =
+      Multiset.map (fun i => singularValuesSorted A i) Finset.univ.val := by
+    have h_multiset : Multiset.map (fun i => singularValues A i) Finset.univ.val =
+        Multiset.sort (Multiset.map (fun i => singularValues A i) Finset.univ.val)
+          (· ≥ ·) := by
       aesop
     convert h_multiset using 1
     refine' congr_arg _ (List.ext_get _ _) <;> simp [singularValuesSorted]
-  have h_sum_eq : Multiset.sum (Multiset.map (fun x => x ^ p) (Multiset.map (fun i => singularValues A i) Finset.univ.val)) = Multiset.sum (Multiset.map (fun x => x ^ p) (Multiset.map (fun i => singularValuesSorted A i) Finset.univ.val)) := by
+  have h_sum_eq : Multiset.sum (Multiset.map (fun x => x ^ p)
+        (Multiset.map (fun i => singularValues A i) Finset.univ.val)) =
+      Multiset.sum (Multiset.map (fun x => x ^ p)
+        (Multiset.map (fun i => singularValuesSorted A i) Finset.univ.val)) := by
     rw [h_perm]
   convert h_sum_eq using 1
   · erw [Multiset.map_map, Finset.sum_eq_multiset_sum]
@@ -94,7 +105,8 @@ lemma sum_singularValues_rpow_eq_sum_sorted (A : Matrix d d ℂ) (p : ℝ) :
 lemma singularValuesSorted_antitone (A : Matrix d d ℂ) :
     Antitone (singularValuesSorted A) := by
   intro i j hij
-  have h_sorted : List.Pairwise (· ≥ ·) (Finset.univ.val.map (singularValues A) |>.sort (· ≥ ·)) := by
+  have h_sorted : List.Pairwise (· ≥ ·)
+      (Finset.univ.val.map (singularValues A) |>.sort (· ≥ ·)) := by
     exact Multiset.pairwise_sort _ _
   exact h_sorted.rel_get_of_le hij
 
@@ -152,7 +164,10 @@ lemma cauchyBinet {m : ℕ} {n : Type*} [Fintype n] [DecidableEq n] [LinearOrder
     (A * B).det = ∑ S : {S : Finset n // S.card = m},
       (A.submatrix id (S.1.orderEmbOfFin S.2)).det *
       (B.submatrix (S.1.orderEmbOfFin S.2) id).det := by
-  have h_cauchy_binet : ∀ (A : Matrix (Fin m) n R) (B : Matrix n (Fin m) R), Matrix.det (A * B) = ∑ σ : Fin m → n, (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) := by
+  have h_cauchy_binet : ∀ (A : Matrix (Fin m) n R) (B : Matrix n (Fin m) R),
+      Matrix.det (A * B) =
+        ∑ σ : Fin m → n,
+          (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) := by
     simp [Matrix.det_apply']
     simp [Matrix.mul_apply, Finset.mul_sum]
     intro A B; rw [← Finset.sum_comm]; congr; ext x; simp [mul_comm]
@@ -173,49 +188,89 @@ lemma cauchyBinet {m : ℕ} {n : Type*} [Fintype n] [DecidableEq n] [LinearOrder
       conv_rhs => rw [← Equiv.prod_comp x]
       simp [Equiv.symm_apply_apply]
   -- Split the sum into injective and non-injective functions.
-  have h_split : ∑ σ : Fin m → n, (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) = ∑ σ : Fin m → n, if Function.Injective σ then (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0 := by
+  have h_split : ∑ σ : Fin m → n,
+        (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) =
+      ∑ σ : Fin m → n, if Function.Injective σ then
+        (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0 := by
     refine Finset.sum_congr rfl fun σ _ => ?_
     split_ifs with hσ <;> simp_all [Function.Injective]
     obtain ⟨i, j, hij, hne⟩ := hσ
-    exact mul_eq_zero_of_right _ (Matrix.det_zero_of_row_eq hne (by ext1; simp only [of_apply, hij]))
+    exact mul_eq_zero_of_right _
+      (Matrix.det_zero_of_row_eq hne (by ext1; simp only [of_apply, hij]))
   -- Group the sum by the image of the injective functions.
-  have h_group : ∑ σ : Fin m → n, (if Function.Injective σ then (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) = ∑ S : {S : Finset n // S.card = m}, ∑ σ : Fin m → n, (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) := by
+  have h_group : ∑ σ : Fin m → n, (if Function.Injective σ then
+        (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) =
+      ∑ S : {S : Finset n // S.card = m}, ∑ σ : Fin m → n,
+        (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then
+          (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) := by
     rw [← Finset.sum_comm, Finset.sum_congr rfl]
     intro σ _
     by_cases hσ : Function.Injective σ
     · simp [hσ]
-      rw [Finset.sum_eq_single ⟨Finset.image σ Finset.univ, by simp [Finset.card_image_of_injective _ hσ]⟩]
+      rw [Finset.sum_eq_single
+        ⟨Finset.image σ Finset.univ, by simp [Finset.card_image_of_injective _ hσ]⟩]
       · simp
       · grind
       · simp
     · simp [hσ]
-  -- For each subset $S$ of size $m$, the inner sum is equal to the product of the determinants of the submatrices of $A$ and $B$ corresponding to $S$.
-  have h_inner : ∀ S : {S : Finset n // S.card = m}, ∑ σ : Fin m → n, (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) = Matrix.det (Matrix.submatrix A id (S.val.orderEmbOfFin S.property)) * Matrix.det (Matrix.submatrix B (S.val.orderEmbOfFin S.property) id) := by
+  -- For each subset $S$ of size $m$, the inner sum is equal to the product of the
+  -- determinants of the submatrices of $A$ and $B$ corresponding to $S$.
+  have h_inner : ∀ S : {S : Finset n // S.card = m}, ∑ σ : Fin m → n,
+        (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then
+          (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) =
+      Matrix.det (Matrix.submatrix A id (S.val.orderEmbOfFin S.property)) *
+        Matrix.det (Matrix.submatrix B (S.val.orderEmbOfFin S.property) id) := by
     intro S
-    have h_inner_sum : ∑ σ : Fin m → n, (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) = ∑ τ : Equiv.Perm (Fin m), (∏ i, A i (S.val.orderEmbOfFin S.property (τ i))) * Matrix.det (Matrix.of (fun i j ↦ B (S.val.orderEmbOfFin S.property (τ i)) j)) := by
-      have h_inner_sum : Finset.filter (fun σ : Fin m → n => Function.Injective σ ∧ Finset.image σ Finset.univ = S.val) Finset.univ = Finset.image (fun τ : Equiv.Perm (Fin m) => fun i => S.val.orderEmbOfFin S.property (τ i)) Finset.univ := by
+    have h_inner_sum : ∑ σ : Fin m → n,
+          (if Function.Injective σ ∧ Finset.image σ Finset.univ = S.val then
+            (∏ i, A i (σ i)) * Matrix.det (Matrix.of (fun i j ↦ B (σ i) j)) else 0) =
+        ∑ τ : Equiv.Perm (Fin m),
+          (∏ i, A i (S.val.orderEmbOfFin S.property (τ i))) *
+            Matrix.det
+              (Matrix.of (fun i j ↦ B (S.val.orderEmbOfFin S.property (τ i)) j)) := by
+      have h_inner_sum : Finset.filter
+            (fun σ : Fin m → n =>
+              Function.Injective σ ∧ Finset.image σ Finset.univ = S.val) Finset.univ =
+          Finset.image
+            (fun τ : Equiv.Perm (Fin m) => fun i =>
+              S.val.orderEmbOfFin S.property (τ i)) Finset.univ := by
         ext σ
         simp [Finset.mem_image]
         constructor
         · intro hσ
-          obtain ⟨a, ha⟩ : ∃ a : Fin m → Fin m, ∀ i, σ i = S.val.orderEmbOfFin S.property (a i) := by
-            have h_exists_a : ∀ i, ∃ a : Fin m, σ i = S.val.orderEmbOfFin S.property a := by
+          obtain ⟨a, ha⟩ :
+              ∃ a : Fin m → Fin m,
+                ∀ i, σ i = S.val.orderEmbOfFin S.property (a i) := by
+            have h_exists_a :
+                ∀ i, ∃ a : Fin m, σ i = S.val.orderEmbOfFin S.property a := by
               intro i
               have h_exists_a : σ i ∈ S.val := by
                 exact hσ.2 ▸ Finset.mem_image_of_mem _ (Finset.mem_univ _)
-              have h_exists_a : Finset.image (fun a : Fin m => S.val.orderEmbOfFin S.property a) Finset.univ = S.val := by
-                refine' Finset.eq_of_subset_of_card_le (Finset.image_subset_iff.mpr fun a _ => Finset.orderEmbOfFin_mem _ _ _) _
-                rw [Finset.card_image_of_injective _ fun a b h => by simpa [Fin.ext_iff] using h]; simp [S.2]
+              have h_exists_a :
+                  Finset.image
+                    (fun a : Fin m => S.val.orderEmbOfFin S.property a)
+                    Finset.univ = S.val := by
+                refine' Finset.eq_of_subset_of_card_le
+                  (Finset.image_subset_iff.mpr
+                    fun a _ => Finset.orderEmbOfFin_mem _ _ _) _
+                rw [Finset.card_image_of_injective _
+                  fun a b h => by simpa [Fin.ext_iff] using h]; simp [S.2]
               grind
-            exact ⟨fun i => Classical.choose (h_exists_a i), fun i => Classical.choose_spec (h_exists_a i)⟩
+            exact ⟨fun i => Classical.choose (h_exists_a i),
+              fun i => Classical.choose_spec (h_exists_a i)⟩
           have ha_inj : Function.Injective a := by
             exact fun i j hij => hσ.1 <| by simp [ha, hij]
-          exact ⟨Equiv.ofBijective a ⟨ha_inj, Finite.injective_iff_surjective.mp ha_inj⟩, funext fun i => ha i ▸ rfl⟩
+          exact ⟨Equiv.ofBijective a
+            ⟨ha_inj, Finite.injective_iff_surjective.mp ha_inj⟩,
+            funext fun i => ha i ▸ rfl⟩
         · rintro ⟨a, rfl⟩
           constructor
           · exact fun i j hij => a.injective <| by simpa using hij
-          · refine Finset.eq_of_subset_of_card_le (Finset.image_subset_iff.mpr fun i _ => Finset.orderEmbOfFin_mem _ _ _) ?_
-            rw [Finset.card_image_of_injective _ fun i j hij => by simpa [Fin.ext_iff] using hij]; simp [S.2]
+          · refine Finset.eq_of_subset_of_card_le
+              (Finset.image_subset_iff.mpr
+                fun i _ => Finset.orderEmbOfFin_mem _ _ _) ?_
+            rw [Finset.card_image_of_injective _
+              fun i j hij => by simpa [Fin.ext_iff] using hij]; simp [S.2]
       rw [← Finset.sum_filter, h_inner_sum, Finset.sum_image]
       exact fun τ _ τ' _ h => Equiv.Perm.ext fun i => by simpa using congr_fun h i
     rw [h_inner_sum, Matrix.det_apply', Matrix.det_apply']
@@ -262,12 +317,19 @@ lemma compoundMatrix_diagonal (f : d → ℂ) (k : ℕ) :
       contrapose! h
       exact Subtype.ext (Finset.eq_of_subset_of_card_le h (by simp [S.2, T.2]))
     obtain ⟨j, hj⟩ : ∃ j : Fin k, (S.val.orderEmbOfFin S.2) j = i := by
-      have h_row_zero : Finset.image (fun j : Fin k => S.val.orderEmbOfFin S.2 j) Finset.univ = S.val := by
-        refine' Finset.eq_of_subset_of_card_le (Finset.image_subset_iff.mpr fun j _ => Finset.orderEmbOfFin_mem _ _ _) _
+      have h_row_zero :
+          Finset.image (fun j : Fin k => S.val.orderEmbOfFin S.2 j)
+            Finset.univ = S.val := by
+        refine' Finset.eq_of_subset_of_card_le
+          (Finset.image_subset_iff.mpr fun j _ => Finset.orderEmbOfFin_mem _ _ _) _
         simp [Finset.card_image_of_injective, Function.Injective, *]
-      exact Exists.elim (Finset.mem_image.mp (h_row_zero.symm ▸ hiS)) fun j hj => ⟨j, hj.2⟩
-    -- Since the row corresponding to $i$ in the submatrix is all zeros, the determinant of this submatrix is zero.
-    have h_det_zero : Matrix.det (Matrix.of (fun i j => if (S.val.orderEmbOfFin S.2 i) = (T.val.orderEmbOfFin T.2 j) then f (T.val.orderEmbOfFin T.2 j) else 0) : Matrix (Fin k) (Fin k) ℂ) = 0 := by
+      exact Exists.elim (Finset.mem_image.mp (h_row_zero.symm ▸ hiS))
+        fun j hj => ⟨j, hj.2⟩
+    -- Since the row corresponding to $i$ in the submatrix is all zeros, the
+    -- determinant of this submatrix is zero.
+    have h_det_zero : Matrix.det (Matrix.of (fun i j =>
+        if (S.val.orderEmbOfFin S.2 i) = (T.val.orderEmbOfFin T.2 j) then
+          f (T.val.orderEmbOfFin T.2 j) else 0) : Matrix (Fin k) (Fin k) ℂ) = 0 := by
       rw [Matrix.det_eq_zero_of_row_eq_zero j]; aesop
     convert h_det_zero using 1
 
@@ -312,17 +374,31 @@ lemma singularValues_compoundMatrix_eq (M : Matrix d d ℂ) (k : ℕ) :
     ∏ i : Fin k, singularValues M (S.1.orderEmbOfFin S.2 i) := by
   unfold singularValues
   intro S
-  have h_eigenvalues : ∃ σ : {S : Finset d // S.card = k} ≃ {S : Finset d // S.card = k}, (Matrix.IsHermitian.eigenvalues (isHermitian_mul_conjTranspose_self (compoundMatrix M k).conjTranspose) ∘ σ) = fun S => ∏ i : Fin k, (Matrix.IsHermitian.eigenvalues (isHermitian_mul_conjTranspose_self M.conjTranspose)) (S.1.orderEmbOfFin S.2 i) := by
+  have h_eigenvalues :
+      ∃ σ : {S : Finset d // S.card = k} ≃ {S : Finset d // S.card = k},
+        (Matrix.IsHermitian.eigenvalues
+          (isHermitian_mul_conjTranspose_self
+            (compoundMatrix M k).conjTranspose) ∘ σ) =
+        fun S => ∏ i : Fin k,
+          (Matrix.IsHermitian.eigenvalues
+            (isHermitian_mul_conjTranspose_self M.conjTranspose))
+            (S.1.orderEmbOfFin S.2 i) := by
     apply IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal
     rotate_right
-    exact compoundMatrix (Matrix.IsHermitian.eigenvectorUnitary (isHermitian_mul_conjTranspose_self M.conjTranspose)) k
+    exact compoundMatrix (Matrix.IsHermitian.eigenvectorUnitary
+      (isHermitian_mul_conjTranspose_self M.conjTranspose)) k
     · exact compoundMatrix_unitary _ (by simp [Matrix.unitaryGroup]) _
-    · have h_compoundMatrix_mul : compoundMatrix (M.conjTranspose * M) k = compoundMatrix M.conjTranspose k * compoundMatrix M k := by
+    · have h_compoundMatrix_mul :
+          compoundMatrix (M.conjTranspose * M) k =
+            compoundMatrix M.conjTranspose k * compoundMatrix M k := by
         exact compoundMatrix_mul _ _ _
-      have h_compoundMatrix_conjTranspose : compoundMatrix M.conjTranspose k = (compoundMatrix M k).conjTranspose := by
+      have h_compoundMatrix_conjTranspose :
+          compoundMatrix M.conjTranspose k = (compoundMatrix M k).conjTranspose := by
         exact compoundMatrix_conjTranspose M k
-      have := Matrix.IsHermitian.spectral_theorem (isHermitian_mul_conjTranspose_self M.conjTranspose)
-      convert congr_arg (fun x => compoundMatrix x k) this using 1 <;> simp [h_compoundMatrix_mul, h_compoundMatrix_conjTranspose]
+      have := Matrix.IsHermitian.spectral_theorem
+        (isHermitian_mul_conjTranspose_self M.conjTranspose)
+      convert congr_arg (fun x => compoundMatrix x k) this using 1 <;>
+        simp [h_compoundMatrix_mul, h_compoundMatrix_conjTranspose]
       rw [compoundMatrix_mul, compoundMatrix_mul]
       rw [← compoundMatrix_conjTranspose]
       rw [compoundMatrix_diagonal]; simp [Matrix.mul_assoc]
@@ -353,7 +429,8 @@ lemma prod_le_prod_sorted {n : ℕ} {f : Fin n → ℝ}
   have h_exists_sorted : ∃ (g' : Fin k → Fin n),
       Function.Injective g' ∧ StrictMono g' ∧
       Finset.image g Finset.univ = Finset.image g' Finset.univ := by
-    exact ⟨Finset.orderEmbOfFin (Finset.image g Finset.univ) (by simp [Finset.card_image_of_injective _ hg]),
+    exact ⟨Finset.orderEmbOfFin (Finset.image g Finset.univ)
+        (by simp [Finset.card_image_of_injective _ hg]),
       fun a b h => by simpa using h,
       fun a b h => by simpa using h,
       by ext x; simp⟩
@@ -373,7 +450,8 @@ lemma prod_le_prod_sorted {n : ℕ} {f : Fin n → ℝ}
   | zero => exact Nat.zero_le _
   | succ m ih =>
     have ihm := ih (by omega)
-    have := hg'_mono (show (⟨m, by omega⟩ : Fin k) < ⟨m + 1, hm⟩ by simp [Fin.lt_def])
+    have := hg'_mono
+      (show (⟨m, by omega⟩ : Fin k) < ⟨m + 1, hm⟩ by simp [Fin.lt_def])
     omega
 
 /-- The 0th sorted singular value is the maximum of the singular values. -/
@@ -383,17 +461,25 @@ lemma singularValuesSorted_zero_eq_sup {e : Type*} [Fintype e] [DecidableEq e]
       (Finset.univ_nonempty_iff.mpr (Fintype.card_pos_iff.mp h))
       (singularValues A) := by
   refine' le_antisymm _ _
-  · -- Since the list is sorted in decreasing order, every element in the list is less than or equal to the supremum of the original set.
-    have h_le_sup : ∀ x ∈ Multiset.sort (Multiset.map (singularValues A) Finset.univ.val) (· ≥ ·), x ≤ Finset.sup' Finset.univ (Finset.univ_nonempty_iff.mpr ⟨Classical.choose (Finset.card_pos.mp h)⟩) (singularValues A) := by
+  · -- Since the list is sorted in decreasing order, every element in the list is
+    -- less than or equal to the supremum of the original set.
+    have h_le_sup :
+        ∀ x ∈ Multiset.sort
+          (Multiset.map (singularValues A) Finset.univ.val) (· ≥ ·),
+          x ≤ Finset.sup' Finset.univ
+            (Finset.univ_nonempty_iff.mpr
+              ⟨Classical.choose (Finset.card_pos.mp h)⟩) (singularValues A) := by
       aesop
     exact h_le_sup _ (by simp [singularValuesSorted])
   · have h_max_le_ge : ∀ i, singularValues A i ≤ singularValuesSorted A ⟨0, h⟩ := by
       intro i
-      have h_max_le_ge : ∀ j, singularValuesSorted A j ≤ singularValuesSorted A ⟨0, h⟩ := by
+      have h_max_le_ge :
+          ∀ j, singularValuesSorted A j ≤ singularValuesSorted A ⟨0, h⟩ := by
         exact fun j => singularValuesSorted_antitone A (Nat.zero_le _)
       exact (by
       have h_max_le_ge : ∃ j, singularValues A i = singularValuesSorted A j := by
-        have h_exists_j : singularValues A i ∈ Multiset.sort (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
+        have h_exists_j : singularValues A i ∈ Multiset.sort
+            (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
           simp [Multiset.mem_sort]
         obtain ⟨j, hj⟩ := List.mem_iff_get.mp h_exists_j
         exact ⟨⟨j, by simpa using j.2⟩, hj.symm⟩
@@ -404,7 +490,8 @@ lemma singularValuesSorted_zero_eq_sup {e : Type*} [Fintype e] [DecidableEq e]
 lemma singularValues_mem_sorted {e : Type*} [Fintype e] [DecidableEq e]
     (A : Matrix e e ℂ) (i : e) :
     ∃ j : Fin (Fintype.card e), singularValues A i = singularValuesSorted A j := by
-  have h_mem : singularValues A i ∈ Multiset.sort (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
+  have h_mem : singularValues A i ∈ Multiset.sort
+      (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
     simp [Multiset.mem_sort]
   obtain ⟨j, hj⟩ := List.mem_iff_get.mp h_mem
   exact ⟨⟨j, by simpa using j.2⟩, hj.symm⟩
@@ -413,30 +500,46 @@ lemma singularValues_mem_sorted {e : Type*} [Fintype e] [DecidableEq e]
 lemma singularValuesSorted_mem_values {e : Type*} [Fintype e] [DecidableEq e]
     (A : Matrix e e ℂ) (j : Fin (Fintype.card e)) :
     ∃ i : e, singularValuesSorted A j = singularValues A i := by
-  have h_mem : singularValuesSorted A j ∈ Multiset.sort (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
+  have h_mem : singularValuesSorted A j ∈ Multiset.sort
+      (Finset.univ.val.map (singularValues A)) (· ≥ ·) := by
     simp [singularValuesSorted]
   rw [Multiset.mem_sort] at h_mem
   simp at h_mem
   obtain ⟨i, hi⟩ := h_mem
   exact ⟨i, hi.symm⟩
 
-/-- Stronger version of `singularValues_compoundMatrix_eq` that exposes the permutation. -/
+/-- Stronger version of `singularValues_compoundMatrix_eq` that exposes the
+    permutation. -/
 lemma singularValues_compoundMatrix_perm (M : Matrix d d ℂ) (k : ℕ) :
     ∃ σ : {S : Finset d // S.card = k} ≃ {S : Finset d // S.card = k},
     ∀ S, singularValues (compoundMatrix M k) (σ S) =
     ∏ i : Fin k, singularValues M (S.1.orderEmbOfFin S.2 i) := by
   unfold singularValues
-  have h_eigenvalues : ∃ σ : {S : Finset d // S.card = k} ≃ {S : Finset d // S.card = k}, (Matrix.IsHermitian.eigenvalues (isHermitian_mul_conjTranspose_self (compoundMatrix M k).conjTranspose) ∘ σ) = fun S => ∏ i : Fin k, (Matrix.IsHermitian.eigenvalues (isHermitian_mul_conjTranspose_self M.conjTranspose)) (S.1.orderEmbOfFin S.2 i) := by
+  have h_eigenvalues :
+      ∃ σ : {S : Finset d // S.card = k} ≃ {S : Finset d // S.card = k},
+        (Matrix.IsHermitian.eigenvalues
+          (isHermitian_mul_conjTranspose_self
+            (compoundMatrix M k).conjTranspose) ∘ σ) =
+        fun S => ∏ i : Fin k,
+          (Matrix.IsHermitian.eigenvalues
+            (isHermitian_mul_conjTranspose_self M.conjTranspose))
+            (S.1.orderEmbOfFin S.2 i) := by
     apply IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal
     rotate_right
-    exact compoundMatrix (Matrix.IsHermitian.eigenvectorUnitary (isHermitian_mul_conjTranspose_self M.conjTranspose)) k
+    exact compoundMatrix (Matrix.IsHermitian.eigenvectorUnitary
+      (isHermitian_mul_conjTranspose_self M.conjTranspose)) k
     · exact compoundMatrix_unitary _ (by simp [Matrix.unitaryGroup]) _
-    · have h_compoundMatrix_mul : compoundMatrix (M.conjTranspose * M) k = compoundMatrix M.conjTranspose k * compoundMatrix M k := by
+    · have h_compoundMatrix_mul :
+          compoundMatrix (M.conjTranspose * M) k =
+            compoundMatrix M.conjTranspose k * compoundMatrix M k := by
         exact compoundMatrix_mul _ _ _
-      have h_compoundMatrix_conjTranspose : compoundMatrix M.conjTranspose k = (compoundMatrix M k).conjTranspose := by
+      have h_compoundMatrix_conjTranspose :
+          compoundMatrix M.conjTranspose k = (compoundMatrix M k).conjTranspose := by
         exact compoundMatrix_conjTranspose M k
-      have := Matrix.IsHermitian.spectral_theorem (isHermitian_mul_conjTranspose_self M.conjTranspose)
-      convert congr_arg (fun x => compoundMatrix x k) this using 1 <;> simp [h_compoundMatrix_mul, h_compoundMatrix_conjTranspose]
+      have := Matrix.IsHermitian.spectral_theorem
+        (isHermitian_mul_conjTranspose_self M.conjTranspose)
+      convert congr_arg (fun x => compoundMatrix x k) this using 1 <;>
+        simp [h_compoundMatrix_mul, h_compoundMatrix_conjTranspose]
       rw [compoundMatrix_mul, compoundMatrix_mul]
       rw [← compoundMatrix_conjTranspose]
       rw [compoundMatrix_diagonal]; simp [Matrix.mul_assoc]
@@ -467,32 +570,53 @@ lemma exists_sorting_equiv (M : Matrix d d ℂ) :
     ∃ σ : Fin (Fintype.card d) ≃ d,
     ∀ i, singularValues M (σ i) = singularValuesSorted M i := by
   -- Apply the lemma `exists_subset_prod_eq_sorted_prod` to obtain the bijection `σ`.
-  have h_bij : ∃ σ : Fin (Fintype.card d) ≃ d, ∀ i, singularValues M (σ i) = singularValuesSorted M i := by
-    have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) = Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
-      have h_multiset : Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) = Finset.univ.val.map (singularValues M) := by
-        have h_multiset : Finset.univ.val = Multiset.map (fun i => (Fintype.equivFin d).symm i) (Finset.univ.val) := by
+  have h_bij : ∃ σ : Fin (Fintype.card d) ≃ d,
+      ∀ i, singularValues M (σ i) = singularValuesSorted M i := by
+    have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) =
+        Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
+      have h_multiset :
+          Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) =
+            Finset.univ.val.map (singularValues M) := by
+        have h_multiset : Finset.univ.val =
+            Multiset.map (fun i => (Fintype.equivFin d).symm i) (Finset.univ.val) := by
           exact Eq.symm (Multiset.map_univ_val_equiv (Fintype.equivFin d |> Equiv.symm))
         rw [h_multiset, Multiset.map_map]
         aesop
-      have h_multiset_sorted : Multiset.ofList (List.ofFn (singularValuesSorted M)) = Multiset.map (singularValues M) Finset.univ.val := by
-        have h_multiset_sorted_eq : List.ofFn (singularValuesSorted M) = Multiset.sort (Multiset.map (singularValues M) Finset.univ.val) (· ≥ ·) := by
-          refine' List.ext_get _ _ <;> simp [List.ofFn_eq_map] at *; aesop (simp_config := { singlePass := true })
+      have h_multiset_sorted :
+          Multiset.ofList (List.ofFn (singularValuesSorted M)) =
+            Multiset.map (singularValues M) Finset.univ.val := by
+        have h_multiset_sorted_eq :
+            List.ofFn (singularValuesSorted M) =
+              Multiset.sort
+                (Multiset.map (singularValues M) Finset.univ.val) (· ≥ ·) := by
+          refine' List.ext_get _ _ <;> simp [List.ofFn_eq_map] at *;
+            aesop (simp_config := { singlePass := true })
         exact h_multiset_sorted_eq ▸ by simp
       rw [h_multiset, h_multiset_sorted]
-    have h_perm : List.Perm (List.ofFn (singularValuesSorted M)) (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
+    have h_perm : List.Perm (List.ofFn (singularValuesSorted M))
+        (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
       exact Multiset.coe_eq_coe.mp h_perm
-    have h_perm : ∃ σ : Fin (Fintype.card d) ≃ Fin (Fintype.card d), ∀ i, singularValuesSorted M i = singularValues M (Fintype.equivFin d |>.symm (σ i)) := by
-      have h_perm : ∀ {l1 l2 : List ℝ}, l1.Perm l2 → ∃ σ : Fin l1.length ≃ Fin l2.length, ∀ i, l1.get i = l2.get (σ i) := by
+    have h_perm : ∃ σ : Fin (Fintype.card d) ≃ Fin (Fintype.card d),
+        ∀ i, singularValuesSorted M i =
+          singularValues M (Fintype.equivFin d |>.symm (σ i)) := by
+      have h_perm : ∀ {l1 l2 : List ℝ}, l1.Perm l2 →
+          ∃ σ : Fin l1.length ≃ Fin l2.length, ∀ i, l1.get i = l2.get (σ i) := by
         intros l1 l2 h_perm; induction' h_perm with l1 l2 h_perm ih <;> simp_all
-        · obtain ⟨σ, hσ⟩ := ‹∃ σ : Fin l2.length ≃ Fin h_perm.length, ∀ i : Fin l2.length, l2[i] = h_perm[σ i]›; use Equiv.ofBijective (fun i => Fin.cases 0 (fun i => Fin.succ (σ i)) i) ⟨fun i j hij => ?_, fun i => ?_⟩
+        · obtain ⟨σ, hσ⟩ :=
+            ‹∃ σ : Fin l2.length ≃ Fin h_perm.length,
+              ∀ i : Fin l2.length, l2[i] = h_perm[σ i]›;
+          use Equiv.ofBijective (fun i => Fin.cases 0 (fun i => Fin.succ (σ i)) i)
+            ⟨fun i j hij => ?_, fun i => ?_⟩
           simp_all [Fin.forall_fin_succ]
-          · rcases i with ⟨_ | i, hi⟩ <;> rcases j with ⟨_ | j, hj⟩ <;> simp_all [Fin.ext_iff]
+          · rcases i with ⟨_ | i, hi⟩ <;> rcases j with ⟨_ | j, hj⟩ <;>
+              simp_all [Fin.ext_iff]
             simpa [Fin.ext_iff] using σ.injective (Fin.ext hij)
           · refine i.cases ?_ ?_
             · simp [Fin.exists_fin_succ]
             · simp only [Fin.exists_fin_succ, Fin.cases_zero, Fin.cases_succ, Fin.succ_inj]
               exact fun i => Or.inr ⟨σ.symm i, by simp⟩
-        · refine' ⟨Equiv.swap ⟨0, by simp⟩ ⟨1, by simp⟩, _⟩; simp [Fin.forall_fin_succ]; aesop
+        · refine' ⟨Equiv.swap ⟨0, by simp⟩ ⟨1, by simp⟩, _⟩;
+            simp [Fin.forall_fin_succ]; aesop
         · rename_i h₁ h₂ h₃ h₄
           obtain ⟨σ₁, hσ₁⟩ := h₃
           obtain ⟨σ₂, hσ₂⟩ := h₄
@@ -503,17 +627,22 @@ lemma exists_sorting_equiv (M : Matrix d d ℂ) :
       · simp
       · exact lt_of_lt_of_le (Fin.is_lt _) (by simp)
       · norm_num [Function.Injective, Function.Surjective]
-        exact fun i j hij => Fin.ext <| by simpa [Fin.ext_iff] using σ.injective <| Fin.ext hij
+        exact fun i j hij =>
+          Fin.ext <| by simpa [Fin.ext_iff] using σ.injective <| Fin.ext hij
       · intro b
-        obtain ⟨a, ha⟩ : ∃ a : Fin (List.ofFn (singularValuesSorted M)).length, σ a = ⟨b, by simp⟩ := by
+        obtain ⟨a, ha⟩ :
+            ∃ a : Fin (List.ofFn (singularValuesSorted M)).length,
+              σ a = ⟨b, by simp⟩ := by
           exact σ.surjective _
         use ⟨a, lt_of_lt_of_le a.2 (by simp)⟩
         exact Fin.ext (by simp [ha])
       · intro i
         specialize hσ ⟨i, by simp⟩
         simp_all
-    exact ⟨Equiv.trans h_perm.choose (Fintype.equivFin d |> Equiv.symm), fun i => h_perm.choose_spec i ▸ rfl⟩
-  exact ⟨h_bij.choose, fun i => by simpa only [Equiv.symm_apply_eq] using h_bij.choose_spec i⟩
+    exact ⟨Equiv.trans h_perm.choose (Fintype.equivFin d |> Equiv.symm),
+      fun i => h_perm.choose_spec i ▸ rfl⟩
+  exact ⟨h_bij.choose,
+    fun i => by simpa only [Equiv.symm_apply_eq] using h_bij.choose_spec i⟩
 
 /-- For any k-subset S of d, the product of singular values over S is ≤ the
     product of the top k sorted singular values. -/
@@ -524,7 +653,8 @@ lemma prod_singularValues_subset_le_sorted_prod (M : Matrix d d ℂ) (k : ℕ)
   obtain ⟨σ, hσ⟩ := exists_sorting_equiv M
   -- Define g : Fin k → Fin (card d) as σ⁻¹ ∘ (S.orderEmbOfFin)
   set g : Fin k → Fin (Fintype.card d) := fun i => σ.symm (S.1.orderEmbOfFin S.2 i)
-  have hg_eq : ∀ i, singularValues M (S.1.orderEmbOfFin S.2 i) = singularValuesSorted M (g i) := by
+  have hg_eq : ∀ i,
+      singularValues M (S.1.orderEmbOfFin S.2 i) = singularValuesSorted M (g i) := by
     intro i
     simp [g]
     rw [← hσ]
@@ -541,22 +671,31 @@ lemma exists_subset_prod_eq_sorted_prod (M : Matrix d d ℂ) (k : ℕ)
     ∏ i : Fin k, singularValues M (S.1.orderEmbOfFin S.2 i) =
     ∏ i : Fin k, singularValuesSorted M ⟨i.val, by omega⟩ := by
   by_contra h_contra
-  obtain ⟨σ, hσ⟩ : ∃ σ : Fin (Fintype.card d) ≃ d, ∀ i : Fin (Fintype.card d), singularValues M (σ i) = singularValuesSorted M i := by
-    have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) = Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
-      have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) = Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
-        have h_sorted : List.ofFn (singularValuesSorted M) = Multiset.sort (Multiset.map (singularValues M) Finset.univ.val) (· ≥ ·) := by
+  obtain ⟨σ, hσ⟩ : ∃ σ : Fin (Fintype.card d) ≃ d, ∀ i : Fin (Fintype.card d),
+      singularValues M (σ i) = singularValuesSorted M i := by
+    have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) =
+        Multiset.ofList (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
+      have h_perm : Multiset.ofList (List.ofFn (singularValuesSorted M)) =
+          Multiset.ofList
+            (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
+        have h_sorted : List.ofFn (singularValuesSorted M) =
+            Multiset.sort
+              (Multiset.map (singularValues M) Finset.univ.val) (· ≥ ·) := by
           refine' List.ext_get _ _ <;> simp
           exact fun n i => rfl
         simp [h_sorted, List.ofFn_eq_map]
         refine' Multiset.eq_of_le_of_card_le _ _ <;> simp [Multiset.le_iff_count]
         intro a; rw [Multiset.count_map]; simp [List.count]
-        rw [← Multiset.toFinset_card_of_nodup] <;> norm_num [Finset.card_image_of_injective, Function.Injective]
+        rw [← Multiset.toFinset_card_of_nodup] <;>
+          norm_num [Finset.card_image_of_injective, Function.Injective]
         · rw [List.countP_eq_length_filter]
           simp [Finset.card]
           rw [← List.toFinset_card_of_nodup] <;> norm_num [List.nodup_finRange]
           · rw [Finset.card_filter]; simp [eq_comm, Fintype.equivFin]
-            rw [← Multiset.toFinset_card_of_nodup] <;> norm_num [Finset.card_image_of_injective, Function.Injective]
-            · refine' le_of_eq _; rw [Finset.card_filter, Finset.card_filter]; rw [← Finset.sum_bij (fun x _ => (Fintype.equivFin d) x)]; aesop
+            rw [← Multiset.toFinset_card_of_nodup] <;>
+              norm_num [Finset.card_image_of_injective, Function.Injective]
+            · refine' le_of_eq _; rw [Finset.card_filter, Finset.card_filter];
+                rw [← Finset.sum_bij (fun x _ => (Fintype.equivFin d) x)]; aesop
               · exact fun x _ y _ h => Fintype.equivFin d |>.injective h ▸ rfl
               · exact fun b _ => ⟨(Fintype.equivFin d).symm b, Finset.mem_univ _, by simp⟩
               · simp [Fintype.equivFin]
@@ -564,21 +703,31 @@ lemma exists_subset_prod_eq_sorted_prod (M : Matrix d d ℂ) (k : ℕ)
           · exact List.Nodup.filter _ (List.nodup_finRange _)
         · exact Multiset.Nodup.filter _ (Finset.nodup _)
       exact h_perm.trans (by simp)
-    have h_perm : List.Perm (List.ofFn (singularValuesSorted M)) (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
+    have h_perm : List.Perm (List.ofFn (singularValuesSorted M))
+        (List.ofFn (singularValues M ∘ (Fintype.equivFin d).symm)) := by
       exact Multiset.coe_eq_coe.mp h_perm
-    have h_perm : ∃ σ : Fin (Fintype.card d) ≃ Fin (Fintype.card d), List.ofFn (singularValuesSorted M) = List.map (fun i => singularValues M ((Fintype.equivFin d).symm (σ i))) (List.finRange (Fintype.card d)) := by
+    have h_perm : ∃ σ : Fin (Fintype.card d) ≃ Fin (Fintype.card d),
+        List.ofFn (singularValuesSorted M) =
+          List.map (fun i => singularValues M ((Fintype.equivFin d).symm (σ i)))
+            (List.finRange (Fintype.card d)) := by
       have := h_perm
-      have h_perm : ∀ {l₁ l₂ : List ℝ}, List.Perm l₁ l₂ → ∃ σ : Fin l₁.length ≃ Fin l₂.length, l₁ = List.map (fun i => l₂.get (σ i)) (List.finRange l₁.length) := by
+      have h_perm : ∀ {l₁ l₂ : List ℝ}, List.Perm l₁ l₂ →
+          ∃ σ : Fin l₁.length ≃ Fin l₂.length,
+            l₁ = List.map (fun i => l₂.get (σ i)) (List.finRange l₁.length) := by
         intro l₁ l₂ h_perm
         induction' h_perm with l₁ l₂ h_perm ih
         · aesop
         · rename_i a_ih
           obtain ⟨σ, hσ⟩ := a_ih
-          use Equiv.ofBijective (fun i => Fin.cases ⟨0, by simp⟩ (fun i => Fin.succ (σ i)) i) ⟨fun i j hij => ?_, fun i => ?_⟩
+          use Equiv.ofBijective
+            (fun i => Fin.cases ⟨0, by simp⟩ (fun i => Fin.succ (σ i)) i)
+            ⟨fun i j hij => ?_, fun i => ?_⟩
           · simp [List.finRange_succ] at *
             exact hσ
-          · rcases i with ⟨_ | i, hi⟩ <;> rcases j with ⟨_ | j, hj⟩ <;> simp [Fin.ext_iff] at hij ⊢
-            simpa [Fin.ext_iff] using σ.injective (Fin.ext hij) |> fun h => by simpa [Fin.ext_iff] using h;
+          · rcases i with ⟨_ | i, hi⟩ <;> rcases j with ⟨_ | j, hj⟩ <;>
+              simp [Fin.ext_iff] at hij ⊢
+            simpa [Fin.ext_iff] using σ.injective (Fin.ext hij) |>
+              fun h => by simpa [Fin.ext_iff] using h;
           · rcases i with ⟨_ | i, hi⟩
             · exact ⟨⟨0, by simp⟩, rfl⟩
             · exact ⟨Fin.succ (σ.symm ⟨i, by simpa using hi⟩), by simp⟩
@@ -593,27 +742,43 @@ lemma exists_subset_prod_eq_sorted_prod (M : Matrix d d ℂ) (k : ℕ)
       obtain ⟨σ, hσ⟩ := h_perm ‹_›
       simp [List.ofFn_eq_map] at hσ ⊢
       generalize_proofs at *; (
-      exact ⟨Equiv.ofBijective (fun i => ⟨σ ⟨i, by simp⟩, by solve_by_elim⟩) ⟨fun i j hij => by simpa [Fin.ext_iff] using σ.injective (Fin.ext <| by simpa [Fin.ext_iff] using hij), fun i => by
+      exact ⟨Equiv.ofBijective (fun i => ⟨σ ⟨i, by simp⟩, by solve_by_elim⟩)
+        ⟨fun i j hij => by
+          simpa [Fin.ext_iff] using
+            σ.injective (Fin.ext <| by simpa [Fin.ext_iff] using hij), fun i => by
         obtain ⟨a, ha⟩ := σ.surjective ⟨i, by simp⟩
-        exact ⟨⟨a, by simpa using a.2⟩, Fin.ext <| by simpa [Fin.ext_iff] using congr_arg Fin.val ha⟩⟩, fun i => by simpa [Fin.ext_iff] using congr_arg (fun l => l[i]!) hσ⟩)
+        exact ⟨⟨a, by simpa using a.2⟩,
+          Fin.ext <| by simpa [Fin.ext_iff] using congr_arg Fin.val ha⟩⟩,
+        fun i => by simpa [Fin.ext_iff] using congr_arg (fun l => l[i]!) hσ⟩)
     obtain ⟨σ, hσ⟩ := h_perm
-    use Equiv.ofBijective (fun i => (Fintype.equivFin d).symm (σ i)) ⟨fun i j hij => by simpa [Fin.ext_iff] using σ.injective (by simpa [Fin.ext_iff] using hij), fun i => by
+    use Equiv.ofBijective (fun i => (Fintype.equivFin d).symm (σ i))
+      ⟨fun i j hij => by
+        simpa [Fin.ext_iff] using σ.injective (by simpa [Fin.ext_iff] using hij),
+        fun i => by
       exact ⟨σ.symm (Fintype.equivFin d i), by simp⟩;⟩
     intro i
     replace hσ := congr_arg (fun l => l[i]!) hσ
     simp_all
-  refine' h_contra ⟨⟨Finset.image σ (Finset.univ.filter fun i => i.val < k), _⟩, _⟩ <;> simp_all
+  refine' h_contra
+    ⟨⟨Finset.image σ (Finset.univ.filter fun i => i.val < k), _⟩, _⟩ <;> simp_all
   rw [Finset.card_image_of_injective _ σ.injective, Finset.card_eq_of_bijective]
   use fun i hi => ⟨i, by linarith⟩
   all_goals norm_num [Fin.ext_iff] at *
-  have h_prod_eq : ∏ x ∈ Finset.image σ (Finset.univ.filter fun i : Fin (Fintype.card d) => i.val < k), singularValues M x = ∏ i : Fin k, singularValuesSorted M ⟨i.val, by omega⟩ := by
+  have h_prod_eq : ∏ x ∈ Finset.image σ
+        (Finset.univ.filter fun i : Fin (Fintype.card d) => i.val < k),
+        singularValues M x =
+      ∏ i : Fin k, singularValuesSorted M ⟨i.val, by omega⟩ := by
     rw [Finset.prod_image] <;> simp [hσ]
-    refine' Finset.prod_bij (fun i hi => ⟨i, by linarith [Fin.is_lt i, Finset.mem_filter.mp hi]⟩) _ _ _ _ <;> simp [Fin.ext_iff]
+    refine' Finset.prod_bij
+      (fun i hi => ⟨i, by linarith [Fin.is_lt i, Finset.mem_filter.mp hi]⟩)
+      _ _ _ _ <;> simp [Fin.ext_iff]
     exact fun b => ⟨⟨b, by linarith [Fin.is_lt b]⟩, by simp, rfl⟩
   convert h_prod_eq using 1
   rw [← Finset.prod_image]
   · congr! 1
-    refine' Finset.eq_of_subset_of_card_le (Finset.image_subset_iff.mpr fun i _ => _) _ <;> simp [Finset.card_image_of_injective, Function.Injective]
+    refine' Finset.eq_of_subset_of_card_le
+      (Finset.image_subset_iff.mpr fun i _ => _) _ <;>
+      simp [Finset.card_image_of_injective, Function.Injective]
     rw [Finset.card_eq_of_bijective]
     use fun i hi => ⟨i, by linarith⟩
     · exact fun a ha => ⟨a, Finset.mem_filter.mp ha |>.2, rfl⟩
@@ -658,40 +823,55 @@ lemma IsHermitian.inner_le_sup_eigenvalue_mul_inner
   have := hH.spectral_theorem
   -- Let $w = U^* v$, then $v^* H v = w^* D w$.
   set w : e → ℂ := star (hH.eigenvectorUnitary : Matrix e e ℂ) |> Matrix.mulVec <| v
-  have h_eq : (star v ⬝ᵥ H *ᵥ v).re = (star w ⬝ᵥ (Matrix.diagonal (RCLike.ofReal ∘ hH.eigenvalues)) *ᵥ w).re := by
-    replace this := congr_arg (fun m => star v ⬝ᵥ m *ᵥ v) this; simp_all [Matrix.mul_assoc]
+  have h_eq : (star v ⬝ᵥ H *ᵥ v).re =
+      (star w ⬝ᵥ (Matrix.diagonal (RCLike.ofReal ∘ hH.eigenvalues)) *ᵥ w).re := by
+    replace this := congr_arg (fun m => star v ⬝ᵥ m *ᵥ v) this;
+      simp_all [Matrix.mul_assoc]
     simp +zetaDelta at *
     simp [Matrix.dotProduct_mulVec, Matrix.star_mulVec]
     congr! 3
     ext i j; simp [Matrix.mul_apply, Matrix.diagonal]
-  -- Since $D$ is diagonal with eigenvalues $\lambda_i$, we have $w^* D w = \sum_{i} \lambda_i |w_i|^2$.
-  have h_diag : (star w ⬝ᵥ (Matrix.diagonal (RCLike.ofReal ∘ hH.eigenvalues)) *ᵥ w).re = ∑ i, (hH.eigenvalues i) * ‖w i‖ ^ 2 := by
+  -- Since $D$ is diagonal with eigenvalues $\lambda_i$, we have
+  -- $w^* D w = \sum_{i} \lambda_i |w_i|^2$.
+  have h_diag :
+      (star w ⬝ᵥ (Matrix.diagonal (RCLike.ofReal ∘ hH.eigenvalues)) *ᵥ w).re =
+        ∑ i, (hH.eigenvalues i) * ‖w i‖ ^ 2 := by
     simp [dotProduct, Matrix.mulVec, Finset.mul_sum _ _ _, mul_assoc, mul_comm,]
     simp [Complex.normSq, Complex.sq_norm, diagonal]
-    rw [← Finset.sum_sub_distrib]; refine' Finset.sum_congr rfl fun i hi => _; rw [Finset.sum_eq_single i, Finset.sum_eq_single i] <;> simp +contextual; ring_nf
+    rw [← Finset.sum_sub_distrib]; refine' Finset.sum_congr rfl fun i hi => _;
+      rw [Finset.sum_eq_single i, Finset.sum_eq_single i] <;> simp +contextual; ring_nf
     · exact fun j hj => Or.inl (by rw [if_neg (Ne.symm hj)]; norm_num)
     · exact fun j hj => Or.inl (by rw [if_neg (Ne.symm hj)]; norm_num)
   -- Since $U$ is unitary, we have $\|w\|^2 = \|v\|^2$.
   have h_unitary : ∑ i, ‖w i‖ ^ 2 = (star v ⬝ᵥ v).re := by
-    have h_unitary : ∀ (U : Matrix e e ℂ), U.conjTranspose * U = 1 → ∀ (v : e → ℂ), ∑ i, ‖(U.mulVec v) i‖ ^ 2 = ∑ i, ‖v i‖ ^ 2 := by
+    have h_unitary : ∀ (U : Matrix e e ℂ), U.conjTranspose * U = 1 →
+        ∀ (v : e → ℂ), ∑ i, ‖(U.mulVec v) i‖ ^ 2 = ∑ i, ‖v i‖ ^ 2 := by
       intro U hU v
       have h_unitary : (star (U.mulVec v) ⬝ᵥ U.mulVec v) = (star v ⬝ᵥ v) := by
-        have h_unitary : (star (U.mulVec v) ⬝ᵥ U.mulVec v) = (star v ⬝ᵥ (Uᴴ * U).mulVec v) := by
+        have h_unitary :
+            (star (U.mulVec v) ⬝ᵥ U.mulVec v) =
+              (star v ⬝ᵥ (Uᴴ * U).mulVec v) := by
           simp [Matrix.mulVec, dotProduct]
-          simp [Matrix.mul_apply, mul_assoc, mul_comm, mul_left_comm, Finset.mul_sum _ _ _, Finset.sum_mul]
-          exact Finset.sum_comm.trans (Finset.sum_congr rfl fun _ _ => Finset.sum_comm) |> Eq.trans <| Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring
+          simp [Matrix.mul_apply, mul_assoc, mul_comm, mul_left_comm,
+            Finset.mul_sum _ _ _, Finset.sum_mul]
+          exact Finset.sum_comm.trans
+            (Finset.sum_congr rfl fun _ _ => Finset.sum_comm) |> Eq.trans <|
+            Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl
+              fun _ _ => Finset.sum_congr rfl fun _ _ => by ring
         rw [h_unitary, hU, Matrix.one_mulVec]
       convert congr_arg Complex.re h_unitary using 1 <;> simp [sq]; ring_nf!
       · simp [dotProduct, sq]; ring_nf!
         simp [Complex.normSq, Complex.sq_norm]; ring_nf!
       · simp [dotProduct]
         simp [← sq, Complex.normSq_apply, Complex.sq_norm]
-    convert h_unitary (star (hH.eigenvectorUnitary : Matrix e e ℂ)) _ v using 1 <;> norm_num [Matrix.mulVec, dotProduct]
+    convert h_unitary (star (hH.eigenvectorUnitary : Matrix e e ℂ)) _ v using 1 <;>
+      norm_num [Matrix.mulVec, dotProduct]
     · norm_num [Complex.normSq, Complex.sq_norm]
     · simp [Matrix.star_eq_conjTranspose]
       simp [Matrix.IsHermitian.eigenvectorUnitary]
   rw [h_eq, h_diag, ← h_unitary, Finset.mul_sum _ _ _]
-  exact Finset.sum_le_sum fun i _ => mul_le_mul_of_nonneg_right (Finset.le_sup' (fun i => hH.eigenvalues i) (Finset.mem_univ i)) (sq_nonneg _)
+  exact Finset.sum_le_sum fun i _ => mul_le_mul_of_nonneg_right
+    (Finset.le_sup' (fun i => hH.eigenvalues i) (Finset.mem_univ i)) (sq_nonneg _)
 
 /- All eigenvalues of `A† A` are bounded by (max singular value)². -/
 lemma eigenvalue_le_singularValuesSorted_sq {e : Type*} [Fintype e] [DecidableEq e]
@@ -699,7 +879,8 @@ lemma eigenvalue_le_singularValuesSorted_sq {e : Type*} [Fintype e] [DecidableEq
   (isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i ≤
     (singularValuesSorted A ⟨0, h⟩) ^ 2 := by
   -- By definition of singular values, we know that $\sigma_i(A)^2 = \lambda_i(A^*A)$.
-  have h_singular_value_squared : ∀ i, (singularValues A i) ^ 2 = (isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i := by
+  have h_singular_value_squared : ∀ i, (singularValues A i) ^ 2 =
+      (isHermitian_mul_conjTranspose_self A.conjTranspose).eigenvalues i := by
     intro i
     simp [singularValues]
     rw [Real.sq_sqrt (_)]
@@ -722,7 +903,8 @@ lemma quadratic_form_le_singularValuesSorted_sq {e : Type*} [Fintype e] [Decidab
     convert eigenvalue_le_singularValuesSorted_sq A h i using 1
     simp [Matrix.conjTranspose_conjTranspose]
   · simp [dotProduct]
-    exact Finset.sum_nonneg fun _ _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)
+    exact Finset.sum_nonneg
+      fun _ _ => add_nonneg (mul_self_nonneg _) (mul_self_nonneg _)
 
 /-- The largest singular value of a matrix product is at most the product of the
 largest singular values: `σ₁(M * N) ≤ σ₁(M) * σ₁(N)`.
@@ -731,33 +913,68 @@ lemma singularValuesSorted_mul_le {e : Type*} [Fintype e] [DecidableEq e]
     (M N : Matrix e e ℂ) (h : 0 < Fintype.card e) :
     singularValuesSorted (M * N) ⟨0, h⟩ ≤
     singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩ := by
-  rw [singularValuesSorted_zero_eq_sup, singularValuesSorted_zero_eq_sup, singularValuesSorted_zero_eq_sup]
-  -- Apply the inequality eigenvalue_le_singularValuesSorted_sq to each eigenvalue of (MN)†(MN).
-  have h_eigenvalue_le : ∀ i, (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤ (singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩) ^ 2 := by
+  rw [singularValuesSorted_zero_eq_sup, singularValuesSorted_zero_eq_sup,
+    singularValuesSorted_zero_eq_sup]
+  -- Apply the inequality eigenvalue_le_singularValuesSorted_sq to each eigenvalue
+  -- of (MN)†(MN).
+  have h_eigenvalue_le : ∀ i,
+      (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤
+        (singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩) ^ 2 := by
     intro i
-    have h_eigenvalue_le : (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤ (singularValuesSorted M ⟨0, h⟩) ^ 2 * (singularValuesSorted N ⟨0, h⟩) ^ 2 := by
-      -- By the properties of singular values and eigenvalues, we know that the eigenvalues of $(MN)^* (MN)$ are bounded by the product of the squares of the singular values of $M$ and $N$.
-      have h_eigenvalue_bound : ∀ (v : e → ℂ), Complex.re (star v ⬝ᵥ ((M * N).conjTranspose * (M * N)).mulVec v) ≤ (singularValuesSorted M ⟨0, h⟩) ^ 2 * (singularValuesSorted N ⟨0, h⟩) ^ 2 * Complex.re (star v ⬝ᵥ v) := by
+    have h_eigenvalue_le :
+        (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤
+          (singularValuesSorted M ⟨0, h⟩) ^ 2 *
+            (singularValuesSorted N ⟨0, h⟩) ^ 2 := by
+      -- By the properties of singular values and eigenvalues, we know that the
+      -- eigenvalues of $(MN)^* (MN)$ are bounded by the product of the squares of
+      -- the singular values of $M$ and $N$.
+      have h_eigenvalue_bound : ∀ (v : e → ℂ),
+          Complex.re (star v ⬝ᵥ ((M * N).conjTranspose * (M * N)).mulVec v) ≤
+            (singularValuesSorted M ⟨0, h⟩) ^ 2 *
+              (singularValuesSorted N ⟨0, h⟩) ^ 2 *
+                Complex.re (star v ⬝ᵥ v) := by
         intro v
-        have h_quadratic_form : Complex.re (star v ⬝ᵥ ((M * N).conjTranspose * (M * N)).mulVec v) ≤ (singularValuesSorted M ⟨0, h⟩) ^ 2 * Complex.re (star v ⬝ᵥ (N.conjTranspose * N).mulVec v) := by
+        have h_quadratic_form :
+            Complex.re (star v ⬝ᵥ ((M * N).conjTranspose * (M * N)).mulVec v) ≤
+              (singularValuesSorted M ⟨0, h⟩) ^ 2 *
+                Complex.re (star v ⬝ᵥ (N.conjTranspose * N).mulVec v) := by
           have := quadratic_form_le_singularValuesSorted_sq M h (N.mulVec v)
-          convert this using 1 <;> simp [Matrix.mul_assoc, Matrix.dotProduct_mulVec, Matrix.star_mulVec]
-        have h_quadratic_form_N : Complex.re (star v ⬝ᵥ (N.conjTranspose * N).mulVec v) ≤ (singularValuesSorted N ⟨0, h⟩) ^ 2 * Complex.re (star v ⬝ᵥ v) := by
+          convert this using 1 <;>
+            simp [Matrix.mul_assoc, Matrix.dotProduct_mulVec, Matrix.star_mulVec]
+        have h_quadratic_form_N :
+            Complex.re (star v ⬝ᵥ (N.conjTranspose * N).mulVec v) ≤
+              (singularValuesSorted N ⟨0, h⟩) ^ 2 * Complex.re (star v ⬝ᵥ v) := by
           convert quadratic_form_le_singularValuesSorted_sq N h v using 1
-        simpa only [mul_assoc] using h_quadratic_form.trans (mul_le_mul_of_nonneg_left h_quadratic_form_N (sq_nonneg _))
-      convert h_eigenvalue_bound ((isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvectorBasis i) using 1
-      · have := (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues_eq i; aesop
+        simpa only [mul_assoc] using h_quadratic_form.trans
+          (mul_le_mul_of_nonneg_left h_quadratic_form_N (sq_nonneg _))
+      convert h_eigenvalue_bound
+        ((isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvectorBasis i)
+        using 1
+      · have := (isHermitian_mul_conjTranspose_self
+          (M * N).conjTranspose).eigenvalues_eq i; aesop
       · simp [dotProduct]
-        have := (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvectorBasis.orthonormal
+        have := (isHermitian_mul_conjTranspose_self
+          (M * N).conjTranspose).eigenvectorBasis.orthonormal
         rw [orthonormal_iff_ite] at this
         simp_all [Complex.ext_iff, inner]
     linarith
-  -- Apply the inequality eigenvalue_le_singularValuesSorted_sq to each eigenvalue of (MN)†(MN) and take the square root.
-  have h_sqrt_eigenvalue_le : ∀ i, singularValues (M * N) i ≤ singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩ := by
+  -- Apply the inequality eigenvalue_le_singularValuesSorted_sq to each eigenvalue
+  -- of (MN)†(MN) and take the square root.
+  have h_sqrt_eigenvalue_le : ∀ i, singularValues (M * N) i ≤
+      singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩ := by
     intro i
-    have h_sqrt_eigenvalue_le_i : (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤ (singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩) ^ 2 := h_eigenvalue_le i
-    have h_sqrt_eigenvalue_le_i' : Real.sqrt ((isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i) ≤ singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩ := by
-      exact Real.sqrt_le_iff.mpr ⟨mul_nonneg (singularValuesSorted_nonneg M ⟨0, h⟩) (singularValuesSorted_nonneg N ⟨0, h⟩), h_sqrt_eigenvalue_le_i⟩
+    have h_sqrt_eigenvalue_le_i :
+        (isHermitian_mul_conjTranspose_self (M * N).conjTranspose).eigenvalues i ≤
+          (singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩) ^ 2 :=
+      h_eigenvalue_le i
+    have h_sqrt_eigenvalue_le_i' :
+        Real.sqrt
+          ((isHermitian_mul_conjTranspose_self
+            (M * N).conjTranspose).eigenvalues i) ≤
+          singularValuesSorted M ⟨0, h⟩ * singularValuesSorted N ⟨0, h⟩ := by
+      exact Real.sqrt_le_iff.mpr
+        ⟨mul_nonneg (singularValuesSorted_nonneg M ⟨0, h⟩)
+          (singularValuesSorted_nonneg N ⟨0, h⟩), h_sqrt_eigenvalue_le_i⟩
     exact h_sqrt_eigenvalue_le_i' |> le_trans (by
     exact le_rfl)
   simp_all [Finset.sup'_le_iff]
@@ -830,16 +1047,24 @@ D_k = ∑_{j=0}^k log(y_j/x_j) = log(∏_{j=0}^k y_j/x_j) = log(∏ y_j / ∏ x_
 because ∏ y_j ≥ ∏ x_j (weak log-majorization) and both products are positive.
 So ∑ x_i * d_i is a sum of nonneg terms, hence ≥ 0.
 Use Finset.sum_range_by_parts from Mathlib. The key Mathlib lemma is:
-Finset.sum_range_by_parts f g n = f (n-1) • ∑_{i<n} g i - ∑_{i<n-1} (f(i+1) - f(i)) • ∑_{j<i+1} g j
+Finset.sum_range_by_parts f g n
+  = f (n-1) • ∑_{i<n} g i - ∑_{i<n-1} (f(i+1) - f(i)) • ∑_{j<i+1} g j
 Here f i = x ⟨i, ...⟩ (antitone) and g i = log(y ⟨i,...⟩ / x ⟨i,...⟩).
-Actually, it may be easier to prove this directly by induction on n, without using Finset.sum_range_by_parts. The induction step would split off the last term and use the IH.
+Actually, it may be easier to prove this directly by induction on n, without
+using Finset.sum_range_by_parts. The induction step would split off the last term
+and use the IH.
 For the direct induction approach on n:
 - n = 0: sum is empty, 0 ≥ 0.
-- n = 1: x_0 * log(y_0/x_0) ≥ 0 since x_0 > 0 and log(y_0/x_0) ≥ 0 (from ∏_{i<1} x_i ≤ ∏_{i<1} y_i, i.e., x_0 ≤ y_0, so y_0/x_0 ≥ 1, so log(y_0/x_0) ≥ 0).
-- n+1 → n+2: Split ∑_{i=0}^{n+1} x_i * log(y_i/x_i) = ∑_{i=0}^{n} x_i * log(y_i/x_i) + x_{n+1} * log(y_{n+1}/x_{n+1}).
-  Now ∑_{i=0}^{n} x_i * log(y_i/x_i) ≥ ∑_{i=0}^{n} x_{n+1} * log(y_i/x_i) (since x_i ≥ x_{n+1} and log(y_i/x_i) could be negative, but x_i * log(y_i/x_i) ≥ x_{n+1} * log(y_i/x_i) when log(y_i/x_i) ≥ 0).
+- n = 1: x_0 * log(y_0/x_0) ≥ 0 since x_0 > 0 and log(y_0/x_0) ≥ 0 (from
+  ∏_{i<1} x_i ≤ ∏_{i<1} y_i, i.e., x_0 ≤ y_0, so y_0/x_0 ≥ 1, so log(y_0/x_0) ≥ 0).
+- n+1 → n+2: Split ∑_{i=0}^{n+1} x_i * log(y_i/x_i)
+  = ∑_{i=0}^{n} x_i * log(y_i/x_i) + x_{n+1} * log(y_{n+1}/x_{n+1}).
+  Now ∑_{i=0}^{n} x_i * log(y_i/x_i) ≥ ∑_{i=0}^{n} x_{n+1} * log(y_i/x_i) (since
+  x_i ≥ x_{n+1} and log(y_i/x_i) could be negative, but
+  x_i * log(y_i/x_i) ≥ x_{n+1} * log(y_i/x_i) when log(y_i/x_i) ≥ 0).
 Hmm, this doesn't work cleanly because log(y_i/x_i) can be negative for some i.
-Better approach: prove it directly using the Abel summation identity and nonnegativity of each term.
+Better approach: prove it directly using the Abel summation identity and
+nonnegativity of each term.
 -/
 set_option backward.isDefEq.respectTransparency false in
 lemma sum_mul_log_nonneg_of_weak_log_maj {n : ℕ}
@@ -854,59 +1079,99 @@ lemma sum_mul_log_nonneg_of_weak_log_maj {n : ℕ}
   -- Let $d_i = \log(y_i / x_i)$ and $D_k = \sum_{j=0}^{k} d_j$.
   set d : Fin n → ℝ := fun i => Real.log (y i / x i)
   set D : Fin n → ℝ := fun k => ∑ i ∈ Finset.Iic k, d i
-  -- By Abel's summation formula, we have $\sum_{i=0}^{n-1} x_i d_i = x_{n-1} D_{n-1} + \sum_{i=0}^{n-2} (x_i - x_{i+1}) D_i$.
+  -- By Abel's summation formula, we have $\sum_{i=0}^{n-1} x_i d_i
+  -- = x_{n-1} D_{n-1} + \sum_{i=0}^{n-2} (x_i - x_{i+1}) D_i$.
   have hn : n ≠ 0 := by rintro rfl; simp at h_neg
-  have h_abel : ∑ i, x i * d i = x ⟨n - 1, by omega⟩ * D ⟨n - 1, by omega⟩ + ∑ i : Fin (n - 1),
-      (x ⟨i.val, by omega⟩ - x ⟨i.val + 1, by omega⟩) * D ⟨i.val, by omega⟩ := by
+  have h_abel : ∑ i, x i * d i =
+      x ⟨n - 1, by omega⟩ * D ⟨n - 1, by omega⟩ + ∑ i : Fin (n - 1),
+        (x ⟨i.val, by omega⟩ - x ⟨i.val + 1, by omega⟩) * D ⟨i.val, by omega⟩ := by
     rcases n with ⟨⟩ <;> norm_num at *
     rename_i n
-    have h_abel : ∀ m : Fin (n + 1), ∑ i ∈ Finset.Iic m, x i * d i = x m * D m + ∑ i ∈ Finset.Iio m, (x i - x (i + 1)) * D i := by
+    have h_abel : ∀ m : Fin (n + 1), ∑ i ∈ Finset.Iic m, x i * d i =
+        x m * D m + ∑ i ∈ Finset.Iio m, (x i - x (i + 1)) * D i := by
       intro m
       induction' m using Fin.inductionOn with m ih
       · simp +zetaDelta at *
         rw [Finset.sum_eq_single 0, Finset.sum_eq_single 0] <;> aesop
-      · rw [show (Finset.Iic (Fin.succ m) : Finset (Fin (n + 1))) = Finset.Iic (Fin.castSucc m) ∪ { Fin.succ m } from ?_, Finset.sum_union] <;> norm_num [Finset.sum_singleton, Finset.sum_union, Finset.sum_Ioc_succ_top, (Nat.succ_eq_succ ▸ Finset.Icc_succ_left_eq_Ioc)] at *
-        · rw [show (Finset.Iio (Fin.succ m) : Finset (Fin (n + 1))) = Finset.Iio (Fin.castSucc m) ∪ { Fin.castSucc m } from ?_, Finset.sum_union] <;> norm_num [Finset.sum_singleton, Finset.sum_union, Finset.sum_Ioc_succ_top, (Nat.succ_eq_succ ▸ Finset.Icc_succ_left_eq_Ioc)] at *
+      · rw [show (Finset.Iic (Fin.succ m) : Finset (Fin (n + 1))) =
+            Finset.Iic (Fin.castSucc m) ∪ { Fin.succ m } from ?_, Finset.sum_union] <;>
+          norm_num [Finset.sum_singleton, Finset.sum_union, Finset.sum_Ioc_succ_top,
+            (Nat.succ_eq_succ ▸ Finset.Icc_succ_left_eq_Ioc)] at *
+        · rw [show (Finset.Iio (Fin.succ m) : Finset (Fin (n + 1))) =
+              Finset.Iio (Fin.castSucc m) ∪ { Fin.castSucc m } from ?_,
+              Finset.sum_union] <;>
+            norm_num [Finset.sum_singleton, Finset.sum_union, Finset.sum_Ioc_succ_top,
+              (Nat.succ_eq_succ ▸ Finset.Icc_succ_left_eq_Ioc)] at *
           · rw [ih]
             ring_nf!
-            rw [show (Finset.Iic (Fin.succ m) : Finset (Fin (n + 1))) = Finset.Iic (Fin.castSucc m) ∪ { Fin.succ m } from ?_, Finset.sum_union] <;> norm_num; ring!
+            rw [show (Finset.Iic (Fin.succ m) : Finset (Fin (n + 1))) =
+              Finset.Iic (Fin.castSucc m) ∪ { Fin.succ m } from ?_,
+              Finset.sum_union] <;> norm_num; ring!
             ext i; simp [Finset.mem_Iic, Finset.mem_insert]
-            exact ⟨fun hi => or_iff_not_imp_left.mpr fun hi' => Nat.le_of_lt_succ <| hi.lt_of_ne hi', fun hi => hi.elim (fun hi => hi.symm ▸ le_rfl) fun hi => Nat.le_trans hi (Nat.le_succ _)⟩
+            exact ⟨fun hi => or_iff_not_imp_left.mpr
+                fun hi' => Nat.le_of_lt_succ <| hi.lt_of_ne hi',
+              fun hi => hi.elim (fun hi => hi.symm ▸ le_rfl)
+                fun hi => Nat.le_trans hi (Nat.le_succ _)⟩
           · ext i; simp [Fin.lt_def, Fin.le_iff_val_le_val]
         · ext i; simp [Finset.mem_Iic, Finset.mem_insert]
-          exact ⟨fun hi => or_iff_not_imp_left.mpr fun hi' => Nat.le_of_lt_succ <| hi.lt_of_ne hi', fun hi => hi.elim (fun hi => hi.symm ▸ le_rfl) fun hi => Nat.le_trans hi (Nat.le_succ _)⟩
+          exact ⟨fun hi => or_iff_not_imp_left.mpr
+              fun hi' => Nat.le_of_lt_succ <| hi.lt_of_ne hi',
+            fun hi => hi.elim (fun hi => hi.symm ▸ le_rfl)
+              fun hi => Nat.le_trans hi (Nat.le_succ _)⟩
     convert h_abel ⟨n, Nat.lt_succ_self _⟩ using 1
-    · rw [show (Iic ⟨n, Nat.lt_succ_self _⟩ : Finset (Fin (n + 1))) = Finset.univ from Finset.eq_univ_of_forall fun i => Finset.mem_Iic.mpr (Nat.le_of_lt_succ i.2)]
-    · refine' congr rfl (Finset.sum_bij (fun i hi => ⟨i, by omega⟩) _ _ _ _) <;> simp [Fin.add_def, Nat.mod_eq_of_lt]
+    · rw [show (Iic ⟨n, Nat.lt_succ_self _⟩ : Finset (Fin (n + 1))) = Finset.univ from
+        Finset.eq_univ_of_forall fun i => Finset.mem_Iic.mpr (Nat.le_of_lt_succ i.2)]
+    · refine' congr rfl (Finset.sum_bij (fun i hi => ⟨i, by omega⟩) _ _ _ _) <;>
+        simp [Fin.add_def, Nat.mod_eq_of_lt]
       · exact fun i j h => Fin.ext h
-      · exact fun i hi => ⟨⟨i, by linarith [Fin.is_lt i, show (i : ℕ) < n from hi]⟩, rfl⟩
-  -- Since $D_k \geq 0$ for all $k$, we have $x_{n-1} D_{n-1} \geq 0$ and $(x_i - x_{i+1}) D_i \geq 0$ for all $i$.
+      · exact fun i hi =>
+          ⟨⟨i, by linarith [Fin.is_lt i, show (i : ℕ) < n from hi]⟩, rfl⟩
+  -- Since $D_k \geq 0$ for all $k$, we have $x_{n-1} D_{n-1} \geq 0$ and
+  -- $(x_i - x_{i+1}) D_i \geq 0$ for all $i$.
   have h_nonneg : ∀ k : Fin n, 0 ≤ D k := by
     intro k
     have h_prod : ∏ i ∈ Finset.Iic k, y i ≥ ∏ i ∈ Finset.Iic k, x i := by
       specialize h_log_maj (k + 1) (by linarith [Fin.is_lt k])
-      rw [show (Finset.Iic k : Finset (Fin n)) = Finset.image (fun i : Fin (k + 1) => ⟨i, by linarith [Fin.is_lt k, Fin.is_lt i]⟩) Finset.univ from ?_, Finset.prod_image] <;> norm_num
-      · rwa [Finset.prod_image <| by intros i hi j hj hij; simpa [Fin.ext_iff] using hij]
+      rw [show (Finset.Iic k : Finset (Fin n)) =
+          Finset.image
+            (fun i : Fin (k + 1) => ⟨i, by linarith [Fin.is_lt k, Fin.is_lt i]⟩)
+            Finset.univ from ?_, Finset.prod_image] <;> norm_num
+      · rwa [Finset.prod_image <| by
+          intros i hi j hj hij; simpa [Fin.ext_iff] using hij]
       · intro i j hij
         exact Fin.ext <| by simpa using congr_arg Fin.val hij
       · ext ⟨i, hi⟩; simp [Fin.ext_iff, Fin.le_iff_val_le_val]
-        exact ⟨fun hi' => ⟨⟨i, by linarith [Fin.is_lt k]⟩, rfl⟩, fun ⟨a, ha⟩ => ha ▸ Nat.le_trans (Nat.le_of_lt_succ (by linarith [Fin.is_lt a, Fin.is_lt k])) (Nat.le_refl _)⟩
+        exact ⟨fun hi' => ⟨⟨i, by linarith [Fin.is_lt k]⟩, rfl⟩,
+          fun ⟨a, ha⟩ => ha ▸ Nat.le_trans
+            (Nat.le_of_lt_succ (by linarith [Fin.is_lt a, Fin.is_lt k]))
+            (Nat.le_refl _)⟩
     simp +zetaDelta at *
-    rw [← Real.log_prod fun i hi => ne_of_gt (div_pos (hy_pos i) (hx_pos i))]; exact Real.log_nonneg (by rw [Finset.prod_div_distrib]; exact by rw [le_div_iff₀ (Finset.prod_pos fun i hi => hx_pos i)]; linarith)
-  exact h_neg <| h_abel.symm ▸ add_nonneg (mul_nonneg (le_of_lt (hx_pos _)) (h_nonneg _)) (Finset.sum_nonneg fun i hi => mul_nonneg (sub_nonneg.mpr (hx_anti <| Nat.le_succ _)) (h_nonneg _))
+    rw [← Real.log_prod fun i hi => ne_of_gt (div_pos (hy_pos i) (hx_pos i))];
+      exact Real.log_nonneg (by rw [Finset.prod_div_distrib]; exact by
+        rw [le_div_iff₀ (Finset.prod_pos fun i hi => hx_pos i)]; linarith)
+  exact h_neg <| h_abel.symm ▸ add_nonneg
+    (mul_nonneg (le_of_lt (hx_pos _)) (h_nonneg _))
+    (Finset.sum_nonneg fun i hi =>
+      mul_nonneg (sub_nonneg.mpr (hx_anti <| Nat.le_succ _)) (h_nonneg _))
 
 /-
 PROBLEM
 For positive reals a, b: b - a ≥ a · log(b/a).
 Equivalently: t - 1 ≥ log(t) for t = b/a.
 PROVIDED SOLUTION
-We need b - a ≥ a * log(b/a) for a, b > 0. Equivalently, dividing by a > 0: b/a - 1 ≥ log(b/a). Let t = b/a > 0. Then we need t - 1 ≥ log(t), which is equivalent to log(t) ≤ t - 1. This is Real.log_le_sub_one_of_le or follows from Real.add_one_le_exp: for any x, 1 + x ≤ exp(x). Taking x = log(t): 1 + log(t) ≤ exp(log(t)) = t, so log(t) ≤ t - 1. Multiply by a > 0 to get a * log(b/a) ≤ a * (b/a - 1) = b - a.
+We need b - a ≥ a * log(b/a) for a, b > 0. Equivalently, dividing by a > 0:
+b/a - 1 ≥ log(b/a). Let t = b/a > 0. Then we need t - 1 ≥ log(t), which is
+equivalent to log(t) ≤ t - 1. This is Real.log_le_sub_one_of_le or follows from
+Real.add_one_le_exp: for any x, 1 + x ≤ exp(x). Taking x = log(t):
+1 + log(t) ≤ exp(log(t)) = t, so log(t) ≤ t - 1. Multiply by a > 0 to get
+a * log(b/a) ≤ a * (b/a - 1) = b - a.
 -/
 lemma sub_ge_mul_log_div {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
     b - a ≥ a * Real.log (b / a) := by
   nlinarith [Real.log_le_sub_one_of_pos (div_pos hb ha), mul_div_cancel₀ b ha.ne']
 
-/- Weak log-majorization of nonneg antitone sequences implies the sum inequality ∑ x_i ≤ ∑ y_i. -/
+/- Weak log-majorization of nonneg antitone sequences implies the sum inequality
+∑ x_i ≤ ∑ y_i. -/
 lemma weak_log_maj_sum_le {n : ℕ}
     {x y : Fin n → ℝ}
     (hx_nn : ∀ i, 0 ≤ x i) (hy_nn : ∀ i, 0 ≤ y i)
@@ -919,20 +1184,30 @@ lemma weak_log_maj_sum_le {n : ℕ}
   · norm_num +zetaDelta at *
   · by_cases h_last : x (Fin.last n) = 0
     · simp [Fin.sum_univ_castSucc, h_last]
-      refine le_add_of_le_of_nonneg (ih (fun i => hx_nn _) (fun i => hy_nn _) (fun i j hij => hx_anti hij) (fun i j hij => hy_anti hij) ?_) (hy_nn _)
+      refine le_add_of_le_of_nonneg (ih (fun i => hx_nn _) (fun i => hy_nn _)
+        (fun i j hij => hx_anti hij) (fun i j hij => hy_anti hij) ?_) (hy_nn _)
       intro k hk
       simp
       exact h_log_maj k (by linarith)
     · -- Since $x_{\text{last}} > 0$, we have $x_i > 0$ for all $i$.
       have hx_pos : ∀ i, 0 < x i := by
-        exact fun i => lt_of_lt_of_le (lt_of_le_of_ne (hx_nn _) (Ne.symm h_last)) (hx_anti (Fin.le_last _))
+        exact fun i => lt_of_lt_of_le
+          (lt_of_le_of_ne (hx_nn _) (Ne.symm h_last)) (hx_anti (Fin.le_last _))
       have hy_pos : ∀ i, 0 < y i := by
-        intro i; specialize h_log_maj (n + 1) le_rfl; contrapose! h_log_maj; simp_all [Fin.prod_univ_castSucc]
-        exact lt_of_le_of_lt (mul_nonpos_of_nonneg_of_nonpos (Finset.prod_nonneg fun _ _ => hy_nn _) (by linarith [hy_anti (show i ≤ Fin.last n from Fin.le_last i)])) (mul_pos (Finset.prod_pos fun _ _ => hx_pos _) (hx_pos _))
+        intro i; specialize h_log_maj (n + 1) le_rfl; contrapose! h_log_maj;
+          simp_all [Fin.prod_univ_castSucc]
+        exact lt_of_le_of_lt
+          (mul_nonpos_of_nonneg_of_nonpos
+            (Finset.prod_nonneg fun _ _ => hy_nn _)
+            (by linarith [hy_anti (show i ≤ Fin.last n from Fin.le_last i)]))
+          (mul_pos (Finset.prod_pos fun _ _ => hx_pos _) (hx_pos _))
       have h_sum_mul_log_nonneg : 0 ≤ ∑ i, x i * Real.log (y i / x i) := by
-        apply sum_mul_log_nonneg_of_weak_log_maj (fun i => hx_pos i) (fun i => hy_pos i) hx_anti (fun k hk => h_log_maj k hk)
-      have h_sum_mul_log_nonneg : ∑ i, (y i - x i) ≥ ∑ i, x i * Real.log (y i / x i) := by
-        exact Finset.sum_le_sum fun i _ => by have := sub_ge_mul_log_div (hx_pos i) (hy_pos i); ring_nf at *; linarith
+        apply sum_mul_log_nonneg_of_weak_log_maj (fun i => hx_pos i)
+          (fun i => hy_pos i) hx_anti (fun k hk => h_log_maj k hk)
+      have h_sum_mul_log_nonneg :
+          ∑ i, (y i - x i) ≥ ∑ i, x i * Real.log (y i / x i) := by
+        exact Finset.sum_le_sum fun i _ => by
+          have := sub_ge_mul_log_div (hx_pos i) (hy_pos i); ring_nf at *; linarith
       norm_num at *; linarith
 
 /-- Weak log-majorization of nonneg antitone sequences implies the sum of
@@ -995,12 +1270,25 @@ lemma holder_step_for_singularValues (A B : Matrix d d ℂ)
       (singularValuesSorted A i ^ r * singularValuesSorted B i ^ r)) ≤
     (∑ i : Fin (Fintype.card d), singularValuesSorted A i ^ p) ^ (r / p) *
     (∑ i : Fin (Fintype.card d), singularValuesSorted B i ^ q) ^ (r / q) := by
-  have h_holder : (∑ i : Fin (Fintype.card d), (singularValuesSorted A i ^ r) * (singularValuesSorted B i ^ r)) ≤ (∑ i : Fin (Fintype.card d), (singularValuesSorted A i ^ r) ^ (p / r)) ^ (r / p) * (∑ i : Fin (Fintype.card d), (singularValuesSorted B i ^ r) ^ (q / r)) ^ (r / q) := by
+  have h_holder : (∑ i : Fin (Fintype.card d),
+        (singularValuesSorted A i ^ r) * (singularValuesSorted B i ^ r)) ≤
+      (∑ i : Fin (Fintype.card d),
+        (singularValuesSorted A i ^ r) ^ (p / r)) ^ (r / p) *
+        (∑ i : Fin (Fintype.card d),
+          (singularValuesSorted B i ^ r) ^ (q / r)) ^ (r / q) := by
     have := @Real.inner_le_Lp_mul_Lq
-    convert @this (Fin (Fintype.card d)) Finset.univ (fun i => singularValuesSorted A i ^ r) (fun i => singularValuesSorted B i ^ r) (p / r) (q / r) _ using 1 <;> norm_num [hr.ne', hp.ne', hq.ne', div_eq_mul_inv]
+    convert @this (Fin (Fintype.card d)) Finset.univ
+        (fun i => singularValuesSorted A i ^ r)
+        (fun i => singularValuesSorted B i ^ r) (p / r) (q / r) _ using 1 <;>
+      norm_num [hr.ne', hp.ne', hq.ne', div_eq_mul_inv]
     · simp only [abs_of_nonneg (Real.rpow_nonneg (singularValuesSorted_nonneg A _) _),
               abs_of_nonneg (Real.rpow_nonneg (singularValuesSorted_nonneg B _) _)]
-    · constructor <;> norm_num [hr.ne', hp.ne', hq.ne'] at hpqr ⊢ <;> ring_nf at hpqr ⊢ <;> nlinarith [inv_pos.2 hr, inv_pos.2 hp, inv_pos.2 hq, mul_inv_cancel₀ hr.ne', mul_inv_cancel₀ hp.ne', mul_inv_cancel₀ hq.ne']
-  convert h_holder using 3 <;> push_cast [← Real.rpow_mul (singularValuesSorted_nonneg _ _), mul_div_cancel₀ _ hr.ne'] <;> ring_nf
+    · constructor <;> norm_num [hr.ne', hp.ne', hq.ne'] at hpqr ⊢ <;>
+        ring_nf at hpqr ⊢ <;>
+        nlinarith [inv_pos.2 hr, inv_pos.2 hp, inv_pos.2 hq,
+          mul_inv_cancel₀ hr.ne', mul_inv_cancel₀ hp.ne', mul_inv_cancel₀ hq.ne']
+  convert h_holder using 3 <;>
+    push_cast [← Real.rpow_mul (singularValuesSorted_nonneg _ _),
+      mul_div_cancel₀ _ hr.ne'] <;> ring_nf
 
 end

--- a/QuantumInfo/ForMathlib/Matrix.lean
+++ b/QuantumInfo/ForMathlib/Matrix.lean
@@ -47,7 +47,8 @@ theorem zero_rank_eq_zero {A : Matrix n n 𝕜} [Fintype n] (hA : A.rank = 0) : 
   have h : ∀ v, A.mulVecLin v = 0 := by
     intro v
     rw [rank, Module.finrank_zero_iff] at hA
-    have := hA.elim ⟨A.mulVecLin v, ⟨v, rfl⟩⟩ ⟨0, ⟨0, by rw [mulVecLin_apply, mulVec_zero]⟩⟩
+    have := hA.elim ⟨A.mulVecLin v, ⟨v, rfl⟩⟩
+      ⟨0, ⟨0, by rw [mulVecLin_apply, mulVec_zero]⟩⟩
     simpa only [Subtype.mk.injEq] using this
   rw [← LinearEquiv.map_eq_zero_iff toLin']
   exact LinearMap.ext h
@@ -74,7 +75,8 @@ theorem smul_real (c : ℝ) : (c • A).IsHermitian := by
   ext
   simp only [smul_apply, smul_eq_mul, RCLike.real_smul_eq_coe_mul]
 
-def HermitianSubspace (n 𝕜 : Type*) [Fintype n] [RCLike 𝕜] : Subspace ℝ (Matrix n n 𝕜) where
+def HermitianSubspace (n 𝕜 : Type*) [Fintype n] [RCLike 𝕜] :
+    Subspace ℝ (Matrix n n 𝕜) where
   carrier := { A : Matrix n n 𝕜 | A.IsHermitian }
   add_mem' _ _ := by simp_all only [Set.mem_setOf_eq, IsHermitian.add]
   zero_mem' := by simp only [Set.mem_setOf_eq, isHermitian_zero]
@@ -199,13 +201,16 @@ theorem outer_self_conj (v : n → 𝕜) : PosSemidef (vecMulVec v (conj v)) := 
 
 omit [Fintype m] in
 include hA hB in
-theorem convex_cone {c₁ c₂ : 𝕜} (hc₁ : 0 ≤ c₁) (hc₂ : 0 ≤ c₂) : (c₁ • A + c₂ • B).PosSemidef :=
+theorem convex_cone {c₁ c₂ : 𝕜} (hc₁ : 0 ≤ c₁) (hc₂ : 0 ≤ c₂) :
+    (c₁ • A + c₂ • B).PosSemidef :=
   (hA.smul hc₁).add (hB.smul hc₂)
 
 variable [dm : DecidableEq m]
 
-/-- A standard basis matrix (with a positive entry) is positive semidefinite iff the entry is on the diagonal. -/
-theorem stdBasisMatrix_iff_eq (i j : m) {c : 𝕜} (hc : 0 < c) : (single i j c).PosSemidef ↔ i = j := by
+/-- A standard basis matrix (with a positive entry) is positive semidefinite iff the entry is on
+the diagonal. -/
+theorem stdBasisMatrix_iff_eq (i j : m) {c : 𝕜} (hc : 0 < c) :
+    (single i j c).PosSemidef ↔ i = j := by
   constructor
   · intro ⟨hherm, _⟩
     rw [IsHermitian, ← ext_iff] at hherm
@@ -236,7 +241,9 @@ theorem stdBasisMatrix_iff_eq (i j : m) {c : 𝕜} (hc : 0 < c) : (single i j c)
       simp only [single, of_apply]
       convert_to 0 ≤ (star (x i)) * c * (x i)
       · rw [←Fintype.sum_prod_type']
-        have h₀ : ∀ x_1 : m × m, x_1 ≠ ⟨i, i⟩ → star (x x_1.1) * ((if i = x_1.1 ∧ i = x_1.2 then c else 0) * x x_1.2) = 0 := fun z hz => by
+        have h₀ : ∀ x_1 : m × m, x_1 ≠ ⟨i, i⟩ →
+            star (x x_1.1) * ((if i = x_1.1 ∧ i = x_1.2 then c else 0) * x x_1.2) = 0 :=
+            fun z hz => by
           have h₁ : ¬(i = z.1 ∧ i = z.2) := by
             rw [ne_eq, Prod.mk_inj] at hz
             by_contra hz'
@@ -281,7 +288,8 @@ open ComplexOrder
 omit [DecidableEq m]
 
 include hA in
-theorem zero_dotProduct_zero_iff : (∀ x : m → 𝕜, 0 = star x ⬝ᵥ A.mulVec x) ↔ A = 0 := by
+theorem zero_dotProduct_zero_iff :
+    (∀ x : m → 𝕜, 0 = star x ⬝ᵥ A.mulVec x) ↔ A = 0 := by
   constructor
   · intro h
     ext i j
@@ -328,7 +336,8 @@ theorem toLin_ker_eq_bot (hA : A.PosDef) : LinearMap.ker A.toLin' = ⊥ := by
   have := @hA.right v
   grind [mulVec_zero, dotProduct_zero, LinearMap.mem_ker, toLin'_apply, Submodule.mem_bot]
 
-theorem of_toLin_ker_eq_bot (hA : LinearMap.ker A.toLin' = ⊥) (hA₂ : A.PosSemidef) : A.PosDef := by
+theorem of_toLin_ker_eq_bot (hA : LinearMap.ker A.toLin' = ⊥) (hA₂ : A.PosSemidef) :
+    A.PosDef := by
   rwa [hA₂.posDef_iff_isUnit, ← Matrix.isUnit_toLin'_iff, LinearMap.isUnit_iff_ker_eq_bot]
 
 theorem ker_range_antitone {d : Type*} [Fintype d] [DecidableEq d] {A B : Matrix d d ℂ}
@@ -408,10 +417,12 @@ theorem diagonal_monotone : Monotone (diagonal : (n → 𝕜) → _) := fun _ _ 
   le_of_nonneg_imp' (diagonalAddMonoidHom n 𝕜) (fun _ ↦ PosSemidef.diagonal)
 
 omit [Fintype n] in
-theorem diagonal_mono {d₁ d₂ : n → 𝕜} : d₁ ≤ d₂ → diagonal d₁ ≤ diagonal d₂ := diagonal_monotone.imp
+theorem diagonal_mono {d₁ d₂ : n → 𝕜} : d₁ ≤ d₂ → diagonal d₁ ≤ diagonal d₂ :=
+  diagonal_monotone.imp
 
 omit [Fintype n] in
-theorem diagonal_le_iff {d₁ d₂ : n → 𝕜} : d₁ ≤ d₂ ↔ diagonal d₁ ≤ diagonal d₂ := ⟨diagonal_mono, by
+theorem diagonal_le_iff {d₁ d₂ : n → 𝕜} : d₁ ≤ d₂ ↔ diagonal d₁ ≤ diagonal d₂ :=
+  ⟨diagonal_mono, by
   intro hd
   rw [Matrix.le_iff, diagonal_sub, posSemidef_diagonal_iff] at hd
   simp only [sub_nonneg] at hd
@@ -522,7 +533,8 @@ end PosSemidef
 --       rw [Pi.zero_apply, Fintype.sum_eq_zero_iff_of_nonneg (fun i ↦ by positivity)] at h
 --       replace h := congrFun h i
 --       dsimp at h
---       rw [add_eq_zero_iff_of_nonneg (sq_nonneg _) (sq_nonneg _), sq_eq_zero_iff, sq_eq_zero_iff] at h
+--       rw [add_eq_zero_iff_of_nonneg (sq_nonneg _) (sq_nonneg _), sq_eq_zero_iff,
+--         sq_eq_zero_iff] at h
 --       apply RCLike.ext (h.left.trans RCLike.zero_re.symm) (h.right.trans (map_zero _).symm)
 --   }
 
@@ -567,7 +579,8 @@ end PosSemidef
 --       rw [Pi.zero_apply, Fintype.sum_eq_zero_iff_of_nonneg (fun i ↦ by positivity)] at h
 --       replace h := congrFun h i
 --       dsimp at h
---       rw [add_eq_zero_iff_of_nonneg (sq_nonneg _) (sq_nonneg _), sq_eq_zero_iff, sq_eq_zero_iff] at h
+--       rw [add_eq_zero_iff_of_nonneg (sq_nonneg _) (sq_nonneg _), sq_eq_zero_iff,
+--         sq_eq_zero_iff] at h
 --       apply RCLike.ext (h.left.trans RCLike.zero_re.symm) (h.right.trans (map_zero _).symm)
 --   }
 
@@ -614,14 +627,16 @@ theorem traceRight_trace (A : Matrix (d₁ × d₂) (d₁ × d₂) R) : A.traceR
   rfl
 
 variable [StarAddMonoid R] in
-theorem IsHermitian.traceLeft {A : Matrix (d × d₁) (d × d₁) R} (hA : A.IsHermitian) : A.traceLeft.IsHermitian := by
+theorem IsHermitian.traceLeft {A : Matrix (d × d₁) (d × d₁) R} (hA : A.IsHermitian) :
+    A.traceLeft.IsHermitian := by
   ext
   simp only [Matrix.traceLeft, conjTranspose_apply, of_apply, star_sum]
   congr!
   exact congrFun₂ hA _ _
 
 variable [StarAddMonoid R] in
-theorem IsHermitian.traceRight {A : Matrix (d₁ × d) (d₁ × d) R} (hA : A.IsHermitian) : A.traceRight.IsHermitian := by
+theorem IsHermitian.traceRight {A : Matrix (d₁ × d) (d₁ × d) R} (hA : A.IsHermitian) :
+    A.traceRight.IsHermitian := by
   ext
   simp only [Matrix.traceRight, conjTranspose_apply, of_apply, star_sum]
   congr!
@@ -662,20 +677,22 @@ theorem PosSemidef.traceLeft [DecidableEq d₁] (hA : A.PosSemidef) : A.traceLef
   constructor
   · exact hA.1.traceLeft
   · intro x
-    convert Finset.sum_nonneg' (s := .univ) (fun (i : d₁) ↦ hA.2 (fun (j,k) ↦ if i = j then x k else 0))
+    convert Finset.sum_nonneg' (s := .univ)
+      (fun (i : d₁) ↦ hA.2 (fun (j,k) ↦ if i = j then x k else 0))
     simp_rw [Matrix.traceLeft, dotProduct_mulVec]
-    simpa [dotProduct, vecMul_eq_sum, ite_apply, Fintype.sum_prod_type, Finset.mul_sum, Finset.sum_mul,
-      apply_ite] using Finset.sum_comm_cycle
+    simpa [dotProduct, vecMul_eq_sum, ite_apply, Fintype.sum_prod_type, Finset.mul_sum,
+      Finset.sum_mul, apply_ite] using Finset.sum_comm_cycle
 
 theorem PosSemidef.traceRight [DecidableEq d₂] (hA : A.PosSemidef) : A.traceRight.PosSemidef := by
   rw [Matrix.posSemidef_iff_dotProduct_mulVec] at hA ⊢
   constructor
   · exact hA.1.traceRight
   · intro x
-    convert Finset.sum_nonneg' (s := .univ) (fun (i : d₂) ↦ hA.2 (fun (j,k) ↦ if i = k then x j else 0))
+    convert Finset.sum_nonneg' (s := .univ)
+      (fun (i : d₂) ↦ hA.2 (fun (j,k) ↦ if i = k then x j else 0))
     simp_rw [Matrix.traceRight, dotProduct_mulVec]
-    simpa [dotProduct, vecMul_eq_sum, ite_apply, Fintype.sum_prod_type, Finset.mul_sum, Finset.sum_mul,
-      apply_ite] using Finset.sum_comm_cycle
+    simpa [dotProduct, vecMul_eq_sum, ite_apply, Fintype.sum_prod_type, Finset.mul_sum,
+      Finset.sum_mul, apply_ite] using Finset.sum_comm_cycle
 
 end partial_trace
 
@@ -684,8 +701,9 @@ section posdef
 open ComplexOrder
 open Kronecker
 
-theorem PosDef.kron {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂] [RCLike 𝕜]
-    {A : Matrix d₁ d₁ 𝕜} {B : Matrix d₂ d₂ 𝕜} (hA : A.PosDef) (hB : B.PosDef) : (A ⊗ₖ B).PosDef := by
+theorem PosDef.kron {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+    [RCLike 𝕜] {A : Matrix d₁ d₁ 𝕜} {B : Matrix d₂ d₂ 𝕜} (hA : A.PosDef) (hB : B.PosDef) :
+    (A ⊗ₖ B).PosDef := by
   rw [hA.left.spectral_theorem, hB.left.spectral_theorem]
   simp only [Unitary.conjStarAlgAut_apply]
   rw [mul_kronecker_mul, mul_kronecker_mul]
@@ -703,19 +721,20 @@ theorem PosDef.kron {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [
     use (star hA.left.eigenvectorUnitary.val) ⊗ₖ (star hB.left.eigenvectorUnitary.val)
     simp [← Matrix.mul_kronecker_mul]
 
-theorem PosDef.reindex {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂] [RCLike 𝕜]
-    {M : Matrix d₁ d₁ 𝕜} (hM : M.PosDef) (e : d₁ ≃ d₂) : (M.reindex e e).PosDef :=
+theorem PosDef.reindex {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+    [RCLike 𝕜] {M : Matrix d₁ d₁ 𝕜} (hM : M.PosDef) (e : d₁ ≃ d₂) : (M.reindex e e).PosDef :=
   hM.submatrix e.symm.injective
 
 @[simp]
-theorem PosDef.reindex_iff {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂] [RCLike 𝕜]
-    {M : Matrix d₁ d₁ 𝕜} (e : d₁ ≃ d₂) : (M.reindex e e).PosDef ↔ M.PosDef := by
+theorem PosDef.reindex_iff {d₁ d₂ 𝕜 : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+    [DecidableEq d₂] [RCLike 𝕜] {M : Matrix d₁ d₁ 𝕜} (e : d₁ ≃ d₂) :
+    (M.reindex e e).PosDef ↔ M.PosDef := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.reindex e⟩
   convert h.reindex e.symm
   simp
 
-theorem PosSemidef.rsmul {n : Type*} [Fintype n] {M : Matrix n n ℂ} (hM : M.PosSemidef) {c : ℝ} (hc : 0 ≤ c) :
-    (c • M).PosSemidef := by
+theorem PosSemidef.rsmul {n : Type*} [Fintype n] {M : Matrix n n ℂ} (hM : M.PosSemidef) {c : ℝ}
+    (hc : 0 ≤ c) : (c • M).PosSemidef := by
   rw [Matrix.posSemidef_iff_dotProduct_mulVec] at hM ⊢
   constructor
   · exact hM.1.smul_real c
@@ -723,7 +742,8 @@ theorem PosSemidef.rsmul {n : Type*} [Fintype n] {M : Matrix n n ℂ} (hM : M.Po
     rw [smul_mulVec, dotProduct_smul]
     positivity
 
-theorem PosDef.Convex {n 𝕜 : Type*} [Fintype n] [RCLike 𝕜] : Convex ℝ (Matrix.PosDef (n := n) (R := 𝕜)) := by
+theorem PosDef.Convex {n 𝕜 : Type*} [Fintype n] [RCLike 𝕜] :
+    Convex ℝ (Matrix.PosDef (n := n) (R := 𝕜)) := by
   intro A hA B hB a b ha hb hab
   rcases ha.lt_or_eq with ha | rfl
   · apply (hA.smul ha).add_posSemidef
@@ -745,21 +765,40 @@ theorem PosDef_iff_eigenvalues' (M : Matrix d d 𝕜) :
   ⟨fun h ↦ ⟨h.left, h.left.posDef_iff_eigenvalues_pos.mp h⟩,
     fun ⟨w, h⟩ ↦ w.posDef_iff_eigenvalues_pos.mpr h⟩
 
---These is disgusting atm. There's cleaner versions of them headed to Mathlib. See #29526 and follow-ups
+--These is disgusting atm. There's cleaner versions of them headed to Mathlib. See #29526 and
+--follow-ups
 theorem IsHermitian.cfc_eigenvalues {M : Matrix d d 𝕜} (hM : M.IsHermitian) (f : ℝ → ℝ) :
-    ∃ (e : d ≃ d), Matrix.IsHermitian.eigenvalues (cfc_predicate f M) = f ∘ hM.eigenvalues ∘ e := by
-  have h_eigenvalues : Multiset.map hM.eigenvalues Finset.univ.val = Multiset.map (fun i => hM.eigenvalues i) Finset.univ.val := by
+    ∃ (e : d ≃ d),
+      Matrix.IsHermitian.eigenvalues (cfc_predicate f M) = f ∘ hM.eigenvalues ∘ e := by
+  have h_eigenvalues : Multiset.map hM.eigenvalues Finset.univ.val =
+      Multiset.map (fun i => hM.eigenvalues i) Finset.univ.val := by
     rfl
   generalize_proofs at *;
-  have h_eigenvalues_cfc : (IsHermitian.cfc hM f).charpoly.roots = Multiset.map (fun i => (f (hM.eigenvalues i) : 𝕜)) Finset.univ.val := by
+  have h_eigenvalues_cfc : (IsHermitian.cfc hM f).charpoly.roots =
+      Multiset.map (fun i => (f (hM.eigenvalues i) : 𝕜)) Finset.univ.val := by
     rw [ Matrix.IsHermitian.cfc, Matrix.charpoly ];
-    -- Since $U$ is unitary, we have $U^* U = I$, and thus the characteristic polynomial of $U D U^*$ is the same as the characteristic polynomial of $D$.
-    have h_charpoly : Matrix.det ((hM.eigenvectorUnitary : Matrix d d 𝕜) * Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) * Star.star (hM.eigenvectorUnitary : Matrix d d 𝕜)).charmatrix = Matrix.det (Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)).charmatrix := by
-      -- Since $U$ is unitary, we have $U^* U = I$, and thus the characteristic polynomial of $U D U^*$ is the same as the characteristic polynomial of $D$ by the properties of determinants.
-      have h_char_poly : ∀ (t : 𝕜), Matrix.det (t • 1 - (hM.eigenvectorUnitary : Matrix d d 𝕜) * Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) * star (hM.eigenvectorUnitary : Matrix d d 𝕜)) = Matrix.det (t • 1 - Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)) := by
+    -- Since $U$ is unitary, we have $U^* U = I$, and thus the characteristic polynomial of
+    -- $U D U^*$ is the same as the characteristic polynomial of $D$.
+    have h_charpoly : Matrix.det ((hM.eigenvectorUnitary : Matrix d d 𝕜) *
+          Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) *
+          Star.star (hM.eigenvectorUnitary : Matrix d d 𝕜)).charmatrix =
+        Matrix.det (Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)).charmatrix := by
+      -- Since $U$ is unitary, we have $U^* U = I$, and thus the characteristic polynomial of
+      -- $U D U^*$ is the same as the characteristic polynomial of $D$ by the properties of
+      -- determinants.
+      have h_char_poly : ∀ (t : 𝕜), Matrix.det (t • 1 - (hM.eigenvectorUnitary : Matrix d d 𝕜) *
+            Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) *
+            star (hM.eigenvectorUnitary : Matrix d d 𝕜)) =
+          Matrix.det (t • 1 - Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)) := by
         intro t;
-        -- Since $U$ is unitary, we have $U^* U = I$, and thus the determinant of $tI - UDU^*$ is the same as the determinant of $tI - D$.
-        have h_det : Matrix.det (t • 1 - (hM.eigenvectorUnitary : Matrix d d 𝕜) * Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) * star (hM.eigenvectorUnitary : Matrix d d 𝕜)) = Matrix.det ((hM.eigenvectorUnitary : Matrix d d 𝕜) * (t • 1 - Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)) * star (hM.eigenvectorUnitary : Matrix d d 𝕜)) := by
+        -- Since $U$ is unitary, we have $U^* U = I$, and thus the determinant of $tI - UDU^*$ is
+        -- the same as the determinant of $tI - D$.
+        have h_det : Matrix.det (t • 1 - (hM.eigenvectorUnitary : Matrix d d 𝕜) *
+              Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues) *
+              star (hM.eigenvectorUnitary : Matrix d d 𝕜)) =
+            Matrix.det ((hM.eigenvectorUnitary : Matrix d d 𝕜) *
+              (t • 1 - Matrix.diagonal (RCLike.ofReal ∘ f ∘ hM.eigenvalues)) *
+              star (hM.eigenvectorUnitary : Matrix d d 𝕜)) := by
           simp [ mul_sub, sub_mul, mul_assoc ];
         rw [ h_det, Matrix.det_mul, Matrix.det_mul ];
         rw [ mul_right_comm, ← Matrix.det_mul, mul_comm ];
@@ -792,7 +831,8 @@ theorem IsHermitian.cfc_eigenvalues {M : Matrix d d 𝕜} (hM : M.IsHermitian) (
 set_option maxHeartbeats 0 in
 --Should be combined the above...? TODO Cleanup
 /--
-If a Hermitian matrix A is unitarily similar to a diagonal matrix with real entries f, then the eigenvalues of A are a permutation of f.
+If a Hermitian matrix A is unitarily similar to a diagonal matrix with real entries f, then the
+eigenvalues of A are a permutation of f.
 -/
 lemma IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal {d 𝕜 : Type*}
     [Fintype d] [DecidableEq d] [RCLike 𝕜]
@@ -803,10 +843,14 @@ lemma IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal {d 𝕜 : Type*}
     ∃ σ : d ≃ d, hA.eigenvalues ∘ σ = f := by
   -- Since A is unitarily similar to D, they have the same characteristic polynomial.
   have h_char_poly : Matrix.charpoly A = Matrix.charpoly (Matrix.diagonal fun i => (f i : 𝕜)) := by
-    have h_char_poly : Matrix.charpoly (U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) = Matrix.charpoly (Matrix.diagonal (fun i => (f i : 𝕜))) := by
-      have h_det : ∀ (t : 𝕜), Matrix.det (t • 1 - U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) = Matrix.det (t • 1 - Matrix.diagonal (fun i => (f i : 𝕜))) := by
+    have h_char_poly : Matrix.charpoly (U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) =
+        Matrix.charpoly (Matrix.diagonal (fun i => (f i : 𝕜))) := by
+      have h_det : ∀ (t : 𝕜),
+          Matrix.det (t • 1 - U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) =
+          Matrix.det (t • 1 - Matrix.diagonal (fun i => (f i : 𝕜))) := by
         intro t
-        have h_det : Matrix.det (t • 1 - U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) = Matrix.det (U * (t • 1 - Matrix.diagonal (fun i => (f i : 𝕜))) * Uᴴ) := by
+        have h_det : Matrix.det (t • 1 - U * Matrix.diagonal (fun i => (f i : 𝕜)) * Uᴴ) =
+            Matrix.det (U * (t • 1 - Matrix.diagonal (fun i => (f i : 𝕜))) * Uᴴ) := by
           simp [ mul_sub, sub_mul, Matrix.mul_assoc ];
           rw [ show U * Uᴴ = 1 from by simpa [mul_eq_one_comm] using hU.2 ];
         rw [h_det, Matrix.det_mul_comm, ← mul_assoc]
@@ -814,16 +858,21 @@ lemma IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal {d 𝕜 : Type*}
         simp
       refine' Polynomial.funext fun t => _;
       convert h_det t using 1 <;> simp [ Matrix.charpoly, Matrix.det_apply' ];
-      · simp [ Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_prod, Matrix.one_apply ];
+      · simp [ Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_prod,
+          Matrix.one_apply ];
         exact Finset.sum_congr rfl fun _ _ => by congr; ext; aesop;
-      · simp [ Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_prod, Matrix.one_apply ];
+      · simp [ Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_prod,
+          Matrix.one_apply ];
         exact Finset.sum_congr rfl fun _ _ => by congr; ext; aesop;
     rw [ h, h_char_poly ];
-  -- The roots of the characteristic polynomial of A are its eigenvalues (by `IsHermitian.charpoly_roots_eq_eigenvalues`).
-  have h_eigenvalues : (Matrix.charpoly A).roots = Multiset.map (RCLike.ofReal ∘ hA.eigenvalues) Finset.univ.val := by
+  -- The roots of the characteristic polynomial of A are its eigenvalues (by
+  -- `IsHermitian.charpoly_roots_eq_eigenvalues`).
+  have h_eigenvalues : (Matrix.charpoly A).roots =
+      Multiset.map (RCLike.ofReal ∘ hA.eigenvalues) Finset.univ.val := by
     exact Matrix.IsHermitian.roots_charpoly_eq_eigenvalues hA;
   -- The roots of the characteristic polynomial of D are the diagonal entries f.
-  have h_diag_roots : (Matrix.charpoly (Matrix.diagonal fun i => (f i : 𝕜))).roots = Multiset.map (fun i => (f i : 𝕜)) Finset.univ.val := by
+  have h_diag_roots : (Matrix.charpoly (Matrix.diagonal fun i => (f i : 𝕜))).roots =
+      Multiset.map (fun i => (f i : 𝕜)) Finset.univ.val := by
     simp [ Matrix.charpoly, Matrix.det_diagonal ];
     rw [ Polynomial.roots_prod ];
     · aesop;
@@ -832,7 +881,8 @@ lemma IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal {d 𝕜 : Type*}
   subst h
   simp_all only [Function.comp_apply, RCLike.ofReal_real_eq_id, id_eq, CompTriple.comp_eq]
   refine' this.mp _ |> fun ⟨ e, he ⟩ => ⟨ e.symm, _ ⟩
-  · simpa [ Function.comp ] using congr_arg ( Multiset.map ( RCLike.re : 𝕜 → ℝ ) ) h_eigenvalues.symm
+  · simpa [ Function.comp ] using
+      congr_arg ( Multiset.map ( RCLike.re : 𝕜 → ℝ ) ) h_eigenvalues.symm
   · exact funext fun x => by simpa using congr_fun he ( e.symm x ) ;
 
 end eigenvalues
@@ -947,25 +997,33 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
     congr! 1;
     ext ⟨ i, j ⟩ ⟨ i', j' ⟩;
     simp [ Algebra.smul_def ]
-  -- Since $A$ and $B$ are Hermitian, they are diagonalizable. Let $P$ and $Q$ be unitary matrices such that $P^*AP$ and $Q^*BQ$ are diagonal.
-  obtain ⟨P, hP₁, ⟨D, hD⟩⟩ : ∃ P : Matrix d d 𝕜, P.det ≠ 0 ∧ ∃ D : Matrix d d 𝕜, D.IsDiag ∧ P⁻¹ * A * P = D := by
+  -- Since $A$ and $B$ are Hermitian, they are diagonalizable. Let $P$ and $Q$ be unitary
+  -- matrices such that $P^*AP$ and $Q^*BQ$ are diagonal.
+  obtain ⟨P, hP₁, ⟨D, hD⟩⟩ : ∃ P : Matrix d d 𝕜, P.det ≠ 0 ∧
+      ∃ D : Matrix d d 𝕜, D.IsDiag ∧ P⁻¹ * A * P = D := by
     refine' ⟨ hA.eigenvectorUnitary, _, Matrix.diagonal ( RCLike.ofReal ∘ hA.eigenvalues ), _, _ ⟩;
     · intro h_det_zero;
-      exact absurd h_det_zero <| isUnit_iff_ne_zero.mp <| UnitaryGroup.det_isUnit hA.eigenvectorUnitary
+      exact absurd h_det_zero <|
+        isUnit_iff_ne_zero.mp <| UnitaryGroup.det_isUnit hA.eigenvectorUnitary
     · exact isDiag_diagonal (RCLike.ofReal ∘ hA.eigenvalues);
     · -- Since $U$ is unitary, $U⁻¹ = U*$, and thus $U⁻¹ * U = I$.
-      have h_unitary : (hA.eigenvectorUnitary : Matrix d d 𝕜)⁻¹ = star (hA.eigenvectorUnitary : Matrix d d 𝕜) := by
+      have h_unitary : (hA.eigenvectorUnitary : Matrix d d 𝕜)⁻¹ =
+          star (hA.eigenvectorUnitary : Matrix d d 𝕜) := by
         rw [ Matrix.inv_eq_left_inv ];
         simp
       -- Substitute h_unitary into the equation.
       rw [h_unitary];
       convert Matrix.IsHermitian.conjStarAlgAut_star_eigenvectorUnitary hA using 1
       simp
-  obtain ⟨Q, hQ₁, ⟨E, hE⟩⟩ : ∃ Q : Matrix d₂ d₂ 𝕜, Q.det ≠ 0 ∧ ∃ E : Matrix d₂ d₂ 𝕜, E.IsDiag ∧ Q⁻¹ * B * Q = E := by
+  obtain ⟨Q, hQ₁, ⟨E, hE⟩⟩ : ∃ Q : Matrix d₂ d₂ 𝕜, Q.det ≠ 0 ∧
+      ∃ E : Matrix d₂ d₂ 𝕜, E.IsDiag ∧ Q⁻¹ * B * Q = E := by
     have := Matrix.IsHermitian.spectral_theorem hB;
-    -- By the spectral theorem, since B is Hermitian, there exists a unitary matrix Q and a diagonal matrix D such that B = Q * D * Q⁻¹.
-    obtain ⟨Q, hQ_unitary, D, hD_diag, hQ⟩ : ∃ Q : Matrix d₂ d₂ 𝕜, Q.det ≠ 0 ∧ ∃ D : Matrix d₂ d₂ 𝕜, D.IsDiag ∧ B = Q * D * Q⁻¹ := by
-      refine' ⟨ hB.eigenvectorUnitary, _, Matrix.diagonal ( RCLike.ofReal ∘ hB.eigenvalues ), _, _ ⟩;
+    -- By the spectral theorem, since B is Hermitian, there exists a unitary matrix Q and a
+    -- diagonal matrix D such that B = Q * D * Q⁻¹.
+    obtain ⟨Q, hQ_unitary, D, hD_diag, hQ⟩ : ∃ Q : Matrix d₂ d₂ 𝕜, Q.det ≠ 0 ∧
+        ∃ D : Matrix d₂ d₂ 𝕜, D.IsDiag ∧ B = Q * D * Q⁻¹ := by
+      refine' ⟨ hB.eigenvectorUnitary, _,
+        Matrix.diagonal ( RCLike.ofReal ∘ hB.eigenvalues ), _, _ ⟩;
       · intro h_det_zero;
         -- Since the eigenvector unitary matrix is unitary, its determinant is non-zero.
         have h_unitary_det : ∀ (U : Matrix d₂ d₂ 𝕜), U * star U = 1 → U.det ≠ 0 :=
@@ -979,11 +1037,15 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
         · simp only [SetLike.coe_mem, Unitary.star_mul_self_of_mem]
     refine ⟨ Q, hQ_unitary, D, hD_diag, ?_ ⟩
     simp [ hQ, mul_assoc, hQ_unitary, isUnit_iff_ne_zero ];
-  -- Then $(P \otimes Q)^{-1}(A \otimes B)(P \otimes Q) = D \otimes E$, where $D$ and $E$ are diagonal matrices.
+  -- Then $(P \otimes Q)^{-1}(A \otimes B)(P \otimes Q) = D \otimes E$, where $D$ and $E$ are
+  -- diagonal matrices.
   have h_diag : (P.kronecker Q)⁻¹ * (A ⊗ₖ B) * (P.kronecker Q) = D ⊗ₖ E := by
-    -- Using the properties of the Kronecker product and the fact that $P$ and $Q$ are invertible, we can simplify the expression.
-    have h_kronecker : (P.kronecker Q)⁻¹ * (A.kronecker B) * (P.kronecker Q) = (P⁻¹ * A * P).kronecker (Q⁻¹ * B * Q) := by
-      have h_kronecker : ∀ (X Y : Matrix d d 𝕜) (Z W : Matrix d₂ d₂ 𝕜), (X.kronecker Z) * (Y.kronecker W) = (X * Y).kronecker (Z * W) := by
+    -- Using the properties of the Kronecker product and the fact that $P$ and $Q$ are
+    -- invertible, we can simplify the expression.
+    have h_kronecker : (P.kronecker Q)⁻¹ * (A.kronecker B) * (P.kronecker Q) =
+        (P⁻¹ * A * P).kronecker (Q⁻¹ * B * Q) := by
+      have h_kronecker : ∀ (X Y : Matrix d d 𝕜) (Z W : Matrix d₂ d₂ 𝕜),
+          (X.kronecker Z) * (Y.kronecker W) = (X * Y).kronecker (Z * W) := by
         intro X Y Z W; ext i j; simp [ Matrix.mul_apply ] ;
         simp only [mul_left_comm, mul_comm, Finset.mul_sum _ _ _];
         exact Fintype.sum_prod_type_right _
@@ -991,17 +1053,22 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
       convert h_kronecker P P⁻¹ Q Q⁻¹ using 1;
       simp [ hP₁, hQ₁, isUnit_iff_ne_zero ];
     aesop;
-  -- Since $D$ and $E$ are diagonal matrices, the determinant of $(D \otimes E - xI)$ is the product of the determinants of $(D - xI)$ and $(E - xI)$.
+  -- Since $D$ and $E$ are diagonal matrices, the determinant of $(D \otimes E - xI)$ is the
+  -- product of the determinants of $(D - xI)$ and $(E - xI)$.
   have h_det_diag : Matrix.det (D ⊗ₖ E - x • 1) = 0 := by
-    have h_det_diag : Matrix.det ((P.kronecker Q)⁻¹ * (A ⊗ₖ B - x • 1) * (P.kronecker Q)) = Matrix.det (D ⊗ₖ E - x • 1) := by
+    have h_det_diag : Matrix.det ((P.kronecker Q)⁻¹ * (A ⊗ₖ B - x • 1) * (P.kronecker Q)) =
+        Matrix.det (D ⊗ₖ E - x • 1) := by
       simp [ ← h_diag, mul_sub, sub_mul ];
       simp [ Matrix.det_kronecker, hP₁, hQ₁ ];
     simp_all [ Matrix.det_mul ];
-  -- Since $D$ and $E$ are diagonal matrices, the determinant of $(D \otimes E - xI)$ is the product of the determinants of $(D - xI)$ and $(E - xI)$. Therefore, there must be some $i$ and $j$ such that $D_{ii} * E_{jj} = x$.
+  -- Since $D$ and $E$ are diagonal matrices, the determinant of $(D \otimes E - xI)$ is the
+  -- product of the determinants of $(D - xI)$ and $(E - xI)$. Therefore, there must be some $i$
+  -- and $j$ such that $D_{ii} * E_{jj} = x$.
   obtain ⟨i, j, hij⟩ : ∃ i : d, ∃ j : d₂, D i i * E j j = x := by
     contrapose! h_det_diag;
     have h_det_diag : Matrix.det (D ⊗ₖ E - x • 1) = ∏ i : d, ∏ j : d₂, (D i i * E j j - x) := by
-      have h_det_diag : Matrix.det (D ⊗ₖ E - x • 1) = Matrix.det (Matrix.diagonal (fun p : d × d₂ => D p.1 p.1 * E p.2 p.2 - x)) := by
+      have h_det_diag : Matrix.det (D ⊗ₖ E - x • 1) =
+          Matrix.det (Matrix.diagonal (fun p : d × d₂ => D p.1 p.1 * E p.2 p.2 - x)) := by
         congr with p q
         simp_all only [ne_eq, kronecker, sub_apply,
           kroneckerMap_apply, smul_apply, smul_eq_mul]
@@ -1016,7 +1083,8 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
         · exact Or.inl ( left h );
       simp_all [ Matrix.det_diagonal ];
       exact Fintype.prod_prod_type fun (x_2 : d × d₂) => D x_2.1 x_2.1 * E x_2.2 x_2.2 - x
-    exact h_det_diag.symm ▸ Finset.prod_ne_zero_iff.mpr fun i _ => Finset.prod_ne_zero_iff.mpr fun j _ => sub_ne_zero_of_ne <| by solve_by_elim;
+    exact h_det_diag.symm ▸ Finset.prod_ne_zero_iff.mpr fun i _ =>
+      Finset.prod_ne_zero_iff.mpr fun j _ => sub_ne_zero_of_ne <| by solve_by_elim;
   refine' ⟨ D i i, _, E j j, _, _ ⟩
   · simp_all [ spectrum.mem_iff ];
     simp_all [ Matrix.isUnit_iff_isUnit_det ];
@@ -1032,7 +1100,8 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
       exact left hij;
     simp_all [ Matrix.det_mul];
     convert h_det_diag using 1;
-    exact congr_arg Matrix.det ( by ext i j; by_cases hi : i = j <;> simp [ hi, Algebra.smul_def ] );
+    exact congr_arg Matrix.det
+      ( by ext i j; by_cases hi : i = j <;> simp [ hi, Algebra.smul_def ] );
   · simp_all [ spectrum.mem_iff ];
     -- Since $E$ is diagonal, $E j j - B$ is singular, hence not invertible.
     have h_singular : Matrix.det (E j j • 1 - B) = 0 := by
@@ -1041,8 +1110,8 @@ private lemma spectrum_prod_complex {d d₂ : Type*}
         rw [ Matrix.det_eq_zero_of_row_eq_zero j ]
         intro j_1
         subst hij
-        simp_all only [map_mul, isUnit_iff_ne_zero, ne_eq, not_false_eq_true, nonsing_inv_mul, sub_apply,
-          smul_apply, smul_eq_mul]
+        simp_all only [map_mul, isUnit_iff_ne_zero, ne_eq, not_false_eq_true, nonsing_inv_mul,
+          sub_apply, smul_apply, smul_eq_mul]
         obtain ⟨left, rfl⟩ := hD
         obtain ⟨left_1, rfl⟩ := hE
         by_cases h : j = j_1 <;> aesop;
@@ -1085,27 +1154,31 @@ theorem spectrum_prod {d d₂ : Type*}
   apply subset_antisymm
   · exact spectrum_prod_le hA hB
   · rintro x ⟨ y, hy, z, hz, rfl ⟩;
-    -- Since $y$ is an eigenvalue of $A$ and $z$ is an eigenvalue of $B$, there exist eigenvectors $v$ and $w$ such that $A*v = y*v$ and $B*w = z*w$.
+    -- Since $y$ is an eigenvalue of $A$ and $z$ is an eigenvalue of $B$, there exist
+    -- eigenvectors $v$ and $w$ such that $A*v = y*v$ and $B*w = z*w$.
     obtain ⟨v, hv⟩ : ∃ v : d → 𝕜, v ≠ 0 ∧ A.mulVec v = y • v := by
       rw [ spectrum.mem_iff ] at hy;
       simp_all [ Matrix.isUnit_iff_isUnit_det ];
       have := Matrix.exists_mulVec_eq_zero_iff.mpr hy;
       simp_all [ funext_iff, Matrix.mulVec, dotProduct ];
       simp_all [ sub_mul, Matrix.one_apply, Algebra.algebraMap_eq_smul_one ];
-      exact ⟨ this.choose, this.choose_spec.1, fun x => by linear_combination -this.choose_spec.2 x ⟩
+      exact ⟨ this.choose, this.choose_spec.1,
+        fun x => by linear_combination -this.choose_spec.2 x ⟩
     obtain ⟨w, hw⟩ : ∃ w : d₂ → 𝕜, w ≠ 0 ∧ B.mulVec w = z • w := by
       rw [ spectrum.mem_iff ] at hz;
       simp_all [ Matrix.isUnit_iff_isUnit_det ];
       have := Matrix.exists_mulVec_eq_zero_iff.mpr hz;
       simp_all [ Matrix.sub_mulVec ];
-      obtain ⟨ w, hw, hw' ⟩ := this; use w; simp_all [ sub_eq_zero, Algebra.algebraMap_eq_smul_one ] ;
+      obtain ⟨ w, hw, hw' ⟩ := this; use w;
+      simp_all [ sub_eq_zero, Algebra.algebraMap_eq_smul_one ] ;
       simp_all [ funext_iff, Matrix.mulVec, dotProduct ];
       simp_all [ Matrix.one_apply];
     refine' spectrum.mem_iff.mpr _;
     -- Consider the vector $v \otimes w$.
     set v_tensor_w : (d × d₂) → 𝕜 := fun p => v p.1 * w p.2;
     -- We need to show that $v \otimes w$ is an eigenvector of $A \otimes B$ with eigenvalue $yz$.
-    have h_eigenvector : (Matrix.kroneckerMap (· * ·) A B).mulVec v_tensor_w = (y * z) • v_tensor_w := by
+    have h_eigenvector : (Matrix.kroneckerMap (· * ·) A B).mulVec v_tensor_w =
+        (y * z) • v_tensor_w := by
       ext ⟨ i, j ⟩ ;
       simp [ Matrix.mulVec, dotProduct] at *
       simp [ funext_iff, Matrix.mulVec, dotProduct ] at hv hw ⊢
@@ -1114,20 +1187,25 @@ theorem spectrum_prod {d d₂ : Type*}
       obtain ⟨left, right⟩ := hv
       obtain ⟨left_1, right_1⟩ := hw
       -- By separating the sums, we can apply the given equalities.
-      have h_separate : ∑ x, ∑ x_1, A i x * B j x_1 * (v x * w x_1) = (∑ x : d, A i x * v x) * (∑ x_1 : d₂, B j x_1 * w x_1) := by
+      have h_separate : ∑ x, ∑ x_1, A i x * B j x_1 * (v x * w x_1) =
+          (∑ x : d, A i x * v x) * (∑ x_1 : d₂, B j x_1 * w x_1) := by
         simp only [mul_left_comm, mul_comm, Finset.mul_sum _ _ _];
-        exact Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+        exact Finset.sum_comm.trans
+          ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
       rw [ h_separate, right, right_1 ]
       simp [RCLike.real_smul_eq_coe_mul]
       ring_nf
-    -- Since $v \otimes w$ is an eigenvector of $A \otimes B$ with eigenvalue $yz$, we have $(A \otimes B - yzI)(v \otimes w) = 0$.
+    -- Since $v \otimes w$ is an eigenvector of $A \otimes B$ with eigenvalue $yz$, we have
+    -- $(A \otimes B - yzI)(v \otimes w) = 0$.
     have h_eigenvector_zero : ((A ⊗ₖ B) - (y * z) • 1) *ᵥ v_tensor_w = 0 := by
       simp [ h_eigenvector, Matrix.sub_mulVec ];
       simp [ Matrix.mulVec, funext_iff ];
       simp [ Matrix.one_apply, dotProduct ];
-    -- Since $v \otimes w$ is non-zero, we have $(A \otimes B - yzI)(v \otimes w) = 0$ implies that $A \otimes B - yzI$ is not invertible.
+    -- Since $v \otimes w$ is non-zero, we have $(A \otimes B - yzI)(v \otimes w) = 0$ implies
+    -- that $A \otimes B - yzI$ is not invertible.
     have h_not_invertible : ¬IsUnit (A ⊗ₖ B - (y * z) • 1) := by
-      simp only [ne_eq, isUnit_iff_isUnit_det, isUnit_iff_ne_zero, Decidable.not_not, v_tensor_w] at *
+      simp only [ne_eq, isUnit_iff_isUnit_det, isUnit_iff_ne_zero, Decidable.not_not,
+        v_tensor_w] at *
       rw [ ← Matrix.exists_mulVec_eq_zero_iff ]
       refine' ⟨ v_tensor_w, _, h_eigenvector_zero ⟩;
       simp [ funext_iff ] at hv hw ⊢
@@ -1142,20 +1220,24 @@ end spectrum_kron
 
 open ComplexOrder in
 open MatrixOrder in
-theorem PosDef.zero_lt {n : Type*} [Nonempty n] [Fintype n] {A : Matrix n n ℂ} (hA : A.PosDef) : 0 < A := by
+theorem PosDef.zero_lt {n : Type*} [Nonempty n] [Fintype n] {A : Matrix n n ℂ} (hA : A.PosDef) :
+    0 < A := by
   apply lt_of_le_of_ne
   · replace hA := hA.posSemidef
     rwa [Matrix.nonneg_iff_posSemidef]
   · rintro rfl; exact absurd (hA.diag_pos (i := Classical.arbitrary n)) (by simp)
 
 
-lemma IsHermitian.spectrum_eq_image_eigenvalues [Fintype n] {A : Matrix n n ℂ} (hA : A.IsHermitian) :
+lemma IsHermitian.spectrum_eq_image_eigenvalues [Fintype n] {A : Matrix n n ℂ}
+    (hA : A.IsHermitian) :
     spectrum ℝ A = Finset.univ.image hA.eigenvalues := by
   simpa using hA.spectrum_real_eq_range_eigenvalues
 
-/- This lemma looks "wrong" in the sense that it's specifically about `Fintype.card foo = Finset.card bar`,
+/- This lemma looks "wrong" in the sense that it's specifically about
+`Fintype.card foo = Finset.card bar`,
 why not just use the underlying fact `foo = ↑bar`? It turns out this actually gives annoying issues
-with dependent rewrites, given the necessary `Fintype` instance. Using the above theorem for example,
+with dependent rewrites, given the necessary `Fintype` instance. Using the above theorem for
+example,
 trying `rw [hA.spectrum_eq_image_eigenvalues]` fails because of dependent types. -/
 lemma IsHermitian.card_spectrum_eq_image [Fintype n] {A : Matrix n n ℂ} (hA : A.IsHermitian)
   [Fintype (spectrum ℝ A)] :
@@ -1181,13 +1263,17 @@ lemma sub_iInf_eignevalues (hA : A.IsHermitian) :
   · simpa [ Matrix.IsHermitian, sub_eq_add_neg ] using hA
   · intro x
     have h_eigenvalue : ∀ i, hA.eigenvalues i ≥ iInf hA.eigenvalues := by
-      -- By definition of infimum, for any eigenvalue $i$, we have $hA.eigenvalues i \geq iInf hA.eigenvalues$.
+      -- By definition of infimum, for any eigenvalue $i$, we have
+      -- $hA.eigenvalues i \geq iInf hA.eigenvalues$.
       intros i
       apply le_of_forall_le
       intro j a
       exact le_trans a (ciInf_le ( Finite.bddBelow_range hA.eigenvalues ) i );
-    -- Since $A$ is Hermitian, we can diagonalize it as $A = Q \Lambda Q^*$, where $Q$ is unitary and $\Lambda$ is diagonal with the eigenvalues on the diagonal.
-    obtain ⟨Q, Λ, hQ, hΛ⟩ : ∃ Q : Matrix d d ℂ, ∃ Λ : d → ℂ, Q.conjTranspose * Q = 1 ∧ A = Q * Matrix.diagonal Λ * Q.conjTranspose ∧ ∀ i, Λ i = Matrix.IsHermitian.eigenvalues hA i := by
+    -- Since $A$ is Hermitian, we can diagonalize it as $A = Q \Lambda Q^*$, where $Q$ is unitary
+    -- and $\Lambda$ is diagonal with the eigenvalues on the diagonal.
+    obtain ⟨Q, Λ, hQ, hΛ⟩ : ∃ Q : Matrix d d ℂ, ∃ Λ : d → ℂ, Q.conjTranspose * Q = 1 ∧
+        A = Q * Matrix.diagonal Λ * Q.conjTranspose ∧
+        ∀ i, Λ i = Matrix.IsHermitian.eigenvalues hA i := by
       have := hA.spectral_theorem;
       refine' ⟨ _, _, _, this, _ ⟩;
       · simp [ ← Matrix.ext_iff ];
@@ -1197,13 +1283,20 @@ lemma sub_iInf_eignevalues (hA : A.IsHermitian) :
         rw [← this i j]
         simp [PiLp.inner_apply, mul_comm]
       · simp
-    -- Since $Q$ is unitary, we have $Q^* Q = I$, and thus $Q^* (A - \lambda_{\min} I) Q = \Lambda - \lambda_{\min} I$.
-    have h_diag : Q.conjTranspose * (A - (iInf (Matrix.IsHermitian.eigenvalues hA)) • 1) * Q = Matrix.diagonal (fun i => Λ i - (iInf (Matrix.IsHermitian.eigenvalues hA))) := by
+    -- Since $Q$ is unitary, we have $Q^* Q = I$, and thus
+    -- $Q^* (A - \lambda_{\min} I) Q = \Lambda - \lambda_{\min} I$.
+    have h_diag : Q.conjTranspose * (A - (iInf (Matrix.IsHermitian.eigenvalues hA)) • 1) * Q =
+        Matrix.diagonal (fun i => Λ i - (iInf (Matrix.IsHermitian.eigenvalues hA))) := by
       simp [ hΛ, mul_sub, sub_mul, mul_assoc, hQ ];
       simp [ ← mul_assoc, hQ];
       ext i j ; by_cases hij : i = j <;> aesop;
-    -- Since $Q$ is unitary, we have $Q^* (A - \lambda_{\min} I) Q = \Lambda - \lambda_{\min} I$, and thus $x^* (A - \lambda_{\min} I) x = (Q^* x)^* (\Lambda - \lambda_{\min} I) (Q^* x)$.
-    have h_quad_form : Star.star x ⬝ᵥ (A - (iInf (Matrix.IsHermitian.eigenvalues hA)) • 1).mulVec x = Star.star (Q.conjTranspose.mulVec x) ⬝ᵥ (Matrix.diagonal (fun i => Λ i - (iInf (Matrix.IsHermitian.eigenvalues hA)))).mulVec (Q.conjTranspose.mulVec x) := by
+    -- Since $Q$ is unitary, we have $Q^* (A - \lambda_{\min} I) Q = \Lambda - \lambda_{\min} I$,
+    -- and thus $x^* (A - \lambda_{\min} I) x = (Q^* x)^* (\Lambda - \lambda_{\min} I) (Q^* x)$.
+    have h_quad_form : Star.star x ⬝ᵥ
+          (A - (iInf (Matrix.IsHermitian.eigenvalues hA)) • 1).mulVec x =
+        Star.star (Q.conjTranspose.mulVec x) ⬝ᵥ
+          (Matrix.diagonal (fun i => Λ i - (iInf (Matrix.IsHermitian.eigenvalues hA)))).mulVec
+            (Q.conjTranspose.mulVec x) := by
       rw [ ← h_diag ];
       simp [ Matrix.mul_assoc, Matrix.dotProduct_mulVec, mul_eq_one_comm.mp hQ];
       simp only [mulVec_conjTranspose, star_star, vecMul_vecMul];
@@ -1211,16 +1304,22 @@ lemma sub_iInf_eignevalues (hA : A.IsHermitian) :
     simp_all only [ge_iff_le, dotProduct, Pi.star_apply, RCLike.star_def, mulVec, sub_apply,
       smul_apply, Complex.real_smul, conjTranspose_apply, star_sum, star_mul',
       RingHomCompTriple.comp_apply, RingHom.id_apply];
-    simp_all only [implies_true, and_self, diagonal_apply, ite_mul, zero_mul, Finset.sum_ite_eq, ↓reduceIte];
-    -- Since the eigenvalues are real and the sums involving Q and x are complex, the product of a complex number and its conjugate is non-negative.
+    simp_all only [implies_true, and_self, diagonal_apply, ite_mul, zero_mul, Finset.sum_ite_eq,
+      ↓reduceIte];
+    -- Since the eigenvalues are real and the sums involving Q and x are complex, the product of a
+    -- complex number and its conjugate is non-negative.
     have h_nonneg : ∀ i, 0 ≤ (∑ x_2, Q x_2 i * star (x x_2)) * (∑ x_2, star (Q x_2 i) * x x_2) := by
       intro i
-      have h_nonneg : 0 ≤ (∑ x_2, Q x_2 i * star (x x_2)) * star (∑ x_2, Q x_2 i * star (x x_2)) := by
+      have h_nonneg : 0 ≤
+          (∑ x_2, Q x_2 i * star (x x_2)) * star (∑ x_2, Q x_2 i * star (x x_2)) := by
         exact mul_star_self_nonneg (∑ x_2, Q x_2 i * star (x x_2))
       convert h_nonneg using 1;
       simp [ mul_comm, Finset.mul_sum _ _ _];
-    -- Since each term in the sum is a product of a non-negative number and a non-negative eigenvalue difference, the entire sum is non-negative.
-    have h_sum_nonneg : ∀ i, 0 ≤ (∑ x_2, Q x_2 i * star (x x_2)) * (((↑(hA.eigenvalues i) : ℂ) - (↑(iInf hA.eigenvalues) : ℂ)) * ∑ x_2, star (Q x_2 i) * x x_2) := by
+    -- Since each term in the sum is a product of a non-negative number and a non-negative
+    -- eigenvalue difference, the entire sum is non-negative.
+    have h_sum_nonneg : ∀ i, 0 ≤ (∑ x_2, Q x_2 i * star (x x_2)) *
+        (((↑(hA.eigenvalues i) : ℂ) - (↑(iInf hA.eigenvalues) : ℂ)) *
+          ∑ x_2, star (Q x_2 i) * x x_2) := by
       intro i
       specialize h_nonneg i
       simp_all only [mul_assoc, mul_comm, mul_left_comm, RCLike.star_def] ;
@@ -1302,18 +1401,28 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
   intro μ hμ
   obtain ⟨v, hv₁, hv₂⟩ : ∃ v : d → 𝕜, v ≠ 0 ∧ x.mulVec v = μ • v := by
     have h_singular : ∃ v : d → 𝕜, v ≠ 0 ∧ (μ • 1 - x).mulVec v = 0 := by
-      simp only [spectrum.mem_iff, Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, ne_eq, Decidable.not_not] at hμ
+      simp only [spectrum.mem_iff, Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, ne_eq,
+        Decidable.not_not] at hμ
       convert Matrix.exists_mulVec_eq_zero_iff.mpr hμ;
       simp [Algebra.smul_def]
     refine h_singular.imp fun v h ↦ ⟨h.left, ?_⟩
-    simp_all [Matrix.sub_mulVec, sub_eq_iff_eq_add, funext_iff, Matrix.mulVec, dotProduct, Matrix.one_apply]
-  -- Since $x - A$ is positive semidefinite, for any eigenvalue $\lambda$ of $x$, we have $\lambda \geq \min(\text{eigenvalues of } A)$.
-  have h_lower_bound : ∀ (v : d → 𝕜), v ≠ 0 → (star v ⬝ᵥ (x.mulVec v)) ≥ (⨅ i, (hA.eigenvalues i)) * (star v ⬝ᵥ v) := by
+    simp_all [Matrix.sub_mulVec, sub_eq_iff_eq_add, funext_iff, Matrix.mulVec, dotProduct,
+      Matrix.one_apply]
+  -- Since $x - A$ is positive semidefinite, for any eigenvalue $\lambda$ of $x$, we have
+  -- $\lambda \geq \min(\text{eigenvalues of } A)$.
+  have h_lower_bound : ∀ (v : d → 𝕜), v ≠ 0 →
+      (star v ⬝ᵥ (x.mulVec v)) ≥ (⨅ i, (hA.eigenvalues i)) * (star v ⬝ᵥ v) := by
     intro v hv_nonzero
     have h_eigenvalue : (star v ⬝ᵥ (A.mulVec v)) ≥ (⨅ i, (hA.eigenvalues i)) * (star v ⬝ᵥ v) := by
-      have h_expand : (star v ⬝ᵥ (A.mulVec v)) = ∑ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
-        change (star v ⬝ᵥ (A.mulVec v)) = ∑ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i))
-        have h_decomp : A = ∑ i, (hA.eigenvalues i) • (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k)))) := by
+      have h_expand : (star v ⬝ᵥ (A.mulVec v)) =
+          ∑ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+            (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
+        change (star v ⬝ᵥ (A.mulVec v)) =
+          ∑ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+            (star v ⬝ᵥ (hA.eigenvectorBasis i))
+        have h_decomp : A = ∑ i, (hA.eigenvalues i) •
+            (Matrix.of (fun j k => (hA.eigenvectorBasis i j) *
+              (star (hA.eigenvectorBasis i k)))) := by
           convert Matrix.IsHermitian.spectral_theorem hA using 1;
           ext i j
           simp only [RCLike.star_def, Matrix.smul_of, Matrix.sum_apply, Matrix.of_apply,
@@ -1325,22 +1434,43 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
           congr! 1
           simp [Algebra.algebraMap_eq_smul_one]
         -- Substitute the decomposition of $A$ into the expression $(star v ⬝ᵥ (A.mulVec v))$.
-        have h_subst : (star v ⬝ᵥ (A.mulVec v)) = ∑ i, (hA.eigenvalues i) * (star v ⬝ᵥ (Matrix.mulVec (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k)))) v)) := by
-          -- Substitute the decomposition of $A$ into the expression $(star v ⬝ᵥ (A.mulVec v))$ and use the linearity of matrix multiplication.
-          have h_subst : (star v ⬝ᵥ (A.mulVec v)) = (star v ⬝ᵥ ((∑ i, (hA.eigenvalues i) • (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k))))).mulVec v)) := by
+        have h_subst : (star v ⬝ᵥ (A.mulVec v)) = ∑ i, (hA.eigenvalues i) *
+            (star v ⬝ᵥ (Matrix.mulVec (Matrix.of (fun j k => (hA.eigenvectorBasis i j) *
+              (star (hA.eigenvectorBasis i k)))) v)) := by
+          -- Substitute the decomposition of $A$ into the expression $(star v ⬝ᵥ (A.mulVec v))$
+          -- and use the linearity of matrix multiplication.
+          have h_subst : (star v ⬝ᵥ (A.mulVec v)) = (star v ⬝ᵥ ((∑ i, (hA.eigenvalues i) •
+              (Matrix.of (fun j k => (hA.eigenvectorBasis i j) *
+                (star (hA.eigenvectorBasis i k))))).mulVec v)) := by
             rw [ ← h_decomp ];
-          -- By the linearity of matrix multiplication and the dot product, we can distribute the sum over the dot product.
-          have h_distribute : (star v ⬝ᵥ (∑ i, (hA.eigenvalues i) • (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k))))).mulVec v) = ∑ i, (star v ⬝ᵥ ((hA.eigenvalues i) • (Matrix.of (fun j k => (hA.eigenvectorBasis i j) * (star (hA.eigenvectorBasis i k))))).mulVec v) := by
-            -- By the linearity of matrix multiplication and the dot product, we can distribute the sum over the dot product. This follows from the fact that matrix multiplication is linear.
-            have h_distribute : ∀ (M N : Matrix d d 𝕜) (v : d → 𝕜), Star.star v ⬝ᵥ (M + N).mulVec v = Star.star v ⬝ᵥ M.mulVec v + Star.star v ⬝ᵥ N.mulVec v := by
+          -- By the linearity of matrix multiplication and the dot product, we can distribute the
+          -- sum over the dot product.
+          have h_distribute : (star v ⬝ᵥ (∑ i, (hA.eigenvalues i) •
+              (Matrix.of (fun j k => (hA.eigenvectorBasis i j) *
+                (star (hA.eigenvectorBasis i k))))).mulVec v) =
+              ∑ i, (star v ⬝ᵥ ((hA.eigenvalues i) •
+                (Matrix.of (fun j k => (hA.eigenvectorBasis i j) *
+                  (star (hA.eigenvectorBasis i k))))).mulVec v) := by
+            -- By the linearity of matrix multiplication and the dot product, we can distribute
+            -- the sum over the dot product. This follows from the fact that matrix
+            -- multiplication is linear.
+            have h_distribute : ∀ (M N : Matrix d d 𝕜) (v : d → 𝕜),
+                Star.star v ⬝ᵥ (M + N).mulVec v =
+                Star.star v ⬝ᵥ M.mulVec v + Star.star v ⬝ᵥ N.mulVec v := by
               simp [ Matrix.add_mulVec, dotProduct_add ];
-            -- By induction on the number of terms in the sum, we can apply the distributive property repeatedly.
-            have h_induction : ∀ (n : ℕ) (M : Fin n → Matrix d d 𝕜) (v : d → 𝕜), Star.star v ⬝ᵥ (∑ i, M i).mulVec v = ∑ i, Star.star v ⬝ᵥ (M i).mulVec v := by
+            -- By induction on the number of terms in the sum, we can apply the distributive
+            -- property repeatedly.
+            have h_induction : ∀ (n : ℕ) (M : Fin n → Matrix d d 𝕜) (v : d → 𝕜),
+                Star.star v ⬝ᵥ (∑ i, M i).mulVec v = ∑ i, Star.star v ⬝ᵥ (M i).mulVec v := by
               intro n M v
               induction n
               · simp [*]
               · simp [Fin.sum_univ_succ, *]
-            convert h_induction ( Fintype.card d ) ( fun i => Matrix.of ( hA.eigenvalues ( Fintype.equivFin d |>.symm i ) • fun j k => hA.eigenvectorBasis ( Fintype.equivFin d |>.symm i ) j * starRingEnd 𝕜 ( hA.eigenvectorBasis ( Fintype.equivFin d |>.symm i ) k ) ) ) v using 1;
+            convert h_induction ( Fintype.card d )
+              ( fun i => Matrix.of ( hA.eigenvalues ( Fintype.equivFin d |>.symm i ) •
+                fun j k => hA.eigenvectorBasis ( Fintype.equivFin d |>.symm i ) j *
+                  starRingEnd 𝕜 ( hA.eigenvectorBasis ( Fintype.equivFin d |>.symm i ) k ) ) )
+              v using 1;
             · rw [ ← Equiv.sum_comp ( Fintype.equivFin d ) ];
               simp [ Fintype.equivFin ];
             · rw [ ← Equiv.sum_comp ( Fintype.equivFin d ) ];
@@ -1354,22 +1484,33 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
         simp only [dotProduct, Pi.star_apply, RCLike.star_def, mul_comm, mul_assoc, Matrix.mulVec,
           Matrix.of_apply, mul_eq_mul_left_iff, map_eq_zero];
         simp [ mul_comm, mul_left_comm, Finset.mul_sum _ _ _ ];
-      -- Since $\lambda_i \geq \inf(\text{eigenvalues of } A)$ for all $i$, we can bound each term in the sum.
-      have h_bound : ∀ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) ≥ (⨅ i, (hA.eigenvalues i)) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
+      -- Since $\lambda_i \geq \inf(\text{eigenvalues of } A)$ for all $i$, we can bound each term
+      -- in the sum.
+      have h_bound : ∀ i, (hA.eigenvalues i) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+            (star v ⬝ᵥ (hA.eigenvectorBasis i)) ≥
+          (⨅ i, (hA.eigenvalues i)) * (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+            (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
         intro i
         have h_eigenvalue_bound : (hA.eigenvalues i) ≥ (⨅ i, (hA.eigenvalues i)) :=
           ciInf_le (Set.finite_range _).bddBelow _
-        -- Since the product of the inner products is real and non-negative, multiplying both sides of the inequality by this product preserves the inequality.
-        have h_nonneg : 0 ≤ (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
-          -- Since the inner product is conjugate symmetric, we have star v ⬝ᵥ (hA.eigenvectorBasis i) = conjugate(star (hA.eigenvectorBasis i) ⬝ᵥ v).
-          have h_conj_symm : star v ⬝ᵥ (hA.eigenvectorBasis i) = star (star (hA.eigenvectorBasis i) ⬝ᵥ v) := by
+        -- Since the product of the inner products is real and non-negative, multiplying both
+        -- sides of the inequality by this product preserves the inequality.
+        have h_nonneg :
+            0 ≤ (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) := by
+          -- Since the inner product is conjugate symmetric, we have
+          -- star v ⬝ᵥ (hA.eigenvectorBasis i) = conjugate(star (hA.eigenvectorBasis i) ⬝ᵥ v).
+          have h_conj_symm : star v ⬝ᵥ (hA.eigenvectorBasis i) =
+              star (star (hA.eigenvectorBasis i) ⬝ᵥ v) := by
             simp [ dotProduct, mul_comm];
           rw [ h_conj_symm ];
           exact mul_star_self_nonneg (star (hA.eigenvectorBasis i) ⬝ᵥ v);
         norm_num [ mul_assoc ];
         exact mul_le_mul_of_nonneg_right ( mod_cast h_eigenvalue_bound ) h_nonneg;
-      -- Since $\sum_{i} (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) = star v ⬝ᵥ v$, we can factor out $(⨅ i, (hA.eigenvalues i))$ from the sum.
-      have h_sum : ∑ i, (star (hA.eigenvectorBasis i) ⬝ᵥ v) * (star v ⬝ᵥ (hA.eigenvectorBasis i)) = star v ⬝ᵥ v := by
+      -- Since $\sum_{i} (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+      -- (star v ⬝ᵥ (hA.eigenvectorBasis i)) = star v ⬝ᵥ v$, we can factor out
+      -- $(⨅ i, (hA.eigenvalues i))$ from the sum.
+      have h_sum : ∑ i, (star (hA.eigenvectorBasis i) ⬝ᵥ v) *
+          (star v ⬝ᵥ (hA.eigenvectorBasis i)) = star v ⬝ᵥ v := by
         have h_sum : ∑ i, (star (hA.eigenvectorBasis i) ⬝ᵥ v) • (hA.eigenvectorBasis i) = v := by
           have := hA.eigenvectorBasis.sum_repr (WithLp.toLp 2 v);
           convert this using 1;
@@ -1385,13 +1526,17 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
             · intro h; apply_fun WithLp.toLp 2 at h; simpa using h
             · intro h; apply_fun WithLp.ofLp at h; simpa using h
           exact key _ _ _
-        -- Taking the inner product of both sides of h_sum with star v, we get the desired equality.
-        have h_inner : star v ⬝ᵥ (∑ i, (star (hA.eigenvectorBasis i) ⬝ᵥ v) • (hA.eigenvectorBasis i)) = star v ⬝ᵥ v := by
+        -- Taking the inner product of both sides of h_sum with star v, we get the desired
+        -- equality.
+        have h_inner : star v ⬝ᵥ
+            (∑ i, (star (hA.eigenvectorBasis i) ⬝ᵥ v) • (hA.eigenvectorBasis i)) =
+            star v ⬝ᵥ v := by
           congr 1
           simp_rw [← WithLp.ofLp_smul, ← WithLp.ofLp_sum, h_sum]
         convert h_inner using 1;
         simp [ dotProduct, Finset.mul_sum _ _ _ ];
-        exact Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+        exact Finset.sum_comm.trans
+          ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
       rw [ h_expand ];
       refine' le_trans _ ( Finset.sum_le_sum fun i _ => h_bound i );
       simp only [ mul_assoc];
@@ -1406,13 +1551,17 @@ theorem IsHermitian.spectrum_subset_Ici_of_sub {d 𝕜 : Type*} [Fintype d] [Dec
     dotProduct_smul];
   simp_all only [dotProduct, mul_comm, RCLike.mul_conj];
   rw [ Algebra.smul_def ] at this;
-  -- Since the sum of the squares of the norms of v is positive, we can divide both sides of the inequality by it.
+  -- Since the sum of the squares of the norms of v is positive, we can divide both sides of the
+  -- inequality by it.
   have h_sum_pos : 0 < ∑ x : d, (‖v x‖ : ℝ) ^ 2 := by
     contrapose! hv₁;
-    simp_all only [funext_iff, Pi.zero_apply, not_forall, forall_exists_index, Matrix.mulVec, Pi.smul_apply]
+    simp_all only [funext_iff, Pi.zero_apply, not_forall, forall_exists_index, Matrix.mulVec,
+      Pi.smul_apply]
     intro i
     rw [← norm_eq_zero]
-    simpa [ sq_nonneg ] using le_antisymm ( le_trans ( Finset.single_le_sum ( fun a _ => sq_nonneg ( ‖v a‖ ) ) ( Finset.mem_univ i ) ) hv₁ ) ( sq_nonneg ( ‖v i‖ ) )
+    simpa [ sq_nonneg ] using le_antisymm
+      ( le_trans ( Finset.single_le_sum ( fun a _ => sq_nonneg ( ‖v a‖ ) ) ( Finset.mem_univ i ) )
+        hv₁ ) ( sq_nonneg ( ‖v i‖ ) )
   norm_cast at this;
   nlinarith
 
@@ -1443,7 +1592,8 @@ theorem IsHermitian.spectrum_subset_of_mem_Icc {d 𝕜 : Type*} [Fintype d] [Dec
   exact Set.subset_inter (hA.spectrum_subset_Ici_of_sub hl) (hB.spectrum_subset_Iic_of_sub hr)
 
 /--
-The right partial trace of a matrix is equal to the left partial trace of the matrix reindexed by swapping the tensor factors.
+The right partial trace of a matrix is equal to the left partial trace of the matrix reindexed by
+swapping the tensor factors.
 -/
 theorem traceRight_eq_traceLeft_reindex {n m R : Type*} [Fintype m] [AddCommMonoid R]
   (M : Matrix (n × m) (n × m) R) :
@@ -1527,7 +1677,8 @@ theorem IsHermitian.piProd [CommSemiring R] [StarRing R] (hA : ∀ i, (A i).IsHe
     (piProd A).IsHermitian := by
   ext j k
   simp [Matrix.piProd]
-  exact Finset.prod_congr rfl fun i _ => by simpa using congr_fun ( congr_fun ( hA i ) ( j i ) ) ( k i ) ;
+  exact Finset.prod_congr rfl fun i _ => by
+    simpa using congr_fun ( congr_fun ( hA i ) ( j i ) ) ( k i ) ;
 
 variable [DecidableEq ι] [∀ i, Fintype (d i)] --[∀ i, DecidableEq (d i)]
 
@@ -1539,9 +1690,12 @@ theorem trace_piProd [CommSemiring R] :
 open ComplexOrder MatrixOrder in
 theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
     (piProd A).PosSemidef := by
-  -- Let B i be the square root of A i. Let BigB be the pi-product of B i. Show that BigB.conjTranspose * BigB equals the pi-product of A i using Fintype.prod_sum. Then use Matrix.PosSemidef.conjTranspose_mul_self to conclude the proof.
+  -- Let B i be the square root of A i. Let BigB be the pi-product of B i. Show that
+  -- BigB.conjTranspose * BigB equals the pi-product of A i using Fintype.prod_sum. Then use
+  -- Matrix.PosSemidef.conjTranspose_mul_self to conclude the proof.
   obtain ⟨B, hB⟩ : ∃ B : ∀ i, Matrix (d i) (d i) R, ∀ i, (A i) = B i * star (B i) := by
-    -- By definition of positive semi-definite matrices, each $A_i$ can be written as $B_i^* B_i$ for some matrix $B_i$.
+    -- By definition of positive semi-definite matrices, each $A_i$ can be written as $B_i^* B_i$
+    -- for some matrix $B_i$.
     have h_decomp : ∀ i, ∃ B : Matrix (d i) (d i) R, A i = B * star B := by
       intro i
       obtain ⟨B, hB⟩ : ∃ B : Matrix (d i) (d i) R, A i = B.conjTranspose * B := by
@@ -1551,11 +1705,16 @@ theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
       use B.conjTranspose;
       convert hB using 1;
       simp [ Matrix.star_eq_conjTranspose ];
-    exact ⟨ fun i => Classical.choose ( h_decomp i ), fun i => Classical.choose_spec ( h_decomp i ) ⟩;
-  have hBigB_conjTranspose_mul_BigB : Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i * star (B i)) (j i) (k i)) = Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i) (j i) (k i)) * star (Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i) (j i) (k i))) := by
+    exact ⟨ fun i => Classical.choose ( h_decomp i ),
+      fun i => Classical.choose_spec ( h_decomp i ) ⟩;
+  have hBigB_conjTranspose_mul_BigB :
+      Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i * star (B i)) (j i) (k i)) =
+      Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i) (j i) (k i)) *
+        star (Matrix.of (fun j k : (∀ i, d i) => ∏ i, (B i) (j i) (k i))) := by
     ext j k; simp [ Matrix.mul_apply]
     simp only [Finset.prod_sum, ← Finset.prod_mul_distrib];
-    refine' Finset.sum_bij ( fun p hp => fun i => p i ( Finset.mem_univ i ) ) _ _ _ _ <;> simp +decide;
+    refine' Finset.sum_bij ( fun p hp => fun i => p i ( Finset.mem_univ i ) ) _ _ _ _ <;>
+      simp +decide;
     · simp [ funext_iff ];
     · exact fun b => ⟨ fun i _ => b i, rfl ⟩;
   simp only [Matrix.posSemidef_iff_dotProduct_mulVec] at hA ⊢
@@ -1572,20 +1731,23 @@ theorem PosSemidef.piProd [RCLike R] (hA : ∀ i, (A i).PosSemidef) :
     simp only [mul_apply, of_apply, star_apply, star_prod, RCLike.star_def, Finset.mul_sum _ _ _,
       mul_left_comm, mulVec, dotProduct, mul_comm, map_sum, map_mul, map_prod,
       RingHomCompTriple.comp_apply, RingHom.id_apply, mul_assoc];
-    exact Finset.sum_congr rfl fun _ _ => Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring )
+    exact Finset.sum_congr rfl fun _ _ => Finset.sum_comm.trans
+      ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring )
 
 end finprod
 
 --TODO: Can this be used for `Matrix.reindex_eq_conj` cleanup?
 theorem submatrix_eq_mul_mul {d d₂ d₃ R : Type*} [DecidableEq d] [Fintype d] [Semiring R]
   (A : Matrix d d R) (e : d₂ → d) (f : d₃ → d) :
-    A.submatrix e f = (submatrix (α := R) 1 e id : Matrix d₂ d R) * A * (submatrix (α := R) 1 id f) := by
+    A.submatrix e f =
+      (submatrix (α := R) 1 e id : Matrix d₂ d R) * A * (submatrix (α := R) 1 id f) := by
   rw [show id = Equiv.refl d by rfl, Matrix.mul_submatrix_one, Matrix.one_submatrix_mul]
   simp
 
 open scoped Matrix Kronecker in
 /--
-The conjugate of a Kronecker product by a Kronecker product is the Kronecker product of the conjugates (for matrices).
+The conjugate of a Kronecker product by a Kronecker product is the Kronecker product of the
+conjugates (for matrices).
 -/
 lemma kronecker_conj_eq {m n p q α : Type*} [CommSemiring α] [StarRing α] [Fintype m] [Fintype n]
     (A : Matrix m m α) (B : Matrix n n α) (C : Matrix p m α) (D : Matrix q n α) :

--- a/QuantumInfo/ForMathlib/MatrixNorm/TraceNorm.lean
+++ b/QuantumInfo/ForMathlib/MatrixNorm/TraceNorm.lean
@@ -89,7 +89,9 @@ theorem traceNorm_unitary_conj {A : Matrix n n R} {U : Matrix.unitaryGroup n R} 
 This is Proposition 9.1.1 in Wilde. -/
 theorem traceNorm_Hermitian_eq_sum_abs_eigenvalues {A : Matrix n n R} (hA : A.IsHermitian) :
     A.traceNorm = ∑ i, abs (hA.eigenvalues i) := by
-  obtain ⟨U, D, hD, hA_eq, h_eig⟩ : ∃ U : Matrix.unitaryGroup n R, ∃ D : Matrix n n R, D.IsDiag ∧ A = U.val * D * U.valᴴ ∧ ∀ i, D i i = hA.eigenvalues i := by
+  obtain ⟨U, D, hD, hA_eq, h_eig⟩ :
+      ∃ U : Matrix.unitaryGroup n R, ∃ D : Matrix n n R,
+        D.IsDiag ∧ A = U.val * D * U.valᴴ ∧ ∀ i, D i i = hA.eigenvalues i := by
     refine' ⟨hA.eigenvectorUnitary, _, isDiag_diagonal _, hA.spectral_theorem, _⟩
     simp [diagonal]
   nth_rw 1 [hA_eq, traceNorm_unitary_conj]
@@ -142,7 +144,8 @@ theorem traceNorm_zero_iff (A : Matrix m n R) : A.traceNorm = 0 ↔ A = 0 := by
     simp
 
 /-- The trace norm is homogeneous under scalar multiplication. Property 9.1.2 in Wilde. -/
-theorem traceNorm_smul (A : Matrix m n R) (c : R) : (c • A).traceNorm = ‖c‖ * A.traceNorm := by
+theorem traceNorm_smul (A : Matrix m n R) (c : R) :
+    (c • A).traceNorm = ‖c‖ * A.traceNorm := by
   have h : (c • A)ᴴ * (c • A) = (‖c‖^2:R) • (Aᴴ * A) := by
     rw [conjTranspose_smul, RCLike.star_def, Matrix.mul_smul, smul_mul, smul_smul]
     rw [RCLike.mul_conj c]
@@ -164,7 +167,8 @@ theorem traceNorm_smul (A : Matrix m n R) (c : R) : (c • A).traceNorm = ‖c�
     apply CFC.sqrt_unique;
     · simp; rw [CFC.sqrt_mul_sqrt_self M hM_pd.nonneg]
     · exact le_trans ( by norm_num ) (
-        smul_le_smul_of_nonneg_left ( show 0 ≤ CFC.sqrt M from by exact (CFC.sqrt_nonneg M) ) ( norm_nonneg c ) );
+        smul_le_smul_of_nonneg_left
+          ( show 0 ≤ CFC.sqrt M from by exact (CFC.sqrt_nonneg M) ) ( norm_nonneg c ) );
 
 section complexTraceNorm
 
@@ -219,12 +223,14 @@ theorem exists_svd_sqrt_eigenvalues (A : Matrix n n ℂ) :
   let V : Matrix.unitaryGroup n ℂ := ⟨Matrix.of (fun i j ↦ b j i), by
     simp only [Matrix.mem_unitaryGroup_iff]
     ext i j
-    simpa [inner] using b.sum_inner_mul_inner (EuclideanSpace.single i 1) (EuclideanSpace.single j 1)⟩
+    simpa [inner] using
+      b.sum_inner_mul_inner (EuclideanSpace.single i 1) (EuclideanSpace.single j 1)⟩
   let W : Matrix.unitaryGroup n ℂ := hH.eigenvectorUnitary
   have hAW : A * W.val = V.val * Matrix.diagonal s := by
     ext i j
     have hleft : (A * W.val) i j = A.mulVec (hH.eigenvectorBasis j).ofLp i := by
-      simp [Matrix.mul_apply, Matrix.mulVec, dotProduct, W, Matrix.IsHermitian.eigenvectorUnitary_apply]
+      simp [Matrix.mul_apply, Matrix.mulVec, dotProduct, W,
+        Matrix.IsHermitian.eigenvectorUnitary_apply]
     by_cases hj : hH.eigenvalues j = 0
     · have hzero : A.mulVec (hH.eigenvectorBasis j).ofLp = 0 := by
         apply (WithLp.toLp_injective (p := 2))
@@ -410,7 +416,8 @@ end complexTraceNorm
 /-- For square complex matrices, the trace norm is the maximum of `re (Tr[U * A])`
 over unitaries `U`. -/
 theorem traceNorm_eq_max_re_tr_U (A : Matrix n n ℂ) :
-    IsGreatest {x : ℝ | ∃ U : unitaryGroup n ℂ, Complex.re ((U.val * A).trace) = x} A.traceNorm := by
+    IsGreatest {x : ℝ | ∃ U : unitaryGroup n ℂ, Complex.re ((U.val * A).trace) = x}
+      A.traceNorm := by
   classical
   let hH : (Aᴴ * A).IsHermitian := by
     simpa using (Matrix.isHermitian_mul_conjTranspose_self A.conjTranspose)
@@ -455,7 +462,8 @@ theorem traceNorm_eq_max_re_tr_U (A : Matrix n n ℂ) :
       nlinarith [hdiag_le i, Real.sqrt_nonneg (hH.eigenvalues i)]
 
 /-- The trace norm satisfies the triangle inequality for square complex matrices. -/
-theorem traceNorm_add_le (A B : Matrix n n ℂ) : (A + B).traceNorm ≤ A.traceNorm + B.traceNorm := by
+theorem traceNorm_add_le (A B : Matrix n n ℂ) :
+    (A + B).traceNorm ≤ A.traceNorm + B.traceNorm := by
   obtain ⟨Uab, h₁⟩ := (traceNorm_eq_max_re_tr_U (A + B)).left
   rw [Matrix.mul_add, Matrix.trace_add, Complex.add_re] at h₁
   obtain h₂ := (traceNorm_eq_max_re_tr_U A).right

--- a/QuantumInfo/ForMathlib/Minimax.lean
+++ b/QuantumInfo/ForMathlib/Minimax.lean
@@ -34,23 +34,30 @@ theorem _root_.IsCompact.exists_isMinOn_lowerSemicontinuousOn {α β : Type*}
   {s : Set β} (hs : IsCompact s) (ne_s : s.Nonempty) {f : β → α} (hf : LowerSemicontinuousOn f s) :
     ∃ x ∈ s, IsMinOn f s x := by
   --Thanks Aristotle
-  -- By the Extreme Value Theorem for lower semicontinuous functions on compact sets, there exists x in s such that f(x) is the minimum value of f on s.
+  -- By the Extreme Value Theorem for lower semicontinuous functions on compact sets, there
+  -- exists x in s such that f(x) is the minimum value of f on s.
   have h_extreme : ∃ x ∈ s, ∀ y ∈ s, f x ≤ f y := by
     by_contra! h;
     choose! g hg using h;
-    -- For each $x \in s$, since $f$ is lower semicontinuous at $x$, there exists a neighborhood $U_x$ of $x$ such that $f(y) > f(g(x))$ for all $y \in U_x \cap s$.
+    -- For each $x \in s$, since $f$ is lower semicontinuous at $x$, there exists a neighborhood
+    -- $U_x$ of $x$ such that $f(y) > f(g(x))$ for all $y \in U_x \cap s$.
     have h_neighborhood : ∀ x ∈ s, ∃ U : Set β, IsOpen U ∧ x ∈ U ∧ ∀ y ∈ U ∩ s, f y > f (g x) := by
       intro x hx;
       have := hf x hx;
-      rcases mem_nhdsWithin_iff_exists_mem_nhds_inter.mp ( this ( f ( g x ) ) ( hg x hx |>.2 ) ) with ⟨ U, hU, hU' ⟩;
-      exact ⟨ interior U, isOpen_interior, mem_interior_iff_mem_nhds.mpr hU, fun y hy => hU' ⟨ interior_subset hy.1, hy.2 ⟩ ⟩;
+      rcases mem_nhdsWithin_iff_exists_mem_nhds_inter.mp ( this ( f ( g x ) ) ( hg x hx |>.2 ) )
+        with ⟨ U, hU, hU' ⟩;
+      exact ⟨ interior U, isOpen_interior, mem_interior_iff_mem_nhds.mpr hU,
+        fun y hy => hU' ⟨ interior_subset hy.1, hy.2 ⟩ ⟩;
     choose! U hU using h_neighborhood;
     -- Since $s$ is compact, the open cover $\{U_x \cap s \mid x \in s\}$ has a finite subcover.
     obtain ⟨t, ht⟩ : ∃ t : Finset β, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x ∩ s := by
       -- Since $s$ is compact, the open cover $\{U_x \mid x \in s\}$ has a finite subcover.
       obtain ⟨t, ht⟩ : ∃ t : Finset β, (∀ x ∈ t, x ∈ s) ∧ s ⊆ ⋃ x ∈ t, U x := by
-        exact hs.elim_nhds_subcover U fun x hx => IsOpen.mem_nhds ( hU x hx |>.1 ) ( hU x hx |>.2.1 );
-      exact ⟨ t, ht.1, fun x hx => by rcases Set.mem_iUnion₂.1 ( ht.2 hx ) with ⟨ y, hy, hy' ⟩ ; exact Set.mem_iUnion₂.2 ⟨ y, hy, ⟨ hy', hx ⟩ ⟩ ⟩;
+        exact hs.elim_nhds_subcover U
+          fun x hx => IsOpen.mem_nhds ( hU x hx |>.1 ) ( hU x hx |>.2.1 );
+      exact ⟨ t, ht.1, fun x hx => by
+        rcases Set.mem_iUnion₂.1 ( ht.2 hx ) with ⟨ y, hy, hy' ⟩ ;
+        exact Set.mem_iUnion₂.2 ⟨ y, hy, ⟨ hy', hx ⟩ ⟩ ⟩;
     -- Since $t$ is finite, there exists $x \in t$ such that $f(g(x))$ is minimal.
     obtain ⟨x, hx⟩ : ∃ x ∈ t, ∀ y ∈ t, f (g x) ≤ f (g y) := by
       apply_rules [ Finset.exists_min_image ];
@@ -64,8 +71,10 @@ theorem _root_.IsCompact.exists_isMinOn_lowerSemicontinuousOn {α β : Type*}
     obtain ⟨⟨w, rfl⟩, right_2⟩ := hy
     simp_all only [Set.mem_iUnion, Set.mem_inter_iff, and_true, exists_prop]
     obtain ⟨left_2, right_2⟩ := right_2
-    exact lt_irrefl _ ( lt_of_le_of_lt ( right_1 _ left_2 ) ( hU _ ( left _ left_2 ) |>.2.2 _ right_2 ( hg _ ( left _ left_1 ) ) ) );
-  -- By definition of IsMinOn, we need to show that for all y in s, f(x) ≤ f(y). This is exactly what h_extreme provides.
+    exact lt_irrefl _ ( lt_of_le_of_lt ( right_1 _ left_2 )
+      ( hU _ ( left _ left_2 ) |>.2.2 _ right_2 ( hg _ ( left _ left_1 ) ) ) );
+  -- By definition of IsMinOn, we need to show that for all y in s, f(x) ≤ f(y). This is exactly
+  -- what h_extreme provides.
   obtain ⟨x, hx_s, hx_min⟩ := h_extreme;
   use x, hx_s;
   exact hx_min
@@ -101,7 +110,8 @@ theorem LinearMap.quasiconcaveOn {E β 𝕜 : Type*} [Semiring 𝕜] [PartialOrd
   (f.quasilinearOn hs).right
 
 --??
-theorem continuous_stupid.{u_2, u_1} {M : Type u_1} [inst : NormedAddCommGroup M] [inst_1 : Module ℝ M]
+theorem continuous_stupid.{u_2, u_1} {M : Type u_1} [inst : NormedAddCommGroup M]
+  [inst_1 : Module ℝ M]
   [inst_3 : ContinuousSMul ℝ M] {N : Type u_2} [inst_4 : NormedAddCommGroup N]
   [inst_5 : Module ℝ N]
   [FiniteDimensional ℝ M]
@@ -121,7 +131,8 @@ theorem continuous_stupid.{u_2, u_1} {M : Type u_1} [inst : NormedAddCommGroup M
 and `T`in a real topological vector space `M`, and a bilinear function `f` on M, we can exchange
 the order of minimizing and maximizing. -/
 theorem minimax
-  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M] [FiniteDimensional ℝ M]
+  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M]
+  [FiniteDimensional ℝ M]
   {N : Type*} [NormedAddCommGroup N] [Module ℝ N] [ContinuousAdd N] [ContinuousSMul ℝ N]
   (f : N →L[ℝ] M →L[ℝ] ℝ)
   (S : Set M) (T : Set N) (hS₁ : IsCompact S) (hT₁ : IsCompact T)
@@ -155,7 +166,8 @@ theorem minimax
 
 /-- **Von-Neumann's Minimax Theorem**, specialized to bilinear forms. -/
 theorem LinearMap.BilinForm.minimax
-  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M] [FiniteDimensional ℝ M]
+  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M]
+  [FiniteDimensional ℝ M]
   (f : LinearMap.BilinForm ℝ M)
   (S : Set M) (T : Set M) (hS₁ : IsCompact S) (hT₁ : IsCompact T)
   (hS₂ : Convex ℝ S) (hT₂ : Convex ℝ T) (hS₃ : S.Nonempty) (hT₃ : T.Nonempty)
@@ -164,9 +176,11 @@ theorem LinearMap.BilinForm.minimax
     toFun := fun x ↦ (f x).toContinuousLinearMap, map_add' := by simp, map_smul' := by simp})
     S T hS₁ hT₁ hS₂ hT₂ hS₃ hT₃
 
-/-- Convenience form of `LinearMap.BilinForm.minimax` with the order inf/sup arguments supplied to f flipped. -/
+/-- Convenience form of `LinearMap.BilinForm.minimax` with the order inf/sup arguments supplied to
+f flipped. -/
 theorem LinearMap.BilinForm.minimax'
-  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M] [FiniteDimensional ℝ M]
+  {M : Type*} [NormedAddCommGroup M] [Module ℝ M] [ContinuousAdd M] [ContinuousSMul ℝ M]
+  [FiniteDimensional ℝ M]
   (f : LinearMap.BilinForm ℝ M)
   (S : Set M) (T : Set M) (hS₁ : IsCompact S) (hT₁ : IsCompact T)
   (hS₂ : Convex ℝ S) (hT₂ : Convex ℝ T) (hS₃ : S.Nonempty) (hT₃ : T.Nonempty)

--- a/QuantumInfo/ForMathlib/Misc.lean
+++ b/QuantumInfo/ForMathlib/Misc.lean
@@ -13,7 +13,8 @@ public import Mathlib.Order.CompletePartialOrder
 --Can this be rewritten more generally? For `finiteness` to work, I don't know how.
 --PR'ed in #33105
 @[aesop (rule_sets := [finiteness]) unsafe apply]
-theorem ite_eq_top {α : Type*} [Top α] (h : Prop) [Decidable h] {x y : α} (hx : x ≠ ⊤) (hy : y ≠ ⊤) :
+theorem ite_eq_top {α : Type*} [Top α] (h : Prop) [Decidable h] {x y : α}
+    (hx : x ≠ ⊤) (hy : y ≠ ⊤) :
     (if h then x else y) ≠ ⊤ := by
   split <;> assumption
 
@@ -24,18 +25,20 @@ When
 https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/diamond.20in.20ConditionallyCompleteLattice/near/538053239
 is fixed, the declarations below should be changed to
 ```
-theorem subtype_val_iSup {ι α : Type*} [ConditionallyCompleteLattice α] {s : Set α} {f : ι → α}
+theorem subtype_val_iSup {ι α : Type*} [ConditionallyCompleteLattice α] {s : Set α}
+    {f : ι → α}
     [Inhabited ↑s] [s.OrdConnected] (h : ∀ i, f i ∈ s) :
     (⨆ i, (⟨f i, h i⟩ : ↑s)).val = ⨆ i, f i := by
   sorry
 
-theorem subtype_val_iSup' {ι α : Type*} [ConditionallyCompleteLattice α] {s : Set α} {f : ι → α}
+theorem subtype_val_iSup' {ι α : Type*} [ConditionallyCompleteLattice α] {s : Set α}
+    {f : ι → α}
     [Inhabited ↑s] [s.OrdConnected] (h : ∀ i, f i ∈ s) :
     ⨆ i, (⟨f i, h i⟩ : ↑s) = ⟨⨆ i, f i, by sorry⟩ := by
   rw [Subtype.eq_iff, subtype_val_iSup]
 ```
-Sadly, though, there's a "diamond" and we need it with the other data (the one we specify more narrowly
-below).
+Sadly, though, there's a "diamond" and we need it with the other data (the one we specify
+more narrowly below).
 -/
 variable {ι α : Type*} [i : Nonempty ι] [ConditionallyCompleteLattice α]
   {f : ι → α} {a b : α} [Fact (a ≤ b)]
@@ -50,7 +53,8 @@ theorem subtype_val_iSup (h : ∀ i, f i ∈ Set.Icc a b) :
 
 theorem subtype_val_iSup' (h : ∀ i, f i ∈ Set.Icc a b) :
     ⨆ i, (⟨f i, h i⟩ : ↑(Set.Icc a b)) =
-      ⟨⨆ i, f i, ⟨(h i.some).1.trans (le_ciSup ⟨b, by intro; grind⟩ _), ciSup_le (h ·|>.2)⟩⟩ := by
+      ⟨⨆ i, f i, ⟨(h i.some).1.trans (le_ciSup ⟨b, by intro; grind⟩ _),
+        ciSup_le (h ·|>.2)⟩⟩ := by
   rw [Subtype.ext_iff, subtype_val_iSup]
 
 /- This isn't marked as `simp` because rewriting from a sup over a `CompleteLattice` into a
@@ -63,7 +67,8 @@ theorem subtype_val_iInf (h : ∀ i, f i ∈ Set.Icc a b) :
 
 theorem subtype_val_iInf' (h : ∀ i, f i ∈ Set.Icc a b) :
     ⨅ i, (⟨f i, h i⟩ : ↑(Set.Icc a b)) =
-      ⟨⨅ i, f i, ⟨le_ciInf (h ·|>.1), (ciInf_le ⟨a, by intro; grind⟩ _).trans (h i.some).2⟩⟩ := by
+      ⟨⨅ i, f i, ⟨le_ciInf (h ·|>.1),
+        (ciInf_le ⟨a, by intro; grind⟩ _).trans (h i.some).2⟩⟩ := by
   rw [Subtype.ext_iff, subtype_val_iInf]
 
 end subtype_val_iSup
@@ -88,7 +93,8 @@ protected lemma ENNReal.bdd_le_mul_tendsto_zero
 -- (after appropriately generalizing to MulPosMono)
 open scoped Pointwise in
 theorem csInf_mul_nonneg {s t : Set ℝ}
-  (hs₀ : s.Nonempty) (hs₁ : ∀ x ∈ s, 0 ≤ x) (ht₀ : t.Nonempty) (ht₁ : ∀ x ∈ t, 0 ≤ x) :
+  (hs₀ : s.Nonempty) (hs₁ : ∀ x ∈ s, 0 ≤ x) (ht₀ : t.Nonempty)
+  (ht₁ : ∀ x ∈ t, 0 ≤ x) :
     sInf (s * t) = sInf s * sInf t := by
   apply le_antisymm
   · set a := sInf s
@@ -102,8 +108,10 @@ theorem csInf_mul_nonneg {s t : Set ℝ}
       intro ε hε
       obtain ⟨x, hx₁, hx₂, y, hy₁, hy₂⟩ := h_eps ε hε
       exact ⟨x, hx₁, y, hy₁, by nlinarith [hs₁ x hx₁, ht₁ y hy₁]⟩
-    have h_lim : Filter.Tendsto (fun ε => (a + ε) * (b + ε)) (nhdsWithin 0 (Set.Ioi 0)) (nhds (a * b)) := by
-      exact tendsto_nhdsWithin_of_tendsto_nhds (Continuous.tendsto' (by continuity) _ _ (by norm_num))
+    have h_lim : Filter.Tendsto (fun ε => (a + ε) * (b + ε)) (nhdsWithin 0 (Set.Ioi 0))
+        (nhds (a * b)) := by
+      exact tendsto_nhdsWithin_of_tendsto_nhds
+        (Continuous.tendsto' (by continuity) _ _ (by norm_num))
     apply le_of_tendsto_of_tendsto tendsto_const_nhds h_lim
     filter_upwards [self_mem_nhdsWithin] with ε hε
     specialize h_prod_eps ε hε
@@ -122,16 +130,19 @@ theorem csInf_mul_nonneg {s t : Set ℝ}
     · exact hs₁ x hx
 
 /--
-If two functions from finite types have the same multiset of values, there exists a bijection between the domains that commutes with the functions.
+If two functions from finite types have the same multiset of values, there exists a
+bijection between the domains that commutes with the functions.
 -/
 lemma Multiset.map_univ_eq_iff {α β : Type*} [Fintype α] (f g : α → β) :
-    Multiset.map f Finset.univ.val = Multiset.map g Finset.univ.val ↔ ∃ (e : α ≃ α), f = g ∘ e := by
+    Multiset.map f Finset.univ.val = Multiset.map g Finset.univ.val
+      ↔ ∃ (e : α ≃ α), f = g ∘ e := by
   apply Iff.intro
   · intro a
     classical
     -- Since these two multisets are equal, their elements must be equal up to permutation.
     have h_perm : ∃ e : α ≃ α, ∀ x, f x = g (e x) := by
-      have h_count_eq : ∀ y : β, Finset.card (Finset.filter (fun x => f x = y) Finset.univ) = Finset.card (Finset.filter (fun x => g x = y) Finset.univ) := by
+      have h_count_eq : ∀ y : β, Finset.card (Finset.filter (fun x => f x = y) Finset.univ)
+          = Finset.card (Finset.filter (fun x => g x = y) Finset.univ) := by
         intro y;
         replace a := congr_arg ( fun m => m.count y ) a;
         simp_all ( config := { decide := Bool.true } ) [ Multiset.count_map ];
@@ -142,7 +153,8 @@ lemma Multiset.map_univ_eq_iff {α β : Type*} [Fintype α] (f g : α → β) :
         exact ⟨ Fintype.equivOfCardEq <| by simpa [ Fintype.card_subtype ] using h_count_eq y ⟩;
       choose e he using h_perm;
       refine' ⟨ _, _ ⟩;
-      exact ( Equiv.sigmaFiberEquiv f ).symm.trans ( Equiv.sigmaCongrRight e ) |> Equiv.trans <| Equiv.sigmaFiberEquiv g;
+      exact ( Equiv.sigmaFiberEquiv f ).symm.trans ( Equiv.sigmaCongrRight e )
+        |> Equiv.trans <| Equiv.sigmaFiberEquiv g;
       intro x
       specialize e ( f x )
       rename_i e_1
@@ -154,25 +166,33 @@ lemma Multiset.map_univ_eq_iff {α β : Type*} [Fintype α] (f g : α → β) :
     obtain ⟨w, h⟩ := a
     subst h
     simp_all only [Function.comp_apply, Finset.univ]
-    -- Since $w$ is a bijection, the multiset of $w(x)$ for $x$ in the original multiset is just a permutation of the original multiset.
-    have h_perm : Multiset.map (fun x => w x) (Finset.val Fintype.elems) = Finset.val Fintype.elems := by
+    -- Since $w$ is a bijection, the multiset of $w(x)$ for $x$ in the original multiset is
+    -- just a permutation of the original multiset.
+    have h_perm : Multiset.map (fun x => w x) (Finset.val Fintype.elems)
+        = Finset.val Fintype.elems := by
       exact Multiset.map_univ_val_equiv w;
     conv_rhs => rw [ ← h_perm ];
     simp +zetaDelta at *
 
 /--
-If two functions from finite types have the same multiset of values, there exists a bijection between the domains that commutes with the functions.
+If two functions from finite types have the same multiset of values, there exists a
+bijection between the domains that commutes with the functions.
 -/
 lemma exists_equiv_of_multiset_map_eq {α β γ : Type*} [Fintype α] [Fintype β] [DecidableEq γ]
-    (f : α → γ) (g : β → γ) (h : Multiset.map f Finset.univ.val = Multiset.map g Finset.univ.val) :
+    (f : α → γ) (g : β → γ)
+    (h : Multiset.map f Finset.univ.val = Multiset.map g Finset.univ.val) :
     ∃ e : α ≃ β, f = g ∘ e := by
-  -- Since the multisets of values are equal, the cardinalities of the domains must be equal (as the multiset size is the cardinality of the domain). Thus there exists a bijection `σ : α ≃ β`.
-  obtain ⟨σ, hσ⟩ : ∃ σ : α ≃ β, Multiset.map f Finset.univ.val = Multiset.map (g ∘ σ) Finset.univ.val := by
+  -- Since the multisets of values are equal, the cardinalities of the domains must be equal
+  -- (as the multiset size is the cardinality of the domain). Thus there exists a bijection
+  -- `σ : α ≃ β`.
+  obtain ⟨σ, hσ⟩ : ∃ σ : α ≃ β, Multiset.map f Finset.univ.val
+      = Multiset.map (g ∘ σ) Finset.univ.val := by
     have h_card : Fintype.card α = Fintype.card β := by
       simpa using congr_arg Multiset.card h;
     obtain σ := Fintype.equivOfCardEq h_card
     use σ
-    have h_multiset_eq : Multiset.map g Finset.univ.val = Multiset.map (g ∘ σ) Finset.univ.val := by
+    have h_multiset_eq : Multiset.map g Finset.univ.val
+        = Multiset.map (g ∘ σ) Finset.univ.val := by
       rw [ ← Multiset.map_univ_val_equiv σ ] ;
       rw [ Multiset.map_map ]
     exact h.trans h_multiset_eq;

--- a/QuantumInfo/ForMathlib/SionMinimax.lean
+++ b/QuantumInfo/ForMathlib/SionMinimax.lean
@@ -27,7 +27,8 @@ section ciSup
 
 variable {ι α : Type*} [ConditionallyCompleteLattice α] {f g : ι → α} {a : α}
 
-/-- The **max-min theorem**. A version of `iSup_iInf_le_iInf_iSup` for conditionally complete lattices. -/
+/-- The **max-min theorem**. A version of `iSup_iInf_le_iInf_iSup` for conditionally complete
+lattices. -/
 theorem ciSup_ciInf_le_ciInf_ciSup {ι': Type*} [Nonempty ι]
   (f : ι → ι' → α) (Ha : ∀ j, BddAbove (Set.range (f · j))) (Hb : ∀ i, BddBelow (Set.range (f i))) :
     ⨆ i, ⨅ j, f i j ≤ ⨅ j, ⨆ i, f i j :=
@@ -38,7 +39,8 @@ theorem BddAbove.range_max (hf : BddAbove (Set.range f)) (hg : BddAbove (Set.ran
   rcases hf with ⟨a, ha⟩
   rcases hg with ⟨b, hb⟩
   use a ⊔ b
-  simp only [mem_upperBounds, Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff, Pi.sup_apply] at ha hb ⊢
+  simp only [mem_upperBounds, Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff,
+    Pi.sup_apply] at ha hb ⊢
   intro i
   specialize ha i
   specialize hb i
@@ -116,14 +118,16 @@ theorem LowerSemicontinuousOn.bddBelow {α : Type*} [TopologicalSpace α] {S : S
   rcases S.eq_empty_or_nonempty with rfl | hS₂
   · simp
   have h_neighborhood : ∀ x ∈ S, ∃ U ∈ nhds x, ∀ y ∈ U ∩ S, g y > g x - 1 := by
-    -- By definition of lower semicontinuity, for each x ∈ S, there exists a neighborhood U_x such that g(y) > g(x) - 1 for all y ∈ U_x ∩ S.
+    -- By definition of lower semicontinuity, for each x ∈ S, there exists a neighborhood U_x such
+    -- that g(y) > g(x) - 1 for all y ∈ U_x ∩ S.
     intros x hx
     specialize hg x hx (g x - 1) (sub_one_lt (g x))
     rw [eventually_nhdsWithin_iff] at hg
     simp only [Set.mem_inter_iff, gt_iff_lt, and_imp]
     exact ⟨_, hg, fun y hy hyS ↦ hy hyS⟩
   choose! U hU using h_neighborhood
-  -- By the finite subcover property, there exists a finite subset t ⊆ S$ such that S ⊆ ⋃_{x ∈ t} U_x$.
+  -- By the finite subcover property, there exists a finite subset t ⊆ S$ such that S ⊆ ⋃_{x ∈ t}
+  -- U_x$.
   obtain ⟨t, ht⟩ : ∃ t, (∀ x ∈ t, x ∈ S) ∧ S ⊆ ⋃ x ∈ t, U x :=
     hS.elim_nhds_subcover U fun x hx ↦ hU x hx |>.1;
   -- Let $m$ be the minimum value of $g$ on the finite set $t$.
@@ -141,7 +145,8 @@ theorem LowerSemicontinuousOn.bddBelow {α : Type*} [TopologicalSpace α] {S : S
 theorem LowerSemicontinuousOn.max {α : Type*} [TopologicalSpace α] {S : Set α} {f g : α → ℝ}
     (hf : LowerSemicontinuousOn f S) (hg : LowerSemicontinuousOn g S) :
     LowerSemicontinuousOn (fun x ↦ max (f x) (g x)) S := by
-  convert lowerSemicontinuousOn_ciSup (s := S) (f := fun (i : Bool) x' ↦ if i then f x' else g x') ?_ ?_
+  convert lowerSemicontinuousOn_ciSup (s := S)
+    (f := fun (i : Bool) x' ↦ if i then f x' else g x') ?_ ?_
   · rw [ciSup_eq_of_forall_le_of_forall_lt_exists_gt] <;> aesop
   · simp
   · simp [hf, hg]
@@ -160,7 +165,8 @@ theorem lowerSemicontinuousOn_iff_isClosed_preimage {f : α → γ} [IsClosed s]
     · simp only [Set.mem_inter_iff, hx', Set.mem_preimage, Set.mem_Iic, true_and, not_le] at hx
       have := a x hx';
       rcases mem_nhdsWithin.1 ( this y hx ) with ⟨ o, ho, h ⟩;
-      exact ⟨ o, ho, h.1, Set.eq_empty_iff_forall_notMem.2 fun z hz => h.2 ⟨ hz.1, hz.2.1 ⟩ |> not_le_of_gt <| Set.mem_Iic.1 hz.2.2 ⟩;
+      exact ⟨ o, ho, h.1, Set.eq_empty_iff_forall_notMem.2 fun z hz => h.2 ⟨ hz.1, hz.2.1 ⟩
+        |> not_le_of_gt <| Set.mem_Iic.1 hz.2.2 ⟩;
     · exact ⟨ sᶜ, IsClosed.isOpen_compl, hx', by aesop ⟩;
   · intro a x hx y hy
     have hx_not_in : x ∉ s ∩ f ⁻¹' Set.Iic y := by
@@ -169,13 +175,16 @@ theorem lowerSemicontinuousOn_iff_isClosed_preimage {f : α → γ} [IsClosed s]
     filter_upwards [ IsOpen.mem_nhds ( isOpen_compl_iff.2 ( a y ) ) hx_not_in ] with z hz hzs
     exact lt_of_not_ge fun h => hz ⟨hzs, h⟩
 
-theorem segment.isConnected {E : Type u_1} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] (a b : E) :
+theorem segment.isConnected {E : Type u_1} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
+    [ContinuousAdd E] [ContinuousSMul ℝ E] (a b : E) :
     IsConnected (segment ℝ a b) := by
   rw [← Path.range_segment a b]
   exact isConnected_range (Path.segment a b).continuous
 
-theorem BddAbove.range_inf_of_image2 {M N α : Type*} {f : M → N → α} [ConditionallyCompleteLinearOrder α]
-  {S : Set M} {T : Set N} (h_bddA : BddAbove (Set.image2 f S T)) (h_bddB : BddBelow (Set.image2 f S T)) :
+theorem BddAbove.range_inf_of_image2 {M N α : Type*} {f : M → N → α}
+  [ConditionallyCompleteLinearOrder α]
+  {S : Set M} {T : Set N} (h_bddA : BddAbove (Set.image2 f S T))
+  (h_bddB : BddBelow (Set.image2 f S T)) :
     BddAbove (Set.range fun y : T ↦ ⨅ x : S, f x y) := by
   rcases isEmpty_or_nonempty T with hT | hT
   · aesop
@@ -191,8 +200,10 @@ theorem BddAbove.range_inf_of_image2 {M N α : Type*} {f : M → N → α} [Cond
     exact hz (Set.mem_image2_of_mem hx hy)
   exact ⟨_, Set.forall_mem_range.2 (h_inf_le_M _ ·.2)⟩
 
-theorem BddBelow.range_sup_of_image2 {M N α : Type*} {f : M → N → α} [ConditionallyCompleteLinearOrder α]
-  {S : Set M} {T : Set N} (h_bddA : BddAbove (Set.image2 f S T)) (h_bddB : BddBelow (Set.image2 f S T)) :
+theorem BddBelow.range_sup_of_image2 {M N α : Type*} {f : M → N → α}
+  [ConditionallyCompleteLinearOrder α]
+  {S : Set M} {T : Set N} (h_bddA : BddAbove (Set.image2 f S T))
+  (h_bddB : BddBelow (Set.image2 f S T)) :
       BddBelow (Set.range fun y : T ↦ ⨆ x : S, f x y) :=
   BddAbove.range_inf_of_image2 (α := αᵒᵈ) h_bddB h_bddA
 
@@ -203,7 +214,8 @@ theorem ciInf_le_ciInf_of_subset {α β : Type*} [ConditionallyCompleteLattice �
     intro y hy
     obtain ⟨w_1, ⟨left_1, right_1⟩⟩ : f y ∈ f '' t := by
       use y, hst hy
-    exact le_trans ( ciInf_le (by simpa [ Set.range ] using hf ) ⟨ w_1, left_1 ⟩ ) ( by simp[right_1] );
+    exact le_trans ( ciInf_le (by simpa [ Set.range ] using hf ) ⟨ w_1, left_1 ⟩ )
+      ( by simp[right_1] );
   apply le_csInf
   · exact ⟨_, ⟨⟨_, hs.choose_spec⟩, rfl⟩⟩;
   · aesop
@@ -224,12 +236,14 @@ theorem LowerSemicontinuousOn.dite_top {α β : Type*} [TopologicalSpace α] [Pr
     filter_upwards [hf]
     simp only [Subtype.forall]
     grind [lt_top_of_lt]
-  · filter_upwards [self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds (hu.isOpen_compl.mem_nhds (show x ∉ u by grind))]
+  · filter_upwards [self_mem_nhdsWithin,
+      mem_nhdsWithin_of_mem_nhds (hu.isOpen_compl.mem_nhds (show x ∉ u by grind))]
     intros
     simp_all only [Set.mem_compl_iff, ↓reduceDIte]
 
 theorem LowerSemicontinuousOn.comp_continuousOn {α β γ : Type*}
-  [TopologicalSpace α] [TopologicalSpace β] [Preorder γ] {f : α → β} {s : Set α} {g : β → γ} {t : Set β}
+  [TopologicalSpace α] [TopologicalSpace β] [Preorder γ] {f : α → β} {s : Set α} {g : β → γ}
+  {t : Set β}
   (hg : LowerSemicontinuousOn g t) (hf : ContinuousOn f s) (h : Set.MapsTo f s t) :
     LowerSemicontinuousOn (g ∘ f) s := by
   intro x hx y hy
@@ -244,13 +258,15 @@ theorem LowerSemicontinuousOn.comp_continuousOn {α β γ : Type*}
   exact h_final.mono fun x' hx' => hU _ hx'
 
 theorem UpperSemicontinuousOn.comp_continuousOn {α β γ : Type*}
-  [TopologicalSpace α] [TopologicalSpace β] [Preorder γ] {f : α → β} {s : Set α} {g : β → γ} {t : Set β}
+  [TopologicalSpace α] [TopologicalSpace β] [Preorder γ] {f : α → β} {s : Set α} {g : β → γ}
+  {t : Set β}
   (hg : UpperSemicontinuousOn g t) (hf : ContinuousOn f s) (h : Set.MapsTo f s t) :
     UpperSemicontinuousOn (g ∘ f) s :=
   LowerSemicontinuousOn.comp_continuousOn (γ := γᵒᵈ) hg hf h
 
 theorem LowerSemicontinuousOn.ite_top {α β : Type*} [TopologicalSpace α] [Preorder β] [OrderTop β]
-  {s : Set α} (p : α → Prop) [DecidablePred p] {f : (a : α) → β} (hf : LowerSemicontinuousOn f (s ∩ setOf p))
+  {s : Set α} (p : α → Prop) [DecidablePred p] {f : (a : α) → β}
+  (hf : LowerSemicontinuousOn f (s ∩ setOf p))
   (h_relatively_closed : ∃ U : Set α, IsClosed U ∧ s ∩ U = s ∩ setOf p) :
     LowerSemicontinuousOn (fun x ↦ ite (p x) (f x) ⊤) s :=
   dite_top p (hf.comp_continuousOn (by fun_prop) (by intro; simp)) h_relatively_closed
@@ -258,7 +274,8 @@ theorem LowerSemicontinuousOn.ite_top {α β : Type*} [TopologicalSpace α] [Pre
 theorem LeftOrdContinuous.comp_lowerSemicontinuousOn_strong_assumptions {α γ δ : Type*}
   [TopologicalSpace α] [LinearOrder γ] [LinearOrder δ] [TopologicalSpace δ] [OrderTopology δ]
   [TopologicalSpace γ] [OrderTopology γ] [DenselyOrdered γ] [DenselyOrdered δ]
-  {s : Set α} {g : γ → δ} {f : α → γ} (hg : LeftOrdContinuous g) (hf : LowerSemicontinuousOn f s) (hg2 : Monotone g) :
+  {s : Set α} {g : γ → δ} {f : α → γ} (hg : LeftOrdContinuous g) (hf : LowerSemicontinuousOn f s)
+  (hg2 : Monotone g) :
     LowerSemicontinuousOn (g ∘ f) s := by
   intros x hx y hy
   have hU : ∃ U ∈ nhds x, ∀ z ∈ U ∩ s, g (f z) > y := by
@@ -283,9 +300,11 @@ theorem LeftOrdContinuous.comp_lowerSemicontinuousOn_strong_assumptions {α γ �
   obtain ⟨w, ⟨left, right⟩⟩ := hU
   exact Filter.eventually_inf_principal.2 (Filter.mem_of_superset left right)
 
-theorem UpperSemicontinuousOn.frequently_lt_of_tendsto {α β γ : Type*} [TopologicalSpace β] [Preorder γ]
+theorem UpperSemicontinuousOn.frequently_lt_of_tendsto {α β γ : Type*} [TopologicalSpace β]
+  [Preorder γ]
   {f : β → γ} {T : Set β} (hf : UpperSemicontinuousOn f T) {c : γ} {zs : α → β} {z : β}
-  {l : Filter α} [l.NeBot] (hzs : l.Tendsto zs (nhds z)) (hx₂ : f z < c) (hzI : ∀ a, zs a ∈ T) (hzT : z ∈ T) :
+  {l : Filter α} [l.NeBot] (hzs : l.Tendsto zs (nhds z)) (hx₂ : f z < c) (hzI : ∀ a, zs a ∈ T)
+  (hzT : z ∈ T) :
     ∀ᶠ a in l, f (zs a) < c := by
   have h : ∀ᶠ n in l, zs n ∈ {y ∈ T | f y < c} := by
     filter_upwards [hzs.eventually (eventually_nhdsWithin_iff.mp ((hf z hzT) c hx₂))] with n hn
@@ -319,7 +338,8 @@ theorem Finset.ciSup_insert {α β : Type*} [DecidableEq α] [ConditionallyCompl
 section sion_minimax
 /-!
 Following https://projecteuclid.org/journals/kodai-mathematical-journal/volume-11/issue-1/Elementary-proof-for-Sions-minimax-theorem/10.2996/kmj/1138038812.full, with some corrections. There are two errors in Lemma 2 and the main theorem: an incorrect step that
-`(∀ x, a < f x) → (a < ⨅ x, f x)`. This is repaired by taking an extra `exists_between` to get `a < b < ⨅ ...`, concluding that
+`(∀ x, a < f x) → (a < ⨅ x, f x)`. This is repaired by taking an extra `exists_between` to get
+`a < b < ⨅ ...`, concluding that
 `(∀ x, b < f x) → (b ≤ ⨅ x, f x)` and so `(a < ⨅ x, f x)`.
 -/
 
@@ -330,7 +350,8 @@ variable  {M : Type*} [NormedAddCommGroup M]
   (hS₁ : IsCompact S) (hS₃ : S.Nonempty) (hT₃ : T.Nonempty)
 
 include hfc₂ hS₁ hS₃ in
-private theorem sion_exists_min_lowerSemi (a : ℝ) (hc : ∀ y₀ : T, ⨅ (x : S), f (↑x) y₀ ≤ a) (z : N) (hzT : z ∈ T) :
+private theorem sion_exists_min_lowerSemi (a : ℝ) (hc : ∀ y₀ : T, ⨅ (x : S), f (↑x) y₀ ≤ a) (z : N)
+    (hzT : z ∈ T) :
     ∃ x ∈ S, f x z ≤ a := by
   let _ := hS₃.to_subtype
   contrapose! hc
@@ -350,8 +371,10 @@ private theorem sion_exists_min_lowerSemi (a : ℝ) (hc : ∀ y₀ : T, ⨅ (x :
       choose! xn hxn using h_eps
       use fun n ↦ xn (1 / (n + 1))
       rw [tendsto_iff_dist_tendsto_zero]
-      refine squeeze_zero (fun _ ↦ abs_nonneg _) (fun n ↦ ?_) tendsto_one_div_add_atTop_nhds_zero_nat
-      refine abs_le.mpr ⟨?_, ?_⟩ <;> linarith [h_lower_bound (xn (1 / (n + 1))), hxn (1 / (n + 1)) (by positivity)]
+      refine squeeze_zero (fun _ ↦ abs_nonneg _) (fun n ↦ ?_)
+        tendsto_one_div_add_atTop_nhds_zero_nat
+      refine abs_le.mpr ⟨?_, ?_⟩ <;>
+        linarith [h_lower_bound (xn (1 / (n + 1))), hxn (1 / (n + 1)) (by positivity)]
     obtain ⟨x, subseq, hsubseq₁, hsubseq₂⟩ : ∃ x : S, ∃ subseq : ℕ → ℕ,
         StrictMono subseq ∧ Filter.Tendsto (fun n => xn (subseq n)) Filter.atTop (nhds x) := by
       simpa using (isCompact_iff_isCompact_univ.mp hS₁).isSeqCompact (x := xn) fun _ ↦ trivial
@@ -370,7 +393,8 @@ private theorem sion_exists_min_lowerSemi (a : ℝ) (hc : ∀ y₀ : T, ⨅ (x :
   order
 
 variable [Module ℝ M] [ContinuousSMul ℝ M]
-variable [AddCommGroup N] [TopologicalSpace N] [SequentialSpace N] [T2Space N] [ContinuousAdd N] [Module ℝ N] [ContinuousSMul ℝ N]
+variable [AddCommGroup N] [TopologicalSpace N] [SequentialSpace N] [T2Space N] [ContinuousAdd N]
+  [Module ℝ N] [ContinuousSMul ℝ N]
 variable
   (hfc₁ : ∀ x, x ∈ S → UpperSemicontinuousOn (f x) T)
   (hfq₂ : ∀ y, y ∈ T → QuasiconvexOn ℝ S (f · y))
@@ -488,7 +512,8 @@ private lemma sion_exists_min_2 (y₁ y₂ : N) (hy₁ : y₁ ∈ T) (hy₂ : y�
       have hAC : A ∩ C z ⊆ A ∩ B := by apply Set.inter_subset_inter_right _ hCB
       rw [hAB, Set.subset_empty_iff, Set.ext_iff] at hAC
       revert hAC
-      simp only [Set.mem_inter_iff, Set.mem_empty_iff_false, iff_false, not_and, imp_false, not_forall, not_not]
+      simp only [Set.mem_inter_iff, Set.mem_empty_iff_false, iff_false, not_and, imp_false,
+        not_forall, not_not]
       exact ⟨x, hxA, hx⟩
     suffices hn : ∃ n, f x (zs n) < β by
       refine hn.imp fun n ↦ ?_
@@ -526,7 +551,8 @@ private lemma sion_exists_min_2 (y₁ y₂ : N) (hy₁ : y₁ ∈ T) (hy₂ : y�
       have hAC : C z ∩ B ⊆ A ∩ B := by apply Set.inter_subset_inter_left _ hCB
       rw [hAB, Set.subset_empty_iff, Set.ext_iff] at hAC
       revert hAC
-      simp only [Set.mem_inter_iff, Set.mem_empty_iff_false, iff_false, not_and, imp_false, not_forall, not_not]
+      simp only [Set.mem_inter_iff, Set.mem_empty_iff_false, iff_false, not_and, imp_false,
+        not_forall, not_not]
       exact ⟨x, hx, hxA⟩
     suffices hn : ∃ n, f x (zs n) < β by
       refine hn.imp fun n ↦ ?_
@@ -595,7 +621,8 @@ private lemma sion_exists_min_fin
       apply lt_of_lt_of_le hab (hb.le.trans ?_)
       classical
       trans (⨅ x : S', ⨆ yi : { x // x ∈ (Insert.insert yₙ t : Finset N)}, f ↑x ↑yi)
-      · apply ciInf_le_ciInf_of_subset (f := fun x ↦ ⨆ yi : { x // x ∈ (Insert.insert yₙ t : Finset N)}, f ↑x ↑yi)
+      · apply ciInf_le_ciInf_of_subset
+          (f := fun x ↦ ⨆ yi : { x // x ∈ (Insert.insert yₙ t : Finset N)}, f ↑x ↑yi)
         · exact hS'_n
         · --BddBelow ((fun x => ⨆ yi, f x ↑yi) '' S)
           convert BddBelow.range_sup_of_image2 (T := S) (S := { x | x ∈ insert yₙ t }) (f := flip f)
@@ -681,7 +708,8 @@ theorem sion_minimax
   have _ := hS₃.to_subtype
   have _ := hT₃.to_subtype
   have h_bdd_0 (i : T) : BddBelow (Set.range fun j : S ↦ f j i) := by
-    --This one actually doesn't require h_bddB, we can just prove it from compactness + semicontinuity
+    --This one actually doesn't require h_bddB, we can just prove it from compactness +
+    --semicontinuity
     convert (hfc₂ i i.2).bddBelow hS₁
     ext; simp
   have h_bdd_1 (j : S) : BddAbove (Set.range fun (x : T) => f j x) :=
@@ -709,7 +737,8 @@ theorem sion_minimax
       rw [lt_ciInf_iff]; swap
       · --BddBelow (Set.range fun x => ⨆ yi : Finset.map ⋯, f ↑x ↑yi)
         exact BddBelow.range_sup_of_image2 (T := S) (S := u.map ⟨_, Subtype.val_injective⟩)
-          (f := flip f) (by apply h_bddA.mono; simp [flip]; grind) (by apply h_bddB.mono; simp [flip]; grind)
+          (f := flip f) (by apply h_bddA.mono; simp [flip]; grind)
+          (by apply h_bddB.mono; simp [flip]; grind)
       use b, hb₁
       intro i
       specialize hu i i.2

--- a/QuantumInfo/ForMathlib/ULift.lean
+++ b/QuantumInfo/ForMathlib/ULift.lean
@@ -19,20 +19,25 @@ instance ULift.instStar {𝕜 : Type u} [Star 𝕜] : Star (ULift.{v,u} 𝕜) wh
   star x := .up (star x.down)
 
 @[simp]
-theorem ULift.star_eq {𝕜 : Type u} [Star 𝕜] (x : ULift.{v,u} 𝕜) : star x = .up (star x.down) := by
+theorem ULift.star_eq {𝕜 : Type u} [Star 𝕜] (x : ULift.{v,u} 𝕜) :
+    star x = .up (star x.down) := by
   rfl
 
-instance ULift.instInvolutiveStar {𝕜 : Type u} [InvolutiveStar 𝕜] : InvolutiveStar (ULift.{v,u} 𝕜) where
+instance ULift.instInvolutiveStar {𝕜 : Type u} [InvolutiveStar 𝕜] :
+    InvolutiveStar (ULift.{v,u} 𝕜) where
   star_involutive x := by simp
 
-instance ULift.instStarMul {𝕜 : Type u} [Mul 𝕜] [StarMul 𝕜] : StarMul (ULift.{v,u} 𝕜) where
+instance ULift.instStarMul {𝕜 : Type u} [Mul 𝕜] [StarMul 𝕜] :
+    StarMul (ULift.{v,u} 𝕜) where
   star_mul x y := by simp; rfl
 
-instance {𝕜 : Type u} [NonUnitalNonAssocSemiring 𝕜] [StarRing 𝕜] : StarRing (ULift.{v,u} 𝕜) where
+instance {𝕜 : Type u} [NonUnitalNonAssocSemiring 𝕜] [StarRing 𝕜] :
+    StarRing (ULift.{v,u} 𝕜) where
   star_add x y := by simp; rfl
 
 @[simp]
-theorem ULift.starRingEnd_down {𝕜 : Type u} (x : ULift.{v,u} 𝕜) [CommSemiring 𝕜] [StarRing 𝕜] :
+theorem ULift.starRingEnd_down {𝕜 : Type u} (x : ULift.{v,u} 𝕜) [CommSemiring 𝕜]
+    [StarRing 𝕜] :
     ((starRingEnd (ULift.{v, u} 𝕜)) x).down = star x.down := by
   rfl
 

--- a/QuantumInfo/ForMathlib/Unitary.lean
+++ b/QuantumInfo/ForMathlib/Unitary.lean
@@ -35,7 +35,9 @@ theorem unitary_apply_star_eq (U : unitary (E →ₗ[𝕜] E)) (v : E) :
 
 /-- Conjugating a linear map by a unitary operator gives a map whose μ-eigenspace is
   isomorphic (same dimension) as those of the original linear map. -/
-noncomputable def conj_unitary_eigenspace_equiv (T : E →ₗ[𝕜] E) (U : unitary (E →ₗ[𝕜] E)) (μ : 𝕜) :
+noncomputable def conj_unitary_eigenspace_equiv (T : E →ₗ[𝕜] E)
+    (U : unitary (E →ₗ[𝕜] E))
+    (μ : 𝕜) :
     eigenspace T μ ≃ₗ[𝕜] eigenspace (U.val * T * star (U.val)) μ where
   toFun v := ⟨U.val v.val, by
     have hv := v.2

--- a/QuantumInfo/Measurements/POVM.lean
+++ b/QuantumInfo/Measurements/POVM.lean
@@ -13,16 +13,17 @@ public import QuantumInfo.Channels.Unbundled
 
 /-! # Positive Operator-Valued Measures
 
-A Positive Operator-Valued Measures, or POVM, is the most general notion of a quantum "measurement":
-a collection of positive semidefinite (PSD) operators that sum to the identity. These induce a distribution,
-`POVM.measure`, of measurement outcomes; and they induce a CPTP map, `POVM.measurement_map`, which changes the state
-but adds learned information.
+A Positive Operator-Valued Measures, or POVM, is the most general notion of a quantum
+"measurement": a collection of positive semidefinite (PSD) operators that sum to the identity.
+These induce a distribution, `POVM.measure`, of measurement outcomes; and they induce a CPTP map,
+`POVM.measurement_map`, which changes the state but adds learned information.
 
-Developing this theory is important if one wants to discuss classical information across quantum channels, as POVMs
-are the route to get back to classical information (a `ProbDistribution` of outcomes).
+Developing this theory is important if one wants to discuss classical information across quantum
+channels, as POVMs are the route to get back to classical information (a `ProbDistribution` of
+outcomes).
 
-TODO: They can also evolve under CPTP maps themselves (the Heisenberg picture of quantum evolution), they might commute
-with each other or not, they might be projective or not.
+TODO: They can also evolve under CPTP maps themselves (the Heisenberg picture of quantum
+evolution), they might commute with each other or not, they might be projective or not.
 -/
 
 @[expose] public section
@@ -56,7 +57,9 @@ state to an `d × X`-dimensional quantum-classical state. -/
 def measurementMap (Λ : POVM X d) : CPTPMap d (d × X) where
   toLinearMap :=
     ∑ (x : X), open Kronecker in {
-      toFun := fun ρ ↦ ((((Λ.mats x) ^ (1/2:ℝ)).mat * ρ * ((Λ.mats x)^(1/2:ℝ)).mat) ⊗ₖ Matrix.single x x 1)
+      toFun := fun ρ ↦
+        ((((Λ.mats x) ^ (1/2:ℝ)).mat * ρ * ((Λ.mats x)^(1/2:ℝ)).mat)
+          ⊗ₖ Matrix.single x x 1)
       map_add' := by simp [mul_add, add_mul, Matrix.kroneckerMap_add_left]
       map_smul' := by simp [Matrix.smul_kronecker]
     }
@@ -65,7 +68,8 @@ def measurementMap (Λ : POVM X d) : CPTPMap d (d × X) where
     · exact fun _ _ ha ↦ ha.add
     · exact MatrixMap.IsCompletelyPositive.zero _ _
     · intro x _
-      --Note: this map M₁ would do as well as an object on its own, it's "measure and forget the result".
+      --Note: this map M₁ would do as well as an object on its own, it's "measure and forget the
+      --result".
       let M₁ : MatrixMap d d ℂ := ⟨⟨
         fun ρ ↦ ((Λ.mats x) ^ (1/2:ℝ)).mat * ρ * ((Λ.mats x)^(1/2:ℝ)).mat,
         by simp [mul_add, add_mul]⟩,
@@ -102,7 +106,8 @@ def measurementMap (Λ : POVM X d) : CPTPMap d (d × X) where
 open Kronecker in
 theorem measurementMap_apply_matrix (Λ : POVM X d) (m : Matrix d d ℂ) :
   Λ.measurementMap.map m =  ∑ x : X,
-    ((((Λ.mats x) ^ (1/2:ℝ)).mat * m * ((Λ.mats x)^(1/2:ℝ)).mat) ⊗ₖ Matrix.single x x 1) := by
+    ((((Λ.mats x) ^ (1/2:ℝ)).mat * m * ((Λ.mats x)^(1/2:ℝ)).mat)
+      ⊗ₖ Matrix.single x x 1) := by
   dsimp [measurementMap, HPMap.map]
   rw [LinearMap.sum_apply]
   rfl
@@ -111,7 +116,8 @@ open HermitianMat in
 theorem measurementMap_apply_hermitianMat (Λ : POVM X d) (m : HermitianMat d ℂ) :
   Λ.measurementMap.toHPMap m = ∑ x : X,
     --TODO: Something like `HermitianMat.single` to make this better
-    ((m.conj ((Λ.mats x)^(1/2:ℝ)).mat : HermitianMat d ℂ) ⊗ₖ HermitianMat.diagonal ℂ (fun y ↦ ite (x = y) 1 0)) := by
+    ((m.conj ((Λ.mats x)^(1/2:ℝ)).mat : HermitianMat d ℂ)
+      ⊗ₖ HermitianMat.diagonal ℂ (fun y ↦ ite (x = y) 1 0)) := by
   ext1
   convert Λ.measurementMap_apply_matrix m.mat
   simp only [conj_apply, conjTranspose_mat, HermitianMat.mat_finset_sum,
@@ -129,7 +135,8 @@ def measure (Λ : POVM X d) (ρ : MState d) : ProbDistribution X := .mk'
       simp [HermitianMat.inner_eq_re_trace, ← Complex.re_sum, ← trace_sum, ← Finset.sum_mul,
         ← HermitianMat.mat_finset_sum, Λ.normalized])
 
-/-- The quantum-classical `POVM.measurement_map`, gives a marginal on the right equal to `POVM.measure`.-/
+/-- The quantum-classical `POVM.measurement_map`, gives a marginal on the right equal to
+`POVM.measure`.-/
 theorem traceLeft_measurementMap_eq_measure (Λ : POVM X d) (ρ : MState d) :
     (Λ.measurementMap ρ).traceLeft = MState.ofClassical (Λ.measure ρ) := by
   open Kronecker in
@@ -146,8 +153,8 @@ theorem traceLeft_measurementMap_eq_measure (Λ : POVM X d) (ρ : MState d) :
   simp only [HermitianMat.diagonal, HermitianMat.mat_mk, diagonal_apply]
   symm; split
   · subst j
-    simp only [measure, ProbDistribution.mk', ProbDistribution.funlike_apply, and_self, Finset.sum_ite_eq',
-      Finset.mem_univ, ↓reduceIte]
+    simp only [measure, ProbDistribution.mk', ProbDistribution.funlike_apply, and_self,
+      Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
     change _ = Matrix.trace _
     rw [Matrix.trace_mul_cycle, HermitianMat.pow_half_mul (Λ.nonneg i)]
     exact HermitianMat.inner_eq_trace_rc _ _

--- a/QuantumInfo/Operators/Unitary.lean
+++ b/QuantumInfo/Operators/Unitary.lean
@@ -9,8 +9,8 @@ public import QuantumInfo.States.Mixed.MState
 
 /-! # Unitary operators on quantum state
 
-This file is intended for lemmas about unitary matrices (`Matrix.unitaryGroup`) and how they apply to
-`Bra`s, `Ket`s, and `MState` mixed states.
+This file is intended for lemmas about unitary matrices (`Matrix.unitaryGroup`) and how they apply
+to `Bra`s, `Ket`s, and `MState` mixed states.
 
 This is imported by `CPTPMap` to define things like unitary channels, Kraus operators, and
 complementary channels, so this file itself does not discuss channels yet. -/
@@ -51,13 +51,14 @@ theorem U_conj_spectrum_eq (ρ : MState d) (U : 𝐔[d]) :
   simp [spectrum, U_conj]
 
 @[simp]
-theorem inner_U_conj (ρ σ : MState d) (U : 𝐔[d]) : ⟪U ◃ ρ, U ◃ σ⟫_Prob = ⟪ρ, σ⟫_Prob := by
+theorem inner_U_conj (ρ σ : MState d) (U : 𝐔[d]) :
+    ⟪U ◃ ρ, U ◃ σ⟫_Prob = ⟪ρ, σ⟫_Prob := by
   simp [U_conj, inner_def]
 
-/-- The **No-cloning theorem**, saying that if states `ψ` and `φ` can both be perfectly cloned using a
-unitary `U` and a fiducial state `f`, and they aren't identical (their inner product is less than 1),
-then the two states must be orthogonal to begin with. In short: only orthogonal states can be simultaneously
-cloned. -/
+/-- The **No-cloning theorem**, saying that if states `ψ` and `φ` can both be perfectly cloned
+using a unitary `U` and a fiducial state `f`, and they aren't identical (their inner product is
+less than 1), then the two states must be orthogonal to begin with. In short: only orthogonal
+states can be simultaneously cloned. -/
 theorem no_cloning {U : 𝐔[d × d]}
   (hψ : U ◃ pure (ψ ⊗ᵠ f) = pure (ψ ⊗ᵠ ψ))
   (hφ : U ◃ pure (φ ⊗ᵠ f) = pure (φ ⊗ᵠ φ))
@@ -65,11 +66,14 @@ theorem no_cloning {U : 𝐔[d × d]}
     ⟪pure ψ, pure φ⟫_Prob = (0 : ℝ) := by
   set ρψ := pure ψ
   set ρφ := pure φ
-  have h1 : ⟪ρψ, ρφ⟫_Prob * ⟪ρψ, ρφ⟫_Prob = ⟪pure (ψ ⊗ᵠ ψ), pure (φ ⊗ᵠ φ)⟫_Prob := by
+  have h1 : ⟪ρψ, ρφ⟫_Prob * ⟪ρψ, ρφ⟫_Prob =
+      ⟪pure (ψ ⊗ᵠ ψ), pure (φ ⊗ᵠ φ)⟫_Prob := by
     grind only [pure_prod_pure, prod_inner_prod]
-  have h2 : (⟪pure (ψ ⊗ᵠ ψ), pure (φ ⊗ᵠ φ)⟫_Prob : ℝ) = ⟪U ◃ pure (ψ ⊗ᵠ f), U ◃ pure (φ ⊗ᵠ f)⟫_Prob := by
+  have h2 : (⟪pure (ψ ⊗ᵠ ψ), pure (φ ⊗ᵠ φ)⟫_Prob : ℝ) =
+      ⟪U ◃ pure (ψ ⊗ᵠ f), U ◃ pure (φ ⊗ᵠ f)⟫_Prob := by
     grind only [pure_prod_pure]
-  replace h2 : ((pure (ψ ⊗ᵠ ψ)).m * (pure (φ ⊗ᵠ φ)).m).trace.re = (ρψ.m * ρφ.m).trace.re := by
+  replace h2 : ((pure (ψ ⊗ᵠ ψ)).m * (pure (φ ⊗ᵠ φ)).m).trace.re =
+      (ρψ.m * ρφ.m).trace.re := by
     convert ← h2
     simp +zetaDelta only [inner_U_conj, pure_prod_pure, prod]
     simp [inner, ← Matrix.mul_kronecker_mul, pure_mul_self,

--- a/QuantumInfo/Regularized.lean
+++ b/QuantumInfo/Regularized.lean
@@ -37,7 +37,9 @@ variable {fn : ℕ → T} {_lb _ub : T} {hl : ∀ n, _lb ≤ fn n} {hu : ∀ n, 
 /-- The `InfRegularized` value is also lower bounded. -/
 theorem lb : _lb ≤ InfRegularized fn hl hu := by
   convert le_csSup ?_ ?_;
-  · exact ⟨ _ub, fun a ha => by rcases Filter.eventually_atTop.mp ha with ⟨ n, hn ⟩ ; exact le_trans ( hn _ le_rfl ) ( hu _ ) ⟩;
+  · exact ⟨ _ub, fun a ha => by
+      rcases Filter.eventually_atTop.mp ha with ⟨ n, hn ⟩ ;
+      exact le_trans ( hn _ le_rfl ) ( hu _ ) ⟩;
   · aesop
 
 /-- The `InfRegularized` value is also upper bounded. -/
@@ -55,8 +57,12 @@ theorem anti_inf (h : Antitone fn) :
   rw [ @csSup_eq_of_forall_le_of_forall_lt_exists_gt ];
   · exact ⟨ _, ⟨ 0, fun n _ => hl n ⟩ ⟩;
   · rintro a ⟨ n, hn ⟩;
-    exact le_csInf ⟨ _, Set.mem_range_self n ⟩ fun x hx => by rcases hx with ⟨ m, rfl ⟩ ; exact hn _ ( le_max_left _ _ ) |> le_trans <| h <| le_max_right _ _;
-  · exact fun w hw => ⟨ _, ⟨ 0, fun n _ => csInf_le ⟨ _lb, Set.forall_mem_range.2 hl ⟩ ⟨ n, rfl ⟩ ⟩, hw ⟩
+    exact le_csInf ⟨ _, Set.mem_range_self n ⟩ fun x hx => by
+      rcases hx with ⟨ m, rfl ⟩ ;
+      exact hn _ ( le_max_left _ _ ) |> le_trans <| h <| le_max_right _ _;
+  · exact fun w hw =>
+      ⟨ _,
+        ⟨ 0, fun n _ => csInf_le ⟨ _lb, Set.forall_mem_range.2 hl ⟩ ⟨ n, rfl ⟩ ⟩, hw ⟩
 
 /-- For `Antitone` functions, the `InfRegularized` is lower bounded by
   any particular value. -/
@@ -66,7 +72,8 @@ theorem anti_ub (h : Antitone fn) : ∀ n, InfRegularized fn hl hu ≤ fn n := b
     convert csSup_le _ _;
     · exact ⟨ _lb, Filter.eventually_atTop.2 ⟨ 0, fun n hn => hl n ⟩ ⟩;
     · simp +zetaDelta at *;
-      exact fun b x hx => le_trans ( hx ( Max.max x n ) ( le_max_left _ _ ) ) ( h ( le_max_right _ _ ) )
+      exact fun b x hx =>
+        le_trans ( hx ( Max.max x n ) ( le_max_left _ _ ) ) ( h ( le_max_right _ _ ) )
   exact h_inf_le
 
 end InfRegularized
@@ -77,9 +84,11 @@ variable {fn : ℕ → T} {_lb _ub : T} {hl : ∀ n, _lb ≤ fn n} {hu : ∀ n, 
 
 /-- The `SupRegularized` value is also lower bounded. -/
 theorem lb : _lb ≤ SupRegularized fn hl hu := by
-  -- Suppose, for contradiction, that $\mathrm{InfRegularized} \; fn < \mathrm{SupRegularized} \; fn$.
+  -- Suppose, for contradiction, that
+  -- $\mathrm{InfRegularized} \; fn < \mathrm{SupRegularized} \; fn$.
   by_contra h_contra;
-  -- By definition of `SupRegularized`, we have that $\mathrm{SupRegularized} \; fn \geq \mathrm{InfRegularized} \; fn$.
+  -- By definition of `SupRegularized`, we have that
+  -- $\mathrm{SupRegularized} \; fn \geq \mathrm{InfRegularized} \; fn$.
   have h_sup_ge_inf : SupRegularized fn hl hu ≥ InfRegularized fn hl hu := by
     apply_rules [ Filter.liminf_le_limsup ];
     · exact ⟨ _ub, Filter.eventually_atTop.2 ⟨ 0, fun n hn => hu n ⟩ ⟩;
@@ -88,7 +97,8 @@ theorem lb : _lb ≤ SupRegularized fn hl hu := by
 
 /-- The `SupRegularized` value is also upper bounded. -/
 theorem ub : SupRegularized fn hl hu ≤ _ub := by
-  -- By definition of `limsup`, we know that for any `ε > 0`, there exists an `N` such that for all `n ≥ N`, `fn n ≤ _ub + ε`.
+  -- By definition of `limsup`, we know that for any `ε > 0`, there exists an `N` such that
+  -- for all `n ≥ N`, `fn n ≤ _ub + ε`.
   apply csInf_le;
   · exact ⟨ _, fun x hx => hx.exists.choose_spec.trans' ( hl _ ) ⟩;
   · aesop
@@ -101,11 +111,14 @@ theorem mono_sup (h : Monotone fn) :
   refine' le_antisymm _ _;
   · refine' csInf_le _ _;
     · exact ⟨ _lb, by rintro x ⟨ n, hn ⟩ ; exact le_trans ( hl n ) ( hn n le_rfl ) ⟩;
-    · exact ⟨ 0, fun n _ => le_csSup ⟨ _ub, by rintro x ⟨ m, rfl ⟩ ; exact hu m ⟩ ⟨ n, rfl ⟩ ⟩;
+    · exact ⟨ 0, fun n _ => le_csSup ⟨ _ub, by
+        rintro x ⟨ m, rfl ⟩ ; exact hu m ⟩ ⟨ n, rfl ⟩ ⟩;
   · refine' csSup_le _ _;
     · exact ⟨ _, ⟨ 0, rfl ⟩ ⟩;
     · norm_num +zetaDelta at *;
-      exact fun n => le_csInf ⟨ _ub, ⟨ n, fun m hm => hu m ⟩ ⟩ fun x hx => by rcases hx with ⟨ m, hm ⟩ ; exact hm _ ( le_max_left _ _ ) |> le_trans ( h ( le_max_right _ _ ) ) ;
+      exact fun n => le_csInf ⟨ _ub, ⟨ n, fun m hm => hu m ⟩ ⟩ fun x hx => by
+        rcases hx with ⟨ m, hm ⟩ ;
+        exact hm _ ( le_max_left _ _ ) |> le_trans ( h ( le_max_right _ _ ) ) ;
 
 /-- For `Monotone` functions, the `SupRegularized` is lower bounded by
   any particular value. -/
@@ -128,7 +141,8 @@ private def realNegOrderIso : ℝ ≃o ℝᵒᵈ where
     change (-b : ℝ) ≤ -a ↔ a ≤ b
     simpa using neg_le_neg_iff
 
-private theorem limsup_eq_neg_liminf_neg {fn : ℕ → ℝ} {_lb _ub : ℝ}Expand commentComment on line R131Resolved
+private theorem limsup_eq_neg_liminf_neg {fn : ℕ → ℝ}
+    {_lb _ub : ℝ}Expand commentComment on line R131Resolved
     (hl : ∀ n, _lb ≤ fn n) (hu : ∀ n, fn n ≤ _ub) :
     Filter.atTop.limsup fn = -Filter.atTop.liminf (fun n => -fn n) := by
   have hneg : -Filter.atTop.limsup fn = Filter.atTop.liminf (fun n => -fn n) := by
@@ -137,7 +151,8 @@ private theorem limsup_eq_neg_liminf_neg {fn : ℕ → ℝ} {_lb _ub : ℝ}Expan
         (Filter.Eventually.of_forall hu))
       (hu_co := Filter.isCoboundedUnder_le_of_le Filter.atTop hl)
       (hgu := Filter.isBoundedUnder_of_eventually_le (α := ℝᵒᵈ) (f := Filter.atTop)
-        (u := fun n => (-fn n : ℝᵒᵈ)) (Filter.Eventually.of_forall fun n => neg_le_neg (hu n)))
+        (u := fun n => (-fn n : ℝᵒᵈ))
+        (Filter.Eventually.of_forall fun n => neg_le_neg (hu n)))
       (hgu_co := Filter.isCoboundedUnder_le_of_le (α := ℝᵒᵈ) Filter.atTop
         (f := fun n => (-fn n : ℝᵒᵈ)) (x := (-_lb : ℝᵒᵈ)) fun n => neg_le_neg (hl n))
     simpa [Filter.limsup, Filter.liminf, Filter.limsSup, Filter.limsInf, realNegOrderIso] using

--- a/QuantumInfo/ResourceTheory/FreeState.lean
+++ b/QuantumInfo/ResourceTheory/FreeState.lean
@@ -45,7 +45,8 @@ class ResourcePretheory (ι : Type*) extends Semigroup ι where
   [NonemptyH : ∀ i, Nonempty (H i)]
   /-- The product structure induces an isomorphism of Hilbert spaces -/
   prodEquiv i j : H (i * j) ≃ (H i) × (H j)
-  --Possible we want some fact like the associativity of `prod` or the existence of an identity space,
+  --Possible we want some fact like the associativity of `prod` or the existence of an identity
+  -- space,
   -- which would then imply MonoidalCategory structure later (instead of just Category). For now we
   -- take the (logically equivalent, in the appropriate model) assumption that the associator is
   -- actually an equality. This is captured in the `Semigroup ι` assumption. If we wanted to turn
@@ -93,8 +94,8 @@ theorem prodRelabel_assoc (ρ₁ : MState (H i)) (ρ₂ : MState (H j)) (ρ₃ :
   rw [MState.relabel_comp, MState.relabel_comp, MState.relabel_comp]
   rfl
 
-/-- A `MState.relabel` can be distributed across a `prodRelabel`, if you have proofs that the factors
-correspond correctly. -/
+/-- A `MState.relabel` can be distributed across a `prodRelabel`, if you have proofs that the
+factors correspond correctly. -/
 theorem prodRelabel_relabel_cast_prod
     (ρ₁ : MState (H i)) (ρ₂ : MState (H j))
     (h : H (k * l) = H (i * j)) (hik : k = i) (hlj : l = j) :
@@ -104,11 +105,12 @@ theorem prodRelabel_relabel_cast_prod
   subst hlj
   rfl
 
-/-- The `prod` operation of `ResourcePretheory` gives the natural product operation on `CPTPMap`s. Accessible
-by the notation `M₁ ⊗ᶜᵖᵣ M₂`. -/
+/-- The `prod` operation of `ResourcePretheory` gives the natural product operation on `CPTPMap`s.
+Accessible by the notation `M₁ ⊗ᶜᵖᵣ M₂`. -/
 noncomputable def prodCPTPMap (M₁ : CPTPMap (H i) (H j)) (M₂ : CPTPMap (H k) (H l)) :
     CPTPMap (H (i * k)) (H (j * l)) :=
-  (CPTPMap.ofEquiv (prodEquiv j l).symm).compose ((M₁ ⊗ᶜᵖ M₂).compose (CPTPMap.ofEquiv (prodEquiv i k)))
+  (CPTPMap.ofEquiv (prodEquiv j l).symm).compose
+    ((M₁ ⊗ᶜᵖ M₂).compose (CPTPMap.ofEquiv (prodEquiv i k)))
 
 @[inherit_doc]
 scoped notation M₁ " ⊗ᶜᵖᵣ " M₂ => prodCPTPMap M₁ M₂
@@ -343,10 +345,11 @@ theorem sandwichedRelRentropy_statePow {α : ℝ} (ρ σ : MState (H i)) (n : �
 
 end UnitalPretheory
 
-/- FreeStateTheories: theories defining some sets of "free states" within a collection of Hilbert spaces. -/
+/- FreeStateTheories: theories defining some sets of "free states" within a collection of Hilbert
+spaces. -/
 
-/-- A `FreeStateTheory` is a collection of mixed states (`MState`s) in a `ResourcePretheory` that obeys
-some necessary axioms:
+/-- A `FreeStateTheory` is a collection of mixed states (`MState`s) in a `ResourcePretheory` that
+obeys some necessary axioms:
  * For each Hilbert space `H i`, the free states are a closed, convex set
  * For each Hilbert space `H i`, there is a free state of full rank
  * If `ρᵢ ∈ H i` and `ρⱼ ∈ H j` are free, then `ρᵢ ⊗ ρⱼ` is free in `H (prod i j)`.
@@ -359,8 +362,10 @@ class FreeStateTheory (ι : Type*) extends ResourcePretheory ι where
   /-- The set F(H) of free states is convex (more precisely, their matrices are) -/
   free_convex : Convex ℝ (MState.M '' (@IsFree i))
   /-- The set of free states is closed under tensor product -/
-  free_prod {ρ₁ : MState (H i)} {ρ₂ : MState (H j)} (h₁ : IsFree ρ₁) (h₂ : IsFree ρ₂) : IsFree (ρ₁ ⊗ᵣ ρ₂)
-  /-- The set F(H) of free states contains a full-rank state `ρfull`, equivalently `ρfull` is positive definite. -/
+  free_prod {ρ₁ : MState (H i)} {ρ₂ : MState (H j)} (h₁ : IsFree ρ₁) (h₂ : IsFree ρ₂) :
+    IsFree (ρ₁ ⊗ᵣ ρ₂)
+  /-- The set F(H) of free states contains a full-rank state `ρfull`, equivalently `ρfull` is
+  positive definite. -/
   free_fullRank (i : ι) : open ComplexOrder in ∃ (ρ : MState (H i)), ρ.m.PosDef ∧ IsFree ρ
 
 namespace FreeStateTheory
@@ -384,7 +389,8 @@ theorem IsCompact_IsFree : IsCompact (IsFree (i := i)) :=
 -- is one, the only relevant property here is `free_convex`.
 theorem IsFree.mix {ι : Type*} [FreeStateTheory ι] {i : ι} {σ₁ σ₂ : MState (H i)}
     (hσ₁ : IsFree σ₁) (hσ₂ : IsFree σ₂) (p : Prob) : IsFree (p [σ₁ ↔ σ₂]) := by
-  obtain ⟨m, hm₁, hm₂⟩ := free_convex (i := i) ⟨σ₁, hσ₁, rfl⟩ ⟨σ₂, hσ₂, rfl⟩ p.zero_le (1 - p).zero_le (by simp)
+  obtain ⟨m, hm₁, hm₂⟩ :=
+    free_convex (i := i) ⟨σ₁, hσ₁, rfl⟩ ⟨σ₂, hσ₂, rfl⟩ p.zero_le (1 - p).zero_le (by simp)
   simp [Mixable.mix, Mixable.mix_ab, MState.instMixable]
   simp at hm₂
   convert ← hm₁
@@ -503,11 +509,12 @@ theorem RelativeEntResource.tendsto_ennreal (ρ : MState (H i)) :
 noncomputable def GlobalRobustness {i : ι} : MState (H i) → ℝ≥0 :=
   fun ρ ↦ sInf {s | ∃ σ, (⟨1 / (1+s), by bound⟩ [ρ ↔ σ]) ∈ IsFree}
 
-/-- A sequence of operations `f_n` is asymptotically nongenerating if `lim_{n→∞} RG(f_n(ρ_n)) = 0`, where
-RG is `GlobalRobustness` and `ρ_n` is any sequence of free states. Equivalently, we can take the `max` (
-over operations and states) on the left-hand side inside the limit.
+/-- A sequence of operations `f_n` is asymptotically nongenerating if `lim_{n→∞} RG(f_n(ρ_n)) = 0`,
+where RG is `GlobalRobustness` and `ρ_n` is any sequence of free states. Equivalently, we can take
+the `max` (over operations and states) on the left-hand side inside the limit.
 -/
-def IsAsymptoticallyNongenerating (dI dO : ι) (f : (n : ℕ) → CPTPMap (H (dI⊗^H[n])) (H (dO⊗^H[n]))) : Prop :=
+def IsAsymptoticallyNongenerating (dI dO : ι)
+    (f : (n : ℕ) → CPTPMap (H (dI⊗^H[n])) (H (dO⊗^H[n]))) : Prop :=
   ∀ (ρs : (n : ℕ) → MState (H (dI⊗^H[n]))), (∀ n, IsFree (ρs n)) →
   Filter.atTop.Tendsto (fun n ↦ GlobalRobustness ((f n) (ρs n))) (𝓝 0)
 

--- a/QuantumInfo/ResourceTheory/HypothesisTesting.lean
+++ b/QuantumInfo/ResourceTheory/HypothesisTesting.lean
@@ -22,13 +22,13 @@ public import QuantumInfo.Channels.Unbundled
 public import QuantumInfo.Measurements.POVM
 
 /-!
-Defines `OptimalHypothesisRate`, the optimal rate of distinguishing an `MState` ρ from a set of other
-mixed states `S`, with at most Type I error ε.
+Defines `OptimalHypothesisRate`, the optimal rate of distinguishing an `MState` ρ from a set of
+other mixed states `S`, with at most Type I error ε.
 
-That is to say: take a projective measurement (a `POVM`) with elements `{T, 1-T}`, where measuring `T`
-will mean we conclude our unknown state was ρ, and measuring `1-T` will mean we think the state was
-something in `S`. We only accept T's such that `Tr[(1-T)ρ] ≤ ε`, that is, we have at most an ε
-probability of incorrectly concluding it was ρ. The Type II error associated to this T is then
+That is to say: take a projective measurement (a `POVM`) with elements `{T, 1-T}`, where measuring
+`T` will mean we conclude our unknown state was ρ, and measuring `1-T` will mean we think the state
+was something in `S`. We only accept T's such that `Tr[(1-T)ρ] ≤ ε`, that is, we have at most an
+ε probability of incorrectly concluding it was ρ. The Type II error associated to this T is then
 `max_{σ ∈ S} Tr[T σ]`, that is, the (worst possible, over possible states) chance of incorrectly
 concluding our state was in `S`. Optimize over `T` to get the lowest possible Type II error rate,
 and the resulting error rate is `OptimalHypothesisRate ρ ε S`.
@@ -55,20 +55,24 @@ noncomputable def OptimalHypothesisRate (ρ : MState d) (ε : Prob) (S : Set (MS
   ⨅ T : { m : HermitianMat d ℂ // ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1},
     ⨆ σ ∈ S, ⟨_, σ.exp_val_prob T.prop.right⟩
 
-scoped[OptimalHypothesisRate] notation "β_" ε " (" ρ "‖" S ")" =>  OptimalHypothesisRate ρ ε S
+scoped[OptimalHypothesisRate] notation "β_" ε " (" ρ "‖" S ")" =>
+  OptimalHypothesisRate ρ ε S
 
 namespace OptimalHypothesisRate
 
-/-- The space of strategies `T` in `OptimalHypothesisRate` is inhabited, we always have some valid strategy. -/
+/-- The space of strategies `T` in `OptimalHypothesisRate` is inhabited, we always have some valid
+strategy. -/
 instance iInf_Inhabited (ρ : MState d) (ε : Prob) :
     Inhabited { m // ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1 } :=
   ⟨1, by simp⟩
 
-instance (ρ : MState d) (ε : Prob) : Inhabited {m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1} :=
+instance (ρ : MState d) (ε : Prob) :
+    Inhabited {m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1} :=
   iInf_Inhabited ρ ε
 
 /-- The space of strategies `T` in `OptimalHypothesisRate` is compact. -/
-theorem iInf_IsCompact (ρ : MState d) (ε : Prob) : IsCompact { m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1 } := by
+theorem iInf_IsCompact (ρ : MState d) (ε : Prob) :
+    IsCompact { m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1 } := by
   have hC₁ : IsCompact {m : HermitianMat d ℂ | 0 ≤ m ∧ m ≤ 1} :=
     HermitianMat.unitInterval_IsCompact
   have hC₂ : IsClosed {m | ρ.exp_val (1 - m) ≤ ε} := by
@@ -79,7 +83,8 @@ theorem iInf_IsCompact (ρ : MState d) (ε : Prob) : IsCompact { m | ρ.exp_val 
   exact hC₁.inter_left hC₂
 
 /-- The space of strategies `T` in `OptimalHypothesisRate` is convex. -/
-theorem iInf_IsConvex (ρ : MState d) (ε : Prob) : Convex ℝ { m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1 } := by
+theorem iInf_IsConvex (ρ : MState d) (ε : Prob) :
+    Convex ℝ { m | ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1 } := by
   --We *could* get this from a more general fact that any linear subspace is convex,
   --and the intersection of convex spaces is convex, and this is an intersection of
   --three convex spaces. That would be more broken-down and lemmaified.
@@ -188,9 +193,11 @@ theorem exists_min (ρ : MState d) (ε : Prob) (S : Set (MState d)):
       ∧ ρ.exp_val T = 1 - ε := by
   obtain ⟨T, hT₁, hT₂⟩ := exists_min' ρ ε S
 
-  --Instead of just `use T`, we (may) have to reduce it so that it saturates the ⟪ρ,T⟫ = 1 - ε bound.
+  --Instead of just `use T`, we (may) have to reduce it so that it saturates the ⟪ρ,T⟫ = 1 - ε
+  --bound.
   --We do this by multiplying it by a scalar less than 1 to get a `T'`. Since this operator is less
-  --than T, it's still optimal in terms of achieving `β_ ε(ρ‖S)`, but it can get the `1 - ε` bound instead.
+  --than T, it's still optimal in terms of achieving `β_ ε(ρ‖S)`, but it can get the `1 - ε`
+  --bound instead.
   set δ := ρ.exp_val ↑T - (1 - ε)-- with δ_def
   by_cases hδ : δ = 0
   · use T, hT₁
@@ -294,7 +301,8 @@ theorem Lemma3 {ρ : MState d} (ε : Prob) {S : Set (MState d)} (hS₁ : IsCompa
   have hT'₃ : T'.Nonempty := Set.Nonempty.of_subtype
 
   ext1 --turn it from Prob equality into ℝ equality
-  convert LinearMap.BilinForm.minimax' (M := HermitianMat d ℂ) f S' T' hS'₁ hT'₁ hS₂ hT'₂ hS'₃ hT'₃
+  convert LinearMap.BilinForm.minimax' (M := HermitianMat d ℂ) f S' T'
+    hS'₁ hT'₁ hS₂ hT'₂ hS'₃ hT'₃
   --The remaining twiddling is about moving the casts inside the iInf's and iSup's.
   --In a better world, this would be mostly handled by some clever simps or push_cast's.
   · have hi := iSup_range' (ι := S) (fun x ↦ ⨅ (y : T'), (f x) ↑y) (·)
@@ -309,10 +317,12 @@ theorem Lemma3 {ρ : MState d} (ε : Prob) {S : Set (MState d)} (hS₁ : IsCompa
     rw [← iSup_subtype'', Set.Icc.coe_iSup zero_le_one, hi]
     rfl
 
---Maybe should be phrased in terms of `0 < ...` instead? Maybe belongs in another file? It's kiinnnd of specialized..
+--Maybe should be phrased in terms of `0 < ...` instead? Maybe belongs in another file? It's kiinnnd
+--of specialized..
 theorem ker_diagonal_prob_eq_bot {q : Prob} (hq₁ : 0 < q) (hq₂ : q < 1) :
     HermitianMat.ker (.diagonal ℂ (ProbDistribution.coin q ·)) = ⊥ := by
-  have hA : (Matrix.toLin' (HermitianMat.diagonal ℂ (ProbDistribution.coin q ·)).mat).ker = ⊥ := by
+  have hA : (Matrix.toLin' (HermitianMat.diagonal ℂ (ProbDistribution.coin q ·)).mat).ker = ⊥
+      := by
     apply Matrix.PosDef.toLin_ker_eq_bot
     apply Matrix.PosDef.diagonal
     intro i; fin_cases i
@@ -336,7 +346,8 @@ theorem optimalHypothesisRate_antitone (ρ σ : MState d) (ℰ : CPTPMap d d₂)
     β_ ε(ρ‖{σ}) ≤ β_ ε(ℰ ρ‖{ℰ σ}) := by
   simp only [of_singleton]
   obtain ⟨ℰdualSubtype, h⟩ :
-      ∃ e : ({ m : HermitianMat d₂ ℂ // (ℰ ρ).exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1} →
+      ∃ e : ({ m : HermitianMat d₂ ℂ //
+          (ℰ ρ).exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1} →
       { m : HermitianMat d ℂ // ρ.exp_val (1 - m) ≤ ε ∧ 0 ≤ m ∧ m ≤ 1}),
       ∀ x, e x = ℰ.hermDual x
        := by
@@ -360,15 +371,17 @@ set_option backward.isDefEq.respectTransparency false in
 /-- This is from [Strong converse exponents for a quantum channel discrimination problem
 and quantum-feedback-assisted communication](https://doi.org/10.1007/s00220-016-2645-4), Lemma 5.
 
-It seems like this is actually true for all 0 < α (with appropriate modifications at α = 1), but we only need
-it for the case of 1 < α.
+It seems like this is actually true for all 0 < α (with appropriate modifications at α = 1), but
+we only need it for the case of 1 < α.
 -/
 theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα : 1 < α) :
     —log β_ ε(ρ‖{σ}) ≤ D̃_ α(ρ‖σ) + —log (1 - ε) *
-      (.ofNNReal ⟨α, zero_le_one.trans hα.le⟩) / (.ofNNReal ⟨α - 1, sub_nonneg_of_le hα.le⟩)
+      (.ofNNReal ⟨α, zero_le_one.trans hα.le⟩) /
+        (.ofNNReal ⟨α - 1, sub_nonneg_of_le hα.le⟩)
     := by
   generalize_proofs pf1 pf2
-  --If ρ isn't in the support of σ, the right hand side is just ⊤. (The left hand side is not, necessarily!)
+  --If ρ isn't in the support of σ, the right hand side is just ⊤. (The left hand side is not,
+  --necessarily!)
   by_cases h_supp : σ.M.ker ≤ ρ.M.ker
   swap
   · simp [SandwichedRelRentropy, h_supp, zero_lt_one.trans hα]
@@ -392,7 +405,8 @@ theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα 
   -/
   -- The "monotonicity of the ..." part here refers to the data processing inequality, and
   -- the (p, 1-p) and (q,1-q) refer to states which are qubits ("coins") of probability p and
-  -- q, respectively. The states ρ and σ can be "processed" into these coins by measuring the optimal T.
+  -- q, respectively. The states ρ and σ can be "processed" into these coins by measuring the
+  -- optimal T.
 
   have h₂ : 0 < 1 - ε.val := by
     change ε.val < 1 at hε
@@ -408,7 +422,8 @@ theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα 
   --from the main proof.
   have hq : 0 < q := pos_of_lt_one {σ} ⟨σ, rfl, h_supp⟩ hε
 
-  suffices —log q ≤ D̃_ α(p2‖q2) + —log (1 - ε) * (.ofNNReal ⟨α, pf1⟩) / (.ofNNReal ⟨α - 1, pf2⟩) by
+  suffices —log q ≤ D̃_ α(p2‖q2) +
+      —log (1 - ε) * (.ofNNReal ⟨α, pf1⟩) / (.ofNNReal ⟨α - 1, pf2⟩) by
     refine this.trans (add_le_add_left ?_ _)
     --Show that this is an instance of the Data Processing Inequality
     obtain ⟨Φ, hΦ₁, hΦ₂⟩ : ∃ (Φ : CPTPMap d (Fin 2)), p2 = Φ ρ ∧ q2 = Φ σ := by
@@ -436,7 +451,8 @@ theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα 
         rw [ProbDistribution.coin_eq_iff]
         ext
         dsimp [MState.exp_val] at hT₂
-        simp [POVM.measure, Λ, p, ProbDistribution.mk', coe_one_minus, ← hT₂, HermitianMat.inner_comm]
+        simp [POVM.measure, Λ, p, ProbDistribution.mk', coe_one_minus, ← hT₂,
+          HermitianMat.inner_comm]
       · congr
         rw [ProbDistribution.coin_eq_iff]
         ext
@@ -459,8 +475,8 @@ theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα 
   rw [SandwichedRelRentropy, dif_pos (zero_lt_one.trans hα), dif_pos ?_]; swap
   · suffices q2.M.ker = ⊥ by
       simp only [this, bot_le]
-    --q2 has eigenvalues β_ ε(ρ‖{σ}) and 1-β_ ε(ρ‖{σ}), so as long as β_ ε(ρ‖{σ}) isn't 0 or 1,
-    --this is true.
+    --q2 has eigenvalues β_ ε(ρ‖{σ}) and 1-β_ ε(ρ‖{σ}), so as long as
+    --β_ ε(ρ‖{σ}) isn't 0 or 1, this is true.
     exact ker_diagonal_prob_eq_bot hq hq₂
 
   conv => enter [2, 1, 1, 1]; rw [if_neg hα.ne']
@@ -530,8 +546,10 @@ theorem Ref81Lem5 (ρ σ : MState d) (ε : Prob) (hε : ε < 1) (α : ℝ) (hα 
     · exact sub_nonneg_of_le q.2.2
 
 set_option backward.isDefEq.respectTransparency false in
-theorem rate_pos_of_smul_pos {ε : Prob} {d : Type*} [Fintype d] [DecidableEq d] {ρ σ₁ σ₂ : MState d}
-    (hσ₂ : 0 < β_ ε(ρ‖{σ₂})) {c : ℝ} (hc : 0 < c) (hσ : c • σ₂ ≤ σ₁.M) : 0 < β_ ε(ρ‖{σ₁}) := by
+theorem rate_pos_of_smul_pos {ε : Prob} {d : Type*} [Fintype d] [DecidableEq d]
+    {ρ σ₁ σ₂ : MState d}
+    (hσ₂ : 0 < β_ ε(ρ‖{σ₂})) {c : ℝ} (hc : 0 < c) (hσ : c • σ₂ ≤ σ₁.M) :
+    0 < β_ ε(ρ‖{σ₁}) := by
   simp only [of_singleton, lt_iInf_iff] at hσ₂ ⊢
   rcases hσ₂ with ⟨⟨b, _, hb_le⟩, hb_pos, hb⟩
   simp only [← Subtype.coe_lt_coe, Prob.coe_zero] at hb_pos
@@ -548,7 +566,8 @@ theorem rate_pos_of_smul_pos {ε : Prob} {d : Type*} [Fintype d] [DecidableEq d]
 
 set_option backward.isDefEq.respectTransparency false in
 @[fun_prop]
-theorem rate_Continuous_singleton {ε : Prob} {d : Type*} [Fintype d] [DecidableEq d] (ρ : MState d) :
+theorem rate_Continuous_singleton {ε : Prob} {d : Type*} [Fintype d] [DecidableEq d]
+    (ρ : MState d) :
     Continuous fun σ ↦ β_ ε(ρ‖{σ}) := by
   have h := HermitianMat.innerₗ.flip.continuous_iInf_fst
     (S := { m | ρ.exp_val (1 - m) ≤ ↑ε ∧ 0 ≤ m ∧ m ≤ 1 })

--- a/QuantumInfo/ResourceTheory/ResourceTheory.lean
+++ b/QuantumInfo/ResourceTheory/ResourceTheory.lean
@@ -9,15 +9,18 @@ public import QuantumInfo.ResourceTheory.FreeState
 
 @[expose] public section
 
-/-- A quantum resource theory extends a `FreeStateTheory` with a collection of free operations. It is
-required that any state we can always prepare for free must be free, and this is all then the resource
-theory is "minimal", but we can have a more restricted set of operations. -/
+/-- A quantum resource theory extends a `FreeStateTheory` with a collection of free operations. It
+is required that any state we can always prepare for free must be free, and this is all then the
+resource theory is "minimal", but we can have a more restricted set of operations. -/
 class ResourceTheory (ι : Type*) extends FreeStateTheory ι where
   freeOps i j : Set (CPTPMap (H i) (H j))
-  /-- Free operations in a ResourceTheory are nongenerating: they only create a free states from a free state. -/
+  /-- Free operations in a ResourceTheory are nongenerating: they only create a free states from a
+  free state. -/
   nongenerating {i j : ι} {f} (h : f ∈ freeOps i j) : ∀ ρ, IsFree ρ → IsFree (f ρ)
-  --We might need to require some more closure properties on `freeOps`, like closure under tensor product...?
-  --For now we just require that they include the identity and composition, so that we have at least a category.
+  --We might need to require some more closure properties on `freeOps`, like closure under tensor
+  --product...?
+  --For now we just require that they include the identity and composition, so that we have at least
+  --a category.
   /-- The identity operation is free -/
   free_id i : CPTPMap.id ∈ freeOps i i
   /-- Free operations are closed under composition -/
@@ -29,8 +32,8 @@ open FreeStateTheory
 
 variable {ι : Type*}
 
-/-- Given a `FreeStateTheory`, there is a maximal set of free operations compatible with the free states.
-That is the set of all operations that don't generate non-free states from free states. We
+/-- Given a `FreeStateTheory`, there is a maximal set of free operations compatible with the free
+states. That is the set of all operations that don't generate non-free states from free states. We
 call this the maximal resource theory. -/
 def maximal [FreeStateTheory ι] : ResourceTheory ι where
   freeOps i j := { f | ∀ ρ, IsFree ρ → IsFree (f ρ)}
@@ -45,7 +48,8 @@ def IsMaximal (r : ResourceTheory ι) : Prop :=
 /-- A resource theory `IsTensorial` if it includes tensor products of operations, creating
 free states, and discarding. This implies that includes a unit object. -/
 structure IsTensorial [UnitalPretheory ι] : Prop where
-  prod :  ∀ {i j k l : ι} {f g}, f ∈ freeOps i k → g ∈ freeOps j l → (f ⊗ᶜᵖᵣ g) ∈ freeOps (prod i j) (prod k l)
+  prod :  ∀ {i j k l : ι} {f g}, f ∈ freeOps i k → g ∈ freeOps j l →
+    (f ⊗ᶜᵖᵣ g) ∈ freeOps (prod i j) (prod k l)
   create : ∀ {i : ι} (ρ), IsFree ρ → CPTPMap.replacement ρ ∈ freeOps Unital.unit i
   destroy : ∀ (i : ι), CPTPMap.destroy ∈ freeOps i Unital.unit
 
@@ -54,7 +58,8 @@ theorem maximal_IsMaximal [FreeStateTheory ι] : IsMaximal (maximal (ι := ι)) 
   fun _ _ ↦ rfl
 
 -- --Helper theorem for ResourceTheory.mk_of_ops
--- private lemma convex_states_of_convex_ops [ResourcePretheory ι] (O : ∀ (i j : ι), Set (CPTPMap (H i) (H j)))
+-- private lemma convex_states_of_convex_ops [ResourcePretheory ι]
+--   (O : ∀ (i j : ι), Set (CPTPMap (H i) (H j)))
 --   (h_convex : ∀ {i j}, Convex ℝ (CPTPMap.choi '' O i j)) (i : ι) :
 --     Convex ℝ (MState.M '' fun ρ ↦ ∀ {j} σ, ∃ f, O j i f ∧ f σ = ρ) := by
 --   intro _ hx _ hy a b ha hb hab
@@ -93,15 +98,19 @@ theorem maximal_IsMaximal [FreeStateTheory ι] : IsMaximal (maximal (ι := ι)) 
 --   · rw [Mixable.mix_ab, Mixable.mkT, MState.instMixable, ← hx2, ← hy2]
 --     rfl
 
--- /-- A `ResourceTheory` can be constructed from a set of operations (satisfying appropriate axioms of closure),
--- and then the free states are taken to be the set of states that can be prepared from any initial state.
+-- /-- A `ResourceTheory` can be constructed from a set of operations (satisfying appropriate axioms
+-- of closure), and then the free states are taken to be the set of states that can be prepared from
+-- any initial state.
 -- -/
 -- def mk_of_ops [ResourcePretheory ι] (O : ∀ (i j : ι), Set (CPTPMap (H i) (H j)))
 --     (h_id : ∀ i, CPTPMap.id ∈ O i i) --Operations include identity
---     (h_comp : ∀ {i j k} (Y : O j k) (X : O i j), Y.1.compose X.1 ∈ O i k) --Operations include compositions
+--     (h_comp : ∀ {i j k} (Y : O j k) (X : O i j), Y.1.compose X.1 ∈ O i k)
+--     --Operations include compositions
 --     (h_closed : ∀ {i j}, IsClosed (O i j)) -- Operations are topologically closed
---     (h_convex : ∀ {i j}, Convex ℝ (CPTPMap.choi '' O i j)) -- (The choi matrices of) operations are convex
---     (h_prod : ∀ {i j k l f g} (hf : f ∈ O i k) (hg : g ∈ O j l), (f ⊗ᶜᵖᵣ g) ∈ O (prod i j) (prod k l)) --Closed under products
+--     (h_convex : ∀ {i j}, Convex ℝ (CPTPMap.choi '' O i j))
+--     -- (The choi matrices of) operations are convex
+--     (h_prod : ∀ {i j k l f g} (hf : f ∈ O i k) (hg : g ∈ O j l),
+--       (f ⊗ᶜᵖᵣ g) ∈ O (prod i j) (prod k l)) --Closed under products
 --     (h_fullRank : ∀ {i : ι}, sorry) --Some statement about having full rank states as output
 --     (h_appendFree : ∀ {i j k : ι}, sorry) --Some statement that appending free states is free
 --     : ResourceTheory ι where
@@ -136,15 +145,16 @@ theorem maximal_IsMaximal [FreeStateTheory ι] : IsMaximal (maximal (ι := ι)) 
 --   assoc := fun f g h ↦ by simpa using CPTPMap.compose_assoc h.1 g.1 f.1
 
 -- open ComplexOrder in
--- /-- The 'fully free' quantum resource theory: the category is all finite Hilbert spaces, all maps are
--- free and all states are free. Marked noncomputable because we use `Fintype.ofFinite`. -/
+-- /-- The 'fully free' quantum resource theory: the category is all finite Hilbert spaces, all maps
+-- are free and all states are free. Marked noncomputable because we use `Fintype.ofFinite`. -/
 -- noncomputable def fullyFreeQRT : ResourceTheory { ι : Type // Finite ι ∧ Nonempty ι} where
 --     H := Subtype.val
 --     FinH := fun i ↦ have := i.prop.left; Fintype.ofFinite i
 --     DecEqH := fun i a b ↦ Classical.propDecidable (a = b)
 --     NonemptyH := fun i ↦ i.prop.right
 
---     prod := fun ⟨i,⟨hi,hi2⟩⟩ ⟨j,⟨hj,hj2⟩⟩ ↦ ⟨i × j, ⟨Finite.instProd, instNonemptyProd⟩⟩
+--     prod := fun ⟨i,⟨hi,hi2⟩⟩ ⟨j,⟨hj,hj2⟩⟩ ↦
+--       ⟨i × j, ⟨Finite.instProd, instNonemptyProd⟩⟩
 --     prodEquiv := fun ⟨_,⟨_,_⟩⟩ ⟨_,⟨_,_⟩⟩ ↦ Equiv.refl _
 
 --     IsFree := Set.univ

--- a/QuantumInfo/ResourceTheory/SteinsLemma.lean
+++ b/QuantumInfo/ResourceTheory/SteinsLemma.lean
@@ -24,12 +24,14 @@ variable {ι : Type*} [UnitalFreeStateTheory ι]
 variable {i : ι}
 
 /-- The \tilde{σ}_n defined in Lemma 6, also in equation (S40) in Lemma 7. -/
-noncomputable def Lemma6_σn (m : ℕ) (σf : MState (H i)) (σₘ : MState (H (i ^ m))) : (n : ℕ) → MState (H (i ^ n)) :=
+noncomputable def Lemma6_σn (m : ℕ) (σf : MState (H i)) (σₘ : MState (H (i ^ m))) :
+    (n : ℕ) → MState (H (i ^ n)) :=
   fun n ↦ (σₘ ⊗ᵣ^[n / m] ⊗ᵣ σf ⊗ᵣ^[n % m]).relabel <| .cast <| congrArg H (by
     rw [← pow_mul, ← spacePow_add, Nat.div_add_mod n m]
   )
 
-theorem Lemma6_σn_IsFree {σ₁ : MState (H i)} {σₘ : (m : ℕ) → MState (H (i ^ m))} (hσ₁_free : IsFree σ₁)
+theorem Lemma6_σn_IsFree {σ₁ : MState (H i)} {σₘ : (m : ℕ) → MState (H (i ^ m))}
+    (hσ₁_free : IsFree σ₁)
     (hσₘ : ∀ (m : ℕ), σₘ m ∈ IsFree) (m n : ℕ) : Lemma6_σn m σ₁ (σₘ m) n ∈ IsFree := by
   rw [Lemma6_σn, relabel_cast_isFree]
   · apply free_prod --pick a better name / alias for this
@@ -47,7 +49,8 @@ private theorem Lemma6 {m : ℕ} (hm : 0 < m) (ρ σf : MState (H i)) (σₘ : M
 
   set σn := Lemma6_σn m σf σₘ with hσn
 
-  have h_add : ∀ α n, D̃_ α(ρ ⊗ᵣ^[n]‖σn n) = (n/m : ℕ) * D̃_ α(ρ ⊗ᵣ^[m]‖σₘ) + (n%m : ℕ) * D̃_ α(ρ‖σf):= by
+  have h_add : ∀ α n, D̃_ α(ρ ⊗ᵣ^[n]‖σn n) =
+      (n/m : ℕ) * D̃_ α(ρ ⊗ᵣ^[m]‖σₘ) + (n%m : ℕ) * D̃_ α(ρ‖σf):= by
     --"Break apart" σn, and apply additivity of `SandwichedRelRentropy`.
     intro α n
     rw [hσn, Lemma6_σn]
@@ -108,7 +111,8 @@ private theorem Lemma6 {m : ℕ} (hm : 0 < m) (ρ σf : MState (H i)) (σₘ : M
       change Filter.atTop.limsup (fun n ↦ x n / n) ≤ Filter.atTop.limsup (fun n ↦ y n / n)
       exact extracted_limsup_inequality z hz y x h_lem5
 
-    · suffices Filter.atTop.Tendsto (fun n ↦ D̃_ α(ρ ⊗ᵣ^[n]‖σn n) / n)  (𝓝 (D̃_ α(ρ ⊗ᵣ^[m]‖σₘ) / m))by
+    · suffices Filter.atTop.Tendsto (fun n ↦ D̃_ α(ρ ⊗ᵣ^[n]‖σn n) / n)
+        (𝓝 (D̃_ α(ρ ⊗ᵣ^[m]‖σₘ) / m))by
         exact this.limsup_eq
       conv =>
         enter [1,n]
@@ -134,16 +138,19 @@ private theorem Lemma6 {m : ℕ} (hm : 0 < m) (ρ σf : MState (H i)) (σₘ : M
           · simp
             omega
         · rename_i v
-          suffices Filter.atTop.Tendsto (fun x ↦ (x:ℝ)⁻¹ * ↑(x / m) * (v:ℝ) : ℕ → ℝ) (𝓝 ((1 / m) * (v : ℝ))) by
+          suffices Filter.atTop.Tendsto (fun x ↦ (x:ℝ)⁻¹ * ↑(x / m) * (v:ℝ) : ℕ → ℝ)
+              (𝓝 ((1 / m) * (v : ℝ))) by
             --Similar to the "convert ENNReal.tendsto_ofReal this" below. Just push casts through
             convert ENNReal.tendsto_ofReal this
             · rename_i x
               cases x
               · simp
-              rw [ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_inv_of_pos (by positivity)]
+              rw [ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_mul (by positivity),
+                ENNReal.ofReal_inv_of_pos (by positivity)]
               simp
               norm_cast
-            · rw [ENNReal.ofReal_mul (by positivity), one_div, ENNReal.ofReal_inv_of_pos (by positivity)]
+            · rw [ENNReal.ofReal_mul (by positivity), one_div,
+                ENNReal.ofReal_inv_of_pos (by positivity)]
               simp
           exact (Filter.Tendsto_inv_nat_mul_div_real m).mul tendsto_const_nhds
       · suffices Filter.atTop.Tendsto (fun x ↦ (x % m : ℕ) * (D̃_ α(ρ‖σf)).toReal / x) (𝓝 0) by
@@ -165,12 +172,14 @@ private theorem Lemma6 {m : ℕ} (hm : 0 < m) (ρ σf : MState (H i)) (σₘ : M
         · exact tendsto_inv_atTop_nhds_zero_nat
 
   --Take the limit as α → 1.
-  replace h_α : Filter.atTop.limsup (fun n ↦ —log β_ ε(ρ ⊗ᵣ^[n]‖{σn n}) / n) ≤ 𝐃(ρ ⊗ᵣ^[m]‖σₘ) / m := by
+  replace h_α : Filter.atTop.limsup (fun n ↦ —log β_ ε(ρ ⊗ᵣ^[n]‖{σn n}) / n) ≤
+      𝐃(ρ ⊗ᵣ^[m]‖σₘ) / m := by
     refine ge_of_tendsto (x :=  (𝓝[>] 1)) ?_ (eventually_nhdsWithin_of_forall h_α)
     apply tendsto_nhdsWithin_of_tendsto_nhds
     convert ContinuousAt.tendsto ?_ using 3
     have _ := ENNReal.continuous_div_const m (by positivity)
-    have _ := (sandwichedRelRentropy.continuousOn (ρ ⊗ᵣ^[m]) σₘ).continuousAt (Ioi_mem_nhds zero_lt_one)
+    have _ := (sandwichedRelRentropy.continuousOn (ρ ⊗ᵣ^[m]) σₘ).continuousAt
+      (Ioi_mem_nhds zero_lt_one)
     fun_prop
 
   exact h_α
@@ -186,10 +195,12 @@ open PosSemidef
 
 open scoped HermitianMat in
 theorem LemmaS2liminf {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
-  {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)] (ρ : (n : ℕ) → MState (d n)) (σ : (n : ℕ) → MState (d n))
+  {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)]
+  (ρ : (n : ℕ) → MState (d n)) (σ : (n : ℕ) → MState (d n))
   {Rinf : ℝ≥0} (hRinf : Rinf ≥ Filter.atTop.liminf (fun (n : ℕ) ↦ —log β_ ε3(ρ n‖{σ n}) / n))
   :
-  (Filter.atTop.liminf (fun (n : ℕ) ↦ ⟪{(ρ n).M ≥ₚ (Real.exp (n * (Rinf + ε4))) • (σ n).M}, (ρ n).M⟫) ≤ 1 - ε3)
+  (Filter.atTop.liminf
+    (fun (n : ℕ) ↦ ⟪{(ρ n).M ≥ₚ (Real.exp (n * (Rinf + ε4))) • (σ n).M}, (ρ n).M⟫) ≤ 1 - ε3)
   := by
   by_contra h
   push Not at h
@@ -210,10 +221,12 @@ theorem LemmaS2liminf {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
       open HermitianMat in
       calc
         β_ ε3(ρ n‖{σ n}) ≤ (σ n).exp_val (T n) := by
-          have hβ' := OptimalHypothesisRate.singleton_le_exp_val (σ := σ n) (T n) (hT n hn) ⟨projLE_nonneg _ _, projLE_le_one _ _⟩
+          have hβ' := OptimalHypothesisRate.singleton_le_exp_val (σ := σ n) (T n) (hT n hn)
+            ⟨projLE_nonneg _ _, projLE_le_one _ _⟩
           simp only [Subtype.coe_le_coe.mpr hβ']
         _ <= ⟪T n, Real.exp (-n * (Rinf + ε4)) • (ρ n).M⟫ := by
-          rw [← mul_le_mul_iff_right₀ (Real.exp_pos ((n * (Rinf + ε4)))), HermitianMat.inner_smul_right, neg_mul, Real.exp_neg]
+          rw [← mul_le_mul_iff_right₀ (Real.exp_pos ((n * (Rinf + ε4)))),
+            HermitianMat.inner_smul_right, neg_mul, Real.exp_neg]
           simp only [isUnit_iff_ne_zero, ne_eq, Real.exp_ne_zero, not_false_eq_true,
             IsUnit.mul_inv_cancel_left]
           rw [MState.exp_val, HermitianMat.inner_comm, ← HermitianMat.inner_smul_right]
@@ -232,7 +245,8 @@ theorem LemmaS2liminf {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
       have hh : n * (Rinf + ε4) = ENNReal.ofReal (n * (Rinf + ε4)) := by
         simp only [Nat.cast_nonneg, ENNReal.ofReal_mul, ENNReal.ofReal_natCast, zero_le_coe,
           ENNReal.ofReal_add, ENNReal.ofReal_coe_nnreal]
-      apply (ENNReal.mul_le_mul_iff_right (a := n) (b := Rinf + ε4) (c := —log β_ ε3(ρ n‖{σ n}) / n) hn1 hn2).mp
+      apply (ENNReal.mul_le_mul_iff_right (a := n) (b := Rinf + ε4)
+        (c := —log β_ ε3(ρ n‖{σ n}) / n) hn1 hn2).mp
       rw [ENNReal.mul_div_cancel hn1 hn2, hh]
       apply Prob.le_negLog_of_le_exp
       rw [← neg_mul]
@@ -254,10 +268,12 @@ theorem LemmaS2liminf {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
 
 open scoped HermitianMat in
 theorem LemmaS2limsup {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
-  {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)] (ρ : (n : ℕ) → MState (d n)) (σ : (n : ℕ) → MState (d n))
+  {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)]
+  (ρ : (n : ℕ) → MState (d n)) (σ : (n : ℕ) → MState (d n))
   {Rsup : ℝ≥0} (hRsup : Rsup ≥ Filter.atTop.limsup (fun (n : ℕ) ↦ —log β_ ε3(ρ n‖{σ n}) / n))
   :
-  (Filter.atTop.limsup (fun (n : ℕ) ↦ ⟪{ρ n ≥ₚ (Real.exp (n * (Rsup + ε4))) • (σ n).M}, ρ n⟫) ≤ 1 - ε3)
+  (Filter.atTop.limsup
+    (fun (n : ℕ) ↦ ⟪{ρ n ≥ₚ (Real.exp (n * (Rsup + ε4))) • (σ n).M}, ρ n⟫) ≤ 1 - ε3)
   := by
   by_contra h
   push Not at h
@@ -278,10 +294,12 @@ theorem LemmaS2limsup {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
       open HermitianMat in
       calc
         β_ ε3(ρ n‖{σ n}) ≤ (σ n).exp_val (T n) := by
-          have hβ' := OptimalHypothesisRate.singleton_le_exp_val (σ := σ n) (T n) hT ⟨projLE_nonneg _ _, projLE_le_one _ _⟩
+          have hβ' := OptimalHypothesisRate.singleton_le_exp_val (σ := σ n) (T n) hT
+            ⟨projLE_nonneg _ _, projLE_le_one _ _⟩
           simp only [Subtype.coe_le_coe.mpr hβ']
         _ <= ⟪T n, Real.exp (-n * (Rsup + ε4)) • ρ n⟫ := by
-          rw [← mul_le_mul_iff_right₀ (Real.exp_pos ((n * (Rsup + ε4)))), HermitianMat.inner_smul_right, neg_mul, Real.exp_neg]
+          rw [← mul_le_mul_iff_right₀ (Real.exp_pos ((n * (Rsup + ε4)))),
+            HermitianMat.inner_smul_right, neg_mul, Real.exp_neg]
           simp only [isUnit_iff_ne_zero, ne_eq, Real.exp_ne_zero, not_false_eq_true,
             IsUnit.mul_inv_cancel_left]
           rw [MState.exp_val, HermitianMat.inner_comm, ← HermitianMat.inner_smul_right]
@@ -301,7 +319,8 @@ theorem LemmaS2limsup {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
       have hn2 : (n : ℝ≥0∞) ≠ ⊤ := by finiteness
       have hh : n * (Rsup + ε4) = ENNReal.ofReal (n * (Rsup + ε4)) := by
         simp [ENNReal.ofReal_add]
-      apply (ENNReal.mul_le_mul_iff_right (a := n) (b := Rsup + ε4) (c := —log β_ ε3(ρ n‖{σ n}) / n) hn1 hn2).mp
+      apply (ENNReal.mul_le_mul_iff_right (a := n) (b := Rsup + ε4)
+        (c := —log β_ ε3(ρ n‖{σ n}) / n) hn1 hn2).mp
       rw [ENNReal.mul_div_cancel hn1 hn2, hh]
       apply Prob.le_negLog_of_le_exp
       rwa [← neg_mul]
@@ -316,7 +335,8 @@ theorem LemmaS2limsup {ε3 : Prob} {ε4 : ℝ≥0} (hε4 : 0 < ε4)
   rw [HermitianMat.inner_comm, ← MState.exp_val]
   exact (ρ n).exp_val_nonneg ((Real.exp (n * (Rsup + ε4)) • (σ n).M).projLE_nonneg (ρ n))
 
-private theorem LemmaS3_helper {ε : Prob} {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)]
+private theorem LemmaS3_helper {ε : Prob} {d : ℕ → Type*} [∀ n, Fintype (d n)]
+    [∀ n, DecidableEq (d n)]
   (ρ σ₁ σ₂ : (n : ℕ) → MState (d n))
   (f : ℕ → ℝ≥0) (hσ : ∀ (i : ℕ), Real.exp (-f i) • (σ₂ i).M ≤ (σ₁ i)) (n : ℕ) :
     —log β_ ε(ρ n‖{σ₁ n}) ≤ —log β_ ε(ρ n‖{σ₂ n}) + f n := by
@@ -348,11 +368,12 @@ private theorem LemmaS3_helper {ε : Prob} {d : ℕ → Type*} [∀ n, Fintype (
   simp only [MState.exp_val, ← HermitianMat.inner_smul_left]
   exact HermitianMat.inner_mono' hx₂ (hσ n)
 
-/-- Lemma S3 from the paper. What they denote as σₙ and σₙ', we denote as σ₁ and σ₂. The `exp(-o(n))`
-we express as a function `f : ℕ → ℝ`, together with the fact that `f` is little-o of `n` (i.e. that
-`f =o[.atTop] id`), and then writing `exp(-f)`. We also split LemmaS3 into two parts, the `lim inf` part
-and the `lim sup` part. The theorem as written is true for any `f`, but we can restrict to nonnegative
-`f` (so, `ℕ → ℝ≥0`) which is easier to work with and more natural in the subsequent proofs. -/
+/-- Lemma S3 from the paper. What they denote as σₙ and σₙ', we denote as σ₁ and σ₂. The
+`exp(-o(n))` we express as a function `f : ℕ → ℝ`, together with the fact that `f` is little-o of
+`n` (i.e. that `f =o[.atTop] id`), and then writing `exp(-f)`. We also split LemmaS3 into two
+parts, the `lim inf` part and the `lim sup` part. The theorem as written is true for any `f`, but
+we can restrict to nonnegative `f` (so, `ℕ → ℝ≥0`) which is easier to work with and more natural in
+the subsequent proofs. -/
 private theorem LemmaS3_inf {ε : Prob}
     {d : ℕ → Type*} [∀ n, Fintype (d n)] [∀ n, DecidableEq (d n)]
     (ρ σ₁ σ₂ : (n : ℕ) → MState (d n))
@@ -447,7 +468,8 @@ private lemma rexp_mul_smul_proj_lt_mul_sub_le_mul_sub {n : ℕ} {x : ℝ}
     rw [HermMul.mul_eq_symmMul, HermitianMat.symmMul_of_commute]
     · simp only [CharP.cast_eq_zero, div_zero, zero_smul, HermitianMat.mat_zero,
         HermitianMat.mat_sub, zero_mul, mul_zero, Matrix.trace_zero, RCLike.re_to_complex,
-        Complex.zero_re, HermitianMat.mat_smul, Algebra.mul_smul_comm, trace_smul, Complex.real_smul,
+        Complex.zero_re, HermitianMat.mat_smul, Algebra.mul_smul_comm, trace_smul,
+        Complex.real_smul,
         RCLike.mul_re, Complex.ofReal_re, RCLike.im_to_complex, Complex.ofReal_im, sub_zero]
       positivity
     · simp
@@ -568,26 +590,58 @@ private lemma f_image_bound (mineig : ℝ) (n : ℕ) (h : 0 < mineig) (hn : 0 < 
   (h_f_le : ∀ (n : ℕ) (lam : ℝ), f n lam < Real.log lam + c n) →
     S.ncard ≤ n + 1 ∧ S.Finite := by
   --Thanks Aristotle. TODO Cleanup
-  -- To show that $S$ is finite, we need to show that the function $f$ maps the interval into a finite set.
-  have h_finite : Set.Finite (Set.image (fun x => Real.exp (⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ * (Real.log (1 / mineig) + Real.log 3 / (max n 1)))) (Set.Icc (mineig^n / 3) 1)) := by
-    -- Since the interval [mineig^n / 3, 1] is bounded and the function Real.log is continuous, the values of Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) will also be bounded. The ceiling function will then map these values to a finite set of integers.
-    have h_bounded : ∃ m M : ℤ, ∀ x ∈ Set.Icc (mineig^n / 3) 1, m ≤ ⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ ∧ ⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ ≤ M := by
-      have h_bounded : ∃ m M : ℝ, ∀ x ∈ Set.Icc (mineig^n / 3) 1, m ≤ Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) ∧ Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) ≤ M := by
-        -- Since the interval [mineig^n / 3, 1] is closed and bounded, and the function Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) is continuous on this interval, it must attain a maximum and minimum value on this interval.
-        have h_cont : ContinuousOn (fun x => Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))) (Set.Icc (mineig^n / 3) 1) := by
-          -- Since Real.log x is continuous on the interval (0, ∞) and the denominator is a non-zero constant, the function Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) is continuous on the interval [mineig^n / 3, 1].
+  -- To show that $S$ is finite, we need to show that the function $f$ maps the interval into a
+  -- finite set.
+  have h_finite : Set.Finite (Set.image
+      (fun x => Real.exp (⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ *
+        (Real.log (1 / mineig) + Real.log 3 / (max n 1))))
+      (Set.Icc (mineig^n / 3) 1)) := by
+    -- Since the interval [mineig^n / 3, 1] is bounded and the function Real.log is continuous, the
+    -- values of Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) will also be bounded.
+    -- The ceiling function will then map these values to a finite set of integers.
+    have h_bounded : ∃ m M : ℤ, ∀ x ∈ Set.Icc (mineig^n / 3) 1,
+        m ≤ ⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ ∧
+        ⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ ≤ M := by
+      have h_bounded : ∃ m M : ℝ, ∀ x ∈ Set.Icc (mineig^n / 3) 1,
+          m ≤ Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) ∧
+          Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) ≤ M := by
+        -- Since the interval [mineig^n / 3, 1] is closed and bounded, and the function
+        -- Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) is continuous on this
+        -- interval, it must attain a maximum and minimum value on this interval.
+        have h_cont : ContinuousOn
+            (fun x => Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)))
+            (Set.Icc (mineig^n / 3) 1) := by
+          -- Since Real.log x is continuous on the interval (0, ∞) and the denominator is a non-zero
+          -- constant, the function Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1)) is
+          -- continuous on the interval [mineig^n / 3, 1].
           have h_cont : ContinuousOn Real.log (Set.Icc (mineig^n / 3) 1) := by
-            exact continuousOn_of_forall_continuousAt fun x hx => Real.continuousAt_log ( by linarith [ hx.1, pow_pos h n ] );
+            exact continuousOn_of_forall_continuousAt fun x hx =>
+              Real.continuousAt_log ( by linarith [ hx.1, pow_pos h n ] );
           exact h_cont.div_const _;
-        exact ⟨ ( InfSet.sInf <| ( fun x => Real.log x / ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 ) ) ) '' Set.Icc ( mineig ^ n / 3 ) 1 ), ( SupSet.sSup <| ( fun x => Real.log x / ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 ) ) ) '' Set.Icc ( mineig ^ n / 3 ) 1 ), fun x hx => ⟨ ( csInf_le <| IsCompact.bddBelow <| isCompact_Icc.image_of_continuousOn h_cont ) <| Set.mem_image_of_mem _ hx, ( le_csSup <| IsCompact.bddAbove <| isCompact_Icc.image_of_continuousOn h_cont ) <| Set.mem_image_of_mem _ hx ⟩ ⟩;
+        exact ⟨
+          ( InfSet.sInf <| ( fun x => Real.log x /
+            ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 ) ) ) ''
+            Set.Icc ( mineig ^ n / 3 ) 1 ),
+          ( SupSet.sSup <| ( fun x => Real.log x /
+            ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 ) ) ) ''
+            Set.Icc ( mineig ^ n / 3 ) 1 ),
+          fun x hx => ⟨
+            ( csInf_le <| IsCompact.bddBelow <| isCompact_Icc.image_of_continuousOn h_cont ) <|
+              Set.mem_image_of_mem _ hx,
+            ( le_csSup <| IsCompact.bddAbove <| isCompact_Icc.image_of_continuousOn h_cont ) <|
+              Set.mem_image_of_mem _ hx ⟩ ⟩;
       obtain ⟨ m, M, hM ⟩ := h_bounded
-      exact ⟨ ⌈m⌉, ⌈M⌉, fun x hx => ⟨ Int.ceil_mono <| hM x hx |>.1, Int.ceil_mono <| hM x hx |>.2 ⟩ ⟩ ;
+      exact ⟨ ⌈m⌉, ⌈M⌉,
+        fun x hx => ⟨ Int.ceil_mono <| hM x hx |>.1, Int.ceil_mono <| hM x hx |>.2 ⟩ ⟩ ;
     cases' h_bounded with m h_bounded
     cases' h_bounded with M h_bounded
-    refine Set.Finite.subset ( Set.toFinite ( Finset.image ( fun i : ℤ => Real.exp ( ( i : ℝ ) * ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 : ℝ ) ) ) ) ( Finset.Icc m M ) ) ) ?_
+    refine Set.Finite.subset ( Set.toFinite ( Finset.image
+      ( fun i : ℤ => Real.exp ( ( i : ℝ ) *
+        ( Real.log ( 1 / mineig ) + Real.log 3 / ( max n 1 : ℝ ) ) ) )
+      ( Finset.Icc m M ) ) ) ?_
     intro _ a_1
-    simp_all only [Set.mem_Icc, one_div, Real.log_inv, Nat.cast_max, Nat.cast_one, and_imp, Set.mem_image,
-      Finset.coe_image, Finset.coe_Icc]
+    simp_all only [Set.mem_Icc, one_div, Real.log_inv, Nat.cast_max, Nat.cast_one, and_imp,
+      Set.mem_image, Finset.coe_image, Finset.coe_Icc]
     obtain ⟨w, ⟨left, rfl⟩⟩ := a_1
     simp_all only [Real.exp_eq_exp, mul_eq_mul_right_iff, Int.cast_inj]
     apply Exists.intro
@@ -599,8 +653,17 @@ private lemma f_image_bound (mineig : ℝ) (n : ℕ) (h : 0 < mineig) (hn : 0 < 
       · simp_all only [and_self]
   intro c f S h_le_f h_f_le
   simp_all only [one_div, Real.log_inv, Nat.cast_max, Nat.cast_one, and_true, f, c, S]
-  -- Since the interval [(n * log(mineig) - log(3)) / c(n), 0 / c(n)] has length (log(3) - n * log(mineig)) / c(n), and c(n) is positive, the number of distinct integer values that ⌈(log lam) / c(n)⌉ can take is at most n + 1.
-  have h_card : Set.ncard (Set.image (fun x => Real.exp (⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ * (Real.log (1 / mineig) + Real.log 3 / (max n 1)))) (Set.Icc (mineig^n / 3) 1)) ≤ Set.ncard (Set.image (fun k : ℤ => Real.exp (k * (Real.log (1 / mineig) + Real.log 3 / (max n 1)))) (Set.Icc (⌈(n * Real.log mineig - Real.log 3) / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0)) := by
+  -- Since the interval [(n * log(mineig) - log(3)) / c(n), 0 / c(n)] has length
+  -- (log(3) - n * log(mineig)) / c(n), and c(n) is positive, the number of distinct integer values
+  -- that ⌈(log lam) / c(n)⌉ can take is at most n + 1.
+  have h_card : Set.ncard (Set.image
+      (fun x => Real.exp (⌈Real.log x / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉ *
+        (Real.log (1 / mineig) + Real.log 3 / (max n 1))))
+      (Set.Icc (mineig^n / 3) 1)) ≤
+      Set.ncard (Set.image
+        (fun k : ℤ => Real.exp (k * (Real.log (1 / mineig) + Real.log 3 / (max n 1))))
+        (Set.Icc (⌈(n * Real.log mineig - Real.log 3) /
+          (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0)) := by
     refine Set.ncard_le_ncard ?_;
     intro _ a_1
     simp_all only [one_div, Real.log_inv, Nat.cast_max, Nat.cast_one, Set.mem_image, Set.mem_Icc]
@@ -609,7 +672,8 @@ private lemma f_image_bound (mineig : ℝ) (n : ℕ) (h : 0 < mineig) (hn : 0 < 
     refine' ⟨_, ⟨_, _ ⟩, Or.inl rfl⟩;
     · gcongr;
       · have := h_f_le n 1 ; norm_num at this ; linarith [ Real.log_le_sub_one_of_pos h ];
-      · -- Taking the logarithm of both sides of the inequality $mineig^n / 3 \leq w$, we get $n \log(mineig) - \log(3) \leq \log(w)$.
+      · -- Taking the logarithm of both sides of the inequality $mineig^n / 3 \leq w$, we get
+        -- $n \log(mineig) - \log(3) \leq \log(w)$.
         have h_log : Real.log (mineig^n / 3) ≤ Real.log w := by
           exact Real.log_le_log ( by positivity ) left;
         rwa [ Real.log_div ( by positivity ) ( by positivity ), Real.log_pow ] at h_log;
@@ -618,8 +682,14 @@ private lemma f_image_bound (mineig : ℝ) (n : ℕ) (h : 0 < mineig) (hn : 0 < 
       · simp_all only [Int.cast_zero, zero_mul]
         exact Real.log_nonpos ( by linarith [ pow_pos h n ] ) right_1;
       · have := h_f_le n 1
-        simp_all only [Real.log_one, zero_div, Int.ceil_zero, Int.cast_zero, zero_mul, zero_add, lt_neg_add_iff_add_lt, add_zero]
-  have h_card_image : Set.ncard (Set.image (fun k : ℤ => Real.exp (k * (Real.log (1 / mineig) + Real.log 3 / (max n 1)))) (Set.Icc (⌈(n * Real.log mineig - Real.log 3) / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0)) ≤ Set.ncard (Set.Icc (⌈(n * Real.log mineig - Real.log 3) / (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0) := by
+        simp_all only [Real.log_one, zero_div, Int.ceil_zero, Int.cast_zero, zero_mul, zero_add,
+          lt_neg_add_iff_add_lt, add_zero]
+  have h_card_image : Set.ncard (Set.image
+      (fun k : ℤ => Real.exp (k * (Real.log (1 / mineig) + Real.log 3 / (max n 1))))
+      (Set.Icc (⌈(n * Real.log mineig - Real.log 3) /
+        (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0)) ≤
+      Set.ncard (Set.Icc (⌈(n * Real.log mineig - Real.log 3) /
+        (Real.log (1 / mineig) + Real.log 3 / (max n 1))⌉) 0) := by
     apply Set.ncard_image_le;
     exact Set.finite_Icc _ _;
   simp_all +decide [ Set.ncard_eq_toFinset_card' ];
@@ -629,15 +699,20 @@ private lemma f_image_bound (mineig : ℝ) (n : ℕ) (h : 0 < mineig) (hn : 0 < 
   simp_all only [lt_add_iff_pos_left, add_pos_iff, zero_lt_one, or_true, Nat.cast_add, Nat.cast_one,
     le_add_iff_nonneg_left, Nat.cast_nonneg, sup_of_le_left, Int.toNat_le, tsub_le_iff_right]
   specialize h_f_le ( n + 1 ) 1;
-  simp_all only [Real.log_one, Nat.cast_add, Nat.cast_one, le_add_iff_nonneg_left, Nat.cast_nonneg, sup_of_le_left,
+  simp_all only [Real.log_one, Nat.cast_add, Nat.cast_one, le_add_iff_nonneg_left, Nat.cast_nonneg,
+    sup_of_le_left,
     zero_div, Int.ceil_zero, Int.cast_zero, zero_mul, zero_add, lt_neg_add_iff_add_lt, add_zero]
   apply Int.le_of_lt_add_one
   rw [ ← @Int.cast_lt ℝ ]
   push_cast
-  nlinarith [ Int.le_ceil ( ( ( n + 1 ) * Real.log mineig - Real.log 3 ) / ( -Real.log mineig + Real.log 3 / ( n + 1 ) ) ),
-    mul_div_cancel₀ ( ( n + 1 ) * Real.log mineig - Real.log 3 ) ( show ( -Real.log mineig + Real.log 3 / ( n + 1 ) ) ≠ 0 by
-      nlinarith [ Real.log_pos ( show ( 3 : ℝ ) > 1 by norm_num ), mul_div_cancel₀ ( Real.log 3 ) ( show ( n + 1 : ℝ ) ≠ 0 by positivity ) ] ),
-        Real.log_pos ( show ( 3 : ℝ ) > 1 by norm_num ), mul_div_cancel₀ ( Real.log 3 ) ( show ( n + 1 : ℝ ) ≠ 0 by positivity ) ]
+  nlinarith [ Int.le_ceil ( ( ( n + 1 ) * Real.log mineig - Real.log 3 ) /
+      ( -Real.log mineig + Real.log 3 / ( n + 1 ) ) ),
+    mul_div_cancel₀ ( ( n + 1 ) * Real.log mineig - Real.log 3 )
+      ( show ( -Real.log mineig + Real.log 3 / ( n + 1 ) ) ≠ 0 by
+        nlinarith [ Real.log_pos ( show ( 3 : ℝ ) > 1 by norm_num ),
+          mul_div_cancel₀ ( Real.log 3 ) ( show ( n + 1 : ℝ ) ≠ 0 by positivity ) ] ),
+        Real.log_pos ( show ( 3 : ℝ ) > 1 by norm_num ),
+        mul_div_cancel₀ ( Real.log 3 ) ( show ( n + 1 : ℝ ) ≠ 0 by positivity ) ]
 
 private lemma c'_bounded {mineig : ℝ} {ε2 : ℕ → ℝ≥0}
     (hε2 : ∀ (n : ℕ), ε2 n < 1) (o : ℝ) :
@@ -645,12 +720,27 @@ private lemma c'_bounded {mineig : ℝ} {ε2 : ℕ → ℝ≥0}
   let c' : ℝ → ℕ → ℝ := fun  ε2 n ↦ (c n + (c n) / n) ⊔ (o + ε2);
   (∀ (n : ℕ), 0 < c n) →
     ∃ (C : NNReal), ∀ᶠ (n : ℕ) in Filter.atTop, c' (↑(ε2 n)) n ≤ ↑C := by
-  have h_bound : ∃ C : ℝ, ∀ᶠ n in Filter.atTop, Real.log (1 / mineig) + Real.log 3 / (Max.max n 1) + (Real.log (1 / mineig) + Real.log 3 / (Max.max n 1)) / n ≤ C := by
-    have h_bound : Filter.Tendsto (fun n => Real.log (1 / mineig) + Real.log 3 / (Max.max n 1) + (Real.log (1 / mineig) + Real.log 3 / (Max.max n 1)) / n) Filter.atTop (nhds (Real.log (1 / mineig) + Real.log 3 / 0 + (Real.log (1 / mineig) + Real.log 3 / 0) / 0)) := by
-      exact le_trans ( Filter.Tendsto.add ( tendsto_const_nhds.add <| Filter.Tendsto.mul tendsto_const_nhds <| Filter.Tendsto.inv_tendsto_atTop <| Filter.tendsto_atTop_atTop.mpr fun x => ⟨ x + 1, fun y hy => le_max_of_le_left <| by linarith ⟩ ) <| Filter.Tendsto.mul ( tendsto_const_nhds.add <| Filter.Tendsto.mul tendsto_const_nhds <| Filter.Tendsto.inv_tendsto_atTop <| Filter.tendsto_atTop_atTop.mpr fun x => ⟨ x + 1, fun y hy => le_max_of_le_left <| by linarith ⟩ ) <| tendsto_inv_atTop_zero ) <| by norm_num;
+  have h_bound : ∃ C : ℝ, ∀ᶠ n in Filter.atTop,
+      Real.log (1 / mineig) + Real.log 3 / (Max.max n 1) +
+        (Real.log (1 / mineig) + Real.log 3 / (Max.max n 1)) / n ≤ C := by
+    have h_bound : Filter.Tendsto
+        (fun n => Real.log (1 / mineig) + Real.log 3 / (Max.max n 1) +
+          (Real.log (1 / mineig) + Real.log 3 / (Max.max n 1)) / n)
+        Filter.atTop
+        (nhds (Real.log (1 / mineig) + Real.log 3 / 0 +
+          (Real.log (1 / mineig) + Real.log 3 / 0) / 0)) := by
+      exact le_trans ( Filter.Tendsto.add
+        ( tendsto_const_nhds.add <| Filter.Tendsto.mul tendsto_const_nhds <|
+          Filter.Tendsto.inv_tendsto_atTop <| Filter.tendsto_atTop_atTop.mpr
+            fun x => ⟨ x + 1, fun y hy => le_max_of_le_left <| by linarith ⟩ ) <|
+        Filter.Tendsto.mul ( tendsto_const_nhds.add <| Filter.Tendsto.mul tendsto_const_nhds <|
+          Filter.Tendsto.inv_tendsto_atTop <| Filter.tendsto_atTop_atTop.mpr
+            fun x => ⟨ x + 1, fun y hy => le_max_of_le_left <| by linarith ⟩ ) <|
+        tendsto_inv_atTop_zero ) <| by norm_num;
     exact ⟨ _, h_bound.eventually ( ge_mem_nhds <| lt_add_one _ ) ⟩;
   intro c c' a
-  simp_all only [one_div, Real.log_inv, Filter.eventually_atTop, ge_iff_le, Nat.cast_max, Nat.cast_one,
+  simp_all only [one_div, Real.log_inv, Filter.eventually_atTop, ge_iff_le, Nat.cast_max,
+    Nat.cast_one,
     lt_neg_add_iff_add_lt, add_zero, sup_le_iff, c, c']
   obtain ⟨w, ⟨w_1, h⟩⟩ := h_bound
   use ⌈w⌉₊ + ⌈o⌉₊ + 1, ⌈w_1⌉₊
@@ -801,7 +891,8 @@ private theorem le_exp_f (n : ℕ) (x : ℝ) (hx : 0 < x) : x ≤ Real.exp (f_ma
   convert Real.exp_monotone (log_le_f i n x)
   rw [Real.exp_log hx]
 
-private theorem exp_f_le (n : ℕ) (x : ℝ) (hx : 0 < x) : Real.exp (f_map i n x) < Real.exp (σ₁_c i n) * x := by
+private theorem exp_f_le (n : ℕ) (x : ℝ) (hx : 0 < x) :
+    Real.exp (f_map i n x) < Real.exp (σ₁_c i n) * x := by
   convert Real.exp_strictMono (f_le_log i n x) using 1
   rw [Real.exp_add (Real.log x), Real.exp_log hx, mul_comm]
 
@@ -980,24 +1071,30 @@ private abbrev ε₀_func (ε' : Prob) : ℝ := (R2 ρ σ - R1 ρ ε).toReal * (
 end sigmas
 
 private theorem EquationS88 (ρ : MState (H i)) (σ : (n : ℕ) → ↑IsFree) {ε ε' : Prob}
-  (hR1R2 : R1 ρ ε < R2 ρ σ) (hR1 : R1 ρ ε ≠ ⊤) (hR2 : R2 ρ σ ≠ ⊤) (hε₀_1 : 0 < ε₀_func ρ ε σ ε') (m : ℕ)
+  (hR1R2 : R1 ρ ε < R2 ρ σ) (hR1 : R1 ρ ε ≠ ⊤) (hR2 : R2 ρ σ ≠ ⊤)
+  (hε₀_1 : 0 < ε₀_func ρ ε σ ε') (m : ℕ)
   :
   let ℰ := fun n => pinching_map (σ'' ρ ε m σ n);
   let ε₀ := ε₀_func ρ ε σ ε';
     (0 < ε₀) →
     (R1 ρ ε).toReal ≤ (R2 ρ σ).toReal + ε₀ →
-      let P1 := fun ε2 (n : ℕ) ↦ {Real.exp (↑n * ((R1 ρ ε).toReal + ε2)) • ↑(σ'' ρ ε m σ n) ≤ₚ ((ℰ n) (ρ ⊗ᵣ^[n]))};
-      let P2 := fun ε2 (n : ℕ) ↦ {Real.exp (↑n * ((R2 ρ σ).toReal + ε₀ + ε2)) • ↑(σ'' ρ ε m σ n) ≤ₚ ((ℰ n) (ρ ⊗ᵣ^[n]))};
+      let P1 := fun ε2 (n : ℕ) ↦
+        {Real.exp (↑n * ((R1 ρ ε).toReal + ε2)) • ↑(σ'' ρ ε m σ n) ≤ₚ ((ℰ n) (ρ ⊗ᵣ^[n]))};
+      let P2 := fun ε2 (n : ℕ) ↦
+        {Real.exp (↑n * ((R2 ρ σ).toReal + ε₀ + ε2)) • ↑(σ'' ρ ε m σ n) ≤ₚ ((ℰ n) (ρ ⊗ᵣ^[n]))};
       let E1 := 1 - P1;
       let E2 := P1 - P2;
       let E3 := P2;
       E1 + E2 + E3 = 1 →
-    (∀ (ε2 : ℝ) (n : ℕ), E1 ε2 n = {↑((ℰ n) (ρ ⊗ᵣ^[n])) <ₚ Real.exp (↑n * ((R1 ρ ε).toReal + ε2)) • ↑(σ'' ρ ε m σ n)}) →
-    (∀ (ε2 : ℝ) (n : ℕ), E2 ε2 n ≤ {↑((ℰ n) (ρ ⊗ᵣ^[n])) <ₚ Real.exp (↑n * ((R2 ρ σ).toReal + ε₀ + ε2)) • ↑(σ'' ρ ε m σ n)}) →
+    (∀ (ε2 : ℝ) (n : ℕ), E1 ε2 n =
+      {↑((ℰ n) (ρ ⊗ᵣ^[n])) <ₚ Real.exp (↑n * ((R1 ρ ε).toReal + ε2)) • ↑(σ'' ρ ε m σ n)}) →
+    (∀ (ε2 : ℝ) (n : ℕ), E2 ε2 n ≤
+      {↑((ℰ n) (ρ ⊗ᵣ^[n])) <ₚ Real.exp (↑n * ((R2 ρ σ).toReal + ε₀ + ε2)) • ↑(σ'' ρ ε m σ n)}) →
     (∀ (ε2 : ℝ) (n : ℕ), 0 ≤ E2 ε2 n) →
     let c' : ℝ → ℕ → ℝ := fun ε2 n => max (σ₁_c i n + σ₁_c i n / ↑n) ((R2 ρ σ).toReal + ε₀ + ε2);
     ∀ (ε2 : ℝ) (n : ℕ), 0 < ε2 → 0 < n →
-    (1 / n : ℝ) • (E3 ε2 n).mat * ((((ℰ n) (ρ ⊗ᵣ^[n])).M).log - ((σ'' ρ ε m σ n).M).log).mat ≤ c' ε2 n • (E3 ε2 n).mat →
+    (1 / n : ℝ) • (E3 ε2 n).mat * ((((ℰ n) (ρ ⊗ᵣ^[n])).M).log - ((σ'' ρ ε m σ n).M).log).mat ≤
+      c' ε2 n • (E3 ε2 n).mat →
 
     ENNReal.ofReal
         ((R1 ρ ε).toReal - (R1 ρ ε).toReal * ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, P1 ε2 n⟫ +
@@ -1024,7 +1121,8 @@ private theorem EquationS88 (ρ : MState (H i)) (σ : (n : ℕ) → ↑IsFree) {
             ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P1 ε2 n⟫_ℝ * (R2 ρ σ).toReal +
           ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P1 ε2 n⟫_ℝ * ε₀ +
         (ε2 - ε2 * ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ) +
-      (-(⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ * (R2 ρ σ).toReal) - ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ * ε₀) +
+      (-(⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ * (R2 ρ σ).toReal) -
+          ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ * ε₀) +
     ⟪↑((ℰ n) (ρ ⊗ᵣ^[n])), P2 ε2 n⟫_ℝ * c' ε2 n; swap
     · ring_nf
       rfl
@@ -1117,7 +1215,8 @@ private theorem EquationS62
       apply OptimalHypothesisRate.optimalHypothesisRate_antitone
     _ ≤ Filter.atTop.liminf (fun n => —log β_ ε(ρ ⊗ᵣ^[n]‖{(«σ⋆» ρ ε n)}) / ↑n) := by --(S68)
       apply LemmaS3_inf _ _ _
-        (f := fun n ↦ ⟨σ₁_c i n + Real.log 3, add_nonneg (σ₁_c_pos i n).le (Real.log_nonneg (by norm_num))⟩)
+        (f := fun n ↦
+          ⟨σ₁_c i n + Real.log 3, add_nonneg (σ₁_c_pos i n).le (Real.log_nonneg (by norm_num))⟩)
         (σ₁_c_littleO i)
       intro n
       rw [toReal, neg_add', Real.exp_sub, Real.exp_log (by positivity)]
@@ -1146,7 +1245,8 @@ private theorem EquationS62
       apply OptimalHypothesisRate.optimalHypothesisRate_antitone
     _ ≤ Filter.atTop.limsup (fun n => —log β_ (1-ε1)(ρ ⊗ᵣ^[n]‖{(«σ̃» m σ n)}) / ↑n) := by --(S71)
       apply LemmaS3_sup _ _ _
-        (f := fun n ↦ ⟨σ₁_c i n + Real.log 3, add_nonneg (σ₁_c_pos i n).le (Real.log_nonneg (by norm_num))⟩)
+        (f := fun n ↦
+          ⟨σ₁_c i n + Real.log 3, add_nonneg (σ₁_c_pos i n).le (Real.log_nonneg (by norm_num))⟩)
         (σ₁_c_littleO i)
       intro n
       rw [toReal, neg_add', Real.exp_sub, Real.exp_log (by positivity)]
@@ -1159,11 +1259,16 @@ private theorem EquationS62
         simpa using hε1.left
     _ ≤ _ := hm.right.le --(S73)
 
-  let P1 ε2 n := {(ℰ n (ρ ⊗ᵣ^[n])).M ≥ₚ (Real.exp (↑n*((R1 ρ ε).toReal + ε2))) • (σ'' ρ ε m σ n).M}
-  let P2 ε2 n := {(ℰ n (ρ ⊗ᵣ^[n])).M ≥ₚ (Real.exp (↑n*((R2 ρ σ).toReal + ε₀ + ε2))) • (σ'' ρ ε m σ n).M}
+  let P1 ε2 n :=
+    {(ℰ n (ρ ⊗ᵣ^[n])).M ≥ₚ (Real.exp (↑n*((R1 ρ ε).toReal + ε2))) • (σ'' ρ ε m σ n).M}
+  let P2 ε2 n :=
+    {(ℰ n (ρ ⊗ᵣ^[n])).M ≥ₚ (Real.exp (↑n*((R2 ρ σ).toReal + ε₀ + ε2))) • (σ'' ρ ε m σ n).M}
 
-  have hEComm ε2 n : Commute (((ℰ n) (ρ ⊗ᵣ^[n])).M - Real.exp ((n : ℝ) * ((R2 ρ σ).toReal + ε₀ + ε2)) • (σ'' ρ ε m σ n).M).mat
-      (((ℰ n) (ρ ⊗ᵣ^[n])).M - Real.exp ((n : ℝ) * ((R1 ρ ε).toReal + ε2)) • (σ'' ρ ε m σ n).M).mat := by
+  have hEComm ε2 n : Commute
+      (((ℰ n) (ρ ⊗ᵣ^[n])).M -
+        Real.exp ((n : ℝ) * ((R2 ρ σ).toReal + ε₀ + ε2)) • (σ'' ρ ε m σ n).M).mat
+      (((ℰ n) (ρ ⊗ᵣ^[n])).M -
+        Real.exp ((n : ℝ) * ((R1 ρ ε).toReal + ε2)) • (σ'' ρ ε m σ n).M).mat := by
     simp only [HermitianMat.mat_sub, MState.mat_M, HermitianMat.mat_smul]
     suffices h : Commute (ℰ n (ρ ⊗ᵣ^[n])).m (σ'' ρ ε m σ n).m by
       apply Commute.sub_left
@@ -1200,12 +1305,14 @@ private theorem EquationS62
     unfold E1 E2 E3
     abel
 
-  have hE1proj ε2 n : E1 ε2 n = {(ℰ n (ρ ⊗ᵣ^[n])).M <ₚ (Real.exp (↑n*((R1 ρ ε).toReal + ε2))) • (σ'' ρ ε m σ n).M} := by
+  have hE1proj ε2 n : E1 ε2 n =
+      {(ℰ n (ρ ⊗ᵣ^[n])).M <ₚ (Real.exp (↑n*((R1 ρ ε).toReal + ε2))) • (σ'' ρ ε m σ n).M} := by
     dsimp [E1, P1]
     rw [sub_eq_iff_eq_add]
     simp only [HermitianMat.proj_le_add_lt]
 
-  have hE2leProj ε2 n : E2 ε2 n ≤ {(ℰ n (ρ ⊗ᵣ^[n])).M <ₚ (Real.exp (↑n*((R2 ρ σ).toReal + ε₀ + ε2))) • (σ'' ρ ε m σ n).M} := by
+  have hE2leProj ε2 n : E2 ε2 n ≤
+      {(ℰ n (ρ ⊗ᵣ^[n])).M <ₚ (Real.exp (↑n*((R2 ρ σ).toReal + ε₀ + ε2))) • (σ'' ρ ε m σ n).M} := by
     dsimp [E2, P1, P2]
     rw [sub_le_iff_le_add]
     simp only [HermitianMat.proj_le_add_lt]
@@ -1263,17 +1370,23 @@ private theorem EquationS62
   -- Leo: I think there's a typo in the third eq. of this step: ρ should be ρ^n.
   -- The next set of equations also have ρ_n instead of ρ^n.
   -- (S88)
-  have hDleq ε2 n (hε2 : 0 < ε2) (hn : 0 < n) : (𝐃(ℰ n (ρ ⊗ᵣ^[n])‖σ'' ρ ε m σ n) / n : ℝ≥0∞) ≤  ((R1 ρ ε) + .ofReal ε2) +
-        .ofReal ⟪P1 ε2 n, ℰ n (ρ ⊗ᵣ^[n])⟫ * ((R2 ρ σ + .ofReal ε₀ + .ofReal ε2) - (R1 ρ ε + .ofReal ε2)) +
-        .ofReal ⟪P2 ε2 n, ℰ n (ρ ⊗ᵣ^[n])⟫ * (.ofReal (c' ε2 n) - (R2 ρ σ + .ofReal ε₀ + .ofReal ε2)) := by
+  have hDleq ε2 n (hε2 : 0 < ε2) (hn : 0 < n) :
+      (𝐃(ℰ n (ρ ⊗ᵣ^[n])‖σ'' ρ ε m σ n) / n : ℝ≥0∞) ≤  ((R1 ρ ε) + .ofReal ε2) +
+        .ofReal ⟪P1 ε2 n, ℰ n (ρ ⊗ᵣ^[n])⟫ *
+          ((R2 ρ σ + .ofReal ε₀ + .ofReal ε2) - (R1 ρ ε + .ofReal ε2)) +
+        .ofReal ⟪P2 ε2 n, ℰ n (ρ ⊗ᵣ^[n])⟫ *
+          (.ofReal (c' ε2 n) - (R2 ρ σ + .ofReal ε₀ + .ofReal ε2)) := by
     -- see (S81) for comments on why that statement had to be changed
     -- (S85)
     -- (first inequality should have $\sigma_n''$ instead of
     -- $\tilde{\sigma}_n''$; corrected in v4, where $\tilde{\sigma}_n'$ takes
     -- the place of $\sigma_n''$) in this and other steps
-    have hE3leq : (1/n : ℝ) • (E3 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat) ≤ (c' ε2 n) • (E3 ε2 n).mat := by
+    have hE3leq : (1/n : ℝ) • (E3 ε2 n).mat *
+        ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat) ≤
+        (c' ε2 n) • (E3 ε2 n).mat := by
       calc
-      (1/n : ℝ) • (E3 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat) ≤ (1/n : ℝ) • (E3 ε2 n).mat * (- (σ'' ρ ε m σ n).M.log.mat) := by
+      (1/n : ℝ) • (E3 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat) ≤
+        (1/n : ℝ) • (E3 ε2 n).mat * (- (σ'' ρ ε m σ n).M.log.mat) := by
         -- first inequality of (S85)
         have hℰρlognonpos : 0 ≤ -(ℰ n (ρ ⊗ᵣ^[n])).M.log.mat := by
           -- log of state is non-positive
@@ -1291,7 +1404,8 @@ private theorem EquationS62
         conv =>
           rhs
           congr; rfl
-          rw [← sub_add (-(σ'' ρ ε m σ n).M.log.mat) ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat) ((σ'' ρ ε m σ n).M.log.mat)]
+          rw [← sub_add (-(σ'' ρ ε m σ n).M.log.mat) ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat)
+            ((σ'' ρ ε m σ n).M.log.mat)]
           rw [add_comm_sub]
           rw [← add_sub_assoc]
           simp [sub_self (σ'' ρ ε m σ n).M.log.mat]
@@ -1300,10 +1414,12 @@ private theorem EquationS62
           apply Commute.mul_nonneg _ hℰρlognonpos (Commute.neg_right (hE3commℰ ε2 n))
           apply HermitianMat.projLE_nonneg
         apply smul_nonneg (inv_nonneg_of_nonneg (Nat.cast_nonneg' n)) hE3ℰnonneg
-      _ ≤ (1/n : ℝ) • (E3 ε2 n).mat * (- (Real.exp (-n * c' ε2 n) • (1 : HermitianMat (H (i ^ n)) ℂ)).log.mat) := by
+      _ ≤ (1/n : ℝ) • (E3 ε2 n).mat *
+          (- (Real.exp (-n * c' ε2 n) • (1 : HermitianMat (H (i ^ n)) ℂ)).log.mat) := by
         -- intermediate step in 2nd ineq of S85
         simp only [mul_neg, neg_mul, neg_le_neg_iff]
-        have h1logleq : (Real.exp (-(n * c' ε2 n)) • 1 : HermitianMat (H (i ^ n)) ℂ).log.mat ≤ ((σ'' ρ ε m σ n).M).log.mat := by
+        have h1logleq : (Real.exp (-(n * c' ε2 n)) • 1 : HermitianMat (H (i ^ n)) ℂ).log.mat ≤
+            ((σ'' ρ ε m σ n).M).log.mat := by
           -- apply hσ'' ε2 n to log by monotonicity
           rw [← HermitianMat.val_eq_coe, ← HermitianMat.val_eq_coe]
           rw [Subtype.coe_le_coe]
@@ -1313,7 +1429,9 @@ private theorem EquationS62
         rw [← sub_nonneg] at h1logleq
         rw [← sub_nonneg, ← mul_sub_left_distrib]
         simp only [one_div, Algebra.smul_mul_assoc]
-        have hE3commlog : Commute (E3 ε2 n).mat ((σ'' ρ ε m σ n).M.log.mat - (Real.exp (-(n * c' ε2 n)) • 1 : HermitianMat _ ℂ).log.mat) := by
+        have hE3commlog : Commute (E3 ε2 n).mat
+            ((σ'' ρ ε m σ n).M.log.mat -
+              (Real.exp (-(n * c' ε2 n)) • 1 : HermitianMat _ ℂ).log.mat) := by
           -- projector commutes with logs
           apply Commute.sub_right
           · -- prove Commute (E3 _) (σ'' _).log
@@ -1356,9 +1474,12 @@ private theorem EquationS62
         have hker : (σ'' ρ ε m σ n).M.ker ≤ (ℰ n (ρ ⊗ᵣ^[n])).M.ker :=
           ker_le_ker_pinching_of_PosDef (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n) (σ''_pd n)
         simp only [hker, ↓reduceDIte]
-        have hMulOne : (ℰ n (ρ ⊗ᵣ^[n])).M.mat * (1 : Matrix (H (i ^ n)) (H (i ^ n)) ℂ) = (ℰ n (ρ ⊗ᵣ^[n])).M.mat := Matrix.mul_one (ℰ n (ρ ⊗ᵣ^[n])).M.mat
-        have hOneMulCommute : Commute (1 : HermitianMat _ ℂ).mat (ℰ n (ρ ⊗ᵣ^[n])).M.mat := Commute.one_left (ℰ n (ρ ⊗ᵣ^[n])).M.mat
-        have hOneIsOne : ∀ (ε : ℝ) (n : ℕ), (1 : ℝ → ℕ → HermitianMat (H (i ^ n)) ℂ) ε n = (1 : HermitianMat (H (i ^ n)) ℂ) := by
+        have hMulOne : (ℰ n (ρ ⊗ᵣ^[n])).M.mat * (1 : Matrix (H (i ^ n)) (H (i ^ n)) ℂ)
+            = (ℰ n (ρ ⊗ᵣ^[n])).M.mat := Matrix.mul_one (ℰ n (ρ ⊗ᵣ^[n])).M.mat
+        have hOneMulCommute : Commute (1 : HermitianMat _ ℂ).mat (ℰ n (ρ ⊗ᵣ^[n])).M.mat :=
+          Commute.one_left (ℰ n (ρ ⊗ᵣ^[n])).M.mat
+        have hOneIsOne : ∀ (ε : ℝ) (n : ℕ),
+            (1 : ℝ → ℕ → HermitianMat (H (i ^ n)) ℂ) ε n = (1 : HermitianMat (H (i ^ n)) ℂ) := by
           intro ε n; rfl
         /- convert Esum to the HermitianMat equality at point (ε2, n) -/
         have Esum' : (E1 ε2 n).mat + (E2 ε2 n).mat + (E3 ε2 n).mat = 1 :=
@@ -1375,9 +1496,11 @@ private theorem EquationS62
 
         /-the next two `have`s are duplicates-/
         -- TODO streamline what's below
-        /-it should transform a HermitianMat inequality into a reals inequality with HermitianMat.inner_mono,
-        the difficulty here is that inner_mono relies on the entries being HermitianMat, but the inequalities are expressed as matrices-/
-        have hE2comm : Commute (E2 ε2 n).mat (((ℰ n (ρ ⊗ᵣ^[n])).M.log - (σ'' ρ ε m σ n).M.log).mat) := by
+        /-it should transform a HermitianMat inequality into a reals inequality with
+        HermitianMat.inner_mono, the difficulty here is that inner_mono relies on the entries
+        being HermitianMat, but the inequalities are expressed as matrices-/
+        have hE2comm : Commute (E2 ε2 n).mat
+            (((ℰ n (ρ ⊗ᵣ^[n])).M.log - (σ'' ρ ε m σ n).M.log).mat) := by
         -- TODO this needs to be extracted from here, it's badly redundant
           apply Commute.sub_right
           · unfold E2 P1 P2
@@ -1410,11 +1533,14 @@ private theorem EquationS62
               apply Commute.sub_left
               · exact pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)
               · simp
-        have hE2leqInner : (n : ℝ)⁻¹ * ((ℰ n (ρ ⊗ᵣ^[n])).M.mat * (E2 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat)).trace.re ≤
+        have hE2leqInner : (n : ℝ)⁻¹ * ((ℰ n (ρ ⊗ᵣ^[n])).M.mat * (E2 ε2 n).mat
+              * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat)).trace.re ≤
             ((R2 ρ σ).toReal + ε₀ + ε2) * ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, E2 ε2 n⟫ := by
           open HermMul in
           -- (S82) -- see (S81) for comments
-          have hE2leq ε2 (n : ℕ) (hε2 : 0 < ε2) : (1/n : ℝ) • (E2 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat) ≤ ((R2 ρ σ).toReal + ε₀ + ε2) • (E2 ε2 n).mat := by
+          have hE2leq ε2 (n : ℕ) (hε2 : 0 < ε2) : (1/n : ℝ) • (E2 ε2 n).mat
+              * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat)
+              ≤ ((R2 ρ σ).toReal + ε₀ + ε2) • (E2 ε2 n).mat := by
             refine rexp_mul_smul_proj_lt_mul_sub_le_mul_sub'
               (pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)) ?_ (σ''_posdef ρ ε m σ n) rfl
             rw [← HermitianMat.zero_le_iff]
@@ -1433,7 +1559,8 @@ private theorem EquationS62
             norm_cast
           specialize hE2leq ε2 n hε2
           rw [← HermitianMat.symmMul_of_commute hE2comm] at hE2leq
-          rw [← Matrix.mul_smul (ℰ n (ρ ⊗ᵣ^[n])).M.mat (Complex.ofReal (n : ℝ)⁻¹) (HermitianMat.symmMul _ _).mat]
+          rw [← Matrix.mul_smul (ℰ n (ρ ⊗ᵣ^[n])).M.mat (Complex.ofReal (n : ℝ)⁻¹)
+            (HermitianMat.symmMul _ _).mat]
           conv =>
             enter [1, 2, 1, 2]
             equals HermitianMat.mat ((n : ℝ)⁻¹ • (HermitianMat.symmMul (E2 ε2 n)
@@ -1444,7 +1571,8 @@ private theorem EquationS62
           exact ((HermitianMat.inner_mono ((ℰ n (ρ ⊗ᵣ^[n]))).nonneg) hE2leq)
         simp at hE3leq
         /-this and the `have` above are duplicates-/
-        have hE3comm : Commute (E3 ε2 n).mat (((ℰ n (ρ ⊗ᵣ^[n])).M.log - (σ'' ρ ε m σ n).M.log).mat) := by
+        have hE3comm : Commute (E3 ε2 n).mat
+            (((ℰ n (ρ ⊗ᵣ^[n])).M.log - (σ'' ρ ε m σ n).M.log).mat) := by
           apply Commute.sub_right
           · simp [(hE3commℰ ε2 n)]
           · unfold E3 P2
@@ -1455,7 +1583,9 @@ private theorem EquationS62
             · exact pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)
             · simp
         /- hE3commℰ -/
-        have hE3leqInner : (n : ℝ)⁻¹ * ((ℰ n (ρ ⊗ᵣ^[n])).M.mat * (E3 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat)).trace.re ≤ (c' ε2 n) * ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, E3 ε2 n⟫ := by
+        have hE3leqInner : (n : ℝ)⁻¹ * ((ℰ n (ρ ⊗ᵣ^[n])).M.mat * (E3 ε2 n).mat
+              * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' ρ ε m σ n).M.log.mat)).trace.re
+            ≤ (c' ε2 n) * ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, E3 ε2 n⟫ := by
           open HermMul in
           rw [← Complex.re_ofReal_mul (↑n)⁻¹ _, ← smul_eq_mul, ← Matrix.trace_smul]
           rw [← RCLike.re_to_complex]
@@ -1477,13 +1607,15 @@ private theorem EquationS62
           conv at hE3leq =>
             rhs
             rw [← HermitianMat.mat_smul _ (E3 ε2 n)]
-          rw [← Matrix.mul_smul (ℰ n (ρ ⊗ᵣ^[n])).M.mat (Complex.ofReal (n : ℝ)⁻¹) (HermitianMat.symmMul _ _).mat]
+          rw [← Matrix.mul_smul (ℰ n (ρ ⊗ᵣ^[n])).M.mat (Complex.ofReal (n : ℝ)⁻¹)
+            (HermitianMat.symmMul _ _).mat]
           conv =>
             enter [1, 2, 1, 2]
             equals HermitianMat.mat ((n : ℝ)⁻¹ • (HermitianMat.symmMul (E3 ε2 n)
               ((((ℰ n) (ρ ⊗ᵣ^[n])).M.log - (σ'' ρ ε m σ n).M.log)))) =>
               rfl --TODO: Lemma to work with this better (see above TODO)
-          rw [← HermitianMat.inner_eq_re_trace (ℰ n (ρ ⊗ᵣ^[n])).M ((n : ℝ)⁻¹ • (HermitianMat.symmMul _ _))]
+          rw [← HermitianMat.inner_eq_re_trace (ℰ n (ρ ⊗ᵣ^[n])).M
+            ((n : ℝ)⁻¹ • (HermitianMat.symmMul _ _))]
           rw [← HermitianMat.inner_smul_right]
           exact ((HermitianMat.inner_mono ((ℰ n (ρ ⊗ᵣ^[n]))).nonneg) hE3leq)
         simp only [IsMaximalSelfAdjoint.RCLike_selfadjMap, MState.mat_M, HermitianMat.mat_sub,
@@ -1502,30 +1634,36 @@ private theorem EquationS62
 
             -- (S81)
             /- A literal translation of the paper would read:
-                (1/n : ℝ) • (E1 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' n).M.log.mat) ≤ ((R1 ρ ε).toReal + ε2) • (E1 ε2 n).mat
-            But this is simply not true! Because what happens when `ℰ n (ρ ⊗ᵣ^[n])` has a zero eigenvalue, which
-            it can? Then (S81) is an inequality of operators where the LHS has an operator with a "negative
-            infinity" eigenvalue, intuitively. This isn't something very well defined, certainly not supported
-            in our definitions. This only becomes mathematically meaningful when we see how it's used later, in
-            (S88): both sides are traced against `ℰ n (ρ ⊗ᵣ^[n])`, so that the 0 eigenvalues becomes irrelevant. This
+                (1/n : ℝ) • (E1 ε2 n).mat * ((ℰ n (ρ ⊗ᵣ^[n])).M.log.mat - (σ'' n).M.log.mat)
+                  ≤ ((R1 ρ ε).toReal + ε2) • (E1 ε2 n).mat
+            But this is simply not true! Because what happens when `ℰ n (ρ ⊗ᵣ^[n])` has a zero
+            eigenvalue, which it can? Then (S81) is an inequality of operators where the LHS has an
+            operator with a "negative infinity" eigenvalue, intuitively. This isn't something very
+            well defined, certainly not supported in our definitions. This only becomes
+            mathematically meaningful when we see how it's used later, in (S88): both sides are
+            traced against `ℰ n (ρ ⊗ᵣ^[n])`, so that the 0 eigenvalues becomes irrelevant. This
             is the version we state and prove, then.
 
-            Luckily, (S82) and (S85) are correct as written (in a particular interpretation), because
-            there the problematic subspaces are indeed projected out by the E₂ and E₃ operators.
+            Luckily, (S82) and (S85) are correct as written (in a particular interpretation),
+            because there the problematic subspaces are indeed projected out by the E₂ and E₃
+            operators.
             -/
             have hE1leq ε2 (n : ℕ) (hε2 : 0 < ε2) :
                 ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, (((1 / (n : ℝ)) • (E1 ε2 n)).symmMul
-                  ((((pinching_map (σ'' ρ ε m σ n)) (ρ ⊗ᵣ^[n])).M).log - ((σ'' ρ ε m σ n).M).log : HermitianMat _ ℂ))⟫ ≤
+                  ((((pinching_map (σ'' ρ ε m σ n)) (ρ ⊗ᵣ^[n])).M).log
+                    - ((σ'' ρ ε m σ n).M).log : HermitianMat _ ℂ))⟫ ≤
                   ⟪(ℰ n (ρ ⊗ᵣ^[n])).M, ((R1 ρ ε).toReal + ε2) • (E1 ε2 n)⟫ := by
               refine rexp_mul_smul_proj_lt_mul_sub_le_mul_sub
-                (pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)) (by positivity) ?_ (σ''_posdef ρ ε m σ n) rfl
+                (pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)) (by positivity) ?_
+                (σ''_posdef ρ ε m σ n) rfl
               rw [← HermitianMat.zero_le_iff]
               apply MState.nonneg
 
             simp only [HermitianMat.inner_def] at hE1leq
             conv at hE1leq =>
               enter [ε2, n, hε2, 1]
-              rw [HermitianMat.symmMul_of_commute (commute_aux n (E := E1 ε2 n) (pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)) rfl)]
+              rw [HermitianMat.symmMul_of_commute (commute_aux n (E := E1 ε2 n)
+                (pinching_commutes (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)) rfl)]
             simp at hE1leq
             conv at hE1leq =>
               intro ε2 n hε2
@@ -1608,7 +1746,8 @@ private theorem EquationS62
               exact ⟨hε1', by norm_num⟩
             · rw [min_lt_iff]
               exact Or.inr (by norm_num)
-          have hlimsupP2  ε2 (hε2 : 0 < ε2) (ε1 : Prob) (hε1 : 0 < (ε1 : ℝ) ∧ (ε1 : ℝ) < 1) := --(S77)
+          --(S77)
+          have hlimsupP2  ε2 (hε2 : 0 < ε2) (ε1 : Prob) (hε1 : 0 < (ε1 : ℝ) ∧ (ε1 : ℝ) < 1) :=
             LemmaS2limsup hε2 (fun n ↦ ℰ n (ρ ⊗ᵣ^[n])) (σ'' ρ ε m σ) (hlimsup_le ε1 hε1)
           specialize hlimsupP2 ⟨ε2, hε2.le⟩ hε2 ⟨ε1, ⟨hε1.1.le, hε1.2.le⟩⟩ hε1
           trans ε1
@@ -1655,13 +1794,16 @@ private theorem EquationS62
         apply HermitianMat.inner_ge_zero
         · apply HermitianMat.projLE_nonneg
         · apply MState.nonneg
-    rcases this with ⟨ε2, hg₁, hg₂, hg₃, hliminf_g₁, hliminf_g₂⟩
+    rcases this with
+      ⟨ε2, hg₁, hg₂, hg₃, hliminf_g₁, hliminf_g₂⟩
 
-    replace hDleq := Filter.liminf_le_liminf (Filter.eventually_atTop.mpr ⟨1, fun (n : ℕ) hnge1 ↦ hDleq (ε2 n) n (hg₁ n) hnge1⟩)
+    replace hDleq := Filter.liminf_le_liminf (Filter.eventually_atTop.mpr
+      ⟨1, fun (n : ℕ) hnge1 ↦ hDleq (ε2 n) n (hg₁ n) hnge1⟩)
     apply le_trans hDleq -- (S89)
     have hP2zero : Filter.atTop.Tendsto (fun n ↦ .ofReal ⟪P2 (ε2 n) n, ℰ n (ρ ⊗ᵣ^[n])⟫ *
         (.ofReal (c' (ε2 n) n) - (R2 ρ σ + .ofReal ε₀ + .ofReal (ε2 n)))) (𝓝 0) := by
-      have hf : Filter.atTop.Tendsto (fun n ↦ .ofReal ⟪P2 (ε2 n) n, ℰ n (ρ ⊗ᵣ^[n])⟫) (𝓝 (0 : ℝ≥0∞)) := by
+      have hf : Filter.atTop.Tendsto (fun n ↦ .ofReal ⟪P2 (ε2 n) n, ℰ n (ρ ⊗ᵣ^[n])⟫)
+          (𝓝 (0 : ℝ≥0∞)) := by
         refine tendsto_of_le_liminf_of_limsup_le bot_le ?_
         convert hliminf_g₂
         apply ENNReal.ofReal_eq_coe_nnreal
@@ -1710,7 +1852,8 @@ private theorem EquationS62
         apply Filter.Eventually.frequently
         apply Filter.Eventually.of_forall
         intro x
-        rw [add_right_comm, ← ENNReal.sub_add_eq_add_sub (add_le_add_left hR1R2.le _) (by finiteness)]
+        rw [add_right_comm,
+          ← ENNReal.sub_add_eq_add_sub (add_le_add_left hR1R2.le _) (by finiteness)]
         exact le_add_self
       · left
         apply ne_top_of_le_ne_top (b := R2 ρ σ + ENNReal.ofReal ε₀ + 1) (by finiteness)
@@ -1748,7 +1891,8 @@ private theorem EquationS62
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Lemma 7 from the paper. We write `ε'` for their `\tilde{ε}`. -/
-theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (n : ℕ) → IsFree (i := i ^ n)) :
+theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1)
+    (σ : (n : ℕ) → IsFree (i := i ^ n)) :
     (R2 ρ σ ≥ R1 ρ ε) →
     ∀ ε' : Prob, (hε' : 0 < ε' ∧ ε' < ε) → -- ε' is written as \tilde{ε} in the paper.
     ∃ σ' : (n : ℕ) → IsFree (i := i ^ n),
@@ -1757,7 +1901,8 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
   --This proof naturally splits out into LemmaS62:
   --  `lim inf n→∞ 1/n D(E_n(ρ^⊗n)‖σ''_n) − R1,ϵ ≤ (1 − ˜ϵ)(R2 − R1,ϵ).`
   --which is proved above. Here, set up the preliminiaries (appropriate finiteness
-  -- conditions, nonzeroness, etc.) get S62, prove S61, and the conclusion is just `rw [S61] at S62`.
+  -- conditions, nonzeroness, etc.) get S62, prove S61, and the conclusion is just
+  -- `rw [S61] at S62`.
 
   --First deal with the easy case of R1 = R2.
   intro hR1R2 ε' ⟨hε'₁, hε'₂⟩
@@ -1805,13 +1950,15 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
       ENNReal.lt_add_right hR2 (by simp [← NNReal.coe_eq_zero, toReal, hε₀.ne'])
     (Filter.frequently_lt_of_liminf_lt (h := h)).forall_exists_of_atTop 1
 
-  have qRel_σ''_le_σ' n : 𝐃(ρ ⊗ᵣ^[n]‖σ'' ρ ε m σ n) ≤ 𝐃(ρ ⊗ᵣ^[n]‖σ' ρ ε m σ n) + ENNReal.ofReal (σ₁_c i n) := by
+  have qRel_σ''_le_σ' n : 𝐃(ρ ⊗ᵣ^[n]‖σ'' ρ ε m σ n) ≤
+      𝐃(ρ ⊗ᵣ^[n]‖σ' ρ ε m σ n) + ENNReal.ofReal (σ₁_c i n) := by
     rw [← Real.log_exp (σ₁_c i n)]
     apply qRelEntropy_le_add_of_le_smul
     rw [← inv_smul_le_iff_of_pos (by positivity), ← Real.exp_neg]
     apply σ'_le_σ''
 
-  have qRel_σ'_le_σ'' n : 𝐃(ρ ⊗ᵣ^[n]‖σ' ρ ε m σ n) ≤ 𝐃(ρ ⊗ᵣ^[n]‖σ'' ρ ε m σ n) + ENNReal.ofReal (σ₁_c i n) := by
+  have qRel_σ'_le_σ'' n : 𝐃(ρ ⊗ᵣ^[n]‖σ' ρ ε m σ n) ≤
+      𝐃(ρ ⊗ᵣ^[n]‖σ'' ρ ε m σ n) + ENNReal.ofReal (σ₁_c i n) := by
     rw [← Real.log_exp (σ₁_c i n)]
     apply qRelEntropy_le_add_of_le_smul
     apply σ''_le_σ'
@@ -1831,8 +1978,10 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
     rw [← Set.ncard_coe_finset]
     simp only [Finset.coe_image, Finset.coe_univ, Set.image_univ]
     have eq : ∃ (e : Equiv.Perm _), (σ'' ρ ε m σ n).M.H.eigenvalues =
-        (fun x ↦ (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x)) ∘ (σ' ρ ε m σ n).M.H.eigenvalues ∘ e := by
-      convert (σ' ρ ε m σ n).M.cfc_eigenvalues (fun x ↦ (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x))
+        (fun x ↦ (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x)) ∘
+          (σ' ρ ε m σ n).M.H.eigenvalues ∘ e := by
+      convert (σ' ρ ε m σ n).M.cfc_eigenvalues
+        (fun x ↦ (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x))
       rw [HermitianMat.cfc_const_mul, ← σ''_unnormalized, σ'']
     rcases eq with ⟨eq, heq⟩
     rw [heq]
@@ -1840,7 +1989,9 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
     let S : Set ℝ := (fun x => Real.exp (f_map i n x)) '' Set.Icc ((σ₁_mineig i ^ n) / 3) 1
     have h_card_subs : Set.ncard S ≤ n + 1 ∧ S.Finite := by
       exact f_image_bound (σ₁_mineig i) n (mineig_pos i) hn (log_le_f i) (f_le_log i)
-    let S₂ : Set ℝ := (fun x => (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x)) '' Set.Icc ((σ₁_mineig i ^ n) / 3) 1
+    let S₂ : Set ℝ :=
+      (fun x => (σ''_unnormalized ρ ε m σ n).trace⁻¹ * Real.exp (f_map i n x)) ''
+        Set.Icc ((σ₁_mineig i ^ n) / 3) 1
     obtain ⟨h_card_subs₂, h_s₂_finite⟩ : Set.ncard S₂ ≤ n + 1 ∧ S₂.Finite := by
       have hS₂ : S₂ = ((σ''_unnormalized ρ ε m σ n).trace⁻¹ * ·) '' S := by
         simp [S, S₂, Set.image_image]
@@ -1850,7 +2001,8 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
       · rw [hS₂]
         exact h_card_subs.right.image _
     refine (Set.ncard_le_ncard (t := (fun x => (σ''_unnormalized ρ ε m σ n).trace⁻¹ *
-      Real.exp (f_map i n x)) '' Set.Icc (((σ₁_mineig i) ^ n) / 3) 1) ?_ h_s₂_finite).trans h_card_subs₂
+      Real.exp (f_map i n x)) '' Set.Icc (((σ₁_mineig i) ^ n) / 3) 1) ?_ h_s₂_finite).trans
+      h_card_subs₂
     apply Set.image_mono
     rintro _ ⟨k, rfl⟩
     refine ⟨?_, MState.eigenvalue_le_one _ _⟩
@@ -1860,7 +2012,8 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
     rw [← Matrix.IsHermitian.spectrum_real_eq_range_eigenvalues]
     rw [← Matrix.IsHermitian.spectrum_real_eq_range_eigenvalues]
     rw [HermitianMat.val_eq_coe, HermitianMat.mat_smul]
-    rw [spectrum.smul_eq_smul _ _ (ContinuousFunctionalCalculus.spectrum_nonempty _ ((σ₁ i) ⊗ᵣ^[n]).M.H)]
+    rw [spectrum.smul_eq_smul _ _
+      (ContinuousFunctionalCalculus.spectrum_nonempty _ ((σ₁ i) ⊗ᵣ^[n]).M.H)]
     rw [Real.sInf_smul_of_nonneg (by norm_num)]
     simp [MState.mat_M, div_eq_inv_mul, sInf_spectrum_spacePow]
 
@@ -1871,7 +2024,8 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
 
   -- Eq. (S60)
   have qRel_ent_bound n : 𝐃(ρ ⊗ᵣ^[n]‖ℰ n (ρ ⊗ᵣ^[n])) ≤ ENNReal.ofReal (Real.log (n + 1)) := calc
-    𝐃(ρ ⊗ᵣ^[n]‖ℰ n (ρ ⊗ᵣ^[n])) ≤ ENNReal.ofReal (Real.log (Fintype.card (spectrum ℝ (σ'' ρ ε m σ n).m))) :=
+    𝐃(ρ ⊗ᵣ^[n]‖ℰ n (ρ ⊗ᵣ^[n])) ≤
+        ENNReal.ofReal (Real.log (Fintype.card (spectrum ℝ (σ'' ρ ε m σ n).m))) :=
       qRelativeEnt_op_le (pinching_bound ..)
     _ ≤ ENNReal.ofReal (Real.log (n + 1)) := by
       grw [hdle n]
@@ -1911,7 +2065,8 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
         use 1
         intro n _
         exact ENNReal.div_le_div (qRel_σ''_le_σ' n) (by rfl)
-    · -- Eq (S59) has a minus sign, which gets complicated when one of the relative entropies is infinite.
+    · -- Eq (S59) has a minus sign, which gets complicated when one of the relative entropies
+      -- is infinite.
       -- However, I don't think we need this version with the minus sign.
       have h_pinching := fun n ↦ pinching_pythagoras (ρ ⊗ᵣ^[n]) (σ'' ρ ε m σ n)
       simp only [h_pinching, ENNReal.add_div, ← Pi.add_apply]
@@ -1946,10 +2101,13 @@ theorem Lemma7 (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) (σ : (
   rw [R2, hliminf]
   exact EquationS62 ρ σ hε'₁ hε'₂ hε.2 hR1R2 hR1 hR2 hε₀ hε₀' m hm
 
-/-- Lemma 7 gives us a way to repeatedly "improve" a sequence σ to one with a smaller gap between R2 and R1.
-The paper paints this as pretty much immediate from Lemma7, but we need to handle the case where R2 is below
+/-- Lemma 7 gives us a way to repeatedly "improve" a sequence σ to one with a smaller gap
+between R2 and R1.
+The paper paints this as pretty much immediate from Lemma7, but we need to handle the case
+where R2 is below
 R1. -/
-noncomputable def Lemma7_improver (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) {ε' : Prob} (hε' : 0 < ε' ∧ ε' < ε) :
+noncomputable def Lemma7_improver (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1)
+    {ε' : Prob} (hε' : 0 < ε' ∧ ε' < ε) :
     --The parameters above are the "fixed" parameters that we'll improve
     --It takes one sequence of free states, `(n : ℕ) → IsFree (i := i ^ n)`, and gives a new one
     ((n : ℕ) → IsFree (i := i ^ n)) → ((n : ℕ) → IsFree (i := i ^ n)) :=
@@ -1960,7 +2118,8 @@ noncomputable def Lemma7_improver (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε 
      σ --The gap was already 0 (or even, negative!) so leave it unchanged.
 
 /-- The Lemma7_improver does its job at shrinking the gap. -/
-theorem Lemma7_gap (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) {ε' : Prob} (hε' : 0 < ε' ∧ ε' < ε) :
+theorem Lemma7_gap (ρ : MState (H i)) {ε : Prob} (hε : 0 < ε ∧ ε < 1) {ε' : Prob}
+    (hε' : 0 < ε' ∧ ε' < ε) :
     ∀ σ,
       letI σ' := Lemma7_improver ρ hε hε' σ;
       R2 ρ σ' - R1 ρ ε ≤ .ofNNReal (1 - ε' : Prob) * (R2 ρ σ - R1 ρ ε) := by
@@ -1986,10 +2145,13 @@ theorem GeneralizedQSteinsLemma {i : ι} (ρ : MState (H i)) {ε : Prob} (hε : 
     --less than ε. We take ε' := ε/2.
      --TODO: Should we have an HDiv Prob Nat instance?
     let ε' : Prob := ⟨ε/2, by constructor <;> linarith [ε.zero_le_coe, ε.coe_le_one]⟩
-    have hε' : 0 < ε' ∧ ε' < ε := by constructor <;> change (_ : ℝ) < (_ : ℝ) <;> simpa [ε'] using hε.1
+    have hε' : 0 < ε' ∧ ε' < ε := by
+      constructor <;> change (_ : ℝ) < (_ : ℝ) <;> simpa [ε'] using hε.1
 
-    --Take some initial sequence σ₁. We need to pick it so that `R2 ρ σ₁` is finite, otherwise we can't "shrink"
-    --it by applying Lemma 7. Taking the full-rank state of dimension `H i` and taking all powers of it, works.
+    --Take some initial sequence σ₁. We need to pick it so that `R2 ρ σ₁` is finite, otherwise
+    --we can't "shrink"
+    --it by applying Lemma 7. Taking the full-rank state of dimension `H i` and taking all
+    --powers of it, works.
     have ⟨σ_free, hσ_free⟩ := free_fullRank i
     set σ₁ : (n : ℕ) → IsFree (i := i ^ n) := fun n ↦
       ⟨σ_free  ⊗ᵣ^[n], IsFree.npow hσ_free.2 n⟩ with hσ₁
@@ -2107,7 +2269,8 @@ theorem GeneralizedQSteinsLemma {i : ι} (ρ : MState (H i)) {ε : Prob} (hε : 
       apply iInf_subtype''
 
 /-- Theorem 4, which is also called the Generalized quantum Stein's lemma in Hayashi & Yamasaki.
-What they state as an equality of limits, which don't exist per se in Mathlib, we state as the existence
+What they state as an equality of limits, which don't exist per se in Mathlib, we state as the
+existence
 of a number (which happens to be `RegularizedRelativeEntResource`) to which both sides converge.
 -/
 theorem limit_hypotesting_eq_limit_rel_entropy (ρ : MState (H i)) (ε : Prob) (hε : 0 < ε ∧ ε < 1) :
@@ -2116,7 +2279,9 @@ theorem limit_hypotesting_eq_limit_rel_entropy (ρ : MState (H i)) (ε : Prob) (
       ∧
       Filter.atTop.Tendsto (fun n ↦ (⨅ σ ∈ IsFree, 𝐃(ρ ⊗ᵣ^[n]‖σ)) / n) (𝓝 d)
       := by
-  use 𝑅ᵣ∞ ρ -- Regularized relative entropy of resource (RegularizedRelativeEntResource) as an NNReal
+  -- Regularized relative entropy of resource (RegularizedRelativeEntResource) as an NNReal
+  use 𝑅ᵣ∞ ρ
   constructor
   · exact GeneralizedQSteinsLemma ρ hε -- Theorem 1 in Hayashi & Yamasaki
-  · exact RelativeEntResource.tendsto_ennreal ρ -- The regularized relative entropy of resource is not infinity
+  -- The regularized relative entropy of resource is not infinity
+  · exact RelativeEntResource.tendsto_ennreal ρ

--- a/QuantumInfo/States/Ensemble.lean
+++ b/QuantumInfo/States/Ensemble.lean
@@ -19,12 +19,14 @@ noncomputable section
 /-- A mixed-state ensemble is a random variable valued in `MState d`. That is,
 a collection of mixed states `var : α → MState d`, each with their own probability weight
 described by `distr : ProbDistribution α`. -/
-abbrev MEnsemble (d : Type*) (α : Type*) [Fintype d] [DecidableEq d] [Fintype α] := ProbDistribution.RandVar α (MState d)
+abbrev MEnsemble (d : Type*) (α : Type*) [Fintype d] [DecidableEq d] [Fintype α] :=
+  ProbDistribution.RandVar α (MState d)
 
 /-- A pure-state ensemble is a random variable valued in `Ket d`. That is,
 a collection of pure states `var : α → Ket d`, each with their own probability weight
 described by `distr : ProbDistribution α`. -/
-abbrev PEnsemble (d : Type*) (α : Type*) [Fintype d] [Fintype α] := ProbDistribution.RandVar α (Ket d)
+abbrev PEnsemble (d : Type*) (α : Type*) [Fintype d] [Fintype α] :=
+  ProbDistribution.RandVar α (Ket d)
 
 variable {α β d : Type*} [Fintype α] [Fintype β] [Fintype d] [DecidableEq d]
 
@@ -46,7 +48,8 @@ theorem toMEnsemble_mk : (toMEnsemble ⟨ps, distr⟩ : MEnsemble d α) = ⟨pur
   rfl
 
 /-- A mixed-state ensemble comes from a pure-state ensemble if and only if all states are pure. -/
-theorem coe_PEnsemble_iff_pure_states (me : MEnsemble d α): (∃ pe : PEnsemble d α, ↑pe = me) ↔ (∃ ψ : α → Ket d, me.states = MState.pure ∘ ψ) := by
+theorem coe_PEnsemble_iff_pure_states (me : MEnsemble d α):
+    (∃ pe : PEnsemble d α, ↑pe = me) ↔ (∃ ψ : α → Ket d, me.states = MState.pure ∘ ψ) := by
   constructor
   · intro ⟨pe, hpe⟩
     use pe.states
@@ -76,41 +79,56 @@ def congrPEnsemble (σ : α ≃ β) : PEnsemble d α ≃ PEnsemble d β := ProbD
 
 /-- Equivalence of mixed-state ensembles leaves the resulting mixed state invariant -/
 @[simp]
-theorem mix_congrMEnsemble_eq_mix (σ : α ≃ β) (e : MEnsemble d α) : mix (congrMEnsemble σ e) = mix e :=
+theorem mix_congrMEnsemble_eq_mix (σ : α ≃ β) (e : MEnsemble d α) :
+    mix (congrMEnsemble σ e) = mix e :=
   ProbDistribution.expect_val_congr_eq_expect_val σ e
 
 /-- Equivalence of pure-state ensembles leaves the resulting mixed state invariant -/
 @[simp]
-theorem mix_congrPEnsemble_eq_mix (σ : α ≃ β) (e : PEnsemble d α) : mix (toMEnsemble (congrPEnsemble σ e)) = mix (↑e : MEnsemble d α) := by
+theorem mix_congrPEnsemble_eq_mix (σ : α ≃ β) (e : PEnsemble d α) :
+    mix (toMEnsemble (congrPEnsemble σ e)) = mix (↑e : MEnsemble d α) := by
   unfold toMEnsemble congrPEnsemble mix
   rw [ProbDistribution.map_congr_eq_congr_map MState.pure σ e]
   exact ProbDistribution.expect_val_congr_eq_expect_val σ (MState.pure <$> e)
 
-/-- The average of a function `f : MState d → T`, where `T` is of `Mixable U T` instance, on a mixed-state ensemble `e`
-is the expectation value of `f` acting on the states of `e`, with the corresponding probability weights from `e.distr`. -/
-def average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (e : MEnsemble d α) : T :=
+/-- The average of a function `f : MState d → T`, where `T` is of `Mixable U T` instance, on a
+mixed-state ensemble `e`
+is the expectation value of `f` acting on the states of `e`, with the corresponding probability
+weights from `e.distr`. -/
+def average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T]
+    (f : MState d → T) (e : MEnsemble d α) : T :=
   ProbDistribution.expect_val <| f <$> e
 
-/-- A version of `average` conveniently specialized for functions `f : MState d → ℝ≥0` returning nonnegative reals.
+/-- A version of `average` conveniently specialized for functions `f : MState d → ℝ≥0` returning
+nonnegative reals.
 Notably, the average is also a nonnegative real number. -/
-def average_NNReal {d : Type _} [Fintype d] [DecidableEq d] (f : MState d → NNReal) (e : MEnsemble d α) : NNReal :=
+def average_NNReal {d : Type _} [Fintype d] [DecidableEq d] (f : MState d → NNReal)
+    (e : MEnsemble d α) : NNReal :=
   ⟨average (NNReal.toReal ∘ f) e,
-    ProbDistribution.zero_le_expect_val e.distr (NNReal.toReal ∘ f ∘ e.states) (fun n => (f <| e.states n).2)⟩
+    ProbDistribution.zero_le_expect_val e.distr (NNReal.toReal ∘ f ∘ e.states)
+      (fun n => (f <| e.states n).2)⟩
 
-/-- The average of a function `f : Ket d → T`, where `T` is of `Mixable U T` instance, on a pure-state ensemble `e`
-is the expectation value of `f` acting on the states of `e`, with the corresponding probability weights from `e.distr`. -/
-def pure_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : Ket d → T) (e : PEnsemble d α) : T :=
+/-- The average of a function `f : Ket d → T`, where `T` is of `Mixable U T` instance, on a
+pure-state ensemble `e`
+is the expectation value of `f` acting on the states of `e`, with the corresponding probability
+weights from `e.distr`. -/
+def pure_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T]
+    (f : Ket d → T) (e : PEnsemble d α) : T :=
   ProbDistribution.expect_val <| f <$> e
 
-/-- A version of `average` conveniently specialized for functions `f : Ket d → ℝ≥0` returning nonnegative reals.
+/-- A version of `average` conveniently specialized for functions `f : Ket d → ℝ≥0` returning
+nonnegative reals.
 Notably, the average is also a nonnegative real number. -/
-def pure_average_NNReal {d : Type _} [Fintype d] (f : Ket d → NNReal) (e : PEnsemble d α) : NNReal :=
+def pure_average_NNReal {d : Type _} [Fintype d] (f : Ket d → NNReal) (e : PEnsemble d α) :
+    NNReal :=
   ⟨pure_average (NNReal.toReal ∘ f) e,
-    ProbDistribution.zero_le_expect_val e.distr (NNReal.toReal ∘ f ∘ e.states) (fun n => (f <| e.states n).2)⟩
+    ProbDistribution.zero_le_expect_val e.distr (NNReal.toReal ∘ f ∘ e.states)
+      (fun n => (f <| e.states n).2)⟩
 
 /-- The average of `f : MState d → T` on a coerced pure-state ensemble `↑e : MEnsemble d α`
 is equal to averaging the restricted function over Kets `f ∘ pure : Ket d → T` on `e`. -/
-theorem average_of_pure_ensemble {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T]
+theorem average_of_pure_ensemble {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U]
+  [inst : Mixable U T]
   (f : MState d → T) (e : PEnsemble d α) :
   average f (toMEnsemble e) = pure_average (f ∘ pure) e := by
   simp only [average, pure_average, toMEnsemble, comp_map]
@@ -143,11 +161,13 @@ theorem mix_pEnsemble_pure_iff_pure {e : PEnsemble d α} :
         rfl
     simp [MState.ext_iff, h_sum, ← Finset.sum_smul]
 
-/- The theorem below is also false for the same reason as the original `mix_pEnsemble_pure_iff_pure`:
+/- The theorem below is also false for the same reason as the original
+   `mix_pEnsemble_pure_iff_pure`:
    knowing `MState.pure (e.states i) = MState.pure ψ` does not imply `e.states i = ψ` as Kets,
    so `f (e.var i) ≠ f ψ` in general for a non-phase-invariant `f : Ket d → T`. -/
 /-- The average of `f : Ket d → T` on an ensemble that mixes to a pure state `ψ` is `f ψ` -/
-theorem mix_pEnsemble_pure_average {e : PEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U]
+theorem mix_pEnsemble_pure_average {e : PEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U]
+    [Module ℝ U]
     [inst : Mixable U T] (f : Ket d → T) (hf : ∀ ψ φ, Ket.PhaseEquiv.r ψ φ → f ψ = f φ)
     (hmix : mix (toMEnsemble e) = MState.pure ψ) :
   pure_average f e = f ψ := by
@@ -158,9 +178,11 @@ theorem mix_pEnsemble_pure_average {e : PEnsemble d α} {T : Type _} {U : Type*}
   simp only [pure_average, Functor.map, ProbDistribution.expect_val]
   apply Mixable.to_U_inj
   simp only [Mixable.to_U_of_mkT, Function.comp_apply]
-  have h1 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • (Mixable.to_U (f (e.var i))) ≠ 0 → e.var i = e.var i := fun _ _ _ => rfl
+  have h1 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • (Mixable.to_U (f (e.var i))) ≠ 0 →
+      e.var i = e.var i := fun _ _ _ => rfl
   -- For nonzero summands, distr i ≠ 0 so f (e.var i) = f ψ
-  have h2 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • Mixable.to_U (f (e.var i)) = (e.distr i : ℝ) • Mixable.to_U (f ψ) := by
+  have h2 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • Mixable.to_U (f (e.var i)) =
+      (e.distr i : ℝ) • Mixable.to_U (f ψ) := by
     intro i _
     by_cases hdi : e.distr i = 0
     · simp [hdi]
@@ -201,8 +223,10 @@ theorem MState.exp_val_pure_eq_one_iff {d : Type*} [Fintype d] [DecidableEq d]
       have := HermitianMat.inner_le_mul_trace ρ.nonneg ρ.nonneg; simpa [ρ.tr]
     have hinner : ⟪ρ.M, (MState.pure ψ).M⟫ = 1 := by simpa [MState.exp_val] using h
     have hsq : ⟪ρ.M - (MState.pure ψ).M, ρ.M - (MState.pure ψ).M⟫ =
-        ⟪ρ.M, ρ.M⟫ - 2 * ⟪ρ.M, (MState.pure ψ).M⟫ + ⟪(MState.pure ψ).M, (MState.pure ψ).M⟫ := by
-      simp only [HermitianMat.inner_def, IsMaximalSelfAdjoint.RCLike_selfadjMap, HermitianMat.mat_sub,
+        ⟪ρ.M, ρ.M⟫ - 2 * ⟪ρ.M, (MState.pure ψ).M⟫ +
+          ⟪(MState.pure ψ).M, (MState.pure ψ).M⟫ := by
+      simp only [HermitianMat.inner_def, IsMaximalSelfAdjoint.RCLike_selfadjMap,
+        HermitianMat.mat_sub,
         MState.mat_M, RCLike.re_to_complex]
       simp [Matrix.mul_sub, Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm (ρ.m)]; ring
     exact MState.ext (eq_of_sub_eq_zero (inner_self_eq_zero.mp (le_antisymm
@@ -212,7 +236,8 @@ theorem MState.exp_val_pure_eq_one_iff {d : Type*} [Fintype d] [DecidableEq d]
 set_option backward.isDefEq.respectTransparency false in
 theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
     mix e = pure ψ ↔ ∀ i : α, e.distr i ≠ 0 → e.states i = MState.pure ψ := by
-  have h : (mix e).exp_val ↑(MState.pure ψ) = ∑ i, ↑(e.distr i) * (e.states i).exp_val ↑(MState.pure ψ) := by
+  have h : (mix e).exp_val ↑(MState.pure ψ) =
+      ∑ i, ↑(e.distr i) * (e.states i).exp_val ↑(MState.pure ψ) := by
     simp [MState.exp_val, HermitianMat.inner_def, Finset.sum_mul]
   rw [← MState.exp_val_pure_eq_one_iff, h, sum_prob_mul_eq_one_iff]
   · simp only [MState.exp_val_pure_eq_one_iff, ne_eq, Set.Icc.coe_eq_zero]
@@ -221,15 +246,18 @@ theorem mix_mEnsemble_pure_iff_pure {e : MEnsemble d α} :
   · intro i
     apply (e.states i).exp_val_le_one (MState.le_one _)
 
-/-- The average of `f : MState d → T` on an ensemble that mixes to a pure state `ψ` is `f (pure ψ)` -/
-theorem mix_mEnsemble_pure_average {e : MEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (hmix : mix e = pure ψ) :
+/-- The average of `f : MState d → T` on an ensemble that mixes to a pure state `ψ` is
+`f (pure ψ)` -/
+theorem mix_mEnsemble_pure_average {e : MEnsemble d α} {T : Type _} {U : Type*} [AddCommGroup U]
+    [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (hmix : mix e = pure ψ) :
   average f e = f (pure ψ) := by
   have hpure := mix_mEnsemble_pure_iff_pure.mp hmix
   simp only [average, Functor.map, ProbDistribution.expect_val]
   apply Mixable.to_U_inj
   rw [MEnsemble.states] at hpure
   simp only [Mixable.to_U_of_mkT, Function.comp_apply]
-  have h1 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • (Mixable.to_U (f (e.var i))) ≠ 0 → e.var i = pure ψ := fun i hi ↦ by
+  have h1 : ∀ i ∈ Finset.univ, (e.distr i : ℝ) • (Mixable.to_U (f (e.var i))) ≠ 0 →
+      e.var i = pure ψ := fun i hi ↦ by
     have h2 : e.distr i = 0 → (e.distr i : ℝ) • (Mixable.to_U (f (e.var i))) = 0 := fun h0 ↦ by
       simp only [h0, Prob.coe_zero, zero_smul]
     exact (hpure i) ∘ h2.mt
@@ -246,21 +274,26 @@ theorem mix_mEnsemble_pure_average {e : MEnsemble d α} {T : Type _} {U : Type*}
   have hpure' : ∀ i ∈ Finset.univ, (↑(e.distr i) : ℝ) ≠ 0 → e.var i = pure ψ := fun i hi hne0 ↦ by
     apply hpure i
     simpa using hne0
-  classical rw [← Finset.sum_smul, ← Finset.sum_filter, Finset.sum_filter_of_ne hpure', ProbDistribution.normalized, one_smul]
+  classical rw [← Finset.sum_smul, ← Finset.sum_filter, Finset.sum_filter_of_ne hpure',
+    ProbDistribution.normalized, one_smul]
 
 /-- The trivial mixed-state ensemble of `ρ` consists of copies of `rho`, with the `i`-th one having
 probability 1. -/
-def trivial_mEnsemble (ρ : MState d) (i : α) : MEnsemble d α := ⟨fun _ ↦ ρ, ProbDistribution.constant i⟩
+def trivial_mEnsemble (ρ : MState d) (i : α) : MEnsemble d α :=
+  ⟨fun _ ↦ ρ, ProbDistribution.constant i⟩
 
 /-- The trivial mixed-state ensemble of `ρ` mixes to `ρ` -/
-theorem trivial_mEnsemble_mix (ρ : MState d) : ∀ i : α, mix (trivial_mEnsemble ρ i) = ρ := fun i ↦by
+theorem trivial_mEnsemble_mix (ρ : MState d) : ∀ i : α, mix (trivial_mEnsemble ρ i) = ρ :=
+  fun i ↦by
   apply MState.ext_m
-  classical simp only [trivial_mEnsemble, ProbDistribution.constant, mix_of, DFunLike.coe, apply_ite,
+  classical simp only [trivial_mEnsemble, ProbDistribution.constant, mix_of, DFunLike.coe,
+    apply_ite,
     Prob.coe_one, Prob.coe_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq,
     Finset.mem_univ, ↓reduceIte]
 
 /-- The average of `f : MState d → T` on a trivial ensemble of `ρ` is `f ρ`-/
-theorem trivial_mEnsemble_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : MState d → T) (ρ : MState d):
+theorem trivial_mEnsemble_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U]
+    [inst : Mixable U T] (f : MState d → T) (ρ : MState d):
   ∀ i : α, average f (trivial_mEnsemble ρ i) = f ρ := fun i ↦ by
     simp only [average, Functor.map, ProbDistribution.expect_val, trivial_mEnsemble]
     apply Mixable.to_U_inj
@@ -271,20 +304,24 @@ instance MEnsemble.instInhabited [Nonempty d] [Inhabited α] : Inhabited (MEnsem
 
 /-- The trivial pure-state ensemble of `ψ` consists of copies of `ψ`, with the `i`-th one having
 probability 1. -/
-def trivial_pEnsemble (ψ : Ket d) (i : α) : PEnsemble d α := ⟨fun _ ↦ ψ, ProbDistribution.constant i⟩
+def trivial_pEnsemble (ψ : Ket d) (i : α) : PEnsemble d α :=
+  ⟨fun _ ↦ ψ, ProbDistribution.constant i⟩
 
 variable (ψ : Ket d)
 
 /-- The trivial pure-state ensemble of `ψ` mixes to `ψ` -/
-theorem trivial_pEnsemble_mix : ∀ i : α, mix (toMEnsemble (trivial_pEnsemble ψ i)) = MState.pure ψ := fun i ↦ by
+theorem trivial_pEnsemble_mix :
+    ∀ i : α, mix (toMEnsemble (trivial_pEnsemble ψ i)) = MState.pure ψ := fun i ↦ by
   apply MState.ext_m
-  classical simp only [trivial_pEnsemble, ProbDistribution.constant, toMEnsemble_mk, mix_of, DFunLike.coe,
+  classical simp only [trivial_pEnsemble, ProbDistribution.constant, toMEnsemble_mk, mix_of,
+    DFunLike.coe,
     apply_ite, Prob.coe_one, Prob.coe_zero, MEnsemble.states, Function.comp_apply, ite_smul,
     one_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte]
 
 omit [DecidableEq d] in
 /-- The average of `f : Ket d → T` on a trivial ensemble of `ψ` is `f ψ`-/
-theorem trivial_pEnsemble_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U] [inst : Mixable U T] (f : Ket d → T) :
+theorem trivial_pEnsemble_average {T : Type _} {U : Type*} [AddCommGroup U] [Module ℝ U]
+    [inst : Mixable U T] (f : Ket d → T) :
   ∀ i : α, pure_average f (trivial_pEnsemble ψ i) = f ψ := fun i ↦ by
     simp only [pure_average, Functor.map, ProbDistribution.expect_val, trivial_pEnsemble]
     apply Mixable.to_U_inj
@@ -293,7 +330,8 @@ theorem trivial_pEnsemble_average {T : Type _} {U : Type*} [AddCommGroup U] [Mod
 instance PEnsemble.instInhabited [Nonempty d] [Inhabited α] : Inhabited (PEnsemble d α) where
   default := trivial_pEnsemble default default
 
-/-- The spectral pure-state ensemble of `ρ`. The states are its eigenvectors, and the probabilities, eigenvalues. -/
+/-- The spectral pure-state ensemble of `ρ`. The states are its eigenvectors, and the
+probabilities, eigenvalues. -/
 def spectral_ensemble (ρ : MState d) : PEnsemble d d where
   var i :=
     { vec := ρ.Hermitian.eigenvectorBasis i
@@ -309,7 +347,8 @@ def spectral_ensemble (ρ : MState d) : PEnsemble d d where
 --PULLOUT
 theorem spectral_decomposition_sum {d 𝕜 : Type*} [Fintype d] [DecidableEq d] [RCLike 𝕜]
     {A : Matrix d d 𝕜} (hA : A.IsHermitian) :
-    A = ∑ i, (hA.eigenvalues i) • (Matrix.vecMulVec (hA.eigenvectorBasis i) (star (hA.eigenvectorBasis i))) := by
+    A = ∑ i, (hA.eigenvalues i) •
+      (Matrix.vecMulVec (hA.eigenvectorBasis i) (star (hA.eigenvectorBasis i))) := by
   nth_rw 1 [hA.spectral_theorem]
   ext
   simp only [Matrix.sum_apply]
@@ -321,7 +360,8 @@ theorem spectral_decomposition_sum {d 𝕜 : Type*} [Fintype d] [DecidableEq d] 
   simp_rw [mul_assoc]
 
 /-- The spectral pure-state ensemble of `ρ` mixes to `ρ` -/
-theorem spectral_ensemble_mix {ρ : MState d} : mix (↑(spectral_ensemble ρ) : MEnsemble d d) = ρ := by
+theorem spectral_ensemble_mix {ρ : MState d} :
+    mix (↑(spectral_ensemble ρ) : MEnsemble d d) = ρ := by
   ext i j
   convert rfl;
   convert rfl;

--- a/QuantumInfo/States/Entanglement.lean
+++ b/QuantumInfo/States/Entanglement.lean
@@ -14,8 +14,8 @@ public import QuantumInfo.Entropy.DPI
 public import QuantumInfo.ClassicalInfo.Entropy
 
 /-!
-Entanglement measures. (Mixed) convex roof extensions. Definition of product / separable / entangled states
-are in `Braket.lean` and/or `MState.lean`
+Entanglement measures. (Mixed) convex roof extensions. Definition of product / separable / entangled
+states are in `Braket.lean` and/or `MState.lean`
 
 Important definitions:
  * `convex_roof`: Convex roof extension of `g : KetUpToPhase d → ℝ≥0`
@@ -23,24 +23,28 @@ Important definitions:
  * `EoF`: Entanglement of Formation
 
 TODO:
- - Other entanglement measures (not necessarily based on convex roof extensions). In roughly increasing order of
-   difficulty to implement: (Logarithmic) Negativity, Entanglement of Purification, Squashed Entanglement, Relative
-   Entropy of Entanglement, Entanglement Cost, Distillable Entanglement.
+ - Other entanglement measures (not necessarily based on convex roof extensions). In roughly
+   increasing order of difficulty to implement: (Logarithmic) Negativity, Entanglement of
+   Purification, Squashed Entanglement, Relative Entropy of Entanglement, Entanglement Cost,
+   Distillable Entanglement.
    For a compendium on the zoo of entanglement measures, see
-   [1] Christandl, Matthias. “The Structure of Bipartite Quantum States - Insights from Group Theory and Cryptography.”
+   [1] Christandl, Matthias. “The Structure of Bipartite Quantum States - Insights from Group Theory
+       and Cryptography.”
        https://doi.org/10.48550/arXiv.quant-ph/0604183.
- - Define classes of entanglement measures with good properties, including: monotonicity under LOCC (easier: just LO),
-   monotonicity on average under LOCC, convexity (if the latter two are present, it is called an entanglement monotone
-   by some), vanishing on separable states, normalized on the maximally entangled state, (sub)additivity, regularisible.
+ - Define classes of entanglement measures with good properties, including: monotonicity under LOCC
+   (easier: just LO), monotonicity on average under LOCC, convexity (if the latter two are present,
+   it is called an entanglement monotone by some), vanishing on separable states, normalized on the
+   maximally entangled state, (sub)additivity, regularisible.
    For other properties, see [1] above and:
    [2] Szalay, Szilárd. “Multipartite Entanglement Measures.” (mainly Sec. IV)
        https://doi.org/10.1103/PhysRevA.92.042329.
-   [3] Horodecki, Ryszard, Paweł Horodecki, Michał Horodecki, and Karol Horodecki. “Quantum Entanglement.”
+   [3] Horodecki, Ryszard, Paweł Horodecki, Michał Horodecki, and Karol Horodecki. “Quantum
+       Entanglement.”
        https://doi.org/10.1103/RevModPhys.81.865.
  - Useful properties of convex roof extensions:
    1. If f is monotonically non-increasing under LOCC, so is its convex roof.
-   2. If f ψ is zero if and only if ψ is a product state, then its convex roof is faithful: zero if and only if
-      the mixed state is separable
+   2. If f ψ is zero if and only if ψ is a product state, then its convex roof is faithful: zero if
+      and only if the mixed state is separable
    For other properties, see Sec. IV.F of [2] above.
 -/
 
@@ -53,27 +57,36 @@ open NNReal
 open MState
 open Ensemble
 
-/-- Convex roof extension of a function `g : KetUpToPhase d → ℝ≥0`, defined as the infimum of all pure-state
-ensembles of a given `ρ` of the average of `g` in that ensemble.
+/-- Convex roof extension of a function `g : KetUpToPhase d → ℝ≥0`, defined as the infimum of all
+pure-state ensembles of a given `ρ` of the average of `g` in that ensemble.
 
-This is valued in the extended nonnegative real numbers `ℝ≥0∞` to have good properties of the infimum, which
-come from the fact that `ℝ≥0∞` is a complete lattice. For example, it is necessary for `le_iInf` and `iInf_le_of_le`.
-However, it is also proven in `convex_roof_ne_top` that the convex roof is never `∞`, so the definition `convex_roof` should
+This is valued in the extended nonnegative real numbers `ℝ≥0∞` to have good properties of the
+infimum, which come from the fact that `ℝ≥0∞` is a complete lattice. For example, it is necessary
+for `le_iInf` and `iInf_le_of_le`.
+However, it is also proven in `convex_roof_ne_top` that the convex roof is never `∞`, so the
+definition `convex_roof` should
 be used in most applications. -/
-def convex_roof_ENNReal {d : Type _} [Fintype d] [DecidableEq d] (g : KetUpToPhase d → ℝ≥0) : MState d → ℝ≥0∞ := fun ρ =>
-  ⨅ (n : ℕ+) (e : PEnsemble d (Fin n)) (_ : mix (toMEnsemble e) = ρ), ↑(pure_average_NNReal (g ∘ KetUpToPhase.mk) e)
+def convex_roof_ENNReal {d : Type _} [Fintype d] [DecidableEq d] (g : KetUpToPhase d → ℝ≥0) :
+    MState d → ℝ≥0∞ := fun ρ =>
+  ⨅ (n : ℕ+) (e : PEnsemble d (Fin n)) (_ : mix (toMEnsemble e) = ρ),
+    ↑(pure_average_NNReal (g ∘ KetUpToPhase.mk) e)
 
-/-- Mixed convex roof extension of a function `f : MState d → ℝ≥0`, defined as the infimum of all mixed-state
-ensembles of a given `ρ` of the average of `f` on that ensemble.
+/-- Mixed convex roof extension of a function `f : MState d → ℝ≥0`, defined as the infimum of all
+mixed-state ensembles of a given `ρ` of the average of `f` on that ensemble.
 
-This is valued in the extended nonnegative real numbers `ℝ≥0∞` to have good properties of the infimum, which
-come from the fact that `ℝ≥0∞` is a complete lattice (see `ENNReal.instCompleteLinearOrder`). However,
-it is also proven in `mixed_convex_roof_ne_top` that the mixed convex roof is never `∞`, so the definition `mixed_convex_roof` should
+This is valued in the extended nonnegative real numbers `ℝ≥0∞` to have good properties of the
+infimum, which come from the fact that `ℝ≥0∞` is a complete lattice
+(see `ENNReal.instCompleteLinearOrder`).
+However,
+it is also proven in `mixed_convex_roof_ne_top` that the mixed convex roof is never `∞`, so the
+definition `mixed_convex_roof` should
 be used in most applications. -/
-def mixed_convex_roof_ENNReal {d : Type _} [Fintype d] [DecidableEq d] (f : MState d → ℝ≥0) : MState d → ℝ≥0∞ := fun ρ =>
+def mixed_convex_roof_ENNReal {d : Type _} [Fintype d] [DecidableEq d] (f : MState d → ℝ≥0) :
+    MState d → ℝ≥0∞ := fun ρ =>
   ⨅ (n : ℕ+) (e : MEnsemble d (Fin n)) (_ : mix e = ρ), ↑(average_NNReal f e)
 
-variable {d d₁ d₂ : Type _} [Fintype d] [Fintype d₁] [Fintype d₂] [Nonempty d] [Nonempty d₁] [Nonempty d₂]
+variable {d d₁ d₂ : Type _} [Fintype d] [Fintype d₁] [Fintype d₂] [Nonempty d] [Nonempty d₁]
+  [Nonempty d₂]
 variable [DecidableEq d] [DecidableEq d₁] [DecidableEq d₂]
 variable (f : MState d → ℝ≥0)
 variable (g : KetUpToPhase d → ℝ≥0)
@@ -99,30 +112,35 @@ theorem mixed_convex_roof_ne_top : ∀ ρ, mixed_convex_roof_ENNReal f ρ ≠ �
   push Not
   exact trivial_mEnsemble_mix ρ 0
 
-/-- Convex roof extension of a function `g : KetUpToPhase d → ℝ≥0`, defined as the infimum of all pure-state
-ensembles of a given `ρ` of the average of `g` in that ensemble.
+/-- Convex roof extension of a function `g : KetUpToPhase d → ℝ≥0`, defined as the infimum of all
+pure-state ensembles of a given `ρ` of the average of `g` in that ensemble.
 
-This is valued in the nonnegative real numbers `ℝ≥0` by applying `ENNReal.toNNReal` to `convex_roof_ENNReal`. Hence,
+This is valued in the nonnegative real numbers `ℝ≥0` by applying `ENNReal.toNNReal` to
+`convex_roof_ENNReal`. Hence,
 it should be used in proofs alongside `convex_roof_ne_top`. -/
 def convex_roof : MState d → ℝ≥0 := fun x ↦ (convex_roof_ENNReal g x).untop (convex_roof_ne_top g x)
 
-/-- Mixed convex roof extension of a function `f : MState d → ℝ≥0`, defined as the infimum of all mixed-state
-ensembles of a given `ρ` of the average of `f` on that ensemble.
+/-- Mixed convex roof extension of a function `f : MState d → ℝ≥0`, defined as the infimum of all
+mixed-state ensembles of a given `ρ` of the average of `f` on that ensemble.
 
-This is valued in the nonnegative real numbers `ℝ≥0` by applying `ENNReal.toNNReal` to `mixed_convex_roof_ENNReal`. Hence,
+This is valued in the nonnegative real numbers `ℝ≥0` by applying `ENNReal.toNNReal` to
+`mixed_convex_roof_ENNReal`. Hence,
 it should be used in proofs alongside `mixed_convex_roof_ne_top`. -/
-def mixed_convex_roof : MState d → ℝ≥0 := fun x ↦ (mixed_convex_roof_ENNReal f x).untop (mixed_convex_roof_ne_top f x)
+def mixed_convex_roof : MState d → ℝ≥0 :=
+  fun x ↦ (mixed_convex_roof_ENNReal f x).untop (mixed_convex_roof_ne_top f x)
 
 /-- Auxiliary function. Convex roof of a function `f : MState d → ℝ≥0` defined over mixed states by
 restricting `f` to pure states, via `pureQ : KetUpToPhase d → MState d`. -/
 def convex_roof_of_MState_fun : MState d → ℝ≥0 := convex_roof (f ∘ pureQ)
 
--- TODO: make `le_convex_roof`, `convex_roof_le`, `le_mixed_convex_roof` and `mixed_convex_roof_le` if-and-only-if statements.
+-- TODO: make `le_convex_roof`, `convex_roof_le`, `le_mixed_convex_roof` and `mixed_convex_roof_le`
+-- if-and-only-if statements.
 
 set_option backward.isDefEq.respectTransparency false in
 omit [Nonempty d] in
 theorem le_mixed_convex_roof (ρ : MState d) :
-  (∀ n > 0, ∀ e : MEnsemble d (Fin n), mix e = ρ → c ≤ average_NNReal f e) → (c ≤ mixed_convex_roof f ρ) := fun h => by
+  (∀ n > 0, ∀ e : MEnsemble d (Fin n), mix e = ρ → c ≤ average_NNReal f e) →
+    (c ≤ mixed_convex_roof f ρ) := fun h => by
   unfold mixed_convex_roof
   rw [WithTop.le_untop_iff]
   apply le_iInf; intro ⟨n, hnpos⟩; apply le_iInf; intro e; apply le_iInf; intro hmix
@@ -131,7 +149,8 @@ theorem le_mixed_convex_roof (ρ : MState d) :
 
 set_option backward.isDefEq.respectTransparency false in
 theorem le_convex_roof (ρ : MState d) :
-  (∀ n > 0, ∀ e : PEnsemble d (Fin n), mix (toMEnsemble e) = ρ → c ≤ pure_average_NNReal (g ∘ KetUpToPhase.mk) e) → (c ≤ convex_roof g ρ) := fun h => by
+  (∀ n > 0, ∀ e : PEnsemble d (Fin n), mix (toMEnsemble e) = ρ →
+    c ≤ pure_average_NNReal (g ∘ KetUpToPhase.mk) e) → (c ≤ convex_roof g ρ) := fun h => by
   unfold convex_roof
   rw [WithTop.le_untop_iff]
   apply le_iInf; intro ⟨n, hnpos⟩; apply le_iInf; intro e; apply le_iInf; intro hmix
@@ -140,7 +159,8 @@ theorem le_convex_roof (ρ : MState d) :
 
 set_option backward.isDefEq.respectTransparency false in
 theorem convex_roof_le (ρ : MState d):
-(∃ n > 0, ∃ e : PEnsemble d (Fin n), mix (toMEnsemble e) = ρ ∧ pure_average_NNReal (g ∘ KetUpToPhase.mk) e ≤ c) → (convex_roof g ρ ≤ c) := fun h => by
+(∃ n > 0, ∃ e : PEnsemble d (Fin n), mix (toMEnsemble e) = ρ ∧
+    pure_average_NNReal (g ∘ KetUpToPhase.mk) e ≤ c) → (convex_roof g ρ ≤ c) := fun h => by
   obtain ⟨n, hnpos, e, hmix, h⟩ := h
   unfold convex_roof
   rw [WithTop.untop_le_iff]
@@ -151,7 +171,8 @@ theorem convex_roof_le (ρ : MState d):
 set_option backward.isDefEq.respectTransparency false in
 omit [Nonempty d] in
 theorem mixed_convex_roof_le (ρ : MState d):
-(∃ n > 0, ∃ e : MEnsemble d (Fin n), mix e = ρ ∧ average_NNReal f e ≤ c) → (mixed_convex_roof f ρ ≤ c) := fun h => by
+(∃ n > 0, ∃ e : MEnsemble d (Fin n), mix e = ρ ∧ average_NNReal f e ≤ c) →
+    (mixed_convex_roof f ρ ≤ c) := fun h => by
   obtain ⟨n, hnpos, e, hmix, h⟩ := h
   unfold mixed_convex_roof
   rw [WithTop.untop_le_iff]
@@ -159,8 +180,8 @@ theorem mixed_convex_roof_le (ρ : MState d):
   rw [some_eq_coe', ENNReal.coe_le_coe]
   exact h
 
-/-- The mixed convex roof extension of `f` is smaller than or equal to its convex roof extension, since
-the former minimizes over a larger set of ensembles. -/
+/-- The mixed convex roof extension of `f` is smaller than or equal to its convex roof extension,
+since the former minimizes over a larger set of ensembles. -/
 theorem mixed_convex_roof_le_convex_roof : mixed_convex_roof f ≤ convex_roof_of_MState_fun f := by
   intro ρ
   apply le_convex_roof (f ∘ pureQ) ρ
@@ -172,7 +193,8 @@ theorem mixed_convex_roof_le_convex_roof : mixed_convex_roof f ≤ convex_roof_o
   apply And.intro hmix
   exact le_of_eq <| NNReal.coe_inj.mp <| average_of_pure_ensemble (toReal ∘ f) e
 
-/-- The convex roof extension of `g : KetUpToPhase d → ℝ≥0` applied to a pure state `ψ` is `g (KetUpToPhase.mk ψ)`. -/
+/-- The convex roof extension of `g : KetUpToPhase d → ℝ≥0` applied to a pure state `ψ` is
+`g (KetUpToPhase.mk ψ)`. -/
 theorem convex_roof_of_pure (ψ : Ket d) : convex_roof g (pure ψ) = g (KetUpToPhase.mk ψ) := by
   rw [le_antisymm_iff]
   constructor
@@ -199,7 +221,8 @@ theorem convex_roof_of_pure (ψ : Ket d) : convex_roof g (pure ψ) = g (KetUpToP
     rfl
 
 omit [Nonempty d] in
-/-- The mixed convex roof extension of `f : MState d → ℝ≥0` applied to a pure state `ψ` is `f (pure ψ)`. -/
+/-- The mixed convex roof extension of `f : MState d → ℝ≥0` applied to a pure state `ψ` is
+`f (pure ψ)`. -/
 theorem mixed_convex_roof_of_pure (ψ : Ket d) : mixed_convex_roof f (pure ψ) = f (pure ψ) := by
   rw [le_antisymm_iff]
   constructor
@@ -223,10 +246,11 @@ theorem mixed_convex_roof_of_pure (ψ : Ket d) : mixed_convex_roof f (pure ψ) =
     rfl
 
 /-- Entanglement of Formation of bipartite systems. It is the convex roof extension of the
-von Neumann entropy of one of the subsystems (here chosen to be the left one, but see `Entropy.Sᵥₙ_of_partial_eq`).
+von Neumann entropy of one of the subsystems (here chosen to be the left one, but see
+`Entropy.Sᵥₙ_of_partial_eq`).
 
-The function `Sᵥₙ ∘ traceRight ∘ pure` is phase-invariant because `pure` maps phase-equivalent kets to the
-same mixed state, so it descends to `KetUpToPhase` via `pureQ`. -/
+The function `Sᵥₙ ∘ traceRight ∘ pure` is phase-invariant because `pure` maps phase-equivalent kets
+to the same mixed state, so it descends to `KetUpToPhase` via `pureQ`. -/
 def EoF : MState (d₁ × d₂) → ℝ≥0 :=
   convex_roof (KetUpToPhase.lift
     (fun ψ ↦ ⟨Sᵥₙ (pure ψ).traceRight, Sᵥₙ_nonneg (pure ψ).traceRight⟩)
@@ -242,7 +266,9 @@ The partial trace of the maximally entangled state is the maximally mixed state.
 theorem traceRight_pure_MES (d : Type*) [Fintype d] [DecidableEq d] [Nonempty d] :
     (MState.pure (Ket.MES d)).traceRight = MState.uniform := by
   -- By definition of partial trace, we sum over the second system.
-  have h_partial_trace : ∀ (i j : d), ∑ k : d, (Ket.MES d).vec (i, k) * (star (Ket.MES d).vec (j, k)) = (1 / Fintype.card d : ℝ) * (if i = j then 1 else 0) := by
+  have h_partial_trace : ∀ (i j : d),
+      ∑ k : d, (Ket.MES d).vec (i, k) * (star (Ket.MES d).vec (j, k)) =
+        (1 / Fintype.card d : ℝ) * (if i = j then 1 else 0) := by
     unfold Ket.MES
     intro i j
     simp only [one_div, Pi.star_apply, RCLike.star_def, ite_mul, zero_mul, Finset.sum_ite_eq,
@@ -263,11 +289,13 @@ theorem traceRight_pure_MES (d : Type*) [Fintype d] [DecidableEq d] [Nonempty d]
   rfl
 
 /-
-The von Neumann entropy of a state is equal to the trace of `ρ log ρ` (technically `cfc ρ negMulLog`).
+The von Neumann entropy of a state is equal to the trace of `ρ log ρ` (technically
+`cfc ρ negMulLog`).
 -/
 theorem Sᵥₙ_eq_trace_cfc {d : Type*} [Fintype d] [DecidableEq d] (ρ : MState d) :
     Sᵥₙ ρ = (HermitianMat.cfc ρ.M Real.negMulLog).trace := by
-  -- By definition of von Neumann entropy, we have Sᵥₙ ρ = Finset.sum Finset.univ (fun x ↦ Real.negMulLog (ρ.M.H.eigenvalues x)).
+  -- By definition of von Neumann entropy, we have Sᵥₙ ρ = Finset.sum Finset.univ
+  -- (fun x ↦ Real.negMulLog (ρ.M.H.eigenvalues x)).
   have h_def : Sᵥₙ ρ = Finset.sum Finset.univ (fun x ↦ Real.negMulLog (ρ.M.H.eigenvalues x)) := by
     rfl
   -- By definition of trace, the trace of `cfc ρ.M Real.negMulLog` is the sum of its eigenvalues.
@@ -282,20 +310,24 @@ theorem Sᵥₙ_eq_trace_cfc {d : Type*} [Fintype d] [DecidableEq d] (ρ : MStat
   conv_lhs => rw [ ← Equiv.sum_comp e ]
 
 /-
-The von Neumann entropy of a classical state (diagonal in the basis) is equal to the Shannon entropy of the corresponding distribution.
+The von Neumann entropy of a classical state (diagonal in the basis) is equal to the Shannon entropy
+of the corresponding distribution.
 -/
 theorem Sᵥₙ_ofClassical {d : Type*} [Fintype d] [DecidableEq d] (dist : ProbDistribution d) :
     Sᵥₙ (MState.ofClassical dist) = Hₛ dist := by
   -- Let's unfold the definition of `Sᵥₙ` using `Sᵥₙ_eq_trace_cfc`.
-  have h_def : Sᵥₙ (MState.ofClassical dist) = (HermitianMat.cfc (MState.ofClassical dist).M Real.negMulLog).trace := by
+  have h_def : Sᵥₙ (MState.ofClassical dist) =
+      (HermitianMat.cfc (MState.ofClassical dist).M Real.negMulLog).trace := by
     exact Sᵥₙ_eq_trace_cfc (ofClassical dist);
   convert h_def using 1;
-  -- By definition of $MState.ofClassical$, we know that $(MState.ofClassical dist).M$ is a diagonal matrix with entries $dist i$.
+  -- By definition of $MState.ofClassical$, we know that $(MState.ofClassical dist).M$ is a diagonal
+  -- matrix with entries $dist i$.
   have h_diag : (MState.ofClassical dist).M = HermitianMat.diagonal ℂ (fun x => dist x) := by
     exact rfl;
   rw [ h_diag, HermitianMat.cfc_diagonal, HermitianMat.trace_diagonal ] ; aesop
 
-/-- The entanglement of formation of the maximally entangled state with on-site dimension 𝕕 is log(𝕕). -/
+/-- The entanglement of formation of the maximally entangled state with on-site dimension 𝕕 is
+log(𝕕). -/
 theorem EoF_of_MES : EoF (pure <| Ket.MES d) = Real.log (Finset.card Finset.univ (α := d)) := by
   simp only [EoF, convex_roof_of_pure, Finset.card_univ]
   simp only [KetUpToPhase.lift_mk]

--- a/QuantumInfo/States/Mixed/Fidelity.lean
+++ b/QuantumInfo/States/Mixed/Fidelity.lean
@@ -130,7 +130,8 @@ theorem fidelity_symm : fidelity ρ σ = fidelity σ ρ := by
 
 /-- The fidelity cannot decrease under the application of a channel. -/
 @[sorryful]
-theorem fidelity_channel_nondecreasing [DecidableEq d₂] (Λ : CPTPMap d d₂) : fidelity (Λ ρ) (Λ σ) ≥ fidelity ρ σ :=
+theorem fidelity_channel_nondecreasing [DecidableEq d₂] (Λ : CPTPMap d d₂) :
+    fidelity (Λ ρ) (Λ σ) ≥ fidelity ρ σ :=
   sorry
 
 --TODO: Real.arccos ∘ fidelity forms a metric (triangle inequality), the Fubini–Study metric.

--- a/QuantumInfo/States/Mixed/MState.lean
+++ b/QuantumInfo/States/Mixed/MState.lean
@@ -29,7 +29,8 @@ The same comments apply as in `Braket`:
 
 These could be done with a Hilbert space of Fintype, which would look like
 ```lean4
-(H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H] [FiniteDimensional ℂ H]
+(H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+  [FiniteDimensional ℂ H]
 ```
 or by choosing a particular `Basis` and asserting it is `Fintype`. But frankly it seems easier to
 mostly focus on the basis-dependent notion of `Matrix`, which has the added benefit of an obvious
@@ -321,7 +322,8 @@ theorem spectrum_pure_eq_constant :
         simp_rw [ρ, pure, Matrix.mulVec, mat, Matrix.vecMulVec_apply, dotProduct,
         Bra.apply', Ket.apply, mul_assoc, ← Finset.mul_sum, ← Complex.normSq_eq_conj_mul_self,
         ← Complex.ofReal_sum, ← Ket.apply, ψ.normalized, Complex.ofReal_one, mul_one]
-      let U : Matrix.unitaryGroup d ℂ := star ρ.M.H.eigenvectorUnitary -- Diagonalizing unitary of ρ
+      -- Diagonalizing unitary of ρ
+      let U : Matrix.unitaryGroup d ℂ := star ρ.M.H.eigenvectorUnitary
       let w : d → ℂ := U *ᵥ ψ
       -- Prove w = U ψ is an eigenvector of the diagonalized matrix of ρ = pure ψ
       have hDiag : Matrix.diagonal (RCLike.ofReal ∘ ρ.M.H.eigenvalues) *ᵥ w = w := by
@@ -393,7 +395,8 @@ theorem pure_of_constant_spectrum (h : ∃ i, ρ.spectrum = ProbDistribution.con
     case neg => rfl
   -- Choose the eigenvector v of ρ with eigenvalue 1 to make ψ
   let ⟨u, huUni⟩ := ρ.M.H.eigenvectorUnitary -- Diagonalizing unitary of ρ
-  let D : Matrix d d ℂ := Matrix.diagonal (RCLike.ofReal ∘ ρ.M.H.eigenvalues) -- Diagonal matrix of ρ
+  -- Diagonal matrix of ρ
+  let D : Matrix d d ℂ := Matrix.diagonal (RCLike.ofReal ∘ ρ.M.H.eigenvalues)
   let v : EuclideanSpace ℂ d := ρ.M.H.eigenvectorBasis i
   -- Prove v is normalized
   have hUvNorm : ∑ x, ‖v x‖^2 = 1 := by
@@ -403,8 +406,10 @@ theorem pure_of_constant_spectrum (h : ∃ i, ρ.spectrum = ProbDistribution.con
       convert this i i
       simp
     simp only [PiLp.inner_apply, RCLike.inner_apply, Complex.mul_conj'] at hinnerv
-    rw [← Fintype.sum_equiv (Equiv.refl d) _ (fun x => (Complex.ofReal ‖v x‖) ^ 2) (fun x => Complex.ofReal_pow ‖v x‖ 2)] at hinnerv
-    rw [← Complex.ofReal_sum Finset.univ (fun x => ‖v x‖ ^ 2), Complex.ofReal_eq_one] at hinnerv
+    rw [← Fintype.sum_equiv (Equiv.refl d) _ (fun x => (Complex.ofReal ‖v x‖) ^ 2)
+      (fun x => Complex.ofReal_pow ‖v x‖ 2)] at hinnerv
+    rw [← Complex.ofReal_sum Finset.univ (fun x => ‖v x‖ ^ 2), Complex.ofReal_eq_one]
+      at hinnerv
     exact hinnerv
   let ψ : Ket d := ⟨v, hUvNorm⟩ -- Construct ψ
   use ψ
@@ -412,12 +417,15 @@ theorem pure_of_constant_spectrum (h : ∃ i, ρ.spectrum = ProbDistribution.con
   -- Use spectral theorem to prove that ρ = pure ψ
   rw [Matrix.IsHermitian.spectral_theorem ρ.M.H, Unitary.conjStarAlgAut_apply, Matrix.mul_apply]
   simp [ψ, v, hEig]
-  have hsum : ∀ x ∈ Finset.univ, x ∉ ({i} : Finset d) → (ρ.M.H.eigenvectorBasis x j) * (↑(if x = i then 1 else 0) : ℝ) * (starRingEnd ℂ) (ρ.Hermitian.eigenvectorBasis x k) = 0 := by
+  have hsum : ∀ x ∈ Finset.univ, x ∉ ({i} : Finset d) →
+      (ρ.M.H.eigenvectorBasis x j) * (↑(if x = i then 1 else 0) : ℝ) *
+        (starRingEnd ℂ) (ρ.Hermitian.eigenvectorBasis x k) = 0 := by
     intros x hx hxnoti
     rw [Finset.mem_singleton] at hxnoti
     rw [if_neg hxnoti, Complex.ofReal_zero]
     ring
-  simp_rw [←Finset.sum_subset (Finset.subset_univ {i}) hsum, Finset.sum_singleton, reduceIte, Complex.ofReal_one, mul_one]
+  simp_rw [←Finset.sum_subset (Finset.subset_univ {i}) hsum, Finset.sum_singleton, reduceIte,
+    Complex.ofReal_one, mul_one]
   rfl
 
 /-- A state ρ is pure iff its spectrum is (1,0,0,...) i.e. a constant distribution. -/
@@ -441,7 +449,8 @@ theorem pure_iff_purity_one : (∃ ψ, ρ = pure ψ) ↔ ρ.purity = 1 := by
     -- Apply the theorem that states a mixed state is pure if and only if its spectrum is constant.
     apply (pure_iff_constant_spectrum ρ).mpr;
     have h_eigenvalues : ∑ i, (ρ.spectrum i).val ^ 2 = 1 := by
-      -- By definition of purity, we know that the sum of the squares of the eigenvalues is equal to the trace of ρ squared.
+      -- By definition of purity, we know that the sum of the squares of the eigenvalues is equal
+      -- to the trace of ρ squared.
       have h_trace_sq : ∑ i, (ρ.spectrum i).val ^ 2 = ρ.purity := by
         have h_eigenvalues : ∑ i, (ρ.M.H.eigenvalues i) ^ 2 = (ρ.M.mat * ρ.M.mat).trace := by
           have := Matrix.IsHermitian.spectral_theorem ρ.M.H;
@@ -455,16 +464,24 @@ theorem pure_iff_purity_one : (∃ ψ, ρ = pure ψ) ↔ ρ.purity = 1 := by
     -- Since each term in the sum is non-positive and their sum is zero, each term must be zero.
     have h_each_zero : ∀ i, (ρ.spectrum i).val * ((ρ.spectrum i).val - 1) = 0 := by
       have h_each_zero : ∀ i, (ρ.spectrum i).val * ((ρ.spectrum i).val - 1) ≤ 0 := by
-        exact fun i => by nlinarith only [ show ( ρ.spectrum i : ℝ ) ≥ 0 by exact_mod_cast ( ρ.spectrum i ) |>.2.1, show ( ρ.spectrum i : ℝ ) ≤ 1 by exact_mod_cast ( ρ.spectrum i ) |>.2.2 ] ;
-      exact fun i => le_antisymm ( h_each_zero i ) ( by simpa [ h_eigenvalues ] using Finset.single_le_sum ( fun i _ => neg_nonneg.mpr ( h_each_zero i ) ) ( Finset.mem_univ i ) );
-    -- Since each term in the sum is non-positive and their sum is zero, each term must be zero. Therefore, for each i, either (ρ.spectrum i).val = 0 or (ρ.spectrum i).val = 1.
+        exact fun i => by
+          nlinarith only [
+            show ( ρ.spectrum i : ℝ ) ≥ 0 by exact_mod_cast ( ρ.spectrum i ) |>.2.1,
+            show ( ρ.spectrum i : ℝ ) ≤ 1 by exact_mod_cast ( ρ.spectrum i ) |>.2.2 ] ;
+      exact fun i => le_antisymm ( h_each_zero i ) ( by
+        simpa [ h_eigenvalues ] using Finset.single_le_sum
+          ( fun i _ => neg_nonneg.mpr ( h_each_zero i ) ) ( Finset.mem_univ i ) );
+    -- Since each term in the sum is non-positive and their sum is zero, each term must be zero.
+    -- Therefore, for each i, either (ρ.spectrum i).val = 0 or (ρ.spectrum i).val = 1.
     have h_each_zero : ∀ i, (ρ.spectrum i).val = 0 ∨ (ρ.spectrum i).val = 1 := by
       exact fun i => mul_eq_zero.mp ( h_each_zero i ) |> Or.imp id fun h => by linarith;
     have h_sum_one : ∑ i, (ρ.spectrum i).val = 1 := by
       grind;
     obtain ⟨i, hi⟩ : ∃ i, (ρ.spectrum i).val = 1 := by
       contrapose! h_sum_one; aesop;
-    -- Since the sum of the eigenvalues is 1 and one of them is 1, the remaining eigenvalues must sum to 0. Given that each eigenvalue is either 0 or 1, the only way their sum can be 0 is if all of them are 0.
+    -- Since the sum of the eigenvalues is 1 and one of them is 1, the remaining eigenvalues must
+    -- sum to 0. Given that each eigenvalue is either 0 or 1, the only way their sum can be 0 is if
+    -- all of them are 0.
     have h_sum_zero : ∑ j ∈ Finset.univ.erase i, (ρ.spectrum j).val = 0 := by
       rw [ ← Finset.sum_erase_add _ _ ( Finset.mem_univ i ), hi ] at h_sum_one ; linarith;
     rw [ Finset.sum_eq_zero_iff_of_nonneg ] at h_sum_zero
@@ -487,7 +504,8 @@ theorem pure_iff_purity_one : (∃ ψ, ρ = pure ψ) ↔ ρ.purity = 1 := by
           simp_all only [not_true_eq_false]
     · intro i_1 a
       simp_all only [Finset.sum_const_zero, mul_eq_zero, Set.Icc.coe_eq_zero, Set.Icc.coe_eq_one,
-        ProbDistribution.normalized, Finset.mem_univ, Finset.sum_erase_eq_sub, Set.Icc.coe_one, sub_self, Finset.mem_erase,
+        ProbDistribution.normalized, Finset.mem_univ, Finset.sum_erase_eq_sub, Set.Icc.coe_one,
+        sub_self, Finset.mem_erase,
         ne_eq, and_true, Prob.zero_le_coe]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -534,7 +552,8 @@ theorem prod_inner_prod (ξ1 ψ1 : MState d₁) (ξ2 ψ2 : MState d₂) :
   simp only [mat_M, mat_mk, Matrix.mul_kronecker_mul]
 
 /-- The product of pure states is a pure product state , `Ket.prod`. -/
-theorem pure_prod_pure (ψ₁ : Ket d₁) (ψ₂ : Ket d₂) : pure (ψ₁ ⊗ᵠ ψ₂) = (pure ψ₁) ⊗ᴹ (pure ψ₂) := by
+theorem pure_prod_pure (ψ₁ : Ket d₁) (ψ₂ : Ket d₂) :
+    pure (ψ₁ ⊗ᵠ ψ₂) = (pure ψ₁) ⊗ᴹ (pure ψ₂) := by
   ext : 3
   simp [Ket.prod, Ket.apply, prod, -mat_apply]
   ac_rfl
@@ -571,7 +590,8 @@ instance instUnique [Unique d] : Unique (MState d) where
     ext
     have h₁ := ρ.tr
     have h₂ := (@uniform _ _ _ _ : MState d).tr
-    simp [Matrix.trace, Unique.eq_default, -MState.tr, HermitianMat.trace_eq_re_trace] at h₁ h₂ ⊢
+    simp [Matrix.trace, Unique.eq_default, -MState.tr, HermitianMat.trace_eq_re_trace]
+      at h₁ h₂ ⊢
     apply Complex.ext
     · exact h₁.trans h₂.symm
     · rw [complex_im_eq_zero, complex_im_eq_zero]
@@ -606,13 +626,15 @@ def traceRight (ρ : MState (d₁ × d₂)) : MState d₁ where
 
 /-- Taking the direct product on the left and tracing it back out gives the same state. -/
 @[simp]
-theorem traceLeft_prod_eq (ρ₁ : MState d₁) (ρ₂ : MState d₂) : (ρ₁ ⊗ᴹ ρ₂).traceLeft = ρ₂ := by
+theorem traceLeft_prod_eq (ρ₁ : MState d₁) (ρ₂ : MState d₂) :
+    (ρ₁ ⊗ᴹ ρ₂).traceLeft = ρ₂ := by
   ext1
   simp [prod]
 
 /-- Taking the direct product on the right and tracing it back out gives the same state. -/
 @[simp]
-theorem traceRight_prod_eq (ρ₁ : MState d₁) (ρ₂ : MState d₂) : (ρ₁ ⊗ᴹ ρ₂).traceRight = ρ₁ := by
+theorem traceRight_prod_eq (ρ₁ : MState d₁) (ρ₂ : MState d₂) :
+    (ρ₁ ⊗ᴹ ρ₂).traceRight = ρ₁ := by
   ext1
   simp [prod]
 
@@ -622,38 +644,61 @@ end ptrace
 
 --TODO: Spectra of left- and right- partial traces of a pure state are equal.
 
-/-- Spectrum of direct product. There is a permutation σ so that the spectrum of the direct product of
-  ρ₁ and ρ₂, as permuted under σ, is the pairwise products of the spectra of ρ₁ and ρ₂. -/
-theorem spectrum_prod (ρ₁ : MState d₁) (ρ₂ : MState d₂) : ∃(σ : d₁ × d₂ ≃ d₁ × d₂),
-    ∀i, ∀j, (ρ₁ ⊗ᴹ ρ₂).spectrum (σ (i, j)) = (ρ₁.spectrum i) * (ρ₂.spectrum j) := by
+/-- Spectrum of direct product. There is a permutation σ so that the spectrum of the direct product
+  of ρ₁ and ρ₂, as permuted under σ, is the pairwise products of the spectra of ρ₁ and
+  ρ₂. -/
+theorem spectrum_prod (ρ₁ : MState d₁) (ρ₂ : MState d₂) :
+    ∃(σ : d₁ × d₂ ≃ d₁ × d₂),
+    ∀i, ∀j, (ρ₁ ⊗ᴹ ρ₂).spectrum (σ (i, j)) =
+      (ρ₁.spectrum i) * (ρ₂.spectrum j) := by
   --TODO Cleanup
   by_contra! h;
-  -- Apply `Matrix.IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal` to $A \otimes B$ and $U_A \otimes U_B$ and the diagonal entries.
-  obtain ⟨σ, hσ⟩ : ∃ σ : d₁ × d₂ ≃ d₁ × d₂, (ρ₁.prod ρ₂).M.H.eigenvalues ∘ σ = fun (i, j) => ((ρ₁.spectrum i) * (ρ₂.spectrum j)) := by
-    have h_unitary : ∃ U : Matrix (d₁ × d₂) (d₁ × d₂) ℂ, U ∈ Matrix.unitaryGroup (d₁ × d₂) ℂ ∧ (ρ₁.prod ρ₂).M = U * Matrix.diagonal (fun (i, j) => ((ρ₁.spectrum i) * (ρ₂.spectrum j)) : d₁ × d₂ → ℂ) * Matrix.conjTranspose U := by
+  -- Apply `Matrix.IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal` to $A \otimes B$ and
+  -- $U_A \otimes U_B$ and the diagonal entries.
+  obtain ⟨σ, hσ⟩ : ∃ σ : d₁ × d₂ ≃ d₁ × d₂,
+      (ρ₁.prod ρ₂).M.H.eigenvalues ∘ σ =
+        fun (i, j) => ((ρ₁.spectrum i) * (ρ₂.spectrum j)) := by
+    have h_unitary : ∃ U : Matrix (d₁ × d₂) (d₁ × d₂) ℂ,
+        U ∈ Matrix.unitaryGroup (d₁ × d₂) ℂ ∧
+        (ρ₁.prod ρ₂).M = U *
+          Matrix.diagonal
+            (fun (i, j) => ((ρ₁.spectrum i) * (ρ₂.spectrum j)) : d₁ × d₂ → ℂ) *
+          Matrix.conjTranspose U := by
       -- Let $U_A$ and $U_B$ be the eigenvector unitaries of $\rho_1$ and $\rho_2$, respectively.
-      obtain ⟨U_A, hU_A⟩ : ∃ U_A : Matrix d₁ d₁ ℂ, U_A ∈ Matrix.unitaryGroup d₁ ℂ ∧ ρ₁.M = U_A * Matrix.diagonal (fun i => (ρ₁.spectrum i : ℂ)) * Matrix.conjTranspose U_A := by
+      obtain ⟨U_A, hU_A⟩ : ∃ U_A : Matrix d₁ d₁ ℂ,
+          U_A ∈ Matrix.unitaryGroup d₁ ℂ ∧
+          ρ₁.M = U_A * Matrix.diagonal (fun i => (ρ₁.spectrum i : ℂ)) *
+            Matrix.conjTranspose U_A := by
         have := ρ₁.M.H.spectral_theorem;
         refine' ⟨ _, _, this ⟩;
         simp
-      obtain ⟨U_B, hU_B⟩ : ∃ U_B : Matrix d₂ d₂ ℂ, U_B ∈ Matrix.unitaryGroup d₂ ℂ ∧ ρ₂.M = U_B * Matrix.diagonal (fun j => (ρ₂.spectrum j : ℂ)) * Matrix.conjTranspose U_B := by
+      obtain ⟨U_B, hU_B⟩ : ∃ U_B : Matrix d₂ d₂ ℂ,
+          U_B ∈ Matrix.unitaryGroup d₂ ℂ ∧
+          ρ₂.M = U_B * Matrix.diagonal (fun j => (ρ₂.spectrum j : ℂ)) *
+            Matrix.conjTranspose U_B := by
         have := ρ₂.M.H.spectral_theorem;
         refine' ⟨ _, _, this ⟩;
         simp
       refine' ⟨ Matrix.kroneckerMap ( fun x y => x * y ) U_A U_B, _, _ ⟩;
       · simp_all only [ne_eq, Matrix.mem_unitaryGroup_iff, mat_M, Matrix.star_kron];
-        have h_unitary : Matrix.kroneckerMap (fun x y => x * y) U_A U_B * Matrix.kroneckerMap (fun x y => x * y) (Star.star U_A) (Star.star U_B) = 1 := by
-          have h_unitary : Matrix.kroneckerMap (fun x y => x * y) U_A U_B * Matrix.kroneckerMap (fun x y => x * y) (Star.star U_A) (Star.star U_B) = Matrix.kroneckerMap (fun x y => x * y) (U_A * Star.star U_A) (U_B * Star.star U_B) := by
+        have h_unitary : Matrix.kroneckerMap (fun x y => x * y) U_A U_B *
+            Matrix.kroneckerMap (fun x y => x * y) (Star.star U_A) (Star.star U_B) = 1 := by
+          have h_unitary : Matrix.kroneckerMap (fun x y => x * y) U_A U_B *
+              Matrix.kroneckerMap (fun x y => x * y) (Star.star U_A) (Star.star U_B) =
+              Matrix.kroneckerMap (fun x y => x * y) (U_A * Star.star U_A)
+                (U_B * Star.star U_B) := by
             ext ⟨ i, j ⟩ ⟨ k, l ⟩ ; simp [ Matrix.mul_apply, Matrix.kroneckerMap_apply ]
             ring_nf
             erw [ Finset.sum_product ]
             simp [ mul_assoc, mul_comm, mul_left_comm, Finset.mul_sum]
-            exact Finset.sum_comm.trans ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
+            exact Finset.sum_comm.trans
+              ( Finset.sum_congr rfl fun _ _ => Finset.sum_congr rfl fun _ _ => by ring );
           simp_all only [zero_mul, implies_true, mul_zero, mul_one, Matrix.kroneckerMap_one_one]
         exact h_unitary
       · simp_all [ MState.prod, Matrix.mul_assoc, Matrix.mul_kronecker_mul ];
         congr 2;
-        · ext ⟨ i, j ⟩ ⟨ i', j' ⟩ ; by_cases hi : i = i' <;> by_cases hj : j = j' <;> simp [ hi, hj ];
+        · ext ⟨ i, j ⟩ ⟨ i', j' ⟩
+          by_cases hi : i = i' <;> by_cases hj : j = j' <;> simp [ hi, hj ];
         · ext i j; simp [ Matrix.conjTranspose_apply, Matrix.kroneckerMap_apply ] ;
     obtain ⟨ U, hU₁, hU₂ ⟩ := h_unitary;
     apply Matrix.IsHermitian.eigenvalues_eq_of_unitary_similarity_diagonal;
@@ -664,7 +709,8 @@ theorem spectrum_prod (ρ₁ : MState d₁) (ρ₂ : MState d₂) : ∃(σ : d�
   exact h ( by exact Subtype.ext this )
 
 theorem sInf_spectrum_prod (ρ : MState d) (σ : MState d₂) :
-    sInf (_root_.spectrum ℝ (ρ ⊗ᴹ σ).m) = sInf (_root_.spectrum ℝ ρ.m) * sInf (_root_.spectrum ℝ σ.m) := by
+    sInf (_root_.spectrum ℝ (ρ ⊗ᴹ σ).m) =
+      sInf (_root_.spectrum ℝ ρ.m) * sInf (_root_.spectrum ℝ σ.m) := by
   rcases isEmpty_or_nonempty d with _ | _; · simp
   rcases isEmpty_or_nonempty d₂ with _ | _; · simp
   rw [MState.m, MState.prod, HermitianMat.spectrum_prod, ← MState.m, ← MState.m]
@@ -680,14 +726,17 @@ theorem sInf_spectrum_prod (ρ : MState d) (σ : MState d₂) :
 
 --TODO: Spectrum of direct sum. Spectrum of partial trace?
 
-/-- A mixed state is separable iff it can be written as a convex combination of product mixed states. -/
+/-- A mixed state is separable iff it can be written as a convex combination of product mixed
+states. -/
 def IsSeparable (ρ : MState (d₁ × d₂)) : Prop :=
   ∃ ρLRs : Finset (MState d₁ × MState d₂), --Finite set of (ρL, ρR) pairs
     ∃ ps : ProbDistribution ρLRs, --ProbDistribution over those pairs, an ensemble
-      ρ.M = ∑ ρLR : ρLRs, (ps ρLR : ℝ) • (Prod.fst ρLR.val).M ⊗ₖ (Prod.snd ρLR.val).M
+      ρ.M =
+        ∑ ρLR : ρLRs, (ps ρLR : ℝ) • (Prod.fst ρLR.val).M ⊗ₖ (Prod.snd ρLR.val).M
 
 /-- A product state `MState.prod` is separable. -/
-theorem IsSeparable_prod (ρ₁ : MState d₁) (ρ₂ : MState d₂) : IsSeparable (ρ₁ ⊗ᴹ ρ₂) := by
+theorem IsSeparable_prod (ρ₁ : MState d₁) (ρ₂ : MState d₂) :
+    IsSeparable (ρ₁ ⊗ᴹ ρ₂) := by
   let only := (ρ₁, ρ₂)
   use { only }, ProbDistribution.constant ⟨only, Finset.mem_singleton_self only⟩
   simp [prod, Unique.eq_default, only]
@@ -696,11 +745,13 @@ set_option backward.isDefEq.respectTransparency false in
 theorem eq_of_sum_eq_pure {d : Type*} [Fintype d] [DecidableEq d]
     {ι : Type*} {s : Finset ι} {p : ι → ℝ} {ρs : ι → MState d}
     {ρ : MState d} (h_pure : ρ.purity = 1) (h_sum : ρ.M = ∑ i ∈ s, p i • (ρs i).M)
-    (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (hp_sum : ∑ i ∈ s, p i = 1) (i : ι) (hi : i ∈ s) (hpi : 0 < p i) :
+    (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (hp_sum : ∑ i ∈ s, p i = 1) (i : ι) (hi : i ∈ s)
+    (hpi : 0 < p i) :
     ρs i = ρ := by
   have h_trace : ∀ j ∈ s, 0 < p j → (⟪ρ.M, (ρs j).M⟫ = 1) := by
     have h_tr_pure : ∑ j ∈ s, p j • ⟪ρ.M, (ρs j).M⟫ = 1 := by
-      have h_tr_pure : ⟪ρ.M, ∑ j ∈ s, p j • (ρs j).M⟫ = ∑ j ∈ s, p j • ⟪ρ.M, (ρs j).M⟫ := by
+      have h_tr_pure : ⟪ρ.M, ∑ j ∈ s, p j • (ρs j).M⟫ =
+          ∑ j ∈ s, p j • ⟪ρ.M, (ρs j).M⟫ := by
         simp [ HermitianMat.inner_def, ← val_eq_coe ];
         rw [AddSubgroup.val_finsetSum]
         simp [Finset.mul_sum]
@@ -720,11 +771,13 @@ theorem eq_of_sum_eq_pure {d : Type*} [Fintype d] [DecidableEq d]
     have h_tr_lt_one : ∑ j ∈ s, p j • ⟪ρ.M, (ρs j).M⟫ < ∑ j ∈ s, p j := by
       apply Finset.sum_lt_sum;
       · exact fun i hi => mul_le_of_le_one_right ( hp_nonneg i hi ) ( h_tr_le_one i hi );
-      · exact ⟨ j, hj, mul_lt_of_lt_one_right hj_pos ( lt_of_le_of_ne ( h_tr_le_one j hj ) h_contra ) ⟩;
+      · exact ⟨ j, hj,
+          mul_lt_of_lt_one_right hj_pos ( lt_of_le_of_ne ( h_tr_le_one j hj ) h_contra ) ⟩;
     linarith;
   have h_eq : ρ.M = (ρs i).M := by
     have h_eq : ⟪ρ.M - (ρs i).M, ρ.M - (ρs i).M⟫ = 0 := by
-      have h_eq : ⟪ρ.M - (ρs i).M, ρ.M - (ρs i).M⟫ = ⟪ρ.M, ρ.M⟫ - 2 * ⟪ρ.M, (ρs i).M⟫ + ⟪(ρs i).M, (ρs i).M⟫ := by
+      have h_eq : ⟪ρ.M - (ρs i).M, ρ.M - (ρs i).M⟫ =
+          ⟪ρ.M, ρ.M⟫ - 2 * ⟪ρ.M, (ρs i).M⟫ + ⟪(ρs i).M, (ρs i).M⟫ := by
         simp only [HermitianMat.inner_def, IsMaximalSelfAdjoint.RCLike_selfadjMap, mat_sub, mat_M,
           RCLike.re_to_complex];
         simp [ Matrix.mul_sub, Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm ( ρ.m ) ]
@@ -740,21 +793,25 @@ theorem eq_of_sum_eq_pure {d : Type*} [Fintype d] [DecidableEq d]
           aesop;
         exact ⟨ by assumption, h_eq _ ( ρs i |>.2 ) ( ρs i |>.3 ) ⟩;
       linarith [ h_trace i hi hpi, (ρ.M - (ρs i).M).inner_self_nonneg ];
-    -- Since the inner product of a matrix with itself is zero if and only if the matrix is zero, we have ρ.M - (ρs i).M = 0.
+    -- Since the inner product of a matrix with itself is zero if and only if the matrix is zero,
+    -- we have ρ.M - (ρs i).M = 0.
     have h_zero : ρ.M - (ρs i).M = 0 := by
       apply inner_self_eq_zero.mp h_eq;
     exact eq_of_sub_eq_zero h_zero;
   exact MState.ext h_eq.symm
 
-theorem purity_prod {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [DecidableEq d₂]
-    (ρ₁ : MState d₁) (ρ₂ : MState d₂) : (ρ₁ ⊗ᴹ ρ₂).purity = ρ₁.purity * ρ₂.purity := by
+theorem purity_prod {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁]
+    [DecidableEq d₂]
+    (ρ₁ : MState d₁) (ρ₂ : MState d₂) :
+    (ρ₁ ⊗ᴹ ρ₂).purity = ρ₁.purity * ρ₂.purity := by
   exact prod_inner_prod ρ₁ ρ₁ ρ₂ ρ₂
 
 theorem pure_eq_pure_iff {d : Type*} [Fintype d] [DecidableEq d] (ψ φ : Ket d) :
     pure ψ = pure φ ↔ ∃ z : ℂ, ‖z‖ = 1 ∧ ψ.vec = z • φ.vec := by
   refine' ⟨ fun h => _, fun h => _ ⟩;
   · -- By definition of pure state, we have that ψ.vec * conj ψ.vec = φ.vec * conj φ.vec.
-    have h_eq : ∀ i j, ψ.vec i * starRingEnd ℂ (ψ.vec j) = φ.vec i * starRingEnd ℂ (φ.vec j) := by
+    have h_eq : ∀ i j,
+        ψ.vec i * starRingEnd ℂ (ψ.vec j) = φ.vec i * starRingEnd ℂ (φ.vec j) := by
       intro i j;
       replace h := congr_arg ( fun ρ => ρ.M.mat i j ) h ; aesop;
     -- Let $k$ be such that $\varphi_k \neq 0$.
@@ -764,19 +821,24 @@ theorem pure_eq_pure_iff {d : Type*} [Fintype d] [DecidableEq d] (ψ φ : Ket d)
     obtain ⟨z, hz⟩ : ∃ z : ℂ, ψ.vec k = z * φ.vec k ∧ ‖z‖ = 1 := by
       specialize h_eq k k
       simp_all only [ne_eq]
-      refine' ⟨ ψ.vec k / φ.vec k, _, _ ⟩ <;> simp_all [ Complex.mul_conj, Complex.normSq_eq_norm_sq ];
+      refine' ⟨ ψ.vec k / φ.vec k, _, _ ⟩ <;>
+        simp_all [ Complex.mul_conj, Complex.normSq_eq_norm_sq ];
       rw [ div_eq_iff ] <;> norm_cast at * <;> aesop;
     refine' ⟨ z, hz.2, funext fun i => _ ⟩;
     specialize h_eq i k
     simp_all
-    -- Since $\overline{z} \cdot \overline{\varphi_k} \neq 0$, we can divide both sides of the equation by $\overline{z} \cdot \overline{\varphi_k}$.
+    -- Since $\overline{z} \cdot \overline{\varphi_k} \neq 0$, we can divide both sides of the
+    -- equation by $\overline{z} \cdot \overline{\varphi_k}$.
     have h_div : ψ.vec i * starRingEnd ℂ z = φ.vec i := by
-      exact mul_left_cancel₀ ( show starRingEnd ℂ ( φ.vec k ) ≠ 0 from by simpa [ Complex.ext_iff ] using hk ) ( by linear_combination' h_eq );
+      exact mul_left_cancel₀
+        ( show starRingEnd ℂ ( φ.vec k ) ≠ 0 from by simpa [ Complex.ext_iff ] using hk )
+        ( by linear_combination' h_eq );
     rw [ ← h_div, mul_left_comm, Complex.mul_conj, Complex.normSq_eq_norm_sq ] ; aesop;
   · cases h
     rename_i h
     obtain ⟨left, right⟩ := h
-    -- Since $|w| = 1$, we have $w \overline{w} = 1$, which simplifies the matrix to $\phi \overline{\phi}^T$.
+    -- Since $|w| = 1$, we have $w \overline{w} = 1$, which simplifies the matrix to
+    -- $\phi \overline{\phi}^T$.
     have h_simp : ∀ i j, ψ.vec i * star (ψ.vec j) = φ.vec i * star (φ.vec j) := by
       simp [ *, Complex.ext_iff ];
       intro i j; rw [ Complex.norm_def ] at left; simp_all [ Complex.normSq ];
@@ -796,22 +858,30 @@ def pureQ {d : Type*} [Fintype d] [DecidableEq d] : KetUpToPhase d → MState d 
 theorem pureQ_mk {d : Type*} [Fintype d] [DecidableEq d] (ψ : Ket d) :
     pureQ (Quotient.mk Ket.PhaseEquiv ψ) = MState.pure ψ := rfl
 
-theorem pureQ_injective {d : Type*} [Fintype d] [DecidableEq d] : Function.Injective (pureQ (d := d)) := by
+theorem pureQ_injective {d : Type*} [Fintype d] [DecidableEq d] :
+    Function.Injective (pureQ (d := d)) := by
   intro a b h
   induction a using Quotient.ind
   induction b using Quotient.ind
   simp [pureQ] at h
   exact Quotient.sound ((PhaseEquiv_iff_pure_eq _ _).mpr h)
 
-theorem pure_separable_imp_IsProd {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [DecidableEq d₂]
+theorem pure_separable_imp_IsProd {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂]
+    [DecidableEq d₁] [DecidableEq d₂]
     (ψ : Ket (d₁ × d₂)) (h : IsSeparable (pure ψ)) : ψ.IsProd := by
   obtain ⟨ ρLRs, ps, hps ⟩ := h;
-  -- Since `pure ψ` is pure (`purity = 1`), by `MState.eq_of_sum_eq_pure`, for any `k` with `p_k > 0`, we have `pure ψ = ρL_k ⊗ᴹ ρR_k`.
-  obtain ⟨k, hk⟩ : ∃ k : { x : MState d₁ × MState d₂ // x ∈ ρLRs }, 0 < (ps k : ℝ) ∧ (MState.pure ψ).M = (k.val.1).M ⊗ₖ (k.val.2).M := by
+  -- Since `pure ψ` is pure (`purity = 1`), by `MState.eq_of_sum_eq_pure`, for any `k` with
+  -- `p_k > 0`, we have `pure ψ = ρL_k ⊗ᴹ ρR_k`.
+  obtain ⟨k, hk⟩ : ∃ k : { x : MState d₁ × MState d₂ // x ∈ ρLRs },
+      0 < (ps k : ℝ) ∧ (MState.pure ψ).M = (k.val.1).M ⊗ₖ (k.val.2).M := by
     have h_pure : (MState.pure ψ).purity = 1 := by
       exact ( pure_iff_purity_one _ ).mp ⟨ ψ, rfl ⟩;
-    obtain ⟨k, hk⟩ : ∃ k : { x : MState d₁ × MState d₂ // x ∈ ρLRs }, 0 < (ps k : ℝ) := by
-      exact ⟨ Classical.choose ( show ∃ k : ρLRs, 0 < ( ps k : ℝ ) from by exact not_forall_not.mp fun h => by have := ps.2; simp_all ), Classical.choose_spec ( show ∃ k : ρLRs, 0 < ( ps k : ℝ ) from by exact not_forall_not.mp fun h => by have := ps.2; simp_all) ⟩;
+    obtain ⟨k, hk⟩ : ∃ k : { x : MState d₁ × MState d₂ // x ∈ ρLRs },
+        0 < (ps k : ℝ) := by
+      exact ⟨ Classical.choose ( show ∃ k : ρLRs, 0 < ( ps k : ℝ ) from by
+          exact not_forall_not.mp fun h => by have := ps.2; simp_all ),
+        Classical.choose_spec ( show ∃ k : ρLRs, 0 < ( ps k : ℝ ) from by
+          exact not_forall_not.mp fun h => by have := ps.2; simp_all) ⟩;
     refine' ⟨ k, hk, _ ⟩;
     convert MState.eq_of_sum_eq_pure h_pure _ _ _ k _ _;
     rotate_left;
@@ -831,7 +901,8 @@ theorem pure_separable_imp_IsProd {d₁ d₂ : Type*} [Fintype d₁] [Fintype d�
       · intro a
         rw [← a]
         rfl
-  -- Since `pure ψ` is pure (`purity = 1`), by `MState.pure_iff_purity_one`, `ρL_k = pure ξ` and `ρR_k = pure φ` for some `ξ, φ`.
+  -- Since `pure ψ` is pure (`purity = 1`), by `MState.pure_iff_purity_one`, `ρL_k = pure ξ` and
+  -- `ρR_k = pure φ` for some `ξ, φ`.
   obtain ⟨ξ, hξ⟩ : ∃ ξ : MState d₁, k.val.1 = ξ ∧ ξ.purity = 1 := by
     have h_purity : (pure ψ).purity = (k.val.1).purity * (k.val.2).purity := by
       convert MState.purity_prod _ _;
@@ -846,7 +917,8 @@ theorem pure_separable_imp_IsProd {d₁ d₂ : Type*} [Fintype d₁] [Fintype d�
     have h_purity_one : (MState.pure ψ).purity = 1 := by
       exact pure_iff_purity_one _ |>.1 ⟨ ψ, rfl ⟩;
     aesop;
-  -- Since `ξ` and `φ` are pure states, we have `ξ = pure ξ'` and `φ = pure φ'` for some `ξ', φ'`.
+  -- Since `ξ` and `φ` are pure states, we have `ξ = pure ξ'` and `φ = pure φ'` for some
+  -- `ξ', φ'`.
   obtain ⟨ξ', hξ'⟩ : ∃ ξ' : Ket d₁, ξ = MState.pure ξ' := by
     have := MState.pure_iff_purity_one ξ;
     exact this.mpr hξ.2
@@ -856,7 +928,8 @@ theorem pure_separable_imp_IsProd {d₁ d₂ : Type*} [Fintype d₁] [Fintype d�
   have h_eq : (pure ψ).M = (pure (ξ' ⊗ᵠ φ')).M := by
     rw [ hk.2, hξ.1, hξ', hφ.1, hφ', MState.pure_prod_pure ];
     exact rfl;
-  -- Since `pure ψ = pure (ξ' ⊗ᵠ φ')`, we have `ψ = ξ' ⊗ᵠ φ'` up to a global phase `z`.
+  -- Since `pure ψ = pure (ξ' ⊗ᵠ φ')`, we have `ψ = ξ' ⊗ᵠ φ'` up to a global phase
+  -- `z`.
   have h_eq_ket : ∃ z : ℂ, ‖z‖ = 1 ∧ ψ.vec = z • (ξ' ⊗ᵠ φ').vec := by
     have := MState.pure_eq_pure_iff ψ ( ξ' ⊗ᵠ φ' );
     exact this.mp ( MState.ext h_eq );
@@ -885,33 +958,47 @@ theorem pure_iff_rank_eq_one {d : Type*} [Fintype d] [DecidableEq d] (ρ : MStat
   constructor <;> intro h;
   · obtain ⟨w, rfl⟩ := h
     -- The rank of the outer product of a vector with itself is 1.
-    have h_rank : ∀ (v : d → ℂ), v ≠ 0 → Matrix.rank (Matrix.vecMulVec v (conj v)) = 1 := by
+    have h_rank : ∀ (v : d → ℂ), v ≠ 0 →
+        Matrix.rank (Matrix.vecMulVec v (conj v)) = 1 := by
       intro v hv_ne_zero
-      have h_outer_product : ∀ (u : d → ℂ), ∃ (c : ℂ), Matrix.mulVec (Matrix.vecMulVec v (conj v)) u = c • v := by
+      have h_outer_product : ∀ (u : d → ℂ),
+          ∃ (c : ℂ), Matrix.mulVec (Matrix.vecMulVec v (conj v)) u = c • v := by
         intro u
         use ∑ i, (starRingEnd ℂ (v i)) * (u i);
-        ext i; simp [ Matrix.vecMulVec, Matrix.mulVec, dotProduct, mul_comm, mul_left_comm, Finset.mul_sum _ _ _ ] ;
+        ext i
+        simp [ Matrix.vecMulVec, Matrix.mulVec, dotProduct, mul_comm, mul_left_comm,
+          Finset.mul_sum _ _ _ ] ;
       apply le_antisymm
-      · have h_outer_product : LinearMap.range (Matrix.mulVecLin (Matrix.vecMulVec v (conj v))) ≤ Submodule.span ℂ {v} := by
+      · have h_outer_product :
+            LinearMap.range (Matrix.mulVecLin (Matrix.vecMulVec v (conj v))) ≤
+            Submodule.span ℂ {v} := by
           rintro x ⟨ u, rfl ⟩ ; obtain ⟨ c, hc ⟩ := h_outer_product u; aesop;
-        exact le_trans ( Submodule.finrank_mono h_outer_product ) ( finrank_span_le_card _ ) |> le_trans <| by simp ;
+        exact le_trans ( Submodule.finrank_mono h_outer_product ) ( finrank_span_le_card _ ) |>
+          le_trans <| by simp ;
       · contrapose! hv_ne_zero; simp_all [ Matrix.rank, Submodule.eq_bot_iff ] ;
         ext i; specialize hv_ne_zero ( Pi.single i 1 ) ; simp_all [ Matrix.vecMulVec ] ;
         simpa using congr_fun hv_ne_zero i;
     exact h_rank _ ( fun h => by simpa [ h ] using w.exists_ne_zero );
   · -- Since ρ is Hermitian and has rank 1, it must be of the form |ψ⟩⟨ψ| for some ket ψ.
-    obtain ⟨ψ, hψ⟩ : ∃ ψ : d → ℂ, ρ.m = Matrix.of (fun i j => ψ i * star (ψ j)) := by
-      -- Since ρ is Hermitian and has rank 1, it must be of the form |ψ⟩⟨ψ| for some ket ψ. Use this fact.
+    obtain ⟨ψ, hψ⟩ : ∃ ψ : d → ℂ,
+        ρ.m = Matrix.of (fun i j => ψ i * star (ψ j)) := by
+      -- Since ρ is Hermitian and has rank 1, it must be of the form |ψ⟩⟨ψ| for some ket ψ.
+      -- Use
+      -- this fact.
       have h_pure : ∃ ψ : d → ℂ, ρ.m = Matrix.of (fun i j => ψ i * star (ψ j)) := by
         have h_rank : ρ.m.rank = 1 := h
         have h_herm : ρ.m.IsHermitian := by
           exact ρ.M.property
         have := h_herm.spectral_theorem;
-        -- Since the rank of ρ.m is 1, the diagonal matrix in the spectral theorem must have exactly one non-zero entry.
-        obtain ⟨i, hi⟩ : ∃ i : d, h_herm.eigenvalues i ≠ 0 ∧ ∀ j : d, j ≠ i → h_herm.eigenvalues j = 0 := by
+        -- Since the rank of ρ.m is 1, the diagonal matrix in the spectral theorem must
+        -- have exactly one non-zero entry.
+        obtain ⟨i, hi⟩ :
+            ∃ i : d, h_herm.eigenvalues i ≠ 0 ∧
+              ∀ j : d, j ≠ i → h_herm.eigenvalues j = 0 := by
           have h_diag : ∑ i : d, (if h_herm.eigenvalues i = 0 then 0 else 1) = 1 := by
             have h_diag : Matrix.rank (Matrix.diagonal (h_herm.eigenvalues)) = 1 := by
-              have h_diag : Matrix.rank (Matrix.diagonal (h_herm.eigenvalues)) = Matrix.rank (ρ.m) := by
+              have h_diag :
+                  Matrix.rank (Matrix.diagonal (h_herm.eigenvalues)) = Matrix.rank (ρ.m) := by
                 exact Eq.symm (Matrix.IsHermitian.rank_eq_rank_diagonal h_herm);
               exact h_diag.trans h_rank;
             rw [ Matrix.rank_diagonal ] at h_diag;
@@ -921,9 +1008,15 @@ theorem pure_iff_rank_eq_one {d : Type*} [Fintype d] [DecidableEq d] (ρ : MStat
             exact not_forall.mp fun h => by simp [ h ] at h_diag;
           rw [ Finset.sum_eq_add_sum_diff_singleton i _ (by simp) ] at h_diag;
           exact ⟨i, hi, fun j hj => Classical.not_not.1 fun hj' =>
-            absurd h_diag ( by rw [ if_neg hi ] ; exact ne_of_gt ( lt_add_of_pos_right _ ( lt_of_lt_of_le ( by simp [ hj' ] ) ( Finset.single_le_sum ( fun x _ => by positivity ) ( Finset.mem_sdiff.2 ⟨ Finset.mem_univ j, by simp [ hj ] ⟩ ) ) ) ) ) ⟩;
-        -- Since the diagonal matrix in the spectral theorem has exactly one non-zero entry, we can write ρ.m as |ψ⟩⟨ψ| for some ket ψ.
-        use fun j => (h_herm.eigenvectorUnitary : Matrix d d ℂ) j i * Real.sqrt (h_herm.eigenvalues i);
+            absurd h_diag ( by
+              rw [ if_neg hi ]
+              exact ne_of_gt ( lt_add_of_pos_right _ ( lt_of_lt_of_le ( by simp [ hj' ] )
+                ( Finset.single_le_sum ( fun x _ => by positivity )
+                  ( Finset.mem_sdiff.2 ⟨ Finset.mem_univ j, by simp [ hj ] ⟩ ) ) ) ) ) ⟩;
+        -- Since the diagonal matrix in the spectral theorem has exactly one non-zero entry, we can
+        -- write ρ.m as |ψ⟩⟨ψ| for some ket ψ.
+        use fun j =>
+          (h_herm.eigenvectorUnitary : Matrix d d ℂ) j i * Real.sqrt (h_herm.eigenvalues i);
         convert this using 1
         ext j k; simp [ Matrix.mul_apply, Matrix.diagonal ]
         ring_nf
@@ -944,29 +1037,38 @@ theorem pure_iff_rank_eq_one {d : Type*} [Fintype d] [DecidableEq d] (ρ : MStat
 /--
 A ket on a product space is a product state if and only if its coefficient matrix has rank 1.
 -/
-theorem Ket.IsProd_iff_rank_eq_one {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂] [DecidableEq d₁] [DecidableEq d₂]
+theorem Ket.IsProd_iff_rank_eq_one {d₁ d₂ : Type*} [Fintype d₁] [Fintype d₂]
+    [DecidableEq d₁] [DecidableEq d₂]
     (ψ : Ket (d₁ × d₂)) :
     ψ.IsProd ↔ (Matrix.of (fun i j => ψ (i, j))).rank = 1 := by
   rw [ Ket.IsProd_iff_mul_eq_mul ];
   constructor;
   · intro h;
-    obtain ⟨ξ, ψ', hξψ'⟩ : ∃ ξ : d₁ → ℂ, ∃ ψ' : d₂ → ℂ, ∀ i j, ψ (i, j) = ξ i * ψ' j := by
+    obtain ⟨ξ, ψ', hξψ'⟩ : ∃ ξ : d₁ → ℂ, ∃ ψ' : d₂ → ℂ,
+        ∀ i j, ψ (i, j) = ξ i * ψ' j := by
       -- Let's choose any $j₀$ such that $\psi(i, j₀) \neq 0$ for some $i$.
       obtain ⟨j₀, hj₀⟩ : ∃ j₀ : d₂, ∃ i₀ : d₁, ψ (i₀, j₀) ≠ 0 := by
         have := ψ.exists_ne_zero;
         exact ⟨ this.choose.2, this.choose.1, this.choose_spec ⟩;
       choose i₀ hi₀ using hj₀;
-      exact ⟨ fun i => ψ ( i, j₀ ) / ψ ( i₀, j₀ ), fun j => ψ ( i₀, j ), fun i j => by rw [ div_mul_eq_mul_div, eq_div_iff hi₀ ] ; linear_combination h i i₀ j j₀ ⟩;
+      exact ⟨ fun i => ψ ( i, j₀ ) / ψ ( i₀, j₀ ), fun j => ψ ( i₀, j ), fun i j => by
+        rw [ div_mul_eq_mul_div, eq_div_iff hi₀ ] ; linear_combination h i i₀ j j₀ ⟩;
     -- Since the matrix is a product of two vectors, its rank is 1.
     have h_rank : Matrix.rank (Matrix.of (fun i j => ξ i * ψ' j)) ≤ 1 := by
       -- The range of the matrix is spanned by the single vector ξ.
-      have h_range : LinearMap.range (Matrix.mulVecLin (Matrix.of (fun i j => ξ i * ψ' j))) ≤ Submodule.span ℂ {ξ} := by
+      have h_range : LinearMap.range (Matrix.mulVecLin (Matrix.of (fun i j => ξ i * ψ' j))) ≤
+          Submodule.span ℂ {ξ} := by
         rintro x ⟨ y, rfl ⟩;
         rw [ Submodule.mem_span_singleton ];
-        exact ⟨ ∑ j, ψ' j * y j, by ext i; simp [ Matrix.mulVec, dotProduct, mul_comm, mul_left_comm, Finset.mul_sum _ _ _ ] ⟩;
-      exact le_trans ( Submodule.finrank_mono h_range ) ( finrank_span_le_card _ ) |> le_trans <| by norm_num;
+        exact ⟨ ∑ j, ψ' j * y j, by
+          ext i; simp [ Matrix.mulVec, dotProduct, mul_comm, mul_left_comm,
+            Finset.mul_sum _ _ _ ] ⟩;
+      exact le_trans ( Submodule.finrank_mono h_range ) ( finrank_span_le_card _ ) |>
+        le_trans <| by norm_num;
     cases h_rank.eq_or_lt <;> simp_all [ Matrix.rank, Submodule.eq_bot_iff ];
-    · convert ‹Module.finrank ℂ ( LinearMap.range ( Matrix.mulVecLin ( Matrix.of fun i j => ξ i * ψ' j ) ) ) = 1› using 3 ; aesop;
+    · convert
+        ‹Module.finrank ℂ ( LinearMap.range ( Matrix.mulVecLin
+          ( Matrix.of fun i j => ξ i * ψ' j ) ) ) = 1› using 3 ; aesop;
       · aesop;
       · ext; simp [hξψ'];
     · have := ψ.exists_ne_zero
@@ -980,8 +1082,10 @@ theorem Ket.IsProd_iff_rank_eq_one {d₁ d₂ : Type*} [Fintype d₁] [Fintype d
   · rw [ Matrix.rank ];
     rw [ finrank_eq_one_iff' ]
     intro a i₁ i₂ j₁ j₂
-    simp_all only [ne_eq, Subtype.forall, LinearMap.mem_range, Matrix.mulVecBilin_apply, forall_exists_index,
-      Subtype.exists, Submodule.mk_eq_zero, SetLike.mk_smul_mk, Subtype.mk.injEq, forall_apply_eq_imp_iff,
+    simp_all only [ne_eq, Subtype.forall, LinearMap.mem_range, Matrix.mulVecBilin_apply,
+      forall_exists_index,
+      Subtype.exists, Submodule.mk_eq_zero, SetLike.mk_smul_mk, Subtype.mk.injEq,
+      forall_apply_eq_imp_iff,
       exists_and_left, exists_prop]
     obtain ⟨w, h⟩ := a
     obtain ⟨left, right⟩ := h
@@ -1002,8 +1106,11 @@ theorem pure_separable_iff_traceLeft_pure (ψ : Ket (d₁ × d₂)) : IsSeparabl
   have h2 := Ket.IsProd_iff_rank_eq_one ψ;
   have h3 := MState.pure_iff_rank_eq_one ( ( MState.pure ψ ).traceLeft )
   simp_all
-  have h4 : Matrix.rank ((MState.pure ψ).traceLeft.m) = Matrix.rank (Matrix.of (fun i j => ψ (i, j))) := by
-    have h4 : (MState.pure ψ).traceLeft.m = Matrix.transpose (Matrix.conjTranspose (Matrix.of (fun i j => ψ (i, j))) * Matrix.of (fun i j => ψ (i, j))) := by
+  have h4 : Matrix.rank ((MState.pure ψ).traceLeft.m) =
+      Matrix.rank (Matrix.of (fun i j => ψ (i, j))) := by
+    have h4 : (MState.pure ψ).traceLeft.m =
+        Matrix.transpose (Matrix.conjTranspose (Matrix.of (fun i j => ψ (i, j))) *
+          Matrix.of (fun i j => ψ (i, j))) := by
       ext i j
       simp [ MState.traceLeft, Matrix.mul_apply ] ;
       exact Finset.sum_congr rfl fun _ _ => mul_comm _ _;
@@ -1015,7 +1122,8 @@ theorem pure_separable_iff_traceLeft_pure (ψ : Ket (d₁ × d₂)) : IsSeparabl
 section purification
 
 /-- The purification of a mixed state. Always uses the full dimension of the Hilbert space (d) to
- purify, so e.g. an existing pure state with d=4 still becomes d=16 in the purification. The defining
+ purify, so e.g. an existing pure state with d=4 still becomes d=16 in the purification. The
+ defining
  property is `MState.traceRight_of_purify`; see also `MState.purify'` for the bundled version. -/
 def purify (ρ : MState d) : Ket (d × d) where
   vec := fun (i,j) ↦
@@ -1044,10 +1152,15 @@ theorem purify_spec (ρ : MState d) : (pure ρ.purify).traceRight = ρ := by
   simp only [Ket.apply]
   simp only [map_mul]
   simp_rw [mul_assoc, mul_comm, ← mul_assoc (Complex.ofReal _), Complex.mul_conj]
-  -- By definition of eigenvectorUnitary and the properties of the unitary matrix and the eigenvalues, we can show that the matrix constructed from the purification is equal to ρ.
-  have h_eigenvectorUnitary : ∀ i j, ∑ x, ρ.Hermitian.eigenvectorUnitary i x * ((ρ.Hermitian.eigenvalues x).sqrt ^ 2) * starRingEnd ℂ (ρ.Hermitian.eigenvectorUnitary j x) = ρ.M i j := by
+  -- By definition of eigenvectorUnitary and the properties of the unitary matrix and the
+  -- eigenvalues, we can show that the matrix constructed from the purification is equal to ρ.
+  have h_eigenvectorUnitary : ∀ i j, ∑ x, ρ.Hermitian.eigenvectorUnitary i x *
+      ((ρ.Hermitian.eigenvalues x).sqrt ^ 2) *
+      starRingEnd ℂ (ρ.Hermitian.eigenvectorUnitary j x) = ρ.M i j := by
     intro i j
-    have h_eigenvectorUnitary : ρ.M = Matrix.of (fun i j => ∑ x, ρ.Hermitian.eigenvectorUnitary i x * ρ.Hermitian.eigenvalues x * starRingEnd ℂ (ρ.Hermitian.eigenvectorUnitary j x)) := by
+    have h_eigenvectorUnitary : ρ.M = Matrix.of (fun i j => ∑ x,
+        ρ.Hermitian.eigenvectorUnitary i x * ρ.Hermitian.eigenvalues x *
+        starRingEnd ℂ (ρ.Hermitian.eigenvectorUnitary j x)) := by
       have := ρ.Hermitian.spectral_theorem;
       convert this using 1;
       ext i j; simp [ Matrix.mul_apply, Matrix.diagonal ] ;
@@ -1092,16 +1205,19 @@ theorem relabel_pure_exists (ψ : Ket d₁) (e : d₂ ≃ d₁) :
 @[simp]
 theorem relabel_relabel {d d₂ d₃ : Type*}
     [Fintype d] [DecidableEq d] [Fintype d₂] [DecidableEq d₂] [Fintype d₃] [DecidableEq d₃]
-    (ρ : MState d) (e : d₂ ≃ d) (e₂ : d₃ ≃ d₂) : (ρ.relabel e).relabel e₂ = ρ.relabel (e₂.trans e) := by
+    (ρ : MState d) (e : d₂ ≃ d) (e₂ : d₃ ≃ d₂) :
+    (ρ.relabel e).relabel e₂ = ρ.relabel (e₂.trans e) := by
   rfl
 
-theorem eq_relabel_iff {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+theorem eq_relabel_iff {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+    [DecidableEq d₂]
     (ρ : MState d₁) (σ : MState d₂) (h : d₁ ≃ d₂) :
     ρ = σ.relabel h ↔ ρ.relabel h.symm = σ := by
   simp only [MState.ext_iff, HermitianMat.ext_iff, mat_M, relabel_m]
   exact ⟨(by simp[·]), (by simp[← ·])⟩
 
-theorem relabel_comp {d₁ d₂ d₃ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+theorem relabel_comp {d₁ d₂ d₃ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+      [DecidableEq d₂]
       [Fintype d₃] [DecidableEq d₃] (ρ : MState d₁) (e : d₂ ≃ d₁) (f : d₃ ≃ d₂) :
     (ρ.relabel e).relabel f = ρ.relabel (f.trans e) := by
   ext
@@ -1110,7 +1226,8 @@ theorem relabel_comp {d₁ d₂ d₃ : Type*} [Fintype d₁] [DecidableEq d₁] 
 theorem relabel_cast {d₁ d₂ : Type u} [Fintype d₁] [DecidableEq d₁]
     [Fintype d₂] [DecidableEq d₂]
        (ρ : MState d₁) (e : d₂ = d₁) :
-    ρ.relabel (Equiv.cast e) = cast (by have := e.symm; congr <;> (apply Subsingleton.helim; congr)) ρ := by
+    ρ.relabel (Equiv.cast e) =
+      cast (by have := e.symm; congr <;> (apply Subsingleton.helim; congr)) ρ := by
   ext i j
   simp only [relabel_M, mat_reindex, mat_M, Matrix.reindex_apply, Matrix.submatrix_apply]
   subst e
@@ -1133,27 +1250,34 @@ theorem spectrum_relabel {ρ : MState d} (e : d₂ ≃ d) :
 
 /-- The purity of a state is invariant under relabeling of the basis. -/
 @[simp]
-theorem purity_relabel (ρ : MState d₁) (e : d₂ ≃ d₁) : (ρ.relabel e).purity = ρ.purity := by
+theorem purity_relabel (ρ : MState d₁) (e : d₂ ≃ d₁) :
+    (ρ.relabel e).purity = ρ.purity := by
   simp [purity, inner_def, -inner_self_eq_norm_sq_to_K]
 --TODO: Swap and assoc for kets.
 --TODO: Connect these to unitaries (when they can be)
 
 /-- The heterogeneous SWAP gate that exchanges the left and right halves of a quantum system.
   This can apply even when the two "halves" are of different types, as opposed to (say) the SWAP
-  gate on quantum circuits that leaves the qubit dimensions unchanged. Notably, it is not unitary. -/
+  gate on quantum circuits that leaves the qubit dimensions unchanged. Notably, it is not
+  unitary. -/
 def SWAP (ρ : MState (d₁ × d₂)) : MState (d₂ × d₁) :=
   ρ.relabel (Equiv.prodComm d₁ d₂).symm
 
 /--
-The multiset of values in the spectrum of a relabeled state is the same as the multiset of values in the spectrum of the original state.
+The multiset of values in the spectrum of a relabeled state is the same as the multiset of values in
+the spectrum of the original state.
 -/
-lemma multiset_spectrum_relabel_eq {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+lemma multiset_spectrum_relabel_eq {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁]
+    [Fintype d₂] [DecidableEq d₂]
     (ρ : MState d₁) (e : d₂ ≃ d₁) :
-    Multiset.map (ρ.relabel e).spectrum Finset.univ.val = Multiset.map ρ.spectrum Finset.univ.val := by
+    Multiset.map (ρ.relabel e).spectrum Finset.univ.val =
+      Multiset.map ρ.spectrum Finset.univ.val := by
   have h_charpoly : Matrix.charpoly (ρ.relabel e).m = Matrix.charpoly ρ.m := by
     exact Matrix.charpoly_reindex e.symm ρ.m
-  have h_eigenvalues : Multiset.map (ρ.relabel e).M.H.eigenvalues Finset.univ.val = Multiset.map ρ.M.H.eigenvalues Finset.univ.val := by
-    have h_eigenvalues : Polynomial.roots (Matrix.charpoly (ρ.relabel e).m) = Polynomial.roots (Matrix.charpoly ρ.m) := by
+  have h_eigenvalues : Multiset.map (ρ.relabel e).M.H.eigenvalues Finset.univ.val =
+      Multiset.map ρ.M.H.eigenvalues Finset.univ.val := by
+    have h_eigenvalues : Polynomial.roots (Matrix.charpoly (ρ.relabel e).m) =
+        Polynomial.roots (Matrix.charpoly ρ.m) := by
       rw [h_charpoly];
     have := ρ.M.H.roots_charpoly_eq_eigenvalues
     have := (ρ.relabel e).M.H.roots_charpoly_eq_eigenvalues
@@ -1175,9 +1299,11 @@ lemma multiset_spectrum_relabel_eq {d₁ d₂ : Type*} [Fintype d₁] [Decidable
     congr! 2;
     exact beq_eq_beq.mp rfl
 
-def spectrum_SWAP (ρ : MState (d₁ × d₂)) : ∃ e, ρ.SWAP.spectrum.relabel e = ρ.spectrum := by
+def spectrum_SWAP (ρ : MState (d₁ × d₂)) :
+    ∃ e, ρ.SWAP.spectrum.relabel e = ρ.spectrum := by
   -- Apply the lemma exists_equiv_of_multiset_map_eq with the appropriate parameters.
-  obtain ⟨w, h⟩ := exists_equiv_of_multiset_map_eq (fun p => ρ.spectrum p) (fun p => ρ.SWAP.spectrum p)
+  obtain ⟨w, h⟩ := exists_equiv_of_multiset_map_eq (fun p => ρ.spectrum p)
+    (fun p => ρ.SWAP.spectrum p)
     (ρ.multiset_spectrum_relabel_eq (Equiv.prodComm _ _).symm ▸ rfl)
   use w
   ext x
@@ -1264,7 +1390,8 @@ theorem kron_relabel (ρ : MState d₁) (σ : MState d₂) (e : d₃ ≃ d₂) :
   rfl
 
 theorem prod_assoc (ρ : MState d₁) (σ : MState d₂) (τ : MState d₃) :
-    (ρ ⊗ᴹ (σ ⊗ᴹ τ)) = (ρ ⊗ᴹ σ ⊗ᴹ τ).relabel (Equiv.prodAssoc d₁ d₂ d₃).symm := by
+    (ρ ⊗ᴹ (σ ⊗ᴹ τ)) =
+      (ρ ⊗ᴹ σ ⊗ᴹ τ).relabel (Equiv.prodAssoc d₁ d₂ d₃).symm := by
   ext : 2
   simp [-Matrix.kronecker_assoc']
   exact (Matrix.kronecker_assoc' ρ.m σ.m τ.m).symm
@@ -1350,26 +1477,33 @@ end finprod
 
 section posdef
 
-theorem PosDef.kron {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
-    {σ₁ : MState d₁} {σ₂ : MState d₂} (hσ₁ : σ₁.m.PosDef) (hσ₂ : σ₂.m.PosDef) : (σ₁ ⊗ᴹ σ₂).m.PosDef :=
+theorem PosDef.kron {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+    [DecidableEq d₂]
+    {σ₁ : MState d₁} {σ₂ : MState d₂} (hσ₁ : σ₁.m.PosDef)
+    (hσ₂ : σ₂.m.PosDef) :
+    (σ₁ ⊗ᴹ σ₂).m.PosDef :=
   hσ₁.kron hσ₂
 
-theorem PosDef.relabel {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂] [DecidableEq d₂]
+theorem PosDef.relabel {d₁ d₂ : Type*} [Fintype d₁] [DecidableEq d₁] [Fintype d₂]
+    [DecidableEq d₂]
     {ρ : MState d₁} (hρ : ρ.m.PosDef) (e : d₂ ≃ d₁) : (ρ.relabel e).m.PosDef :=
   Matrix.PosDef.reindex hρ e.symm
 
 /-- If both states positive definite, so is their mixture. -/
 theorem PosDef_mix {d : Type*} [Fintype d] [DecidableEq d] {σ₁ σ₂ : MState d}
-    (hσ₁ : σ₁.m.PosDef) (hσ₂ : σ₂.m.PosDef) (p : Prob) : (p [σ₁ ↔ σ₂]).m.PosDef :=
+    (hσ₁ : σ₁.m.PosDef) (hσ₂ : σ₂.m.PosDef) (p : Prob) :
+    (p [σ₁ ↔ σ₂]).m.PosDef :=
   Matrix.PosDef.Convex hσ₁ hσ₂ p.zero_le (1 - p).zero_le (by simp)
 
-/-- If one state is positive definite and the mixture is nondegenerate, their mixture is also positive definite. -/
+/-- If one state is positive definite and the mixture is nondegenerate, their mixture is also
+positive definite. -/
 theorem PosDef_mix_of_ne_zero {d : Type*} [Fintype d] [DecidableEq d] {σ₁ σ₂ : MState d}
     (hσ₁ : σ₁.m.PosDef) (p : Prob) (hp : p ≠ 0) : (p [σ₁ ↔ σ₂]).m.PosDef := by
   rw [← zero_lt_iff] at hp
   exact (hσ₁.smul hp).add_posSemidef (σ₂.psd.rsmul (1 - p).zero_le)
 
-/-- If the second state is positive definite and the mixture is nondegenerate, their mixture is also positive definite. -/
+/-- If the second state is positive definite and the mixture is nondegenerate, their mixture is also
+positive definite. -/
 theorem PosDef_mix_of_ne_one {d : Type*} [Fintype d] [DecidableEq d] {σ₁ σ₂ : MState d}
     (hσ₂ : σ₂.m.PosDef) (p : Prob) (hp : p ≠ 1) : (p [σ₁ ↔ σ₂]).m.PosDef := by
   have : 0 < 1 - p := by
@@ -1389,7 +1523,8 @@ theorem uniform_posDef {d : Type*} [Nonempty d] [Fintype d] [DecidableEq d] :
   simp [uniform, ofClassical, m, HermitianMat.diagonal]
   exact Fintype.card_pos
 
-theorem posDef_of_unique {d : Type*} [Fintype d] [DecidableEq d] (ρ : MState d) [Unique d] : ρ.m.PosDef := by
+theorem posDef_of_unique {d : Type*} [Fintype d] [DecidableEq d] (ρ : MState d) [Unique d] :
+    ρ.m.PosDef := by
   rw [Subsingleton.allEq ρ uniform]
   exact uniform_posDef
 

--- a/QuantumInfo/States/Pure/Braket.lean
+++ b/QuantumInfo/States/Pure/Braket.lean
@@ -45,15 +45,16 @@ open scoped Matrix ComplexOrder
 section
 variable (d : Type*) [Fintype d]
 
-/-- A ket as a vector of unit norm. We follow the convention in `Matrix` of vectors as simple functions
- from a Fintype. Kets are distinctly not a vector space in our notion, as they represent only normalized
- states and so cannot (in general) be added or scaled. -/
+/-- A ket as a vector of unit norm. We follow the convention in `Matrix` of vectors as simple
+ functions from a Fintype. Kets are distinctly not a vector space in our notion, as they represent
+ only normalized states and so cannot (in general) be added or scaled. -/
 structure Ket where
   vec : d → ℂ
   normalized' : ∑ x, ‖vec x‖ ^ 2 = 1
   --TODO: change to `vec : EuclideanSpace ℂ d` / `normalized' : ‖vec‖ = 1`
 
-/-- A bra is identical in definition to a `Ket`, but are separate to avoid complex conjugation confusion.
+/-- A bra is identical in definition to a `Ket`, but are separate to avoid complex conjugation
+ confusion.
  They can be interconverted with the adjoint: `Ket.to_bra` and `Bra.to_ket` -/
 structure Bra where
   vec : d → ℂ
@@ -141,14 +142,16 @@ theorem Bra.apply' (ψ : Ket d) (i : d) : 〈ψ∣ i = conj (ψ.vec i) :=
   rfl
 
 theorem Ket.exists_ne_zero (ψ : Ket d) : ∃ x, ψ x ≠ 0 := by
-  have hzerolt : ∑ x : d, Complex.normSq (ψ x) > ∑ x : d, 0 := by rw [ψ.normalized, Finset.sum_const_zero]; exact zero_lt_one
+  have hzerolt : ∑ x : d, Complex.normSq (ψ x) > ∑ x : d, 0 := by
+    rw [ψ.normalized, Finset.sum_const_zero]; exact zero_lt_one
   have hpos : ∃ x ∈ Finset.univ, 0 < Complex.normSq (ψ x) := Finset.exists_lt_of_sum_lt hzerolt
   obtain ⟨x, _, hpos⟩ := hpos
   rw [Complex.normSq_pos] at hpos
   use x
 
 theorem Bra.exists_ne_zero (ψ : Bra d) : ∃ x, ψ x ≠ 0 := by
-  have hzerolt : ∑ x : d, Complex.normSq (ψ x) > ∑ x : d, 0 := by rw [ψ.normalized, Finset.sum_const_zero]; exact zero_lt_one
+  have hzerolt : ∑ x : d, Complex.normSq (ψ x) > ∑ x : d, 0 := by
+    rw [ψ.normalized, Finset.sum_const_zero]; exact zero_lt_one
   have hpos : ∃ x ∈ Finset.univ, 0 < Complex.normSq (ψ x) := Finset.exists_lt_of_sum_lt hzerolt
   obtain ⟨x, _, hpos⟩ := hpos
   rw [Complex.normSq_pos] at hpos
@@ -160,18 +163,21 @@ def Ket.normalize (v : d → ℂ) (h : ∃ x, v x ≠ 0) : Ket d :=
     normalized' := by
       simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_div,
         Complex.normSq_ofReal, ←sq]
-      have hnonneg : ∑ x : d, Complex.normSq (v x) ≥ 0 := Fintype.sum_nonneg (fun x => Complex.normSq_nonneg (v x))
+      have hnonneg : ∑ x : d, Complex.normSq (v x) ≥ 0 :=
+        Fintype.sum_nonneg (fun x => Complex.normSq_nonneg (v x))
       simp only [Real.sq_sqrt hnonneg, div_eq_inv_mul, ←Finset.mul_sum]
       apply inv_mul_cancel₀
       by_contra hzero
       rw [Fintype.sum_eq_zero_iff_of_nonneg (fun x => Complex.normSq_nonneg (v x))] at hzero
       obtain ⟨a, ha⟩ := h
-      have h₁ : (fun x => Complex.normSq (v x)) a ≠ 0 := by simp only [ne_eq, map_eq_zero]; exact ha
+      have h₁ : (fun x => Complex.normSq (v x)) a ≠ 0 := by
+        simp only [ne_eq, map_eq_zero]; exact ha
       exact h₁ (congrFun hzero a)
   }
 
 /-- A ket is already normalized -/
-theorem Ket.normalize_ket_eq_self (ψ : Ket d) : Ket.normalize (ψ.vec) (Ket.exists_ne_zero ψ) = ψ := by
+theorem Ket.normalize_ket_eq_self (ψ : Ket d) :
+    Ket.normalize (ψ.vec) (Ket.exists_ne_zero ψ) = ψ := by
   ext x
   unfold normalize
   simp only [apply, ψ.normalized', Real.sqrt_one, Complex.ofReal_one, div_one]
@@ -182,13 +188,15 @@ def Bra.normalize (v : d → ℂ) (h : ∃ x, v x ≠ 0) : Bra d :=
     normalized' := by
       simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_div,
       Complex.normSq_ofReal, ←sq]
-      have hnonneg : ∑ x : d, Complex.normSq (v x) ≥ 0 := Fintype.sum_nonneg (fun x => Complex.normSq_nonneg (v x))
+      have hnonneg : ∑ x : d, Complex.normSq (v x) ≥ 0 :=
+        Fintype.sum_nonneg (fun x => Complex.normSq_nonneg (v x))
       simp only [Real.sq_sqrt hnonneg, div_eq_inv_mul, ←Finset.mul_sum]
       apply inv_mul_cancel₀
       by_contra hzero
       rw [Fintype.sum_eq_zero_iff_of_nonneg (fun x => Complex.normSq_nonneg (v x))] at hzero
       obtain ⟨a, ha⟩ := h
-      have h₁ : (fun x => Complex.normSq (v x)) a ≠ 0 := by simp only [ne_eq, map_eq_zero]; exact ha
+      have h₁ : (fun x => Complex.normSq (v x)) a ≠ 0 := by
+        simp only [ne_eq, map_eq_zero]; exact ha
       exact h₁ (congrFun hzero a)
   }
 
@@ -286,44 +294,54 @@ theorem Ket.IsProd_iff_mul_eq_mul (ψ : Ket (d₁ × d₂)) : ψ.IsProd ↔
       simp only [← Complex.normSq_eq_norm_sq, v₁, Complex.normSq_mul, Complex.normSq_div,
       Complex.normSq_ofReal, ← sq]
       rw [div_self _]
-      have hnonneg : ∑ i : d₁, Complex.normSq (ψ (i, b)) ≥ 0 := Fintype.sum_nonneg (fun i => Complex.normSq_nonneg (ψ (i, b)))
+      have hnonneg : ∑ i : d₁, Complex.normSq (ψ (i, b)) ≥ 0 :=
+        Fintype.sum_nonneg (fun i => Complex.normSq_nonneg (ψ (i, b)))
       · simp_rw [Real.sq_sqrt hnonneg, one_mul, div_eq_inv_mul, ←Finset.mul_sum]
         apply inv_mul_cancel₀
         by_contra hzero
         rw [Fintype.sum_eq_zero_iff_of_nonneg (fun i => Complex.normSq_nonneg (ψ (i, b)))] at hzero
-        have h₁ : (fun i => Complex.normSq (ψ (i,b))) a ≠ 0 := by simp only [ne_eq, map_eq_zero]; exact hψnonZero
+        have h₁ : (fun i => Complex.normSq (ψ (i,b))) a ≠ 0 := by
+          simp only [ne_eq, map_eq_zero]; exact hψnonZero
         rw [hzero, Pi.zero_apply, ne_eq, eq_self, not_true_eq_false] at h₁
         exact h₁
       · simp_all only [ne_eq, map_eq_zero, not_false_eq_true]
     have hv2Norm : ∑ x, ‖v₂ x‖^2 = 1 := by
       simp only [← Complex.normSq_eq_norm_sq, v₂, Complex.normSq_div,
       Complex.normSq_ofReal, ← sq]
-      have hnonneg : ∑ j : d₂, Complex.normSq (ψ (a, j)) ≥ 0 := Fintype.sum_nonneg (fun j => Complex.normSq_nonneg (ψ (a, j)))
+      have hnonneg : ∑ j : d₂, Complex.normSq (ψ (a, j)) ≥ 0 :=
+        Fintype.sum_nonneg (fun j => Complex.normSq_nonneg (ψ (a, j)))
       simp_rw [Real.sq_sqrt hnonneg, div_eq_inv_mul, ←Finset.mul_sum]
       apply inv_mul_cancel₀
       by_contra hzero
       rw [Fintype.sum_eq_zero_iff_of_nonneg (fun j => Complex.normSq_nonneg (ψ (a, j)))] at hzero
-      have h₁ : (fun j => Complex.normSq (ψ (a, j))) b ≠ 0 := by simp only [ne_eq, map_eq_zero]; exact hψnonZero
+      have h₁ : (fun j => Complex.normSq (ψ (a, j))) b ≠ 0 := by
+        simp only [ne_eq, map_eq_zero]; exact hψnonZero
       rw [hzero, Pi.zero_apply, ne_eq, eq_self, not_true_eq_false] at h₁
       exact h₁
     let ψ₁ : Ket d₁ := ⟨v₁, hv1Norm⟩
     let ψ₂ : Ket d₂ := ⟨v₂, hv2Norm⟩
     use ψ₁, ψ₂
     ext ⟨x, y⟩
-    have hψfun : ψ (x, y) = (ψ (x, b) * ψ (a, y)) / ψ (a, b) := eq_div_of_mul_eq hψnonZero (hcrossm x a y b)
-    have hψnorm : (∑ z : d₁ × d₂, Complex.normSq (ψ.vec (z.1, b) * ψ.vec (a, z.2))) = Complex.normSq (ψ (a, b)) :=
+    have hψfun : ψ (x, y) = (ψ (x, b) * ψ (a, y)) / ψ (a, b) :=
+      eq_div_of_mul_eq hψnonZero (hcrossm x a y b)
+    have hψnorm : (∑ z : d₁ × d₂, Complex.normSq (ψ.vec (z.1, b) * ψ.vec (a, z.2))) =
+        Complex.normSq (ψ (a, b)) :=
     calc
       ∑ z : d₁ × d₂, Complex.normSq (ψ.vec (z.1, b) * ψ.vec (a, z.2)) =
-        ∑ z : d₁ × d₂, Complex.normSq (ψ.vec (a, b) * ψ.vec (z.1, z.2)) := by simp only [← apply, hcrossm, mul_comm]
-      _ = ∑ z : d₁ × d₂, Complex.normSq (ψ.vec (a, b)) * Complex.normSq (ψ.vec (z.1, z.2)) := by simp only [Complex.normSq_mul]
-      _ = Complex.normSq (ψ.vec (a, b)) * ∑ z : d₁ × d₂, Complex.normSq (ψ.vec z) := by rw [←Finset.mul_sum]
+        ∑ z : d₁ × d₂, Complex.normSq (ψ.vec (a, b) * ψ.vec (z.1, z.2)) := by
+          simp only [← apply, hcrossm, mul_comm]
+      _ = ∑ z : d₁ × d₂, Complex.normSq (ψ.vec (a, b)) * Complex.normSq (ψ.vec (z.1, z.2)) := by
+          simp only [Complex.normSq_mul]
+      _ = Complex.normSq (ψ.vec (a, b)) * ∑ z : d₁ × d₂, Complex.normSq (ψ.vec z) := by
+          rw [←Finset.mul_sum]
       _ = Complex.normSq (ψ.vec (a, b)) := by simp only [← apply, ψ.normalized, mul_one]
     simp [prod, apply, ψ₁, ψ₂, v₁, v₂]
     rw [mul_assoc, ←mul_div_mul_comm, ←Complex.ofReal_mul, ←Real.sqrt_mul (Finset.sum_nonneg _)]
     ·
       simp_rw [Fintype.sum_mul_sum, ←Fintype.sum_prod_type']
       simp only [← Complex.normSq_eq_norm_sq]
-      simp_rw [Fintype.sum_congr _ _ (fun z : d₁ × d₂ => (Complex.normSq_mul (ψ.vec (z.1, b)) (ψ.vec (a, z.2))).symm)]
+      simp_rw [Fintype.sum_congr _ _
+        (fun z : d₁ × d₂ => (Complex.normSq_mul (ψ.vec (z.1, b)) (ψ.vec (a, z.2))).symm)]
       simp_rw [hψnorm, Complex.normSq_eq_norm_sq, Real.sqrt_sq_eq_abs, abs_norm, apply]
       ring_nf
       rw [mul_comm, ←mul_assoc, ←mul_assoc, ←mul_assoc]
@@ -413,7 +431,8 @@ theorem KetUpToPhase.ind {p : KetUpToPhase d → Prop}
   @Quotient.ind _ Ket.PhaseEquiv p h
 
 theorem KetUpToPhase.surjective_mk : Function.Surjective (KetUpToPhase.mk (d := d)) :=
-  fun q => @Quotient.ind _ Ket.PhaseEquiv (fun q => ∃ a, KetUpToPhase.mk a = q) (fun a => ⟨a, rfl⟩) q
+  fun q => @Quotient.ind _ Ket.PhaseEquiv (fun q => ∃ a, KetUpToPhase.mk a = q)
+    (fun a => ⟨a, rfl⟩) q
 
 end equiv
 

--- a/QuantumInfo/States/Pure/Qubit.lean
+++ b/QuantumInfo/States/Pure/Qubit.lean
@@ -31,7 +31,8 @@ abbrev Qubit := Fin 2
 open Lean.Parser.Tactic in
 open Lean in
 /--
-Proves goals equating small matrices by expanding out products and simpliying standard Real arithmetic.
+Proves goals equating small matrices by expanding out products and simpliying standard Real
+arithmetic.
 -/
 syntax (name := matrix_expand) "matrix_expand"
   (" [" ((simpStar <|> simpErase <|> simpLemma),*,?) "]")?
@@ -110,7 +111,8 @@ theorem S_sq : S * S = Z := by
 theorem T_sq : T * T = S := by
   matrix_expand [T, S]
 
-/-- The anticommutator `{X,Y}` is zero. Marked simp as to put Pauli products in a canonical Y-X-Z order. -/
+/-- The anticommutator `{X,Y}` is zero. Marked simp as to put Pauli products in a canonical
+Y-X-Z order. -/
 @[simp]
 theorem X_Y_anticomm : X * Y = -Y * X := by
   matrix_expand [X, Y]
@@ -143,8 +145,8 @@ theorem T_Z_comm : Z * T = T * Z := by
 theorem S_T_comm : S * T = T * S := by
   simp [← T_sq, mul_assoc]
 
-/-- Given a unitary `U` on some Hilbert space `k`, we have the controllized version that acts on `Fin 2 ⊗ k`
-where `U` is conditionally applied if the first qubit is `1`. -/
+/-- Given a unitary `U` on some Hilbert space `k`, we have the controllized version that acts on
+`Fin 2 ⊗ k` where `U` is conditionally applied if the first qubit is `1`. -/
 def controllize (g : 𝐔[k]) : 𝐔[Qubit × k] :=
   ⟨Matrix.of fun (q₁,t₁) (q₂,t₂) ↦
     if (q₁,q₂) = (0,0) then


### PR DESCRIPTION
This was done entirely using Claude Opus 4.8. 

# AI summary 

## Wrap `QuantumInfo` source lines to 100 characters

Reformats every file under `./QuantumInfo` so no line exceeds 100 characters, by redistributing existing content across multiple lines. **Pure formatting change** — comments wrapped at word boundaries; Lean code broken at safe points (binder groups, after binary operators / `:=`, deeper-indented tactic continuations, inside bracketed argument lists) per the project's house style. 61 files changed.

### Lemmas / definitions added or removed

**None.** No declarations were added, removed, or modified. Verified mechanically: the set of `theorem`/`lemma`/`def`/`abbrev`/`instance`/`structure`/`class`/`inductive` declarations is identical before and after (2146 in both), and the whitespace- and comment-stripped token stream of all 61 files matches the previous revision exactly, except for the semantics-preserving edits noted below.

### Only non-whitespace edits (all semantics-preserving)

- [`Channels/CPTP.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Channels/CPTP.lean), [`States/Mixed/MState.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/States/Mixed/MState.lean) — 4 places where a `;` tactic separator became a newline (equivalent in Lean 4; the following tactic stays at the same indentation column).
- [`Capacity/Capacity.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Capacity/Capacity.lean), [`ForMathlib/HermitianMat/CFC.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HermitianMat/CFC.lean) — one `variable [..] [..]` command split into two `variable` lines (equivalent).
- [`Channels/Dual.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Channels/Dual.lean), [`States/Mixed/MState.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/States/Mixed/MState.lean) — a few trailing `-- comments` moved onto their own line above the code (comments are inert).

### Reviewer map

Review in this order; spend the most time on the first group (densest wrapping decisions), and on the "non-whitespace edits" files above:

1. **Largest / densest wraps** — [`Entropy/Relative.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Entropy/Relative.lean), [`ForMathlib/HermitianMat/CFC.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HermitianMat/CFC.lean), [`ForMathlib/Majorization.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/Majorization.lean), [`ForMathlib/Matrix.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/Matrix.lean), [`ResourceTheory/SteinsLemma.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ResourceTheory/SteinsLemma.lean), [`Entropy/SSA.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Entropy/SSA.lean), [`States/Mixed/MState.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/States/Mixed/MState.lean).
2. **Medium** — [`ForMathlib/LimSupInf.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/LimSupInf.lean), [`ForMathlib/HermitianMat/LogExp.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HermitianMat/LogExp.lean), [`ForMathlib/HermitianMat/Rpow.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HermitianMat/Rpow.lean), [`ForMathlib/HermitianMat/Inner.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HermitianMat/Inner.lean), [`Channels/Unbundled.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Channels/Unbundled.lean), [`ForMathlib/Isometry.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/Isometry.lean), [`States/Entanglement.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/States/Entanglement.lean), [`Entropy/DPI.lean`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/Entropy/DPI.lean).
3. **Remainder** — the other ~40 files (small, mechanical splits).

Tip: review with whitespace ignored (`git diff -w` / "Hide whitespace" on GitHub) — most hunks collapse to nothing, leaving only the genuine edits called out above for scrutiny.

### Known exception

One line remains >100 chars: [`ForMathlib/HayataGroup/TraceInequality/LownerHeinzCore.lean:10`](https://github.com/jstoobysmith/JTSphyslib/blob/QuantumInfoLines/QuantumInfo/ForMathlib/HayataGroup/TraceInequality/LownerHeinzCore.lean#L10), a Lean `import` whose module path is a single unsplittable token (already over-length before this PR).
