### PR TITLE
feat(space): add spherical cylinder surface

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -3,5 +3,6 @@ module
 public import PhyslibAlpha.Basic
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Ring
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalCylinder
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell
 public import PhyslibAlpha.QuantumMechanics.QuantumHarmonicOscillator

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalCylinder.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalCylinder.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Sneiderman
+-/
+module
+
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Ring
+public import Physlib.SpaceAndTime.Space.Integrals.Basic
+public import Mathlib.MeasureTheory.Integral.Prod
+/-!
+
+## Spherical cylinder surface in `Space 3`
+
+The spherical cylinder is the unit circular shell in `Space 2` extruded along the
+third coordinate.
+
+-/
+
+@[expose] public section
+open SchwartzMap NNReal
+noncomputable section
+open Physlib Distribution
+variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]
+  [NormedAddCommGroup F'] [NormedSpace ℝ E] [NormedSpace ℝ F]
+
+namespace Space
+
+open MeasureTheory Real
+
+/-!
+
+## A. The definition of the spherical cylinder surface
+
+-/
+
+/-- The map embedding the unit circular shell extruded along the axis into `Space 3`. -/
+def sphericalCylinder : Metric.sphere (0 : Space 2) 1 × ℝ → Space 3 := fun x =>
+  (slice 2).symm (x.2, sphericalShell 1 x.1)
+
+lemma sphericalCylinder_eq :
+    sphericalCylinder = (slice 2).symm ∘ (fun x => (x.2, sphericalShell 1 x.1)) := rfl
+
+lemma sphericalCylinder_injective : Function.Injective sphericalCylinder := by
+  intro x y h
+  have h' := congrArg (slice 2) h
+  simp [sphericalCylinder] at h'
+  exact Prod.ext (sphericalShell_injective 1 h'.2) h'.1
+
+@[fun_prop]
+lemma sphericalCylinder_continuous : Continuous sphericalCylinder := by
+  apply Continuous.comp
+  · fun_prop
+  · fun_prop
+
+lemma sphericalCylinder_measurableEmbedding : MeasurableEmbedding sphericalCylinder :=
+  Continuous.measurableEmbedding sphericalCylinder_continuous sphericalCylinder_injective
+
+@[simp]
+lemma norm_sphericalCylinder (x : Metric.sphere (0 : Space 2) 1 × ℝ) :
+    ‖sphericalCylinder x‖ = √(‖x.2‖ ^ 2 + 1) := by
+  rw [sphericalCylinder, norm_slice_symm_eq, norm_sphericalShell]
+  norm_num
+
+/-!
+
+## B. The measure associated with the spherical cylinder
+
+-/
+
+/-- The measure on `Space 3` corresponding to integration over a spherical cylinder. -/
+def sphericalCylinderMeasure : Measure (Space 3) :=
+  MeasureTheory.Measure.map sphericalCylinder
+    ((MeasureTheory.Measure.toSphere volume).prod (volume (α := ℝ)))
+
+instance sphericalCylinderMeasure_hasTemperateGrowth :
+    sphericalCylinderMeasure.HasTemperateGrowth := by
+  rw [sphericalCylinderMeasure]
+  refine { exists_integrable := ?_ }
+  obtain ⟨n, hn⟩ := MeasureTheory.Measure.HasTemperateGrowth.exists_integrable
+    (μ := volume (α := ℝ))
+  use n
+  rw [MeasurableEmbedding.integrable_map_iff sphericalCylinder_measurableEmbedding]
+  change Integrable
+    (fun x : Metric.sphere (0 : Space 2) 1 × ℝ =>
+      (1 + ‖sphericalCylinder x‖) ^ (-(n : ℝ)))
+    ((MeasureTheory.Measure.toSphere volume).prod (volume (α := ℝ)))
+  apply Integrable.mono' (hn.comp_snd (MeasureTheory.Measure.toSphere volume))
+  · apply AEMeasurable.aestronglyMeasurable
+    exact ((continuous_const.add sphericalCylinder_continuous.norm).rpow_const
+      (fun x => Or.inl (by positivity : (1 : ℝ) + ‖sphericalCylinder x‖ ≠ 0))).aemeasurable
+  · filter_upwards with x
+    rw [Real.norm_eq_abs, abs_of_nonneg (Real.rpow_nonneg (by positivity) _)]
+    apply Real.rpow_le_rpow_of_nonpos
+    · positivity
+    · simp only [norm_sphericalCylinder]
+      exact add_le_add_right (Real.le_sqrt_of_sq_le (le_add_of_nonneg_right zero_le_one)) 1
+    · simp
+
+instance sphericalCylinderMeasure_sFinite : SFinite sphericalCylinderMeasure := by
+  rw [sphericalCylinderMeasure]
+  exact Measure.instSFiniteMap ((MeasureTheory.Measure.toSphere volume).prod (volume (α := ℝ)))
+    sphericalCylinder
+
+/-!
+
+## C. The distribution associated with the spherical cylinder
+
+-/
+
+/-- The distribution on `Space 3` corresponding to integration over a spherical cylinder. -/
+def sphericalCylinderDist : (Space 3) →d[ℝ] ℝ :=
+  SchwartzMap.integralCLM ℝ sphericalCylinderMeasure
+
+lemma sphericalCylinderDist_apply_eq_integral_sphericalCylinderMeasure (f : 𝓢(Space 3, ℝ)) :
+    sphericalCylinderDist f = ∫ x, f x ∂sphericalCylinderMeasure := by
+  rw [sphericalCylinderDist, SchwartzMap.integralCLM_apply]
+
+lemma sphericalCylinderDist_apply_eq_integral_sphere_volume (f : 𝓢(Space 3, ℝ)) :
+    sphericalCylinderDist f =
+    ∫ x, f (sphericalCylinder x)
+      ∂((MeasureTheory.Measure.toSphere volume).prod (volume (α := ℝ))) := by
+  rw [sphericalCylinderDist_apply_eq_integral_sphericalCylinderMeasure, sphericalCylinderMeasure,
+    MeasurableEmbedding.integral_map sphericalCylinder_measurableEmbedding]
+
+end Space


### PR DESCRIPTION
## Summary
Adds the spherical cylinder surface API under `PhyslibAlpha.SpaceAndTime.Space.Surfaces`.

## Changes
- Defines the spherical cylinder embedding into `Space 3` as the unit circular shell in `Space 2` transported through `slice 2`, extruded along `ℝ`.
- Adds injectivity, continuity, and measurable embedding lemmas.
- Adds the induced surface measure, tempered-growth instance, and `SFinite` instance.
- Adds the corresponding distribution and integral application lemmas.

## Notes
- This intentionally does not add `IsFiniteMeasure`: the cylinder is unbounded along the axis.
- No measure-zero theorem: issue #943 asks for that only where applicable, and the sibling surface files do not expose analogous null-range theorems.
