### PR TITLE
feat: Representation on Lorentz Vectors

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -368,6 +368,7 @@ public import Physlib.Relativity.Tensors.OfInt
 public import Physlib.Relativity.Tensors.Product
 public import Physlib.Relativity.Tensors.RealTensor.Basic
 public import Physlib.Relativity.Tensors.RealTensor.CoVector.Basic
+public import Physlib.Relativity.Tensors.RealTensor.CoVector.Representation
 public import Physlib.Relativity.Tensors.RealTensor.CoVector.Tensorial
 public import Physlib.Relativity.Tensors.RealTensor.Matrix.Pre
 public import Physlib.Relativity.Tensors.RealTensor.Metrics.Basic

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -380,10 +380,10 @@ public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.Basic
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.LightLike
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.TimeLike
 public import Physlib.Relativity.Tensors.RealTensor.Vector.MinkowskiProduct
-public import Physlib.Relativity.Tensors.RealTensor.Vector.Representation
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Basic
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Contraction
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Modules
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Representation
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Tensorial
 public import Physlib.Relativity.Tensors.RealTensor.Velocity.Basic
 public import Physlib.Relativity.Tensors.TensorSpecies.Basic

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -379,6 +379,7 @@ public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.Basic
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.LightLike
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Causality.TimeLike
 public import Physlib.Relativity.Tensors.RealTensor.Vector.MinkowskiProduct
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Representation
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Basic
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Contraction
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Pre.Modules

--- a/Physlib/Electromagnetism/Distributional/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Distributional/Dynamics/IsExtrema.lean
@@ -73,7 +73,7 @@ lemma isExtrema_iff_components {𝓕 : FreeSpace}
     simp [h]
   · intro h
     rw [isExtrema_iff_gradLagrangian]
-    ext ε
+    ext1 ε
     funext i
     match i with
     | Sum.inl 0 => exact h.1 ε
@@ -219,7 +219,7 @@ lemma isExterma_iff_tensor {𝓕 : FreeSpace}
     exact h1
   · intro h
     simp only [IsExtrema]
-    ext x
+    ext1 x
     funext ν
     rw [gradLagrangian_eq_tensor A J, h]
     simp

--- a/Physlib/Electromagnetism/Distributional/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Distributional/Dynamics/KineticTerm.lean
@@ -82,7 +82,7 @@ noncomputable def gradKineticTerm {d} (𝓕 : FreeSpace) :
       ring_nf
     cont := by fun_prop}
   map_add' A1 A2 := by
-    ext ε
+    ext1 ε
     simp only [one_div, map_add, ContinuousLinearMap.add_apply, Lorentz.Vector.apply_add,
       ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk]
     rw [← Finset.sum_add_distrib]
@@ -92,7 +92,7 @@ noncomputable def gradKineticTerm {d} (𝓕 : FreeSpace) :
     simp only [← add_smul]
     ring_nf
   map_smul' r A := by
-    ext ε
+    ext1 ε
     simp only [one_div, map_smul, ContinuousLinearMap.smul_apply, Lorentz.Vector.apply_smul,
       ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk]
     simp [Finset.smul_sum, smul_smul]

--- a/Physlib/Electromagnetism/Distributional/Dynamics/Lagrangian.lean
+++ b/Physlib/Electromagnetism/Distributional/Dynamics/Lagrangian.lean
@@ -88,10 +88,10 @@ noncomputable def gradFreeCurrentPotential {d} :
     cont := by fun_prop
   }
   map_add' J₁ J₂ := by
-    ext ε
+    ext1 ε
     simp [Finset.sum_add_distrib, add_smul]
   map_smul' r J := by
-    ext ε
+    ext1 ε
     simp [Finset.smul_sum, smul_smul]
     congr
     funext i

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -161,7 +161,8 @@ noncomputable def ofPotentials {d} (c : SpeedOfLight) (ϕ : Time → Space d →
 lemma ofPotentials_eq_add {d} (c : SpeedOfLight) (ϕ : Time → Space d → ℝ)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d)) :
     ofPotentials c ϕ A = ofScalarPotential c ϕ + ofVectorPotential c A := by
