### PR TITLE
feat(QuantumMechanics): Begin spectral theory of self-adjoint operators

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -274,6 +274,7 @@ public import Physlib.QuantumMechanics.DDimensions.Operators.Momentum
 public import Physlib.QuantumMechanics.DDimensions.Operators.Multiplication
 public import Physlib.QuantumMechanics.DDimensions.Operators.Position
 public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Basic
+public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.SelfAdjoint
 public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Symmetric
 public import Physlib.QuantumMechanics.DDimensions.Operators.StateObservables.ExpectedValue
 public import Physlib.QuantumMechanics.DDimensions.Operators.StateObservables.IsEigenvector

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -105,7 +105,7 @@ open Pointwise
 abbrev resolvent (T : H →ₗ.[ℂ] H) (z : ℂ) : H →ₗ.[ℂ] H := (T - z • 1).inverse
 
 @[inherit_doc resolvent]
-local notation "𝑅" => resolvent
+scoped notation "𝑅" => resolvent
 
 /-!
 ## A. Regularity domain
@@ -662,7 +662,7 @@ def resolventSet (T : H →ₗ.[ℂ] H) : Set ℂ :=
   {z : ℂ | (T - z • 1).toFun.ker = ⊥ ∧ (T - z • 1).toFun.range = ⊤ ∧ Continuous (𝑅 T z)}
 
 @[inherit_doc resolventSet]
-local notation "ρ" => resolventSet
+scoped notation "ρ" => resolventSet
 
 lemma resolventSet_eq (T : H →ₗ.[ℂ] H) :
     ρ T = {z | (T - z • 1).toFun.ker = ⊥ ∧ (T - z • 1).toFun.range = ⊤ ∧ Continuous (𝑅 T z)} :=
