### PR TITLE
feat(QuantumMechanics): Add orthogonal subspaces

### DIFF
--- a/Physlib/Mathematics/LinearPMap.lean
+++ b/Physlib/Mathematics/LinearPMap.lean
@@ -33,10 +33,11 @@ composition of partial linear maps while having the domain implicitly accounted 
 ## iii. Table of contents
 
 - A. Inequalities
-- B. Finite sums
-- C. Restricted composition
-- D. Monoid
-- E. Inverses
+- B. Zero smul
+- C. Finite sums
+- D. Restricted composition
+- E. Monoid
+- F. Inverses
 
 ## iv. References
 
@@ -120,7 +121,23 @@ lemma sub_left_le_of_le (h : g₁ ≤ g₂) : f - g₁ ≤ f - g₂ :=
 end Inequalities
 
 /-!
-## B. Finite sums
+## B. Zero smul
+-/
+
+section
+
+variable {𝕜 : Type*} [Field 𝕜] [Module 𝕜 E] [Module 𝕜 F]
+
+lemma zero_smul_le (f : E →ₗ.[𝕜] F) : (0 : 𝕜) • f ≤ 0 := ⟨le_top, by simp⟩
+
+@[simp]
+lemma zero_smul_eq {f : E →ₗ.[𝕜] F} (h : f.domain = ⊤) : (0 : 𝕜) • f = 0 :=
+  eq_of_le_of_domain_eq f.zero_smul_le h
+
+end
+
+/-!
+## C. Finite sums
 -/
 
 section Sums
@@ -146,7 +163,7 @@ lemma sum_apply (ψ : (sum f).domain) : sum f ψ = ∑ a, f a ⟨ψ, sum_domain_
 end Sums
 
 /-!
-## C. Restricted composition
+## D. Restricted composition
 -/
 
 section Composition