-  ext x
+  ext1
+  ext1 x
   refine Lorentz.Vector.ext_of_apply (fun i => ?_)
   match i with
   | Sum.inl 0 =>

--- a/Physlib/Relativity/Tensors/RealTensor/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Basic.lean
@@ -58,6 +58,10 @@ instance modulesModule (d : ℕ) : ∀ c, Module ℝ (modules d c)
 
 end realLorentzTensor
 
+TODO "Replace Lorentz.ContrMod and Lorentz.CoMod in the definition of realLorentzTensor
+  directly with Lorentz.Vector and Lorentz.Covector, and
+  representations defined on them."
+
 noncomputable section
 open realLorentzTensor in
 /-- The tensor structure for complex Lorentz tensors. -/

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Basic.lean
@@ -50,6 +50,12 @@ def equivEuclid (d : ℕ) :
     CoVector d ≃ₗ[ℝ] EuclideanSpace ℝ (Fin 1 ⊕ Fin d) :=
   (WithLp.linearEquiv _ _ _).symm
 
+@[ext]
+lemma eq_of_apply_eq {d : ℕ} {v w : CoVector d} (h : ∀ i, v i = w i) : v = w := by
+  apply (equivEuclid d).injective
+  ext i
+  simpa using h i
+
 instance (d : ℕ) : Norm (CoVector d) where
   norm := fun v => ‖equivEuclid d v‖
 
@@ -115,6 +121,10 @@ lemma apply_add {d : ℕ} (v w : CoVector d) (i : Fin 1 ⊕ Fin d) :
 @[simp]
 lemma apply_sub {d : ℕ} (v w : CoVector d) (i : Fin 1 ⊕ Fin d) :
     (v - w) i = v i - w i := by rfl
+
+@[simp]
+lemma apply_sum {d : ℕ} {ι : Type} [Fintype ι] (f : ι → CoVector d) (i : Fin 1 ⊕ Fin d) :
+    (∑ j, f j) i = ∑ j, f j i := Finset.sum_apply i Finset.univ f
 
 @[simp]
 lemma neg_apply {d : ℕ} (v : CoVector d) (i : Fin 1 ⊕ Fin d) :

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Mathlib.RepresentationTheory.Basic
+public import Physlib.Relativity.LorentzGroup.Basic
+public import Physlib.Relativity.Tensors.RealTensor.CoVector.Basic
+/-!
+
+# Representation of the Lorentz group on Lorentz vectors
+
+In this module we define the representation of the Lorentz group on Lorentz covectors.
+This does not define the MulAction on `Lorentz.CoVector`, which is induced
+by its tensor structure.
+
+-/
+
+@[expose] public section
+
+
+open Module
+open Matrix
+open MatrixGroups
+open Complex
+open TensorProduct
+
+noncomputable section
+
+namespace Lorentz
+
+namespace CoVector
+attribute [-simp] Fintype.sum_sum_type
+
+/-- The representation of the Lorentz group on Lorentz vectors. -/
+def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (CoVector d) where
+  toFun g := Matrix.toLinAlgEquiv basis (LorentzGroup.transpose g⁻¹)
+  map_one' := by
+    simp only [inv_one, LorentzGroup.transpose_one, lorentzGroupIsGroup_one_coe, _root_.map_one]
+  map_mul' x y := by
+    simp only [_root_.mul_inv_rev, LorentzGroup.inv_eq_dual, LorentzGroup.transpose_mul,
+      lorentzGroupIsGroup_mul_coe, _root_.map_mul]
+
+/-!
+
+## Properties of the representation.
+
+-/
+
+lemma rep_apply_eq_mulVec (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) :
+    rep d Λ v = (LorentzGroup.transpose Λ⁻¹) *ᵥ v := by rfl
+
+lemma rep_apply_eq_sum (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) (k : Fin 1 ⊕ Fin d) :
+    rep d Λ v k = ∑ j, (Λ⁻¹).1 j k • v j := rfl
+
+lemma rep_apply_eq_sum_coe (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) (k : Fin 1 ⊕ Fin d) :
+    rep d Λ v k = ∑ j, Λ.1⁻¹ j k • v j := by
+  rw [rep_apply_eq_sum, LorentzGroup.coe_inv]
+
+lemma rep_apply_basis {d} (μ : Fin 1 ⊕ Fin d) (Λ : LorentzGroup d) :
+    rep d Λ (basis μ) = ∑ j, Λ.1⁻¹ μ j • basis j := by
+  ext k
+  simp [rep_apply_eq_sum_coe, apply_sum]
+
+lemma rep_toMatrix (d : ℕ) (Λ : LorentzGroup d) :
+    LinearMap.toMatrix basis basis (rep d Λ) = Λ.1⁻¹ᵀ := by
+  simp only [rep, MonoidHom.coe_mk, OneHom.coe_mk]
+  rw [← LorentzGroup.coe_inv]
+  exact (LinearEquiv.eq_symm_apply (LinearMap.toMatrix basis basis)).mp rfl
+
+lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep d Λ) := by
+  intro v1 v2 h
+  rw [rep_apply_eq_mulVec, rep_apply_eq_mulVec] at h
+  exact Matrix.mulVec_injective_of_isUnit (isUnit_of_invertible _) h
+
+lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep d Λ) := by
+  intro v
+  use (LorentzGroup.transpose Λ⁻¹)⁻¹ *ᵥ v
+  rw [rep_apply_eq_mulVec]
+  simp
+
+lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep d Λ) :=
+  ⟨rep_injective d Λ, rep_surjective d Λ⟩
+
+end CoVector
+
+end Lorentz

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
@@ -21,11 +21,7 @@ by its tensor structure.
 @[expose] public section
 
 