@@ -738,7 +738,7 @@ lemma resolventSet_isOpen [CompleteSpace H] (T : H →ₗ.[ℂ] H) : IsOpen (ρ 
 def spectrum (T : H →ₗ.[ℂ] H) : Set ℂ := (ρ T)ᶜ
 
 @[inherit_doc spectrum]
-local notation "σ" => spectrum
+scoped notation "σ" => spectrum
 
 lemma spectrum_eq (T : H →ₗ.[ℂ] H) : σ T = (ρ T)ᶜ := rfl
 
@@ -765,7 +765,7 @@ lemma spectrum_isClosed [CompleteSpace H] (T : H →ₗ.[ℂ] H) : _root_.IsClos
 def pointSpectrum (T : H →ₗ.[ℂ] H) : Set ℂ := {z : ℂ | (T - z • 1).toFun.ker ≠ ⊥}
 
 @[inherit_doc pointSpectrum]
-local notation "σᵖ" => pointSpectrum
+scoped notation "σᵖ" => pointSpectrum
 
 lemma pointSpectrum_eq (T : H →ₗ.[ℂ] H) : σᵖ T = {z | (T - z • 1).toFun.ker ≠ ⊥} := rfl
 
@@ -787,7 +787,7 @@ def residualSpectrum (T : H →ₗ.[ℂ] H) : Set ℂ :=
   {z : ℂ | (T - z • 1).toFun.ker = ⊥ ∧ (T - z • 1).toFun.range ≠ ⊤ ∧ Continuous (𝑅 T z)}
 
 @[inherit_doc residualSpectrum]
-local notation "σʳ" => residualSpectrum
+scoped notation "σʳ" => residualSpectrum
 
 lemma residualSpectrum_eq (T : H →ₗ.[ℂ] H) :
     σʳ T = {z | (T - z • 1).toFun.ker = ⊥ ∧ (T - z • 1).toFun.range ≠ ⊤ ∧ Continuous (𝑅 T z)} :=
@@ -811,7 +811,7 @@ def continuousSpectrum (T : H →ₗ.[ℂ] H) : Set ℂ :=
   {z : ℂ | ¬_root_.IsClosed ((T - z • 1).toFun.range : Set H)}
 
 @[inherit_doc continuousSpectrum]
-local notation "σᶜ" => continuousSpectrum
+scoped notation "σᶜ" => continuousSpectrum
 
 lemma continuousSpectrum_eq (T : H →ₗ.[ℂ] H) :
     σᶜ T = {z | ¬_root_.IsClosed ((T - z • 1).toFun.range : Set H)} := rfl

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Basic.lean
@@ -800,6 +800,9 @@ lemma mem_residualSpectrum_iff {T : H →ₗ.[ℂ] H} {z : ℂ} :
 lemma residualSpectrum_subset_spectrum (T : H →ₗ.[ℂ] H) : σʳ T ⊆ σ T :=
   fun _ ⟨_, h, _⟩ ↦ mem_spectrum_iff.mpr (Or.inr <| Or.inl h)
 
+lemma residualSpectrum_subset_regularityDomain (T : H →ₗ.[ℂ] H) : σʳ T ⊆ T.regularityDomain :=
+  fun _ hz ↦ mem_regularityDomain_iff.mpr ⟨hz.1, hz.2.2⟩
+
 /-!
 #### D.2.3. Continuous spectrum
 -/

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Gregory J. Loges. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gregory J. Loges
+-/
+module
+
+public import Physlib.QuantumMechanics.DDimensions.Operators.SpectralTheory.Symmetric
+/-!
+
+# Spectral theory for self-adjoint operators
+
+## i. Overview
+
+In this module we develop the spectral theory for self-adjoint operators.
+
+## ii. Key results
+
+- `spectrum_real` : The spectrum of a self-adjoint unbounded operator is real.
+
+## iii. Table of contents
+
+- A. Resolvent set
+- B. Spectrum
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace LinearPMap
+namespace IsSelfAdjoint
+
+open Complex
+open ComplexConjugate
+open Set
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+variable {T : H →ₗ.[ℂ] H} (hT : IsSelfAdjoint T)
+include hT
+
+/-!
+## A. Resolvent set
+-/
+
+lemma resolventSet_eq_regularityDomain : ρ T = T.regularityDomain := by
+  refine Subset.antisymm T.resolventSet_subset_regularityDomain fun z hz ↦ ?_
+  obtain ⟨h_ker, h_cont⟩ := mem_regularityDomain_iff.mp hz
+  refine ⟨h_ker, ?_, h_cont⟩
+  have h_ker' : (T - conj z • 1).toFun.ker = ⊥ := by
+    by_cases hz' : conj z = z
+    · exact hz'.symm ▸ h_ker
+    · suffices conj z ∉ σᵖ T by simp_all [pointSpectrum_eq]
+      refine fun h ↦ hz' ?_
+      obtain ⟨r, hr⟩ := (isSymmetric hT).pointSpectrum_real h
+      have hr' : conj (↑r) = z := by simp [hr]
+      simp [← hr']
+  have h_orthog := (isUnbounded hT).orthogonal_adjoint_sub_ker hz
+  rw [isSelfAdjoint_def.mp hT, (isClosed hT).closure_eq, h_ker'] at h_orthog
+  simp [← h_orthog]
+
+/-- `(T - z • 1).range = ⊤` is both a necessary and sufficient condition for `z ∈ ρ T`. -/
+lemma mem_resolventSet_of_range_eq_top {z : ℂ} (h : (T - z • 1).toFun.range = ⊤) : z ∈ ρ T := by
+  by_cases hz_im : z.im = 0
+  · rw [(isClosed hT).resolventSet_eq]
+    refine ⟨?_, h⟩
+    have h_orthog := (isUnbounded hT).orthogonal_closure_sub_range z
+    rw [isSelfAdjoint_def.mp hT, (isClosed hT).closure_eq, conj_eq_iff_im.mpr hz_im, h,
+      Submodule.top_orthogonal_eq_bot, Eq.comm, Submodule.ext_iff] at h_orthog
+    ext x
+    specialize h_orthog x
+    simp_all
+  · rw [resolventSet_eq_regularityDomain hT]
+    exact (isSymmetric hT).mem_regularityDomain_of_im_ne_zero hz_im
+
+/-!
+## B. Spectrum
+-/
+
+/-- The spectrum of a self-adjoint operator is real. -/
+lemma spectrum_real : σ T ⊆ range ofReal := by
+  rw [spectrum_eq, resolventSet_eq_regularityDomain hT]
+  exact compl_subset_comm.mp (isSymmetric hT).compl_ofReal_subset_regularityDomain
+
+/-- The residual spectrum of a self-adjoint operator is empty. -/
+lemma residualSpectrum_eq_empty : σʳ T = ∅ := by
+  apply eq_empty_of_subset_empty
+  refine inter_compl_self (ρ T) ▸ subset_inter ?_ ?_
+  · exact resolventSet_eq_regularityDomain hT ▸ T.residualSpectrum_subset_regularityDomain
+  · exact T.spectrum_eq ▸ T.residualSpectrum_subset_spectrum
+
+end IsSelfAdjoint
+end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
@@ -16,6 +16,8 @@ In this module we develop the spectral theory for self-adjoint operators.
 
 ## ii. Key results
 
+- `resolventSet_eq_regularityDomain` : The resolvent set and regularity domain coincide. That is,
+    if `T - z • 1` has a continuous (equivalently, bounded) inverse then its range is all of `H`.
 - `spectrum_real` : The spectrum of a self-adjoint unbounded operator is real.
 
 ## iii. Table of contents
@@ -59,7 +61,8 @@ lemma resolventSet_eq_regularityDomain : ρ T = T.regularityDomain := by
   rw [isSelfAdjoint_def.mp hT, (isClosed hT).closure_eq, h_ker'] at h_orthog
   simp [← h_orthog]
 
-/-- `(T - z • 1).range = ⊤` is both a necessary and sufficient condition for `z ∈ ρ T`. -/
+/-- `(T - z • 1).range = ⊤` is a sufficient condition for `z ∈ ρ T`
+  (and it is a necessary condition by definition of `ρ`). -/
 lemma mem_resolventSet_of_range_eq_top {z : ℂ} (h : (T - z • 1).toFun.range = ⊤) : z ∈ ρ T := by
   by_cases hz_im : z.im = 0
   · rw [(isClosed hT).resolventSet_eq]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/SelfAdjoint.lean
@@ -54,8 +54,7 @@ lemma resolventSet_eq_regularityDomain : ρ T = T.regularityDomain := by
     · suffices conj z ∉ σᵖ T by simp_all [pointSpectrum_eq]
       refine fun h ↦ hz' ?_
       obtain ⟨r, hr⟩ := (isSymmetric hT).pointSpectrum_real h
-      have hr' : conj (↑r) = z := by simp [hr]
-      simp [← hr']
+      simp [show z = conj (↑r) from by simp [hr]]
   have h_orthog := (isUnbounded hT).orthogonal_adjoint_sub_ker hz
   rw [isSelfAdjoint_def.mp hT, (isClosed hT).closure_eq, h_ker'] at h_orthog
   simp [← h_orthog]

--- a/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/SpectralTheory/Symmetric.lean
@@ -212,5 +212,23 @@ lemma regularityDomain_isConnected_of_bddAbove (h : BddAbove (Θᵣₑ T)) :
   apply hT.regularityDomain_isConnected_iff.mpr
   exact ⟨m + 1, hT.Ioi_subset_regularityDomain hm ⟨m + 1, by simp⟩⟩
 
+/-!
+## C. Point spectrum
+-/
+
+/-- Eigenvalues of a symmetric unbounded operator are real. -/
+lemma pointSpectrum_real : σᵖ T ⊆ range ofReal := by
+  intro z hz
+  apply hT.numericalRange_subset
+  obtain ⟨x, hx, hx₀⟩ := (Submodule.ne_bot_iff _).mp hz
+  suffices z = (‖x‖ ^ 2)⁻¹ * ⟪↑x, T ⟨x, x.2.1⟩⟫_ℂ by
+    exact this ▸ mem_numericalRange (T := T) (x := ⟨x, x.2.1⟩) (by simp [hx₀])
+  rw [ofReal_inv]
+  refine (eq_inv_mul_iff_mul_eq₀ (by simp [hx₀])).mpr (Eq.symm ?_)
+  calc
+    _ = ⟪↑x, (T - z • 1) x + z • x⟫_ℂ := by simp [sub_apply]
+    _ = ⟪x, z • x⟫_ℂ := by simp [← toFun_eq_coe, LinearMap.mem_ker.mp hx]
+    _ = ↑(‖x‖ ^ 2) * z := by simp [inner_smul_right, mul_comm]
+
 end IsSymmetric
 end LinearPMap

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -209,10 +209,11 @@ lemma HasDenseDomain.orthogonal_adjoint_ker [CompleteSpace H] [CompleteSpace H']
 ### B.2. Closability
 -/
 
-lemma IsClosable.isClosed_iff (h : U.IsClosable) : U.IsClosed ↔ U.closure = U := by
-  constructor <;> intro h'
-  · exact eq_of_eq_graph (h.graph_closure_eq_closure_graph ▸ h'.submodule_topologicalClosure_eq)
-  · exact h' ▸ h.closure_isClosed
+lemma IsClosed.closure_eq (h : U.IsClosed) : U.closure = U :=
+  eq_of_eq_graph (h.isClosable.graph_closure_eq_closure_graph ▸ h.submodule_topologicalClosure_eq)
+
+lemma IsClosable.isClosed_iff (h : U.IsClosable) : U.IsClosed ↔ U.closure = U :=
+  ⟨IsClosed.closure_eq, fun h' ↦ h' ▸ h.closure_isClosed⟩
 
 /-- A LinearPMap with densely-defined formal adjoint is closable. -/
 lemma isClosable_of_exists_dense_formalAdjoint [CompleteSpace H] [CompleteSpace H']

--- a/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
+++ b/Physlib/QuantumMechanics/DDimensions/Operators/Unbounded.lean
@@ -465,7 +465,7 @@ lemma IsClosed.isClosed_toFun_graph (hU : U.IsClosed) :
   refine isClosed_of_closure_subset fun ⟨x₁, x₂⟩ hx ↦ ?_
   simp only [SetLike.mem_coe, LinearMap.mem_graph_iff, toFun_eq_coe]
   suffices (↑x₁, x₂) ∈ U.graph.topologicalClosure by
-    simp_all [hU.isClosable.graph_closure_eq_closure_graph, hU.isClosable.isClosed_iff.mp hU]
+    simp_all [hU.isClosable.graph_closure_eq_closure_graph, hU.closure_eq]
   obtain ⟨b, hb, hbx⟩ := mem_closure_iff_seq_limit.mp hx
   apply mem_closure_iff_seq_limit.mpr
   rw [nhds_prod_eq] at *
@@ -532,7 +532,7 @@ lemma IsClosed.add_continuous [CompleteSpace H']
       _ < ε := dist_eq_norm (b n).1 (b N).1 ▸ (lt_inv_mul_iff₀ hM).mp (hN n hn)
   obtain ⟨y, hy⟩ := CompleteSpace.complete hCS
   have hU₁ : (x₁, x₂ - y) ∈ U₁.graph := by
-    rw [← h₁.isClosable.isClosed_iff.mp h₁, ← h₁.isClosable.graph_closure_eq_closure_graph]
+    rw [← h₁.closure_eq, ← h₁.isClosable.graph_closure_eq_closure_graph]
     apply mem_closure_iff_seq_limit.mpr
     refine ⟨fun n ↦ ((b n).1, (b n).2 - U₂ ⟨(b n).1, hb₁U₂ n⟩), fun n ↦ ?_, ?_⟩
     · simp_all [add_apply, eq_sub_iff_add_eq]
@@ -687,8 +687,7 @@ lemma IsSelfAdjoint.isUnbounded [CompleteSpace H] (h : IsSelfAdjoint T) : T.IsUn
 
 lemma IsSelfAdjoint.isEssentiallySelfAdjoint [CompleteSpace H] (h : IsSelfAdjoint T) :
     T.IsEssentiallySelfAdjoint :=
-  isEssentiallySelfAdjoint_def.mpr <|
-    ((IsSelfAdjoint.isClosable h).isClosed_iff.mp h.isClosed).symm ▸ h
+  isEssentiallySelfAdjoint_def.mpr (h.isClosed.closure_eq.symm ▸ h)
 
 @[aesop safe apply]
 lemma IsSelfAdjoint.adjoint [CompleteSpace H] (h : IsSelfAdjoint T) : IsSelfAdjoint T† := by
@@ -736,8 +735,7 @@ lemma IsEssentiallySelfAdjoint.unique_self_adjoint_extension [CompleteSpace H]
     T₂ = T.closure := by
   have h_dense : T.HasDenseDomain := h.hasDenseDomain
   have h_cl : T₂.IsClosed := IsSelfAdjoint.isClosed h₂
-  have h_cl' : T₂.closure = T₂ := h_cl.isClosable.isClosed_iff.mp h_cl
-  have h_le' : T.closure ≤ T₂ := h_cl' ▸ h_cl.isClosable.closure_mono h_le
+  have h_le' : T.closure ≤ T₂ := h_cl.closure_eq ▸ h_cl.isClosable.closure_mono h_le
   exact eq_of_le_of_ge (h ▸ h₂ ▸ adjoint_antitone (Or.inl <| h_dense.closure) h_le') h_le'
 
 @[aesop safe apply]


### PR DESCRIPTION
Begins the spectral theory for self-adjoint unbounded operators with a few facts about the resolvent set and spectrum:
- Two lemmas which phrase that `z ∈ ρ T`, `z ∈ T.regularityDomain` and `(T - z • 1).range = ⊤` are all equivalent.
- `spectrum_real` : The full spectrum is real (a strengthening of the familiar fact that the _point_ spectrum is real for symmetric operators).
- `residualSpectrum_eq_empty` : The residual spectrum is trivial.