### PR TITLE
refactor(Superadditive): satisfy linters and remove exemption

### DIFF
--- a/QuantumInfo/ForMathlib/Superadditive.lean
+++ b/QuantumInfo/ForMathlib/Superadditive.lean
@@ -7,8 +7,18 @@ module
 
 public import Mathlib.Analysis.Subadditive
 
+/-! # Superadditive sequences
+
+This file develops the basic theory of superadditive sequences `u : ℕ → ℝ`, mirroring
+Mathlib's `Subadditive`. A sequence is `Superadditive` when `u (m + n) ≥ u m + u n` for all
+`m n`, equivalently when `-u` is `Subadditive`. The main result is `Superadditive.tendsto_lim`,
+a version of Fekete's lemma: a superadditive sequence which is bounded above has `u n / n`
+converging to its supremum `Superadditive.lim`.
+-/
+
 @[expose] public section
 
+/-- A sequence `u : ℕ → ℝ` is superadditive if `u (m + n) ≥ u m + u n` for all `m n`. -/
 def Superadditive (u : ℕ → ℝ) : Prop :=
   ∀ m n, u (m + n) ≥ u m + u n
 
@@ -20,6 +30,8 @@ include h in
 theorem to_Subadditive : Subadditive (-u ·) :=
   (by dsimp; linarith [h · ·])
 
+/-- The limit of a superadditive sequence `u`, defined as the supremum of `u n / n` over `n ≥ 1`.
+By `Superadditive.tendsto_lim`, when `u` is bounded above this is the limit of `u n / n`. -/
 noncomputable def lim (_h : Superadditive u) :=
   sSup ((fun n : ℕ => u n / n) '' .Ici 1)
 
@@ -33,7 +45,7 @@ theorem tendsto_lim (hbdd : BddAbove (Set.range fun n => u n / n)) :
   )
   convert this.neg using 1
   · ext; rw [neg_div', neg_neg]
-  · simp only [lim, Subadditive.lim, Real.sInf_def, neg_neg, nhds_eq_nhds_iff,
+  · simp only [lim, Subadditive.lim, Real.sInf_def, neg_neg,
       ← Set.image_neg_eq_neg, Set.image_image, neg_div', neg_neg]
 
 end Superadditive

--- a/scripts/LinterExemption.txt
+++ b/scripts/LinterExemption.txt
@@ -61,7 +61,6 @@ QuantumInfo/ForMathlib/MatrixNorm/TraceNorm.lean
 QuantumInfo/ForMathlib/Minimax.lean
 QuantumInfo/ForMathlib/Misc.lean
 QuantumInfo/ForMathlib/SionMinimax.lean
-QuantumInfo/ForMathlib/Superadditive.lean
 QuantumInfo/ForMathlib/Tactic/Commutes.lean
 QuantumInfo/ForMathlib/Tactic/Commutes/Attribute.lean
 QuantumInfo/ForMathlib/ULift.lean


### PR DESCRIPTION
## Summary

This PR removes `QuantumInfo/ForMathlib/Superadditive.lean` from
`scripts/LinterExemption.txt` and fixes the issues that were preventing it from
passing the linters, so the linters now enforce the rules on this file.

## File

- `QuantumInfo/ForMathlib/Superadditive.lean`

## Linters that were failing

- **`./scripts/lint-style.sh`** (text/style linter): reported `ERR_MOD`
  (module docstring missing or too late) because the file had no `/-! ... -/`
  module docstring after its imports.
- **`lake exe runPhyslibLinters`** (Physlib/Lean linters): the `docBlame` linter
  requires doc-strings on all definitions; `Superadditive` and `Superadditive.lim`
  had none. The file also emitted an `unusedSimpArgs` warning for an unused
  `simp only` argument.

## Changes

- Added a module docstring describing superadditive sequences and Fekete's lemma.
- Added doc-strings to the `Superadditive` definition and the `Superadditive.lim`
  definition.
- Removed the unused `nhds_eq_nhds_iff` argument from the `simp only` call in
  `Superadditive.tendsto_lim`.
- Removed the file's line from `scripts/LinterExemption.txt`.

No proof statements or meanings were changed.

## Verification

- `lake build` — completes successfully.
- `lake exe runPhyslibLinters` — `Linting passed for Physlib` and
  `Linting passed for QuantumInfo`.
- `./scripts/lint-style.sh` — clean for this file.