-open Module
-open Matrix
-open MatrixGroups
-open Complex
-open TensorProduct
+open Module Matrix MatrixGroups Complex TensorProduct
 
 noncomputable section
 

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
@@ -31,7 +31,7 @@ namespace CoVector
 attribute [-simp] Fintype.sum_sum_type
 
 /-- The representation of the Lorentz group on Lorentz vectors. -/
-def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (CoVector d) where
+def rep {d : ℕ} : Representation ℝ (LorentzGroup d) (CoVector d) where
   toFun Λ := Matrix.toLinAlgEquiv basis (LorentzGroup.transpose Λ⁻¹)
   map_one' := by
     simp only [inv_one, LorentzGroup.transpose_one, lorentzGroupIsGroup_one_coe, _root_.map_one]
@@ -46,38 +46,38 @@ def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (CoVector d) where
 -/
 
 lemma rep_apply_eq_mulVec (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) :
-    rep d Λ v = (LorentzGroup.transpose Λ⁻¹) *ᵥ v := by rfl
+    rep Λ v = (LorentzGroup.transpose Λ⁻¹) *ᵥ v := by rfl
 
 lemma rep_apply_eq_sum (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) (k : Fin 1 ⊕ Fin d) :
-    rep d Λ v k = ∑ j, (Λ⁻¹).1 j k • v j := rfl
+    rep Λ v k = ∑ j, (Λ⁻¹).1 j k • v j := rfl
 
 lemma rep_apply_eq_sum_coe (d : ℕ) (Λ : LorentzGroup d) (v : CoVector d) (k : Fin 1 ⊕ Fin d) :
-    rep d Λ v k = ∑ j, Λ.1⁻¹ j k • v j := by
+    rep Λ v k = ∑ j, Λ.1⁻¹ j k • v j := by
   rw [rep_apply_eq_sum, LorentzGroup.coe_inv]
 
 lemma rep_apply_basis {d} (μ : Fin 1 ⊕ Fin d) (Λ : LorentzGroup d) :
-    rep d Λ (basis μ) = ∑ j, Λ.1⁻¹ μ j • basis j := by
+    rep Λ (basis μ) = ∑ j, Λ.1⁻¹ μ j • basis j := by
   ext k
   simp [rep_apply_eq_sum_coe, apply_sum]
 
 lemma rep_toMatrix (d : ℕ) (Λ : LorentzGroup d) :
-    LinearMap.toMatrix basis basis (rep d Λ) = Λ.1⁻¹ᵀ := by
+    LinearMap.toMatrix basis basis (rep Λ) = Λ.1⁻¹ᵀ := by
   simp only [rep, MonoidHom.coe_mk, OneHom.coe_mk]
   rw [← LorentzGroup.coe_inv]
   exact (LinearEquiv.eq_symm_apply (LinearMap.toMatrix basis basis)).mp rfl
 
-lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep d Λ) := by
+lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep Λ) := by
   intro v1 v2 h
   rw [rep_apply_eq_mulVec, rep_apply_eq_mulVec] at h
   exact Matrix.mulVec_injective_of_isUnit (isUnit_of_invertible _) h
 
-lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep d Λ) := by
+lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep Λ) := by
   intro v
-  use (LorentzGroup.transpose Λ⁻¹)⁻¹ *ᵥ v
+  use (LorentzGroup.transpose Λ) *ᵥ v
   rw [rep_apply_eq_mulVec]
-  simp
+  simp [← LorentzGroup.transpose_inv, LorentzGroup.coe_inv]
 
-lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep d Λ) :=
+lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep Λ) :=
   ⟨rep_injective d Λ, rep_surjective d Λ⟩
 
 end CoVector

--- a/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/CoVector/Representation.lean
@@ -32,7 +32,7 @@ attribute [-simp] Fintype.sum_sum_type
 
 /-- The representation of the Lorentz group on Lorentz vectors. -/
 def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (CoVector d) where
-  toFun g := Matrix.toLinAlgEquiv basis (LorentzGroup.transpose g⁻¹)
+  toFun Λ := Matrix.toLinAlgEquiv basis (LorentzGroup.transpose Λ⁻¹)
   map_one' := by
     simp only [inv_one, LorentzGroup.transpose_one, lorentzGroupIsGroup_one_coe, _root_.map_one]
   map_mul' x y := by

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Basic.lean
@@ -54,6 +54,12 @@ def equivEuclid (d : ℕ) :
 lemma equivEuclid_apply (d : ℕ) (v : Vector d) (i : Fin 1 ⊕ Fin d) :
     equivEuclid d v i = v i := rfl
 
+@[ext]
+lemma eq_of_apply_eq {d : ℕ} {v w : Vector d} (h : ∀ i, v i = w i) : v = w := by
+  apply (equivEuclid d).injective
+  ext i
+  simpa using h i
+
 instance (d : ℕ) : Norm (Vector d) where
   norm := fun v => ‖equivEuclid d v‖
 

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/MinkowskiProduct.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/MinkowskiProduct.lean
@@ -253,7 +253,7 @@ lemma map_minkowskiProduct_eq_self_forall_iff {d : ℕ} (f : Vector d →ₗ[ℝ
     (∀ p q : Vector d, ⟪f p, q⟫ₘ = ⟪p, q⟫ₘ) ↔ f = LinearMap.id := by
   constructor
   · intro h
-    ext p
+    ext1 p
     have h1 := h p
     have h2 : ∀ q, ⟪f p - p, q⟫ₘ = 0 := by
       intro q

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
@@ -21,11 +21,7 @@ by its tensor structure.
 @[expose] public section
 
 
-open Module
-open Matrix
-open MatrixGroups
-open Complex
-open TensorProduct
+open Module Matrix MatrixGroups Complex TensorProduct
 
 noncomputable section
 
@@ -35,8 +31,8 @@ namespace Vector
 attribute [-simp] Fintype.sum_sum_type
 
 /-- The representation of the Lorentz group on Lorentz vectors. -/
-def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (Vector d) where
-  toFun g := Matrix.toLinAlgEquiv basis g
+def rep {d : ℕ} : Representation ℝ (LorentzGroup d) (Vector d) where
+  toFun Λ := Matrix.toLinAlgEquiv basis Λ
   map_one' := EmbeddingLike.map_eq_one_iff.mpr rfl
   map_mul' x y := by simp only [lorentzGroupIsGroup_mul_coe, _root_.map_mul]
 
@@ -47,13 +43,13 @@ def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (Vector d) where
 -/
 
 lemma rep_apply_eq_mulVec (d : ℕ) (Λ : LorentzGroup d) (v : Vector d) :
-    rep d Λ v = Λ *ᵥ v := by rfl
+    rep Λ v = Λ *ᵥ v := by rfl
 
 lemma rep_apply_eq_sum (d : ℕ) (Λ : LorentzGroup d) (v : Vector d) (k : Fin 1 ⊕ Fin d) :
-    rep d Λ v k = ∑ j, Λ.1 k j • v j := rfl
+    rep Λ v k = ∑ j, Λ.1 k j • v j := rfl
 
 lemma rep_apply_basis {d} (μ : Fin 1 ⊕ Fin d) (Λ : LorentzGroup d) :
-    rep d Λ (basis μ) = ∑ j, Λ.1 j μ • basis j := by
+    rep Λ (basis μ) = ∑ j, Λ.1 j μ • basis j := by
   ext k
   simp [rep_apply_eq_sum, apply_sum]
 
@@ -62,28 +58,28 @@ lemma rep_toMatrix (d : ℕ) (Λ : LorentzGroup d) :
   simp only [rep, MonoidHom.coe_mk, OneHom.coe_mk]
   exact (LinearEquiv.eq_symm_apply (LinearMap.toMatrix basis basis)).mp rfl
 
-lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep d Λ) := by
+lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep Λ) := by
   intro v1 v2 h
   rw [rep_apply_eq_mulVec, rep_apply_eq_mulVec] at h
   exact Matrix.mulVec_injective_of_isUnit (isUnit_of_invertible Λ.1) h
 
-lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep d Λ) := by
+lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep Λ) := by
   intro v
   use Λ⁻¹ *ᵥ v
   rw [rep_apply_eq_mulVec]
   simp
 
-lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep d Λ) :=
+lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep Λ) :=
   ⟨rep_injective d Λ, rep_surjective d Λ⟩
 
 @[fun_prop]
-lemma rep_contDiff (d : ℕ) {n} (Λ : LorentzGroup d) : ContDiff ℝ n (rep d Λ) := by
-  refine (contDiff_apply ⇑((rep d) Λ)).mp ?_
+lemma rep_contDiff (d : ℕ) {n} (Λ : LorentzGroup d) : ContDiff ℝ n (rep Λ) := by
+  refine (contDiff_apply ⇑(rep Λ)).mp ?_
   intro μ
   simp only [rep_apply_eq_sum, smul_eq_mul]
   fun_prop
 
-lemma rep_left_injective (d : ℕ) : Function.Injective (rep d) := by
+lemma rep_left_injective (d : ℕ) : Function.Injective (rep (d := d)) := by
   intro Λ Λ' h
   apply LorentzGroup.eq_of_mulVec_eq
   intro v

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Mathlib.RepresentationTheory.Basic
+public import Physlib.Relativity.LorentzGroup.Basic
+public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
+/-!
+
+# Representation of the Lorentz group on Lorentz vectors
+
+In this module we define the representation of the Lorentz group on Lorentz vectors.
+This does not define the MulAction on `Lorentz.Vector`, which is induced
+by its tensor structure.
+
+-/
+
+@[expose] public section
+
+
+open Module
+open Matrix
+open MatrixGroups
+open Complex
+open TensorProduct
+
+noncomputable section
+
+namespace Lorentz
+
+namespace Vector
+attribute [-simp] Fintype.sum_sum_type
+
+/-- The representation of the Lorentz group on Lorentz vectors. -/
+def rep (d : ℕ) : Representation ℝ (LorentzGroup d) (Vector d) where
+  toFun g := Matrix.toLinAlgEquiv basis g
+  map_one' := EmbeddingLike.map_eq_one_iff.mpr rfl
+  map_mul' x y := by simp only [lorentzGroupIsGroup_mul_coe, _root_.map_mul]
+
+/-!
+
+## Properties of the representation.
+
+-/
+
+lemma rep_apply_eq_mulVec (d : ℕ) (Λ : LorentzGroup d) (v : Vector d) :
+    rep d Λ v = Λ *ᵥ v := by rfl
+
+lemma rep_apply_eq_sum (d : ℕ) (Λ : LorentzGroup d) (v : Vector d) (k : Fin 1 ⊕ Fin d) :
+    rep d Λ v k = ∑ j, Λ.1 k j • v j := rfl
+
+lemma rep_apply_basis {d} (μ : Fin 1 ⊕ Fin d) (Λ : LorentzGroup d) :
+    rep d Λ (basis μ) = ∑ j, Λ.1 j μ • basis j := by
+  ext k
+  simp [rep_apply_eq_sum, apply_sum]
+
+lemma rep_toMatrix (d : ℕ) (Λ : LorentzGroup d) :
+    LinearMap.toMatrix basis basis (rep d Λ) = Λ.1 := by
+  simp only [rep, MonoidHom.coe_mk, OneHom.coe_mk]
+  exact (LinearEquiv.eq_symm_apply (LinearMap.toMatrix basis basis)).mp rfl
+
+lemma rep_injective (d : ℕ) (Λ : LorentzGroup d) : Function.Injective (rep d Λ) := by
+  intro v1 v2 h
+  rw [rep_apply_eq_mulVec, rep_apply_eq_mulVec] at h
+  exact Matrix.mulVec_injective_of_isUnit (isUnit_of_invertible Λ.1) h
+
+lemma rep_surjective (d : ℕ) (Λ : LorentzGroup d) : Function.Surjective (rep d Λ) := by
+  intro v
+  use Λ⁻¹ *ᵥ v
+  rw [rep_apply_eq_mulVec]
+  simp
+
+lemma rep_bijective (d : ℕ) (Λ : LorentzGroup d) : Function.Bijective (rep d Λ) :=
+  ⟨rep_injective d Λ, rep_surjective d Λ⟩
+
+@[fun_prop]
+lemma rep_contDiff (d : ℕ) {n} (Λ : LorentzGroup d) : ContDiff ℝ n (rep d Λ) := by
+  refine (contDiff_apply ⇑((rep d) Λ)).mp ?_
+  intro μ
+  simp only [rep_apply_eq_sum, smul_eq_mul]
+  fun_prop
+
+lemma rep_left_injective (d : ℕ) : Function.Injective (rep d) := by
+  intro Λ Λ' h
+  apply LorentzGroup.eq_of_mulVec_eq
+  intro v
+  rw [← rep_apply_eq_mulVec, ← rep_apply_eq_mulVec]
+  exact LinearMap.congr_fun h v
+
+end Vector
+
+end Lorentz

