### PR TITLE
feat(space): add half-plane surface

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -16,6 +16,7 @@ public import PhyslibAlpha.ClassicalFieldTheory.Local.JetPointRegularity
 public import PhyslibAlpha.ClassicalFieldTheory.Local.Lagrangian
 public import PhyslibAlpha.ClassicalFieldTheory.Local.TotalDerivative
 public import PhyslibAlpha.ClassicalFieldTheory.Local.Variation
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.HalfPlane
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Line
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Ring
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/HalfPlane.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/HalfPlane.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Sneiderman
+-/
+module
+
+public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.Line
+/-!
+
+## Half-plane surface in `Space 3`
+
+The half-plane is the coordinate plane in `Space 3` with nonnegative second
+coordinate.
+
+-/
+
+@[expose] public section
+open SchwartzMap NNReal
+noncomputable section
+open Physlib Distribution
+variable (𝕜 : Type) {E F F' : Type} [RCLike 𝕜] [NormedAddCommGroup E] [NormedAddCommGroup F]
+  [NormedAddCommGroup F'] [NormedSpace ℝ E] [NormedSpace ℝ F]
+
+namespace Space
+
+open MeasureTheory Real
+
+/-!
+
+## A. The definition of the half-plane surface
+
+-/
+
+/-- The domain of the half-plane inside `Space 2`. -/
+def halfPlaneDomain : Set (Space 2) := {x | 0 ≤ x (1 : Fin 2)}
+
+/-- The coordinate plane embedding used for the half-plane surface in `Space 3`. -/
+def halfPlane : Space 2 → Space 3 := fun x => (slice (2 : Fin 3)).symm (0, x)
+
+lemma halfPlane_eq : halfPlane = (slice (2 : Fin 3)).symm ∘ (fun x : Space 2 => (0, x)) := rfl
+
+lemma halfPlane_injective : Function.Injective halfPlane := by
+  intro x y h
+  have h' := congrArg (slice (2 : Fin 3)) h
+  simp [halfPlane] at h'
+  exact h'
+
+@[fun_prop]
+lemma halfPlane_continuous : Continuous halfPlane := by
+  rw [halfPlane_eq]
+  fun_prop
+
+lemma halfPlane_measurableEmbedding : MeasurableEmbedding halfPlane :=
+  Continuous.measurableEmbedding halfPlane_continuous halfPlane_injective
+
+@[simp]
+lemma norm_halfPlane (x : Space 2) : ‖halfPlane x‖ = ‖x‖ := by
+  rw [halfPlane, norm_slice_symm_eq]
+  simp
+
+/-!
+
+## B. The measure associated with the half-plane
+
+-/
+
+/-- The measure on `Space 3` corresponding to integration over a half-plane. -/
+def halfPlaneMeasure : Measure (Space 3) :=
+  MeasureTheory.Measure.map halfPlane (volume.restrict halfPlaneDomain)
+
+instance halfPlaneMeasure_hasTemperateGrowth :
+    halfPlaneMeasure.HasTemperateGrowth := by
+  rw [halfPlaneMeasure]
+  refine { exists_integrable := ?_ }
+  obtain ⟨n, hn⟩ := MeasureTheory.Measure.HasTemperateGrowth.exists_integrable
+    (μ := volume (α := Space 2))
+  use n
+  rw [MeasurableEmbedding.integrable_map_iff halfPlane_measurableEmbedding]
+  convert hn.restrict using 1
+  ext x
+  simp [norm_halfPlane]
+
+instance halfPlaneMeasure_sFinite : SFinite halfPlaneMeasure := by
+  rw [halfPlaneMeasure]
+  exact Measure.instSFiniteMap (volume.restrict halfPlaneDomain) halfPlane
+
+/-!
+
+## C. The distribution associated with the half-plane
+
+-/
+
+/-- The distribution on `Space 3` corresponding to integration over a half-plane. -/
+def halfPlaneDist : (Space 3) →d[ℝ] ℝ :=
+  SchwartzMap.integralCLM ℝ halfPlaneMeasure
+
+lemma halfPlaneDist_apply_eq_integral_halfPlaneMeasure (f : 𝓢(Space 3, ℝ)) :
+    halfPlaneDist f = ∫ x, f x ∂halfPlaneMeasure := by
+  rw [halfPlaneDist, SchwartzMap.integralCLM_apply]
+
+lemma halfPlaneDist_apply_eq_integral_volume (f : 𝓢(Space 3, ℝ)) :
+    halfPlaneDist f = ∫ x, f (halfPlane x) ∂(volume.restrict halfPlaneDomain) := by
+  rw [halfPlaneDist_apply_eq_integral_halfPlaneMeasure, halfPlaneMeasure,
+    MeasurableEmbedding.integral_map halfPlane_measurableEmbedding]
+
+/-!
+
+## D. The half-plane has ambient volume zero
+
+-/
+
+/-- The coordinate plane containing the half-plane in `Space 3`. -/
+def halfPlaneSubmodule : Submodule ℝ (Space 3) where
+  carrier := {x | x (2 : Fin 3) = 0}
+  zero_mem' := by simp
+  add_mem' hx hy := by
+    rw [Set.mem_setOf_eq] at hx hy ⊢
+    rw [Space.add_apply, hx, hy, add_zero]
+  smul_mem' c x hx := by
+    rw [Set.mem_setOf_eq] at hx ⊢
+    rw [Space.smul_apply, hx, mul_zero]
+
+lemma halfPlane_mem_halfPlaneSubmodule (x : Space 2) : halfPlane x ∈ halfPlaneSubmodule := by
+  simp [halfPlaneSubmodule, halfPlane]
+
+lemma halfPlane_image_domain_subset_halfPlaneSubmodule :
+    halfPlane '' halfPlaneDomain ⊆ (halfPlaneSubmodule : Set (Space 3)) := by
+  rintro x ⟨y, _, rfl⟩
+  exact halfPlane_mem_halfPlaneSubmodule y
+
+lemma halfPlaneSubmodule_ne_top : halfPlaneSubmodule ≠ ⊤ := by
+  intro htop
+  have hbasis : basis (2 : Fin 3) ∈ halfPlaneSubmodule := by
+    rw [htop]
+    exact Submodule.mem_top
+  simp [halfPlaneSubmodule] at hbasis
+
+lemma volume_halfPlane_image_domain :
+    volume (halfPlane '' halfPlaneDomain : Set (Space 3)) = 0 := by
+  refine measure_mono_null halfPlane_image_domain_subset_halfPlaneSubmodule ?_
+  rw [volume_eq_addHaar]
+  exact MeasureTheory.Measure.addHaar_submodule
+    (Space.basis.toBasis.addHaar : Measure (Space 3))
+    halfPlaneSubmodule halfPlaneSubmodule_ne_top
+
+end Space


### PR DESCRIPTION
## Summary
Adds the half-plane surface API under `PhyslibAlpha.SpaceAndTime.Space.Surfaces`.

## Changes
- Defines `halfPlaneDomain` as the nonnegative coordinate half-plane inside `Space 2`.
- Defines `halfPlane : Space 2 → Space 3` as the coordinate-plane embedding through `slice 2`.
- Adds injectivity, continuity, measurable embedding, and norm lemmas.
- Adds the induced half-plane surface measure by restricting `Space 2` volume to `halfPlaneDomain` before mapping into `Space 3`.
- Adds tempered-growth and `SFinite` instances for `halfPlaneMeasure`.
- Adds the corresponding distribution and integral application lemmas.
- Proves the half-plane image has ambient `Space 3` volume zero, by containment in a proper coordinate submodule.