@@ -297,7 +314,7 @@ lemma smul_compRestricted {M : Type*} [Monoid M] [DistribMulAction M G] [SMulCom
 end Composition
 
 /-!
-## D. Monoid
+## E. Monoid
 
 Partial linear maps `E →ₗ.[R] E` with `compRestricted` for multiplication and
 the identity map (domain `⊤`) for `1` comprise a monoid.
@@ -334,7 +351,7 @@ lemma one_coe : (1 : E →ₗ.[R] E).toFun' = ⇑topEquiv.toLinearMap := rfl
 end Monoid
 
 /-!
-## E. Inverses
+## F. Inverses
 -/
 
 section Inverses

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -290,8 +290,7 @@ lemma IsUnbounded.orthogonal_closure_sub_range [CompleteSpace H]
     refine (eq_of_le_of_domain_eq ?_ ?_).symm
     · refine le_of_eq_of_le ?_ (adjoint_sub_le_sub_adjoint T.closure (z • 1) hS_dense)
       rcases eq_zero_or_neZero z with rfl | hz₀
-      · suffices (0 : ℂ) • (1 : H →ₗ.[ℂ] H) = 0 by simp [this]
-        exact dExt rfl (by simp)
+      · simp
       · simp [adjoint_smul _ hz₀.ne]
     · ext x
       simp only [sub_domain, smul_domain, one_domain, le_top, inf_of_le_left]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -97,6 +97,7 @@ open Submodule
 open Metric
 open InnerProductSpace
 open Complex
+open ComplexConjugate
 open Set
 open Pointwise
 
@@ -275,6 +276,51 @@ lemma IsClosed.sub_range_isClosed [CompleteSpace H]
     _root_.IsClosed ((T - z • 1).toFun.range : Set H) := by
   have hT' : T.closure = T := hT.isClosable.isClosed_iff.mp hT
   exact (hT' ▸ hT.isClosable.closure_range_sub_eq_range_closure_sub hz) ▸ isClosed_closure
+
+/-- `(T.closure - z • 1).rangeᗮ = (T† - conj z • 1).ker` -/
+lemma IsUnbounded.orthogonal_closure_sub_range [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} (hT : T.IsUnbounded) (z : ℂ) :
+    (T.closure - z • 1).toFun.rangeᗮ
+      = (T† - conj z • 1).toFun.ker.map (T† - conj z • 1).domain.subtype := by
+  let S := T.closure - z • 1
+  have hS_domain : S.domain = T.closure.domain := by simp [S, sub_domain]
+  have hS_dense : S.HasDenseDomain := hT.hasDenseDomain.mono (by simp [hS_domain, T.le_closure.1])
+  have hS_adjoint : S† = T† - conj z • 1 := by
+    rw [← hT.adjoint_closure_eq_adjoint]
+    refine (eq_of_le_of_domain_eq ?_ ?_).symm
+    · refine le_of_eq_of_le ?_ (adjoint_sub_le_sub_adjoint T.closure (z • 1) hS_dense)
+      rcases eq_zero_or_neZero z with rfl | hz₀
+      · suffices (0 : ℂ) • (1 : H →ₗ.[ℂ] H) = 0 by simp [this]
+        exact dExt rfl (by simp)
+      · simp [adjoint_smul _ hz₀.ne]
+    · ext x
+      simp only [sub_domain, smul_domain, one_domain, le_top, inf_of_le_left]
+      constructor <;> intro h
+      · apply mem_adjoint_domain_of_exists
+        use T.closure† ⟨x, h⟩ - conj z • x
+        intro y
+        have h_inner : ⟪T.closure† ⟨x, h⟩, y⟫_ℂ = ⟪x, T.closure ⟨y, hS_domain ▸ y.2⟩⟫_ℂ :=
+          adjoint_isFormalAdjoint hT.hasDenseDomain.closure ⟨x, h⟩ ⟨y, hS_domain ▸ y.2⟩
+        simp [inner_sub_left, h_inner, S, sub_apply, inner_sub_right, inner_smul_left,
+          inner_smul_right]
+      · apply mem_adjoint_domain_of_exists
+        use S† ⟨x, h⟩ + conj z • x
+        intro y
+        have h_inner : ⟪S† ⟨x, h⟩, y⟫_ℂ = ⟪x, S ⟨y, by simp [hS_domain]⟩⟫_ℂ :=
+          adjoint_isFormalAdjoint hS_dense ⟨x, h⟩ ⟨y, by simp [hS_domain]⟩
+        simp [inner_add_left, h_inner, S, sub_apply, inner_sub_right, inner_smul_left,
+          inner_smul_right]
+  exact hS_adjoint ▸ hS_dense.orthogonal_range
+
+/-- `(T† - conj z • 1).kerᗮ = (T.closure - z • 1).range` -/
+lemma IsUnbounded.orthogonal_adjoint_sub_ker [CompleteSpace H]
+    {T : H →ₗ.[ℂ] H} (hT : T.IsUnbounded) {z : ℂ} (hz : z ∈ T.regularityDomain) :
+    ((T† - conj z • 1).toFun.ker.map (T† - conj z • 1).domain.subtype)ᗮ
+      = (T.closure - z • 1).toFun.range := by
+  have hT' : IsClosable T.closure := hT.isClosable.closureIsClosable
+  have hTcl : T.closure.closure = T.closure := hT'.isClosed_iff.mp hT.isClosable.closure_isClosed
+  rw [← hTcl, ← hT.orthogonal_closure_sub_range, orthogonal_orthogonal_eq_closure]
+  exact hT'.closure_range_sub_eq_range_closure_sub (T.regularityDomain_closure ▸ hz)
 
 /-!
 ## B. Deficiency subspace & defect number

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -199,6 +199,12 @@ lemma HasDenseDomain.orthogonal_range [CompleteSpace H] (h : U.HasDenseDomain) :
   · intro ⟨hu, hu'⟩ v ⟨x, hxv⟩
     simp [← hxv, ← adjoint_isFormalAdjoint h ⟨u, hu⟩, hu']
 
+/-- `U†.kerᗮ = U.range.closure` -/
+lemma HasDenseDomain.orthogonal_adjoint_ker [CompleteSpace H] [CompleteSpace H']
+    (h : U.HasDenseDomain) :
+    (U†.toFun.ker.map U†.domain.subtype)ᗮ = U.toFun.range.closure :=
+  h.orthogonal_range ▸ orthogonal_orthogonal_eq_closure _
+
 /-!
 ### B.2. Closability
 -/
@@ -814,15 +820,10 @@ lemma IsUnbounded.orthogonal_adjoint_range [CompleteSpace H] [CompleteSpace H']
     (h : U.IsUnbounded) : U†.toFun.rangeᗮ = U.closure.toFun.ker.map U.closure.domain.subtype :=
   h.adjoint_adjoint_eq_closure ▸ h.adjoint.hasDenseDomain.orthogonal_range
 
-/-- `U†.kerᗮ = U.range.closure` -/
-lemma IsUnbounded.orthogonal_adjoint_ker [CompleteSpace H] [CompleteSpace H'] (h : U.IsUnbounded) :
-    (U†.toFun.ker.map U†.domain.subtype)ᗮ = U.toFun.range.closure :=
-  h.hasDenseDomain.orthogonal_range ▸ orthogonal_orthogonal_eq_closure _
-
 /-- `U.closure.kerᗮ = U†.range` -/
 lemma IsUnbounded.orthogonal_closure_ker [CompleteSpace H] [CompleteSpace H'] (h : U.IsUnbounded) :
     (U.closure.toFun.ker.map U.closure.domain.subtype)ᗮ = U†.toFun.range.closure :=
-  h.adjoint_adjoint_eq_closure ▸ h.adjoint.orthogonal_adjoint_ker
+  h.adjoint_adjoint_eq_closure ▸ h.adjoint.hasDenseDomain.orthogonal_adjoint_ker
 
 /-- A LinearPMap constructed from a symmetric LinearMap with dense domain
   is an unbounded operator. -/

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -357,6 +357,11 @@ lemma adjoint_add_le_add_adjoint [CompleteSpace H]
       adjoint_isFormalAdjoint h₁ ⟨u, u.2.1⟩ ⟨w, w.2.1⟩,
       adjoint_isFormalAdjoint h₂ ⟨u, u.2.2⟩ ⟨w, w.2.2⟩]
 
+lemma adjoint_sub_le_sub_adjoint [CompleteSpace H]
+    (U₁ U₂ : H →ₗ.[ℂ] H') (h₁₂ : (U₁ - U₂).HasDenseDomain) : U₁† - U₂† ≤ (U₁ - U₂)† := by
+  simp only [sub_eq_add_neg, ← adjoint_neg]
+  exact adjoint_add_le_add_adjoint U₁ (-U₂) h₁₂
+
 lemma adjoint_compRestricted_le_compRestricted_adjoint [CompleteSpace H] [CompleteSpace H']
     (hV : V.HasDenseDomain) (hVU : (V ∘ᵣ U).HasDenseDomain) : U† ∘ᵣ V† ≤ (V ∘ᵣ U)† := by
   have hU : U.HasDenseDomain := hVU.mono (compRestricted_domain_le V U)

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -185,6 +185,20 @@ lemma pow_hasDenseDomain_of_le
     {n : ℕ} (h : (T ^ n).HasDenseDomain) {k : ℕ} (hle : k ≤ n) : (T ^ k).HasDenseDomain :=
   h.mono <| pow_sub_mul_pow T hle ▸ compRestricted_domain_le _ _
 
+/-- `U.rangeᗮ = U†.ker`
+
+  c.f. `LinearMap.orthogonal_range` and `ContinuousLinearMap.orthogonal_range` -/
+lemma HasDenseDomain.orthogonal_range [CompleteSpace H] (h : U.HasDenseDomain) :
+    U.toFun.rangeᗮ = U†.toFun.ker.map U†.domain.subtype := by
+  ext u
+  simp only [mem_orthogonal', Subtype.exists, mem_map, LinearMap.mem_ker, subtype_apply,
+    exists_and_right, exists_eq_right, toFun_eq_coe]
+  constructor
+  · intro h'
+    exact ⟨mem_adjoint_domain_of_exists u ⟨0, by simp [h']⟩, adjoint_apply_eq h _ (by simp [h'])⟩
+  · intro ⟨hu, hu'⟩ v ⟨x, hxv⟩
+    simp [← hxv, ← adjoint_isFormalAdjoint h ⟨u, hu⟩, hu']
+
 /-!
 ### B.2. Closability
 -/
@@ -789,6 +803,21 @@ lemma IsUnbounded.le_adjoint_adjoint [CompleteSpace H] [CompleteSpace H'] (h : U
 lemma IsUnbounded.isClosed_iff [CompleteSpace H] [CompleteSpace H'] (h : U.IsUnbounded) :
     U.IsClosed ↔ U†† = U :=
   h.adjoint_adjoint_eq_closure ▸ h.2.isClosed_iff
+
+/-- `U†.rangeᗮ = U.closure.ker` -/
+lemma IsUnbounded.orthogonal_adjoint_range [CompleteSpace H] [CompleteSpace H']
+    (h : U.IsUnbounded) : U†.toFun.rangeᗮ = U.closure.toFun.ker.map U.closure.domain.subtype :=
+  h.adjoint_adjoint_eq_closure ▸ h.adjoint.hasDenseDomain.orthogonal_range
+
+/-- `U†.kerᗮ = U.range.closure` -/
+lemma IsUnbounded.orthogonal_adjoint_ker [CompleteSpace H] [CompleteSpace H'] (h : U.IsUnbounded) :
+    (U†.toFun.ker.map U†.domain.subtype)ᗮ = U.toFun.range.closure :=
+  h.hasDenseDomain.orthogonal_range ▸ orthogonal_orthogonal_eq_closure _
+
+/-- `U.closure.kerᗮ = U†.range` -/
+lemma IsUnbounded.orthogonal_closure_ker [CompleteSpace H] [CompleteSpace H'] (h : U.IsUnbounded) :
+    (U.closure.toFun.ker.map U.closure.domain.subtype)ᗮ = U†.toFun.range.closure :=
+  h.adjoint_adjoint_eq_closure ▸ h.adjoint.orthogonal_adjoint_ker
 
 /-- A LinearPMap constructed from a symmetric LinearMap with dense domain
   is an unbounded operator. -/

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -289,6 +289,9 @@ lemma adjoint_of_zero [CompleteSpace H] (h_zero : ⇑U = 0) : U† = 0 := by
     · exact adjoint_apply_of_not_dense h x
 
 @[simp]
+lemma adjoint_zero [CompleteSpace H] : (0 : H →ₗ.[ℂ] H)† = 0 := adjoint_of_zero rfl
+
+@[simp]
 lemma adjoint_smul [CompleteSpace H] (U : H →ₗ.[ℂ] H') {c : ℂ} (hc : c ≠ 0) :
     (c • U)† = conj c • U† := by
   refine dExt ?_ fun x y hxy ↦ ?_

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -303,7 +303,7 @@ lemma adjoint_of_zero [CompleteSpace H] (h_zero : ⇑U = 0) : U† = 0 := by
     · exact adjoint_apply_of_not_dense h x
 
 @[simp]
-lemma adjoint_zero [CompleteSpace H] : (0 : H →ₗ.[ℂ] H)† = 0 := adjoint_of_zero rfl
+lemma adjoint_zero [CompleteSpace H] : (0 : H →ₗ.[ℂ] H')† = 0 := adjoint_of_zero rfl
 
 @[simp]
 lemma adjoint_smul [CompleteSpace H] (U : H →ₗ.[ℂ] H') {c : ℂ} (hc : c ≠ 0) :


### PR DESCRIPTION
Adds several orthogonal subspaces for unbounded operators:
- `HasDenseDomain.orthogonal_range` : `U.rangeᗮ = U†.ker`
- `HasDenseDomain.orthogonal_adjoint_ker` : `U†.kerᗮ = U.range.closure`
- `IsUnbounded.orthogonal_adjoint_range` : `U†.rangeᗮ = U.closure.ker`
- `IsUnbounded.orthogonal_closure_ker` : `U.closure.kerᗮ = U†.range`

Also two variants useful for the spectral theory (the latter holds for `z` in the regularity domain):
- `IsUnbounded.orthogonal_closure_sub_range` : `(T.closure - z • 1).rangeᗮ = (T† - conj z • 1).ker`
- `IsUnbounded.orthogonal_adjoint_sub_ker` : `(T† - conj z • 1).kerᗮ = (T.closure - z • 1).range`