--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Representation.lean
@@ -54,7 +54,7 @@ lemma rep_apply_basis {d} (μ : Fin 1 ⊕ Fin d) (Λ : LorentzGroup d) :
   simp [rep_apply_eq_sum, apply_sum]
 
 lemma rep_toMatrix (d : ℕ) (Λ : LorentzGroup d) :
-    LinearMap.toMatrix basis basis (rep d Λ) = Λ.1 := by
+    LinearMap.toMatrix basis basis (rep Λ) = Λ.1 := by
   simp only [rep, MonoidHom.coe_mk, OneHom.coe_mk]
   exact (LinearEquiv.eq_symm_apply (LinearMap.toMatrix basis basis)).mp rfl
 

--- a/Physlib/Relativity/Tensors/RealTensor/Velocity/Basic.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Velocity/Basic.lean
@@ -160,7 +160,7 @@ noncomputable def pathFromZero (u : Velocity d) : Path zero u where
   source' := by
     simp
   target' := by
-    ext
+    ext1
     simp only [Set.Icc.coe_one,
       one_pow, one_mul, Fin.isValue, mul_one, one_smul, add_eq_right, smul_eq_zero]
     left

--- a/Physlib/SpaceAndTime/SpaceTime/Basic.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Basic.lean
@@ -531,7 +531,7 @@ lemma det_timeSpaceBasisEquiv {d : ℕ} (c : SpeedOfLight) :
 lemma timeSpaceBasis_eq_map_basis {d : ℕ} (c : SpeedOfLight) :
     timeSpaceBasis (d := d) c =
     Module.Basis.map (Lorentz.Vector.basis (d := d)) (timeSpaceBasisEquiv c).toLinearEquiv := by
-  ext μ
+  ext1 μ
   match μ with
   | Sum.inl 0 =>
     simp [timeSpaceBasisEquiv]


### PR DESCRIPTION
The representation of the Lorentz group on Lorentz vectors. This is needed as part of a larger move to clean up Tensors, although it should be independently useful. 