### PR TITLE
Replace erw with simp only + rw in kineticTerm_eq_sum

### DIFF
--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -138,11 +138,13 @@ lemma kineticTerm_eq_sum {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     enter [1]
     rw [prodT_basis_repr_apply]
     enter [1]
-    erw [coMetric_repr_apply_eq_minkowskiMatrix]
+    simp only [Tensorial.self_toTensor_apply]
+    rw [coMetric_repr_apply_eq_minkowskiMatrix]
     change η μ' μ
   conv_lhs =>
     enter [2, 2, μ, 2, ν, 1, 2, μ', 2, ν', 1, 2]
-    erw [coMetric_repr_apply_eq_minkowskiMatrix]
+    simp only [Tensorial.self_toTensor_apply]
+    rw [coMetric_repr_apply_eq_minkowskiMatrix]
     change η (ν') (ν)
   conv_lhs =>
     enter [2, 2, μ, 2, ν, 1, 2, μ', 2, ν', 2]


### PR DESCRIPTION
Small cleanup in kineticTerm_eq_sum: the two erw calls are replaced by simp only [Tensorial.self_toTensor_apply] then a plain rw [coMetric_repr_apply_eq_minkowskiMatrix]