### PR TITLE
Susy n1 conj foundation

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -76,6 +76,7 @@ public import Physlib.Mathematics.Calculus.Divergence
 public import Physlib.Mathematics.Calculus.ParametricIntegration
 public import Physlib.Mathematics.Calculus.Wirtinger.Basic
 public import Physlib.Mathematics.Calculus.Wirtinger.Coordinate
+public import Physlib.Mathematics.ConjModule
 public import Physlib.Mathematics.DataStructures.FourTree.Basic
 public import Physlib.Mathematics.DataStructures.FourTree.UniqueMap
 public import Physlib.Mathematics.DataStructures.Matrix.LieTrace

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -356,6 +356,7 @@ public import Physlib.Relativity.Tensors.ComponentIdx.Basic
 public import Physlib.Relativity.Tensors.ComponentIdx.Contraction
 public import Physlib.Relativity.Tensors.ComponentIdx.Product
 public import Physlib.Relativity.Tensors.ComponentIdx.Single
+public import Physlib.Relativity.Tensors.Conjugation.Basic
 public import Physlib.Relativity.Tensors.Constructors
 public import Physlib.Relativity.Tensors.Contraction.Basic
 public import Physlib.Relativity.Tensors.Contraction.Basis

--- a/Physlib/Mathematics/ConjModule.lean
+++ b/Physlib/Mathematics/ConjModule.lean
@@ -68,8 +68,8 @@ def conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M where
 namespace ConjModule
 
 /-- Conjugating twice returns the original module: the `k`-linear isomorphism
-`ConjModule (ConjModule M) ≃ₗ[k] M`. It is `k`-linear, not merely semilinear, because `starRingEnd k`
-composed with itself is the identity. -/
+`ConjModule (ConjModule M) ≃ₗ[k] M`. It is `k`-linear, not merely semilinear, because
+`starRingEnd k` composed with itself is the identity. -/
 def involution : ConjModule (ConjModule M) ≃ₗ[k] M :=
   ((conjEquiv (k := k) (M := M)).trans (conjEquiv (k := k) (M := ConjModule M))).symm
 

--- a/Physlib/Mathematics/ConjModule.lean
+++ b/Physlib/Mathematics/ConjModule.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Andrea Pari. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrea Pari
+-/
+module
+
+public import Mathlib.Algebra.Module.Equiv.Defs
+public import Mathlib.Algebra.Star.Module
+public import Mathlib.LinearAlgebra.Basis.Defs
+public import Mathlib.Tactic.Ring
+
+/-!
+
+# The conjugate module
+
+Over a commutative star-ring `k`, the *conjugate module* `ConjModule M` of a `k`-module `M` is the
+same additive group with the scalar action twisted by conjugation: `r • v := star r • v`. It is the
+device that turns a sesquilinear pairing into a genuine bilinear one: a map conjugate-linear in a
+slot `M` is linear in the slot `ConjModule M`.
+
+`ConjModule M` is a type synonym carrying a fresh `Module k` instance (`Module.compHom` along
+`starRingEnd k`), so the twisted action does not leak onto `M` and vice versa. The canonical
+conjugate-linear identity `conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M`, the involution
+`ConjModule (ConjModule M) ≃ₗ[k] M`, and the transported basis `Basis.conj` are provided.
+
+## Key results
+
+- `ConjModule` : the conjugate-module type synonym, with its twisted `Module` instance.
+- `conjEquiv` : the canonical conjugate-linear equivalence `M ≃ₛₗ[starRingEnd k] ConjModule M`.
+- `ConjModule.involution` : the involution `ConjModule (ConjModule M) ≃ₗ[k] M`.
+- `Basis.conj` : a basis of `M` transported to a basis of `ConjModule M` (coordinates by `star`).
+
+-/
+
+@[expose] public section
+
+open Module
+
+variable {k : Type*} [CommRing k] [StarRing k]
+variable {M : Type*} [AddCommGroup M] [Module k M]
+
+/-- The conjugate module of `M`: the same additive group with the scalar action twisted by
+conjugation, `r • v = star r • v`. A type synonym so the twisted action stays off `M`. -/
+def ConjModule (M : Type*) := M
+
+namespace ConjModule
+
+instance : AddCommGroup (ConjModule M) := inferInstanceAs (AddCommGroup M)
+
+/-- The twisted action `r • v = star r • v`, obtained by restricting scalars along the
+conjugation ring endomorphism `starRingEnd k`. -/
+noncomputable instance instModule : Module k (ConjModule M) :=
+  Module.compHom M (starRingEnd k)
+
+lemma smul_def (r : k) (v : M) :
+    (r • (id v : ConjModule M) : ConjModule M) = (star r • v : M) := rfl
+
+end ConjModule
+
+/-- The canonical conjugate-linear equivalence `M ≃ₛₗ[starRingEnd k] ConjModule M`, the identity on
+the underlying additive group. -/
+noncomputable def conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M where
+  toFun v := v
+  map_add' _ _ := rfl
+  map_smul' r v := by show (r • v : M) = (star (star r) • v : M); rw [star_star]
+  invFun v := v
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+namespace ConjModule
+
+/-- Conjugating twice returns the original module: `ConjModule (ConjModule M) ≃ₗ[k] M`. Built by
+composing the two `conjEquiv`s (`starRingEnd ∘ starRingEnd = id`) and taking the inverse. -/
+noncomputable def involution : ConjModule (ConjModule M) ≃ₗ[k] M :=
+  ((conjEquiv (k := k) (M := M)).trans (conjEquiv (k := k) (M := ConjModule M))).symm
+
+variable {ι : Type*}
+
+/-- Coordinate-wise conjugation on `ι →₀ k`, a conjugate-linear self-equivalence. -/
+noncomputable def starFinsupp : (ι →₀ k) ≃ₛₗ[starRingEnd k] (ι →₀ k) where
+  toFun f := f.mapRange star (star_zero k)
+  invFun f := f.mapRange star (star_zero k)
+  map_add' f g := by ext i; simp [Finsupp.mapRange_apply, star_add]
+  map_smul' r f := by
+    ext i
+    simp only [Finsupp.mapRange_apply, Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul,
+      starRingEnd_apply, star_mul']
+  left_inv f := by ext i; simp [Finsupp.mapRange_apply]
+  right_inv f := by ext i; simp [Finsupp.mapRange_apply]
+
+/-- A basis of `M` transported to a basis of `ConjModule M`: the same basis vectors, with
+coordinates conjugated (`(Basis.conj b).repr v = star ∘ b.repr v`). -/
+noncomputable def _root_.Basis.conj (b : Basis ι k M) : Basis ι k (ConjModule M) :=
+  Basis.ofRepr
+    (((conjEquiv (k := k) (M := M)).symm.trans b.repr).trans starFinsupp)
+
+end ConjModule
+
+end

--- a/Physlib/Mathematics/ConjModule.lean
+++ b/Physlib/Mathematics/ConjModule.lean
@@ -15,9 +15,9 @@ public import Mathlib.Tactic.Ring
 # The conjugate module
 
 Over a commutative star-ring `k`, the *conjugate module* `ConjModule M` of a `k`-module `M` is the
-same additive group with the scalar action twisted by conjugation: `r • v := star r • v`. It is the
-device that turns a sesquilinear pairing into a genuine bilinear one: a map conjugate-linear in a
-slot `M` is linear in the slot `ConjModule M`.
+same additive group with the scalar action twisted by conjugation: `r • v := star r • v`. It turns a
+sesquilinear pairing into a bilinear one: a map conjugate-linear in a slot `M` is linear in the slot
+`ConjModule M`.
 
 `ConjModule M` is a type synonym carrying a fresh `Module k` instance (`Module.compHom` along
 `starRingEnd k`), so the twisted action does not leak onto `M` and vice versa. The canonical
@@ -50,17 +50,14 @@ instance : AddCommGroup (ConjModule M) := inferInstanceAs (AddCommGroup M)
 
 /-- The twisted action `r • v = star r • v`, obtained by restricting scalars along the
 conjugation ring endomorphism `starRingEnd k`. -/
-noncomputable instance instModule : Module k (ConjModule M) :=
+instance instModule : Module k (ConjModule M) :=
   Module.compHom M (starRingEnd k)
-
-lemma smul_def (r : k) (v : M) :
-    (r • (id v : ConjModule M) : ConjModule M) = (star r • v : M) := rfl
 
 end ConjModule
 
 /-- The canonical conjugate-linear equivalence `M ≃ₛₗ[starRingEnd k] ConjModule M`, the identity on
 the underlying additive group. -/
-noncomputable def conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M where
+def conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M where
   toFun v := v
   map_add' _ _ := rfl
   map_smul' r v := by show (r • v : M) = (star (star r) • v : M); rw [star_star]
@@ -70,9 +67,10 @@ noncomputable def conjEquiv : M ≃ₛₗ[starRingEnd k] ConjModule M where
 
 namespace ConjModule
 
-/-- Conjugating twice returns the original module: `ConjModule (ConjModule M) ≃ₗ[k] M`. Built by
-composing the two `conjEquiv`s (`starRingEnd ∘ starRingEnd = id`) and taking the inverse. -/
-noncomputable def involution : ConjModule (ConjModule M) ≃ₗ[k] M :=
+/-- Conjugating twice returns the original module: the `k`-linear isomorphism
+`ConjModule (ConjModule M) ≃ₗ[k] M`. It is `k`-linear, not merely semilinear, because `starRingEnd k`
+composed with itself is the identity. -/
+def involution : ConjModule (ConjModule M) ≃ₗ[k] M :=
   ((conjEquiv (k := k) (M := M)).trans (conjEquiv (k := k) (M := ConjModule M))).symm
 
 variable {ι : Type*}
@@ -94,6 +92,19 @@ coordinates conjugated (`(Basis.conj b).repr v = star ∘ b.repr v`). -/
 noncomputable def _root_.Basis.conj (b : Basis ι k M) : Basis ι k (ConjModule M) :=
   Basis.ofRepr
     (((conjEquiv (k := k) (M := M)).symm.trans b.repr).trans starFinsupp)
+
+/-- Coordinates in `Basis.conj b` are the `star` of the coordinates in `b`. -/
+@[simp] lemma _root_.Basis.conj_repr_apply (b : Basis ι k M) (v : ConjModule M) (i : ι) :
+    (Basis.conj b).repr v i = star (b.repr ((conjEquiv (k := k) (M := M)).symm v) i) := rfl
+
+/-- The basis vectors of `Basis.conj b` are those of `b`, viewed through `conjEquiv`. -/
+@[simp] lemma _root_.Basis.conj_apply (b : Basis ι k M) (i : ι) :
+    Basis.conj b i = conjEquiv (k := k) (M := M) (b i) := by
+  apply (Basis.conj b).repr.injective
+  ext j
+  rcases eq_or_ne j i with h | h
+  · subst h; simp [Basis.conj_repr_apply]
+  · simp [Basis.conj_repr_apply, Finsupp.single_eq_of_ne, h]
 
 end ConjModule
 

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -54,24 +54,21 @@ Contracting a colour against its `τ`-dual is
 the dot product of their coordinate vectors in the fixed basis, which on basis
 labels is the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the
 same element, the δ "cap" `∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`.
-Supplying this `TensorSpecies` instance equips the chiral sector with the
-framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
+Supplying this instance equips the chiral sector with the framework's generic
+tensor API (`.Tensor`, `.contrT`, and so on).
 
-Conjugation is a separate operation layered on top of the species. The species
-fixes which indices contract (via `τ`) but has no notion of complex-conjugating
-a tensor; that is the role of `TensorSpecies.Conj`, a structure parameterized by
-a species. The chiral sector opts in with `chiralConjStructure` (§F), supplying
-the map `conjT` (conjugate the components and flip each index's holomorphy by
-`ChiralColor.bar`) and its laws. `bar` is the holomorphy dual, distinct from and
-commuting with the variance dual `τ`; it is not used in contraction.
+Conjugation is intrinsic species data, bundled into the same object: `chiralTensor`
+is a `ConjTensorSpecies`, a `TensorSpecies` extended with the conjugate-colour
+involution `ChiralColor.bar` and its coherence. The framework then supplies the
+map `conjT` (conjugate the components and flip each index's holomorphy by `bar`)
+and its laws. `bar` is the holomorphy dual, distinct from and commuting with the
+variance dual `τ`; it is not used in contraction.
 
 Conjugation enters wherever reality does. It is what lets one state that the
 Kähler metric is Hermitian (`conjT g` equals `g` with its two indices swapped),
 that the anti-chiral sector is the complex conjugate of the chiral one
 (`D̄_J̄ W̄ = conjT (D_I W)`), and hence that the F-term `g^{IJ̄} D_I W D̄_J̄ W̄`
-is real. The species can express none of these alone. Since `chiralConjStructure`
-has type `(chiralTensor …).Conj` and its coherence is a fact about
-`chiralTensor`'s contraction, it necessarily follows the species definition (§F).
+is real. The species can express none of these alone.
 
 ## ii. Key results
 
@@ -80,11 +77,9 @@ has type `(chiralTensor …).Conj` and its coherence is a fact about
     field data in the sector.
 - `SUSY.N1.ChiralColor` : the four colours `chiral`/`anti` × `up`/`down`, with the
     dual-colour involution `ChiralColor.tau`.
-- `SUSY.N1.chiralTensor` : the `TensorSpecies` assembled from the above, whose
-    `τ`-discipline makes the F-term contraction type-safe.
-- `SUSY.N1.chiralConjStructure` : the `TensorSpecies.Conj` instance realizing the
-    chiral-antichiral conjugation carried by `ChiralColor.bar`, the operation in
-    which reality and Hermiticity conditions are phrased.
+- `SUSY.N1.chiralTensor` : the `ConjTensorSpecies` assembled from the above, whose
+    `τ`-discipline makes the F-term contraction type-safe and whose `bar` carries the
+    chiral-antichiral conjugation in which reality and Hermiticity conditions are phrased.
 
 ## iii. Table of contents
 
@@ -98,7 +93,7 @@ has type `(chiralTensor …).Conj` and its coherence is a fact about
   - D.4. The coherence laws in `toSpanSingleton` form
 - E. The chiral-index tensor species
 - F. Conjugation
-  - F.1. The conjugation structure
+  - F.1. Smoke tests
   - F.2. Scalar and covector helpers
 
 ## iv. References
@@ -407,12 +402,15 @@ lemma deltaContr_metric (b : Basis ι ℂ M) :
 
 -/
 
-/-- The chiral-index tensor species. Its colours are `chiral`/`anti` × `up`/`down`, all carried
-by `ι → ℂ`, and every colour contracts by the bare δ pairing with the δ cap serving as both
-metric and unit. Each coherence law reduces, by case analysis on the colour, to the
-corresponding abstract δ lemma above. Instantiating `TensorSpecies` this way gives the chiral
-sector the framework's generic tensor API. -/
-def chiralTensor : TensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fun _ => ι)
+/-- The chiral-index tensor species, bundled with its conjugation. Its colours are
+`chiral`/`anti` × `up`/`down`, all carried by `ι → ℂ`, and every colour contracts by the bare δ
+pairing with the δ cap serving as both metric and unit. Each `TensorSpecies` coherence law reduces,
+by case analysis on the colour, to the corresponding abstract δ lemma above. The conjugation flips
+holomorphy (`ChiralColor.bar`) while preserving variance; since every colour shares the index type
+`ι`, the identification `barIdx_eq` is `rfl`, and `conj_contrComm` is `star δ = δ`. Instantiating
+`ConjTensorSpecies` this way gives the chiral sector both the framework's generic tensor API and
+its conjugation API (`conjT` and its laws) on one object. -/
+def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fun _ => ι)
     (chiralRep (ι := ι) (G := G)) (chiralBasis (ι := ι)) where
   τ := ChiralColor.tau
   τ_involution c := by cases c <;> rfl
@@ -428,6 +426,19 @@ def chiralTensor : TensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fu
   unit_symm c := by cases c <;> exact deltaUnit_symm _
   contr_unit c x := by cases c <;> exact deltaContr_unit _ x
   contr_metric c := by cases c <;> exact deltaContr_metric _
+  -- Conjugation data: `bar` flips holomorphy, the index set is shared (`rfl`), `star δ = δ`.
+  bar := ChiralColor.bar
+  bar_involution := ChiralColor.bar_bar
+  bar_tau := ChiralColor.bar_tau
+  barIdx_eq _ := rfl
+  conj_contrComm := by
+    intro d x₁ x₂
+    -- Every colour's contraction is the real δ, so `star` fixes it; the `bar`-side casts are `rfl`,
+    -- so each case reduces by defeq to this single fact.
+    have h : star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
+        = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂) := by
+      rw [deltaContr_basis_basis]; split <;> simp
+    cases d <;> exact h
 
 /-- Type-safety smoke test. `chiralUp` and `chiralDown` are `τ`-dual, so a rank-2 tensor with
 those index colours admits the framework contraction `contrT`. A same-variance pair would
@@ -441,69 +452,47 @@ example (t : (chiralTensor (ι := ι) (G := G)).Tensor
 /-!
 ## F. Conjugation
 
-Conjugation is a layer on top of the species of §E, not part of it: `TensorSpecies.Conj S` is a
-structure parameterized by a species `S`, and the framework defines the conjugation map `conjT`
-and its laws once, abstractly, against any species that supplies one. This section therefore
-follows §E: `chiralConjStructure` has type `(chiralTensor …).Conj`, and its `conj_contrComm`
-field is a fact about `chiralTensor`'s contraction, neither of which can be stated before the
-species exists.
-
-The chiral sector's conjugation flips holomorphy (`ChiralColor.bar`) while preserving variance, and
-through the resulting `conjT` the reality and Hermiticity conditions are phrased. The basis index
-type `ι` is the same for every colour, so the index identification `barIdx_eq` is `rfl` and the
-component reindexing is the identity.
-
-### F.1. The conjugation structure
+Conjugation is bundled into `chiralTensor` itself (§E): as a `ConjTensorSpecies` it carries `bar`
+beside `τ`, and the framework supplies the conjugation map `conjT` and its laws (`conjT_smul`,
+`conjT_conjT`, `conjT_contrT`, `conjT_eq_permT_iff`) once, abstractly, against any
+`ConjTensorSpecies`. The chiral sector's conjugation flips holomorphy (`ChiralColor.bar`) while
+preserving variance, and through `chiralTensor.conjT` the reality and Hermiticity conditions are
+phrased. The basis index type `ι` is the same for every colour, so the identification `barIdx_eq`
+is `rfl` and the component reindexing is the identity.
 
 -/
 
 section Conjugation
 
-open TensorSpecies TensorSpecies.Tensor ChiralColor
+open TensorSpecies TensorSpecies.Tensor ConjTensorSpecies ChiralColor
 
-/-- The chiralTensor contraction coefficient of two basis vectors is the Kronecker δ, stated at
-the colour level so it matches goals carrying `chiralModule d`. -/
-lemma chiralTensor_contr_chiralBasis (d : ChiralColor) (x₁ x₂ : ι) :
-    (chiralTensor (ι := ι) (G := G)).contr d
-        (chiralBasis d x₁ ⊗ₜ[ℂ] chiralBasis ((chiralTensor (ι := ι) (G := G)).τ d) x₂)
-      = if x₁ = x₂ then 1 else 0 := by
-  cases d <;>
-    exact deltaContr_basis_basis _ x₁ x₂
+/-!
+### F.1. Smoke tests
 
-/-- The conjugation structure on the chiral tensor species: `bar` flips holomorphy while
-preserving variance, and the basis labels of each colour are identified with those of its
-conjugate via the identity (both carry the same index type `ι`). -/
-def chiralConjStructure : (chiralTensor (ι := ι) (G := G)).Conj where
-  bar := ChiralColor.bar
-  bar_involution := ChiralColor.bar_bar
-  bar_tau := ChiralColor.bar_tau
-  barIdx_eq _ := rfl
-  conj_contrComm := by
-    intro d x₁ x₂
-    cases d <;> simp [chiralTensor_contr_chiralBasis, apply_ite (starRingEnd ℂ), basisIdxCongr]
+Type-safety and behaviour checks for `chiralTensor`'s conjugation.
+-/
 
--- Smoke tests: type-safety and behaviour checks for `chiralConjStructure`.
-
-/-- Conjugating a metric-typed tensor `g : Tensor ![chiralDown, antiDown]` via `chiralConjStructure`
+/-- Conjugating a metric-typed tensor `g : Tensor ![chiralDown, antiDown]` via `chiralTensor.conjT`
 lands in the conjugate-colour list `ChiralColor.bar ∘ ![chiralDown, antiDown]`, i.e.
 `![antiDown, chiralDown]`. This is purely a type-safety check. -/
 example (g : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown, antiDown]) :
     (chiralTensor (ι := ι) (G := G)).Tensor (ChiralColor.bar ∘ ![chiralDown, antiDown]) :=
-  chiralConjStructure.conjT g
+  (chiralTensor (ι := ι) (G := G)).conjT g
 
 /-- `conjT_contrT` applies to a one-index contraction: conjugating first and then contracting
 equals contracting the conjugate. Checked at colour `![chiralUp, chiralDown]` contracted at
 slots `0` and `1`. -/
 example (t : (chiralTensor (ι := ι) (G := G)).Tensor
     ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
-    chiralConjStructure.conjT (TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t)
-      = TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ (chiralConjStructure.conjT t) :=
-  chiralConjStructure.conjT_contrT 0 1 ⟨by decide, rfl⟩ t
+    (chiralTensor (ι := ι) (G := G)).conjT (TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t)
+      = TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩
+          ((chiralTensor (ι := ι) (G := G)).conjT t) :=
+  (chiralTensor (ι := ι) (G := G)).conjT_contrT 0 1 ⟨by decide, rfl⟩ t
 
 /-!
 ### F.2. Scalar and covector helpers
 
-These two definitions normalize the output of `chiralConjStructure.conjT` back to the canonical
+These two definitions normalize the output of `(chiralTensor (ι := ι) (G := G)).conjT` back to the canonical
 colour lists for scalar and anti-holomorphic covector tensors respectively.
 
 -/
@@ -512,7 +501,7 @@ colour lists for scalar and anti-holomorphic covector tensors respectively.
 def conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
     (chiralTensor (ι := ι) (G := G)).Tensor ![] :=
   permT id ⟨Function.bijective_id, fun i => by fin_cases i⟩
-    (chiralConjStructure.conjT t)
+    ((chiralTensor (ι := ι) (G := G)).conjT t)
 
 /-- Conjugation of a holomorphic covector, normalized to the anti-holomorphic covector colour
 list `![antiDown]`. -/
@@ -520,7 +509,7 @@ def conjChiralCovector
     (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
     (chiralTensor (ι := ι) (G := G)).Tensor ![antiDown] :=
   permT ![0] ⟨by decide, fun i => by fin_cases i; rfl⟩
-    (chiralConjStructure.conjT t)
+    ((chiralTensor (ι := ι) (G := G)).conjT t)
 
 /-- For scalar tensors, `toField` of the normalized tensor conjugate is the complex conjugate of
 `toField`. -/
@@ -528,25 +517,25 @@ theorem toField_conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
     (conjScalar t).toField = star t.toField := by
   rw [conjScalar, toField_permT]
   rw [toField_eq_repr, toField_eq_repr]
-  change componentMap (S := chiralTensor (ι := ι) (G := G))
-      (chiralConjStructure.bar ∘ ![]) (chiralConjStructure.conjT t) (fun j => Fin.elim0 j) =
-    star ((basis (S := chiralTensor (ι := ι) (G := G)) ![]).repr t (fun j => Fin.elim0 j))
-  rw [TensorSpecies.Conj.componentMap_conjT (cj := chiralConjStructure)]
+  change componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
+      ((chiralTensor (ι := ι) (G := G)).bar ∘ ![]) ((chiralTensor (ι := ι) (G := G)).conjT t) (fun j => Fin.elim0 j) =
+    star ((basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![]).repr t (fun j => Fin.elim0 j))
+  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι) (G := G))]
   rfl
 
 /-- Component formula for the holomorphic covector conjugate: the `![I]` basis component of
 `conjChiralCovector t` is the complex conjugate of the `![I]` component of `t`. -/
 theorem repr_conjChiralCovector
     (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) (I : ι) :
-    (basis (S := chiralTensor (ι := ι) (G := G)) ![antiDown]).repr
+    (basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![antiDown]).repr
         (conjChiralCovector t) ![I] =
-      star ((basis (S := chiralTensor (ι := ι) (G := G)) ![chiralDown]).repr t ![I]) := by
+      star ((basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![chiralDown]).repr t ![I]) := by
   rw [conjChiralCovector, permT_basis_repr_symm_apply]
-  change componentMap (S := chiralTensor (ι := ι) (G := G))
-      (chiralConjStructure.bar ∘ ![chiralDown]) (chiralConjStructure.conjT t) _ = _
-  rw [TensorSpecies.Conj.componentMap_conjT (cj := chiralConjStructure)]
+  change componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
+      ((chiralTensor (ι := ι) (G := G)).bar ∘ ![chiralDown]) ((chiralTensor (ι := ι) (G := G)).conjT t) _ = _
+  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι) (G := G))]
   apply congrArg star
-  apply congrArg (fun idx => componentMap (S := chiralTensor (ι := ι) (G := G))
+  apply congrArg (fun idx => componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
     ![chiralDown] t idx)
   funext i
   fin_cases i
@@ -557,7 +546,7 @@ theorem repr_conjChiralCovector
 theorem conjChiralCovector_add
     (t₁ t₂ : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
     conjChiralCovector (t₁ + t₂) = conjChiralCovector t₁ + conjChiralCovector t₂ := by
-  rw [conjChiralCovector, chiralConjStructure.conjT_add]
+  rw [conjChiralCovector, (chiralTensor (ι := ι) (G := G)).conjT_add]
   simp [conjChiralCovector, map_add]
 
 /-- Conjugation of a holomorphic covector is conjugate-linear: a scalar `r` pulls out as
@@ -566,7 +555,7 @@ theorem conjChiralCovector_add
 theorem conjChiralCovector_smul (r : ℂ)
     (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
     conjChiralCovector (r • t) = star r • conjChiralCovector t := by
-  rw [conjChiralCovector, chiralConjStructure.conjT_smul]
+  rw [conjChiralCovector, (chiralTensor (ι := ι) (G := G)).conjT_smul]
   simp [conjChiralCovector]
 
 end Conjugation

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -39,17 +39,18 @@ configuration.
 The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`. The chiral
 colours carry the standard carrier `ι → ℂ`; the anti colours carry its conjugate
 module `ConjModule (ι → ℂ)`, where `i` acts as `−i`, so anti-holomorphy is genuine
-carrier data and complex conjugation is an honest linear map between the two. Each
-carries the trivial `G`-representation, so `G` acts as the identity and the chiral
-scalars hold no `G`-charge. Contracting a colour against its `τ`-dual is the dot
+carrier data. Complex conjugation is then the conjugate-linear identity
+`conjEquiv : (ι → ℂ) ≃ₛₗ[starRingEnd ℂ] ConjModule (ι → ℂ)`: the anti basis is its transport
+`Basis.conj piBasis`, and the species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Each
+colour carries the trivial representation over the trivial group `Unit`, so the chiral scalars hold no
+charge. Contracting a colour against its `τ`-dual is the dot
 product of their coordinate vectors in that colour's basis, which on basis labels is
 the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the δ "cap"
 `∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`. Supplying this instance equips the
 chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
 
-Conjugation is intrinsic species data, bundled into the same object: `chiralTensor`
-is a `ConjTensorSpecies`, a `TensorSpecies` extended with the conjugate-colour
-involution `ChiralColor.bar` and its coherence. The framework then supplies the
+Conjugation is intrinsic species data: a `ConjTensorSpecies` is a `TensorSpecies`
+extended with the conjugate-colour involution `ChiralColor.bar` and its coherence. The framework then supplies the
 map `conjT` (conjugate the components and flip each index's holomorphy by `bar`)
 and its laws. `bar` is the holomorphy dual, distinct from and commuting with the
 variance dual `τ`; it is not used in contraction.
@@ -105,7 +106,6 @@ through it to `α → ℂ` and applies Mathlib's function-space calculus lemmas 
 abbrev ChiralScalarConfiguration (ChiralIndexingType : Type*) := ChiralIndexingType → ℂ
 
 variable (ι : Type) [Fintype ι] [DecidableEq ι]
-variable (G : Type) [Group G]
 
 /-!
 ## B. The chiral colours and the dual involution
@@ -145,15 +145,15 @@ def bar : ChiralColor → ChiralColor
 
 end ChiralColor
 
-variable {ι G}
+variable {ι}
 
 /-!
 ## C. Carrier, representation, and basis
 
-A `TensorSpecies` takes, for each colour `c`, a carrier module, a `G`-representation on it, and a
+A `TensorSpecies` takes, for each colour `c`, a carrier module, a group representation on it, and a
 basis. The carrier depends on holomorphy: chiral colours carry the standard `ι → ℂ`, anti colours
 its conjugate module `ConjModule (ι → ℂ)` (so anti-holomorphy is genuine carrier data). The
-`G`-representation is trivial (no `G`-charge) for every colour; the basis is the indicator basis
+representation is trivial over the trivial group `Unit` (no charge) for every colour; the basis is the indicator basis
 `piBasis` on the chiral carrier and its conjugate `Basis.conj piBasis` on the anti carrier. Variance
 (`τ`) preserves holomorphy, so it never leaves a colour's carrier; conjugation (`bar`) flips
 holomorphy and so maps a carrier to its conjugate.
@@ -176,10 +176,10 @@ noncomputable instance instModuleChiralModule : ∀ c, Module ℂ (chiralModule 
   | .chiralUp | .chiralDown => inferInstance
   | .antiUp | .antiDown => inferInstance
 
-/-- The `G`-representation on each colour, taken trivial: the chiral scalars carry no
-`G`-charge in this sector. -/
-def chiralRep : (c : ChiralColor) → Representation ℂ G (chiralModule (ι := ι) c) :=
-  fun _ => Representation.trivial ℂ G _
+/-- The representation on each colour, taken trivial over the trivial group `Unit`: the chiral
+scalars carry no charge in this sector. -/
+def chiralRep : (c : ChiralColor) → Representation ℂ Unit (chiralModule (ι := ι) c) :=
+  fun _ => Representation.trivial ℂ Unit _
 
 /-- The standard basis of the chiral carrier `ι → ℂ` (the indicator functions). -/
 def piBasis : Basis ι ℂ (ι → ℂ) := Pi.basisFun ℂ ι
@@ -404,8 +404,8 @@ The conjugation flips holomorphy (`ChiralColor.bar`) while preserving variance; 
 is shared, so `barIdx_eq` is `rfl`, and `conj_contrComm` is `star δ = δ`. Instantiating
 `ConjTensorSpecies` this way gives the chiral sector both the framework's generic tensor API and
 its conjugation API (`conjT` and its laws) on one object. -/
-def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fun _ => ι)
-    (chiralRep (ι := ι) (G := G)) (chiralBasis (ι := ι)) where
+def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := ι)) (fun _ => ι)
+    (chiralRep (ι := ι)) (chiralBasis (ι := ι)) where
   τ := ChiralColor.tau
   τ_involution c := by cases c <;> rfl
   -- The δ data at each colour's own basis: `piBasis` on the chiral carrier, `Basis.conj piBasis`
@@ -464,6 +464,13 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι))
 /-!
 ## F. Conjugation
 
+Reality is a physical input the bare species cannot express: that the anti-chiral fields are the
+complex conjugates of the chiral ones, that the Kähler metric is Hermitian, that the F-term
+potential is real. Each is a statement that some quantity equals its own conjugate, so it can only
+be phrased once conjugation is available. This section exposes that operation for the two shapes the
+sector actually conjugates — the scalar `W` and the holomorphic covector `D_I W` — and certifies on
+components that it is honest complex conjugation.
+
 Conjugation is bundled into `chiralTensor` itself (§E): as a `ConjTensorSpecies` it carries `bar`
 beside `τ`, and the framework supplies the conjugation map `conjT` and its laws (`conjT_smul`,
 `conjT_conjT`, `conjT_contrT`, `conjT_eq_permT_iff`) once, abstractly, against any
@@ -479,50 +486,50 @@ section Conjugation
 open TensorSpecies TensorSpecies.Tensor ConjTensorSpecies ChiralColor
 
 /-!
-The following normalize the output of `(chiralTensor (ι := ι) (G := G)).conjT` back to the
+The following normalize the output of `(chiralTensor (ι := ι)).conjT` back to the
 canonical colour lists for scalar and anti-holomorphic covector tensors respectively.
 
 -/
 
 /-- Conjugation of a scalar tensor, normalized back to the scalar colour list `![]`. -/
-def conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
-    (chiralTensor (ι := ι) (G := G)).Tensor ![] :=
+def conjScalar (t : (chiralTensor (ι := ι)).Tensor ![]) :
+    (chiralTensor (ι := ι)).Tensor ![] :=
   permT id ⟨Function.bijective_id, fun i => by fin_cases i⟩
-    ((chiralTensor (ι := ι) (G := G)).conjT t)
+    ((chiralTensor (ι := ι)).conjT t)
 
 /-- Conjugation of a holomorphic covector, normalized to the anti-holomorphic covector colour
 list `![antiDown]`. -/
 def conjChiralCovector
-    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
-    (chiralTensor (ι := ι) (G := G)).Tensor ![antiDown] :=
+    (t : (chiralTensor (ι := ι)).Tensor ![chiralDown]) :
+    (chiralTensor (ι := ι)).Tensor ![antiDown] :=
   permT ![0] ⟨by decide, fun i => by fin_cases i; rfl⟩
-    ((chiralTensor (ι := ι) (G := G)).conjT t)
+    ((chiralTensor (ι := ι)).conjT t)
 
 /-- For scalar tensors, `toField` of the normalized tensor conjugate is the complex conjugate of
 `toField`. -/
-theorem toField_conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
+lemma toField_conjScalar (t : (chiralTensor (ι := ι)).Tensor ![]) :
     (conjScalar t).toField = star t.toField := by
   rw [conjScalar, toField_permT]
   rw [toField_eq_repr, toField_eq_repr]
-  change componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
-      ((chiralTensor (ι := ι) (G := G)).bar ∘ ![]) ((chiralTensor (ι := ι) (G := G)).conjT t) (fun j => Fin.elim0 j) =
-    star ((basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![]).repr t (fun j => Fin.elim0 j))
-  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι) (G := G))]
+  change componentMap (S := (chiralTensor (ι := ι)).toTensorSpecies)
+      ((chiralTensor (ι := ι)).bar ∘ ![]) ((chiralTensor (ι := ι)).conjT t) (fun j => Fin.elim0 j) =
+    star ((basis (S := (chiralTensor (ι := ι)).toTensorSpecies) ![]).repr t (fun j => Fin.elim0 j))
+  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι))]
   rfl
 
 /-- Component formula for the holomorphic covector conjugate: the `![I]` basis component of
 `conjChiralCovector t` is the complex conjugate of the `![I]` component of `t`. -/
-theorem repr_conjChiralCovector
-    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) (I : ι) :
-    (basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![antiDown]).repr
+lemma repr_conjChiralCovector
+    (t : (chiralTensor (ι := ι)).Tensor ![chiralDown]) (I : ι) :
+    (basis (S := (chiralTensor (ι := ι)).toTensorSpecies) ![antiDown]).repr
         (conjChiralCovector t) ![I] =
-      star ((basis (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies) ![chiralDown]).repr t ![I]) := by
+      star ((basis (S := (chiralTensor (ι := ι)).toTensorSpecies) ![chiralDown]).repr t ![I]) := by
   rw [conjChiralCovector, permT_basis_repr_symm_apply]
-  change componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
-      ((chiralTensor (ι := ι) (G := G)).bar ∘ ![chiralDown]) ((chiralTensor (ι := ι) (G := G)).conjT t) _ = _
-  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι) (G := G))]
+  change componentMap (S := (chiralTensor (ι := ι)).toTensorSpecies)
+      ((chiralTensor (ι := ι)).bar ∘ ![chiralDown]) ((chiralTensor (ι := ι)).conjT t) _ = _
+  rw [ConjTensorSpecies.componentMap_conjT (S := chiralTensor (ι := ι))]
   apply congrArg star
-  apply congrArg (fun idx => componentMap (S := (chiralTensor (ι := ι) (G := G)).toTensorSpecies)
+  apply congrArg (fun idx => componentMap (S := (chiralTensor (ι := ι)).toTensorSpecies)
     ![chiralDown] t idx)
   funext i
   fin_cases i
@@ -530,19 +537,19 @@ theorem repr_conjChiralCovector
 
 /-- Conjugation of a holomorphic covector is additive. -/
 @[simp]
-theorem conjChiralCovector_add
-    (t₁ t₂ : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
+lemma conjChiralCovector_add
+    (t₁ t₂ : (chiralTensor (ι := ι)).Tensor ![chiralDown]) :
     conjChiralCovector (t₁ + t₂) = conjChiralCovector t₁ + conjChiralCovector t₂ := by
-  rw [conjChiralCovector, (chiralTensor (ι := ι) (G := G)).conjT_add]
+  rw [conjChiralCovector, (chiralTensor (ι := ι)).conjT_add]
   simp [conjChiralCovector, map_add]
 
 /-- Conjugation of a holomorphic covector is conjugate-linear: a scalar `r` pulls out as
 `star r`. -/
 @[simp]
-theorem conjChiralCovector_smul (r : ℂ)
-    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
+lemma conjChiralCovector_smul (r : ℂ)
+    (t : (chiralTensor (ι := ι)).Tensor ![chiralDown]) :
     conjChiralCovector (r • t) = star r • conjChiralCovector t := by
-  rw [conjChiralCovector, (chiralTensor (ι := ι) (G := G)).conjT_smul]
+  rw [conjChiralCovector, (chiralTensor (ι := ι)).conjT_smul]
   simp [conjChiralCovector]
 
 end Conjugation

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -5,81 +5,569 @@ Authors: Andrea Pari
 -/
 module
 
-public import Mathlib.Data.Fintype.Defs
-public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Logic.Equiv.Basic
+public import Physlib.Relativity.Tensors.TensorSpecies.Basic
+public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RepresentationTheory.Intertwining
+public import Mathlib.Data.Complex.Basic
+public import Mathlib.LinearAlgebra.Basis.Defs
+public import Mathlib.LinearAlgebra.StdBasis
+public import Mathlib.Algebra.Group.TransferInstance
+public import Mathlib.Algebra.Module.TransferInstance
+public import Mathlib.Algebra.Module.RingHom
+-- Contraction machinery for the type-safety smoke test below. Public because the test lives
+-- in the public section and references `TensorSpecies.Tensor` and `contrT`.
+public import Physlib.Relativity.Tensors.Contraction.Basic
+public import Physlib.Relativity.Tensors.Conjugation.Basic
 
 /-!
 
-# SUSY N=1 chiral sector — basic indexing data
+# SUSY N=1 chiral sector: index, configuration, and conjugation data
 
 ## i. Overview
 
-The minimal label and configuration data for the N=1 chiral sector.
+This file fixes the data that indexes the scalars of the N=1 chiral sector,
+makes their contractions type-safe, and equips them with conjugation.
 
-A `Model` packages two finite index types — `ChiralIndexingType` (written `C`
-below) indexing the chiral scalars and `AntiChiralIndexingType` (written `A`)
-the anti-chiral (barred) slots — with an equivalence `equiv : C ≃ A`, kept
-distinct so the two slots of a contraction `g_{IJ̄}` cannot be confused. The
-physical configuration is `ChiralScalarConfiguration C = C → ℂ`, carrying
-`2 · Fintype.card C` real degrees of freedom — the only field data; the
-anti-chiral scalars are its complex conjugates, never an independent
+A single finite type `ι` indexes the chiral scalars; it appears as
+`ChiralIndexingType` in the signatures. It is the only index type. Variance
+(upper versus lower) and holomorphy (a scalar versus its complex conjugate) are
+not separate index types but the two axes of a four-element type `ChiralColor`,
+the product of `chiral`/`anti` with `up`/`down`.
+
+The dual-colour involution `τ` flips variance and preserves holomorphy. Two
+indices may contract exactly when their colours are `τ`-related, so a holomorphic
+index pairs only with a holomorphic index of the opposite variance, and a
+conjugate ("barred") index only with a conjugate index of the opposite variance.
+This is the discipline that makes the F-term contraction `g^{IJ̄} D_I W D̄_J̄ W̄`
+type-check.
+
+The physical field content is the configuration `ChiralScalarConfiguration ι =
+ι → ℂ`, carrying `2 · Fintype.card ι` real degrees of freedom. The anti-chiral
+scalars are the complex conjugates of this data, never an independent
 configuration.
 
-Doubling — adding an independent `A → ℂ` configuration — is the wrong choice:
-the physical identities would then hold only where anti-chiral is the conjugate
-of chiral, so every theorem carries that subspace as a hypothesis (e.g. the
-Kähler potential is real only there, making hermiticity of `g_{IJ̄}`
-conditional). Building the conjugate in keeps them unconditional — `K` is real
-by construction — and leaves `A` an index type only.
+The index data is packaged as a `TensorSpecies` over `ChiralColor`. Every colour
+shares the one carrier `ι → ℂ`; the four colours are labels recording variance
+and holomorphy, not distinct spaces. Each carries the trivial `G`-representation,
+so `G` acts as the identity and the chiral scalars hold no `G`-charge.
+Contracting a colour against its `τ`-dual is
+the dot product of their coordinate vectors in the fixed basis, which on basis
+labels is the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the
+same element, the δ "cap" `∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`.
+Supplying this `TensorSpecies` instance equips the chiral sector with the
+framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
 
-This file carries only the index/configuration data; the chiral and anti-chiral
-derivatives `∂_I` / `∂_J̄` (the `Model` methods `M.dChiralScalar` /
-`M.dAntiChiralScalar`) are built on top of it in `Derivative.lean`.
+Conjugation is a separate operation layered on top of the species. The species
+fixes which indices contract (via `τ`) but has no notion of complex-conjugating
+a tensor; that is the role of `TensorSpecies.Conj`, a structure parameterized by
+a species. The chiral sector opts in with `chiralConjStructure` (§F), supplying
+the map `conjT` (conjugate the components and flip each index's holomorphy by
+`ChiralColor.bar`) and its laws. `bar` is the holomorphy dual, distinct from and
+commuting with the variance dual `τ`; it is not used in contraction.
 
-The files of this `Particles/SuperSymmetry/N1/` folder:
-
-* `Basic.lean` (this file) — the `Model` indexing data and the chiral
-  configuration type.
-* `Derivative.lean` — the chiral / anti-chiral derivative wrappers
-  `M.dChiralScalar` / `M.dAntiChiralScalar` over the Wirtinger calculus.
-* `SuperPotential.lean` — the abstract holomorphic superpotential `W` and its
-  conjugate `W̄`.
-* `KahlerPotential.lean` — the abstract Kähler potential `K`.
-* `KahlerMetric.lean` — the Kähler metric `g_{IJ̄} = ∂_I ∂_J̄ K` and its
-  hermiticity.
-* `LogKahlerHn.lean` — worked example: the `Hⁿ` log Kähler potential (the
-  reusable upper-half-plane calculus lives in
-  `Mathematics/Calculus/Wirtinger/UpperHalfPlane.lean`).
+Conjugation enters wherever reality does. It is what lets one state that the
+Kähler metric is Hermitian (`conjT g` equals `g` with its two indices swapped),
+that the anti-chiral sector is the complex conjugate of the chiral one
+(`D̄_J̄ W̄ = conjT (D_I W)`), and hence that the F-term `g^{IJ̄} D_I W D̄_J̄ W̄`
+is real. The species can express none of these alone. Since `chiralConjStructure`
+has type `(chiralTensor …).Conj` and its coherence is a fact about
+`chiralTensor`'s contraction, it necessarily follows the species definition (§F).
 
 ## ii. Key results
 
-- `SUSY.N1.Model` : the indexing data of an N=1 sector — a chiral index type,
-    an anti-chiral (barred) index type, and an equivalence `equiv` between them.
-- `SUSY.N1.ChiralScalarConfiguration` : the physical scalar configuration space
-    `C → ℂ`, where `C` is the finite type indexing the chiral scalars — the only
+- `SUSY.N1.ChiralScalarConfiguration` : the scalar configuration space `ι → ℂ`,
+    where `ι` is the finite type indexing the chiral scalars. This is the only
     field data in the sector.
+- `SUSY.N1.ChiralColor` : the four colours `chiral`/`anti` × `up`/`down`, with the
+    dual-colour involution `ChiralColor.tau`.
+- `SUSY.N1.chiralTensor` : the `TensorSpecies` assembled from the above, whose
+    `τ`-discipline makes the F-term contraction type-safe.
+- `SUSY.N1.chiralConjStructure` : the `TensorSpecies.Conj` instance realizing the
+    chiral-antichiral conjugation carried by `ChiralColor.bar`, the operation in
+    which reality and Hermiticity conditions are phrased.
+
+## iii. Table of contents
+
+- A. The chiral scalar configuration
+- B. The chiral colours and the dual involution
+- C. Carrier, representation, and basis
+- D. The δ structure on a based finite module
+  - D.1. The bilinear form, contraction, and cap
+  - D.2. Computation lemmas
+  - D.3. The coherence laws
+  - D.4. The coherence laws in `toSpanSingleton` form
+- E. The chiral-index tensor species
+- F. Conjugation
+  - F.1. The conjugation structure
+  - F.2. Scalar and covector helpers
+
+## iv. References
 
 -/
 
 @[expose] public section
-
+open TensorProduct Module ComplexConjugate
 noncomputable section
 
 namespace SUSY.N1
 
-/-- The indexing data of an N=1 sector: a chiral index type `ChiralIndexingType`,
-an anti-chiral (barred) index type `AntiChiralIndexingType`, and a bijection
-`equiv` between them. -/
-structure Model (ChiralIndexingType : Type*) [Fintype ChiralIndexingType]
-    (AntiChiralIndexingType : Type*) [Fintype AntiChiralIndexingType] where
-  /-- The correspondence between chiral and anti-chiral (barred) labels. -/
-  equiv : ChiralIndexingType ≃ AntiChiralIndexingType
+/-!
+## A. The chiral scalar configuration
 
-/-- The chiral scalar configuration: an assignment of complex values to each
-chiral label. An `abbrev` so unification applies Mathlib's `α → ℂ` calculus
-lemmas directly. -/
+-/
+
+/-- The chiral scalar configuration: a complex value for each chiral label. This is
+the sector's only field data. Declared as an `abbrev` so that unification sees
+through it to `α → ℂ` and applies Mathlib's function-space calculus lemmas directly. -/
 abbrev ChiralScalarConfiguration (ChiralIndexingType : Type*) := ChiralIndexingType → ℂ
+
+variable (ι : Type) [Fintype ι] [DecidableEq ι]
+variable (G : Type) [Group G]
+
+/-!
+## B. The chiral colours and the dual involution
+
+-/
+
+/-- The four colours carried by a chiral-sector index: holomorphy (`chiral` versus
+`anti`, a scalar versus its complex conjugate) crossed with variance (`up` versus
+`down`, contravariant versus covariant). Carrying both axes here lets the single index
+type `ι` label the scalars. -/
+inductive ChiralColor | chiralUp | chiralDown | antiUp | antiDown
+deriving DecidableEq
+
+namespace ChiralColor
+
+/-- The dual colour: flips variance and preserves holomorphy. Two indices may contract
+exactly when their colours are `τ`-related, so `V^I` pairs only with `V_I` (same
+holomorphy, opposite variance) and never with a conjugate index. -/
+def tau : ChiralColor → ChiralColor
+  | chiralUp => chiralDown
+  | chiralDown => chiralUp
+  | antiUp => antiDown
+  | antiDown => antiUp
+
+/-- The conjugate colour: flips holomorphy (`chiral`↔`anti`) and preserves variance. Complex
+conjugation sends an index to its conjugate carrier, so `bar` swaps `chiral*` with `anti*`.
+Distinct from the variance dual `tau`; the two commute (`bar_tau`). -/
+def bar : ChiralColor → ChiralColor
+  | chiralUp => antiUp
+  | antiUp => chiralUp
+  | chiralDown => antiDown
+  | antiDown => chiralDown
+
+@[simp] lemma bar_bar (c : ChiralColor) : bar (bar c) = c := by cases c <;> rfl
+
+@[simp] lemma bar_tau (c : ChiralColor) : bar (tau c) = tau (bar c) := by cases c <;> rfl
+
+end ChiralColor
+
+variable {ι G}
+
+/-!
+## C. Carrier, representation, and basis
+
+A `TensorSpecies` takes, for each colour `c`, a carrier module, a `G`-representation on it, and a
+basis. Here none of these depend on the colour: every colour gets the same carrier `ι → ℂ`, the
+trivial `G`-representation (no `G`-charge), and the indicator basis `piBasis`. So `chiralModule`,
+`chiralRep`, and `chiralBasis` are constant in `c`; the colour is only the bookkeeping label that
+`τ` and `bar` act on.
+
+-/
+
+/-- The carrier module of each colour: every colour shares the single carrier `ι → ℂ`. The
+distinctions between colours (variance and holomorphy) are recorded by the colour and the maps
+`τ`/`bar`, not by the carrier, so all four colours live in the same space. -/
+def chiralModule : ChiralColor → Type := fun _ => ι → ℂ
+
+instance instAddCommGroupChiralModule (c : ChiralColor) :
+    AddCommGroup (chiralModule (ι := ι) c) := inferInstanceAs (AddCommGroup (ι → ℂ))
+
+noncomputable instance instModuleChiralModule (c : ChiralColor) :
+    Module ℂ (chiralModule (ι := ι) c) := inferInstanceAs (Module ℂ (ι → ℂ))
+
+/-- The `G`-representation on each colour, taken trivial: the chiral scalars carry no
+`G`-charge in this sector. -/
+def chiralRep : (c : ChiralColor) → Representation ℂ G (chiralModule (ι := ι) c) :=
+  fun _ => Representation.trivial ℂ G _
+
+/-- The standard basis of the carrier `ι → ℂ` (the indicator functions). -/
+def piBasis : Basis ι ℂ (ι → ℂ) := Pi.basisFun ℂ ι
+
+/-- The standard basis of each colour's carrier: every colour shares the carrier `ι → ℂ`, hence
+the basis `piBasis`. -/
+def chiralBasis : (c : ChiralColor) → Basis ι ℂ (chiralModule (ι := ι) c) :=
+  fun _ => piBasis
+
+/-!
+## D. The δ structure on a based finite module
+
+The contraction, unit, and metric are the same δ structure, written in basis coordinates: the
+contraction is the Kronecker δ pairing `(x, y) ↦ ∑_I x_I y_I`, while the unit and metric are both
+the matching δ "cap" `∑_I b_I ⊗ b_I`. They are defined once below over an abstract based module
+`(M, b)`, then used at `piBasis` to build the species' fields in §E. A contraction only ever pairs
+a colour with its `τ`-dual (same holomorphy, opposite variance), so it stays within one holomorphy
+and needs no conjugation; conjugation is carried instead by the tensor `conjT` and the
+anti-holomorphic Wirtinger derivatives that produce barred components.
+
+### D.1. The bilinear form, contraction, and cap
+
+-/
+
+variable {M : Type*} [AddCommGroup M] [Module ℂ M]
+
+/-- The δ bilinear form: the dot product of coordinate vectors in a basis `b`,
+`(x, y) ↦ ∑_I (b x)_I (b y)_I`. -/
+def deltaBil (b : Basis ι ℂ M) : M →ₗ[ℂ] M →ₗ[ℂ] ℂ :=
+  LinearMap.mk₂ ℂ (fun x y => ∑ I, b.equivFun x I * b.equivFun y I)
+    (fun x x' y => by simp only [map_add, Pi.add_apply, add_mul, Finset.sum_add_distrib])
+    (fun a x y => by
+      simp only [map_smul, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
+      exact Finset.sum_congr rfl fun I _ => by ring)
+    (fun x y y' => by simp only [map_add, Pi.add_apply, mul_add, Finset.sum_add_distrib])
+    (fun a x y => by
+      simp only [map_smul, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
+      exact Finset.sum_congr rfl fun I _ => by ring)
+
+/-- The δ contraction `M ⊗ M → ℂ`: the bilinear form `deltaBil` lifted to the tensor
+product. -/
+def deltaContr (b : Basis ι ℂ M) : M ⊗[ℂ] M →ₗ[ℂ] ℂ := TensorProduct.lift (deltaBil b)
+
+/-- The δ cap `∑_I b_I ⊗ b_I`: the rank-2 tensor in `M ⊗ M` with two upper indices, whose
+components in the basis `b` are `δⁱʲ`. It is an element of `M ⊗ M` (the inverse-metric "cap"
+dual to `deltaContr`), not a linear map, and serves as both the metric and the unit of the
+species. -/
+def deltaCap (b : Basis ι ℂ M) : M ⊗[ℂ] M := ∑ I, b I ⊗ₜ[ℂ] b I
+
+/-!
+### D.2. Computation lemmas
+
+Rewrite rules that evaluate the abstractly-defined `deltaContr` and `deltaCap` on concrete
+inputs, together with their two symmetries. They are the only place that unfolds the δ
+definitions and the basis coordinate facts; the coherence laws of §D.3 are assembled entirely
+from them.
+
+`deltaContr_tmul` is the base rule, `deltaContr b (x ⊗ₜ y) = ∑_I x_I y_I`. Specializing the
+second argument to a basis vector (`deltaContr_tmul_basis`) reads off one coordinate, and
+specializing both (`deltaContr_basis_basis`) gives the Kronecker `δ_{IJ}`, i.e. the basis is
+orthonormal for the δ pairing. `deltaContr_comm` and `deltaCap_comm` record that the
+contraction is symmetric in its arguments and that the cap is fixed by swapping its factors.
+
+-/
+
+omit [DecidableEq ι] in
+/-- `deltaContr b (x ⊗ₜ y) = ∑_I x_I y_I`, the dot product of the coordinate vectors of `x` and
+`y` in the basis `b` (writing `x_I := (b.equivFun x) I`). -/
+lemma deltaContr_tmul (b : Basis ι ℂ M) (x y : M) :
+    deltaContr b (x ⊗ₜ[ℂ] y) = ∑ I, b.equivFun x I * b.equivFun y I := by
+  simp only [deltaContr, TensorProduct.lift.tmul, deltaBil, LinearMap.mk₂_apply]
+
+/-- `deltaContr b (x ⊗ₜ b J) = x_J`: pairing with the basis vector `b J` reads off the `J`-th
+coordinate `(b.equivFun x) J`. -/
+lemma deltaContr_tmul_basis (b : Basis ι ℂ M) (x : M) (J : ι) :
+    deltaContr b (x ⊗ₜ[ℂ] b J) = b.equivFun x J := by
+  simp [deltaContr_tmul, Basis.equivFun_self]
+
+/-- `deltaContr b (b I ⊗ₜ b J) = δ_{IJ}` (`if I = J then 1 else 0`): the basis vectors are
+orthonormal for the δ pairing. -/
+lemma deltaContr_basis_basis (b : Basis ι ℂ M) (I J : ι) :
+    deltaContr b (b I ⊗ₜ[ℂ] b J) = if I = J then 1 else 0 := by
+  rw [deltaContr_tmul_basis, Basis.equivFun_self]
+
+omit [DecidableEq ι] in
+/-- `deltaContr b (x ⊗ₜ y) = deltaContr b (y ⊗ₜ x)`: the δ contraction is symmetric, since
+`∑_I x_I y_I = ∑_I y_I x_I`. -/
+lemma deltaContr_comm (b : Basis ι ℂ M) (x y : M) :
+    deltaContr b (x ⊗ₜ[ℂ] y) = deltaContr b (y ⊗ₜ[ℂ] x) := by
+  rw [deltaContr_tmul, deltaContr_tmul]
+  exact Finset.sum_congr rfl fun I _ => mul_comm _ _
+
+omit [DecidableEq ι] in
+/-- `comm (deltaCap b) = deltaCap b`: swapping the two tensor factors fixes the cap, since
+every summand `b_I ⊗ b_I` is symmetric. -/
+lemma deltaCap_comm (b : Basis ι ℂ M) :
+    TensorProduct.comm ℂ M M (deltaCap b) = deltaCap b := by
+  rw [deltaCap, map_sum]
+  exact Finset.sum_congr rfl fun I _ => by rw [TensorProduct.comm_tmul]
+
+/-!
+### D.3. The coherence laws
+
+The three nontrivial axioms a `TensorSpecies` demands of its `unit`, `contr`, and `metric`,
+proved here for the δ structure over an abstract based module `(M, b)` so that every colour
+inherits them. Each corresponds to one species field:
+
+- `deltaCap_unit_symm` (`unit_symm`): the cap is unchanged by swapping its factors;
+- `deltaContr_deltaCap` (`contr_unit`): the snake identity, contracting the cap against a
+  vector returns that vector;
+- `deltaCap_contr_deltaCap` (`contr_metric`): contracting two adjacent caps yields one cap.
+
+The fourth axiom, `contr_tmul_symm`, is just `deltaContr_comm` from §D.2 and is not repeated
+here. These statements use `deltaCap`/`deltaContr` directly; §D.4 repackages them into the
+`toSpanSingleton` form the species fields literally require.
+
+-/
+
+omit [DecidableEq ι] in
+/-- The `unit_symm` law for the δ cap: `deltaCap b = lTensor M id (comm (deltaCap b))`.
+On the right, `comm` swaps the cap's two tensor factors and `lTensor M id` applies the identity
+to the left factor (it is the identity because `τ` here keeps the carrier fixed, so the
+species' type-cast is trivial). Both operations leave the cap alone, so the law reduces to
+`comm (deltaCap b) = deltaCap b` (`deltaCap_comm`): swapping the two legs of `∑_I b_I ⊗ b_I`
+leaves it unchanged. -/
+lemma deltaCap_unit_symm (b : Basis ι ℂ M) :
+    deltaCap b = LinearMap.lTensor M (LinearEquiv.refl ℂ M).toLinearMap
+      (TensorProduct.comm ℂ M M (deltaCap b)) := by
+  simp only [deltaCap_comm, LinearEquiv.refl_toLinearMap, LinearMap.lTensor_id, LinearMap.id_coe,
+    id_eq]
+
+/-- The snake identity `∑_I (x · b_I) b_I = ∑_I x_I b_I = x` (the `contr_unit` law): contracting
+`x` into the left leg of the cap `∑_I b_I ⊗ b_I` and keeping the right leg returns `x`. The
+displayed term is the framework's spelling of this via `assoc`/`lid`. -/
+lemma deltaContr_deltaCap (b : Basis ι ℂ M) (x : M) :
+    (TensorProduct.lid ℂ M) ((deltaContr b).rTensor M
+      ((TensorProduct.assoc ℂ M M M).symm (x ⊗ₜ[ℂ] deltaCap b))) = x := by
+  rw [deltaCap, TensorProduct.tmul_sum, map_sum, map_sum, map_sum]
+  conv_rhs => rw [← b.sum_equivFun x]
+  refine Finset.sum_congr rfl fun I _ => ?_
+  rw [TensorProduct.assoc_symm_tmul, LinearMap.rTensor_tmul, TensorProduct.lid_tmul,
+    deltaContr_tmul_basis]
+
+/-- `∑_{IJ} (b_I · b_J) b_I ⊗ b_J = ∑_I b_I ⊗ b_I = deltaCap b` (the `contr_metric` law): contracting
+the two inner legs of `deltaCap b ⊗ deltaCap b` collapses it to a single cap, using
+`b_I · b_J = δ_{IJ}`. -/
+lemma deltaCap_contr_deltaCap (b : Basis ι ℂ M) :
+    (TensorProduct.comm ℂ M M ((TensorProduct.lid ℂ M).lTensor M
+      (((deltaContr b).rTensor M).lTensor M
+        (((TensorProduct.assoc ℂ M M M).symm.toLinearMap.lTensor M)
+          ((TensorProduct.assoc ℂ M M (M ⊗[ℂ] M))
+            (deltaCap b ⊗ₜ[ℂ] deltaCap b)))))) = deltaCap b := by
+  conv_lhs => rw [deltaCap, TensorProduct.sum_tmul]
+  conv_rhs => rw [deltaCap]
+  simp only [TensorProduct.tmul_sum, map_sum]
+  simp [TensorProduct.assoc_tmul, LinearEquiv.lTensor_tmul, LinearMap.lTensor_tmul,
+    TensorProduct.assoc_symm_tmul, LinearMap.rTensor_tmul, TensorProduct.lid_tmul,
+    TensorProduct.comm_tmul, deltaContr_basis_basis, ite_smul]
+  simp [TensorProduct.ite_tmul, Finset.sum_ite_eq]
+
+/-!
+### D.4. The coherence laws in `toSpanSingleton` form
+
+The species' `unit` and `metric` fields are not the bare element `deltaCap b` but the map
+`toSpanSingleton ℂ _ (deltaCap b)` sending `1 ↦ deltaCap b`, so the coherence goals mention
+`toSpanSingleton _ (deltaCap b) 1` wherever §D.3 has `deltaCap b`. These three lemmas bridge
+that gap: each rewrites `toSpanSingleton_apply_one` (`toSpanSingleton _ v 1 = v`) and then
+applies the matching §D.3 law, restating it in the exact shape the fields require.
+
+- `deltaUnit_symm` ← `deltaCap_unit_symm` (`unit_symm`);
+- `deltaContr_unit` ← `deltaContr_deltaCap` (`contr_unit`);
+- `deltaContr_metric` ← `deltaCap_contr_deltaCap` (`contr_metric`).
+
+Stated abstractly over `(M, b)`, they reduce each coherence field of `chiralTensor` to a single
+`cases c <;> exact …`. The fourth law, `contr_tmul_symm`, needs no adapter and uses
+`deltaContr_comm` from §D.2 directly.
+
+-/
+
+omit [DecidableEq ι] in
+/-- The `unit_symm` law with `unit = toSpanSingleton _ (deltaCap b)`: evaluated at `1` it is
+`deltaCap b = lTensor M id (comm (deltaCap b))` (`deltaCap_unit_symm`). -/
+lemma deltaUnit_symm (b : Basis ι ℂ M) :
+    LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 =
+      LinearMap.lTensor M (LinearEquiv.refl ℂ M).toLinearMap
+        (TensorProduct.comm ℂ M M (LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1)) := by
+  simp only [LinearMap.toSpanSingleton_apply_one]
+  exact deltaCap_unit_symm b
+
+/-- The `contr_unit` law with the cap as `toSpanSingleton _ (deltaCap b)`: at `1` it is
+`∑_I (x · b_I) b_I = x` (`deltaContr_deltaCap`). -/
+lemma deltaContr_unit (b : Basis ι ℂ M) (x : M) :
+    (TensorProduct.lid ℂ M) ((deltaContr b).rTensor M
+      ((TensorProduct.assoc ℂ M M M).symm
+        (x ⊗ₜ[ℂ] LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1))) = x := by
+  rw [LinearMap.toSpanSingleton_apply_one]
+  exact deltaContr_deltaCap b x
+
+/-- The `contr_metric` law with the metric as `toSpanSingleton _ (deltaCap b)`: at `1` it is
+`∑_{IJ} (b_I · b_J) b_I ⊗ b_J = deltaCap b` (`deltaCap_contr_deltaCap`). -/
+lemma deltaContr_metric (b : Basis ι ℂ M) :
+    (TensorProduct.comm ℂ M M ((TensorProduct.lid ℂ M).lTensor M
+      (((deltaContr b).rTensor M).lTensor M
+        (((TensorProduct.assoc ℂ M M M).symm.toLinearMap.lTensor M)
+          ((TensorProduct.assoc ℂ M M (M ⊗[ℂ] M))
+            (LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 ⊗ₜ[ℂ]
+              LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1)))))) =
+      LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 := by
+  rw [LinearMap.toSpanSingleton_apply_one]
+  exact deltaCap_contr_deltaCap b
+
+/-!
+## E. The chiral-index tensor species
+
+-/
+
+/-- The chiral-index tensor species. Its colours are `chiral`/`anti` × `up`/`down`, all carried
+by `ι → ℂ`, and every colour contracts by the bare δ pairing with the δ cap serving as both
+metric and unit. Each coherence law reduces, by case analysis on the colour, to the
+corresponding abstract δ lemma above. Instantiating `TensorSpecies` this way gives the chiral
+sector the framework's generic tensor API. -/
+def chiralTensor : TensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fun _ => ι)
+    (chiralRep (ι := ι) (G := G)) (chiralBasis (ι := ι)) where
+  τ := ChiralColor.tau
+  τ_involution c := by cases c <;> rfl
+  -- The carrier is `ι → ℂ` for every colour, so the data fields are uniform in `c`.
+  contr _ := { deltaContr piBasis with
+      isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
+  unit _ := { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
+      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+  metric _ := { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
+      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+  -- Each coherence law reduces, by case analysis on `c`, to the matching abstract δ lemma.
+  contr_tmul_symm c x y := by cases c <;> exact deltaContr_comm _ _ _
+  unit_symm c := by cases c <;> exact deltaUnit_symm _
+  contr_unit c x := by cases c <;> exact deltaContr_unit _ x
+  contr_metric c := by cases c <;> exact deltaContr_metric _
+
+/-- Type-safety smoke test. `chiralUp` and `chiralDown` are `τ`-dual, so a rank-2 tensor with
+those index colours admits the framework contraction `contrT`. A same-variance pair would
+fail the `τ`-hypothesis `S.τ (c I) = c J`, which is exactly the safety the species provides. -/
+example (t : (chiralTensor (ι := ι) (G := G)).Tensor
+      ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
+    (chiralTensor (ι := ι) (G := G)).Tensor
+      (![ChiralColor.chiralUp, ChiralColor.chiralDown] ∘ Fin.succSuccAbove 0 1) :=
+  TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t
+
+/-!
+## F. Conjugation
+
+Conjugation is a layer on top of the species of §E, not part of it: `TensorSpecies.Conj S` is a
+structure parameterized by a species `S`, and the framework defines the conjugation map `conjT`
+and its laws once, abstractly, against any species that supplies one. This section therefore
+follows §E: `chiralConjStructure` has type `(chiralTensor …).Conj`, and its `conj_contrComm`
+field is a fact about `chiralTensor`'s contraction, neither of which can be stated before the
+species exists.
+
+The chiral sector's conjugation flips holomorphy (`ChiralColor.bar`) while preserving variance, and
+through the resulting `conjT` the reality and Hermiticity conditions are phrased. The basis index
+type `ι` is the same for every colour, so the index identification `barIdx_eq` is `rfl` and the
+component reindexing is the identity.
+
+### F.1. The conjugation structure
+
+-/
+
+section Conjugation
+
+open TensorSpecies TensorSpecies.Tensor ChiralColor
+
+/-- The chiralTensor contraction coefficient of two basis vectors is the Kronecker δ, stated at
+the colour level so it matches goals carrying `chiralModule d`. -/
+lemma chiralTensor_contr_chiralBasis (d : ChiralColor) (x₁ x₂ : ι) :
+    (chiralTensor (ι := ι) (G := G)).contr d
+        (chiralBasis d x₁ ⊗ₜ[ℂ] chiralBasis ((chiralTensor (ι := ι) (G := G)).τ d) x₂)
+      = if x₁ = x₂ then 1 else 0 := by
+  cases d <;>
+    exact deltaContr_basis_basis _ x₁ x₂
+
+/-- The conjugation structure on the chiral tensor species: `bar` flips holomorphy while
+preserving variance, and the basis labels of each colour are identified with those of its
+conjugate via the identity (both carry the same index type `ι`). -/
+def chiralConjStructure : (chiralTensor (ι := ι) (G := G)).Conj where
+  bar := ChiralColor.bar
+  bar_involution := ChiralColor.bar_bar
+  bar_tau := ChiralColor.bar_tau
+  barIdx_eq _ := rfl
+  conj_contrComm := by
+    intro d x₁ x₂
+    cases d <;> simp [chiralTensor_contr_chiralBasis, apply_ite (starRingEnd ℂ), basisIdxCongr]
+
+-- Smoke tests: type-safety and behaviour checks for `chiralConjStructure`.
+
+/-- Conjugating a metric-typed tensor `g : Tensor ![chiralDown, antiDown]` via `chiralConjStructure`
+lands in the conjugate-colour list `ChiralColor.bar ∘ ![chiralDown, antiDown]`, i.e.
+`![antiDown, chiralDown]`. This is purely a type-safety check. -/
+example (g : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown, antiDown]) :
+    (chiralTensor (ι := ι) (G := G)).Tensor (ChiralColor.bar ∘ ![chiralDown, antiDown]) :=
+  chiralConjStructure.conjT g
+
+/-- `conjT_contrT` applies to a one-index contraction: conjugating first and then contracting
+equals contracting the conjugate. Checked at colour `![chiralUp, chiralDown]` contracted at
+slots `0` and `1`. -/
+example (t : (chiralTensor (ι := ι) (G := G)).Tensor ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
+    chiralConjStructure.conjT (TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t)
+      = TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ (chiralConjStructure.conjT t) :=
+  chiralConjStructure.conjT_contrT 0 1 ⟨by decide, rfl⟩ t
+
+/-!
+### F.2. Scalar and covector helpers
+
+These two definitions normalize the output of `chiralConjStructure.conjT` back to the canonical
+colour lists for scalar and anti-holomorphic covector tensors respectively.
+
+-/
+
+/-- Conjugation of a scalar tensor, normalized back to the scalar colour list `![]`. -/
+def conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
+    (chiralTensor (ι := ι) (G := G)).Tensor ![] :=
+  permT id ⟨Function.bijective_id, fun i => by fin_cases i⟩
+    (chiralConjStructure.conjT t)
+
+/-- Conjugation of a holomorphic covector, normalized to the anti-holomorphic covector colour
+list `![antiDown]`. -/
+def conjChiralCovector
+    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
+    (chiralTensor (ι := ι) (G := G)).Tensor ![antiDown] :=
+  permT ![0] ⟨by decide, fun i => by fin_cases i; rfl⟩
+    (chiralConjStructure.conjT t)
+
+/-- For scalar tensors, `toField` of the normalized tensor conjugate is the complex conjugate of
+`toField`. -/
+theorem toField_conjScalar (t : (chiralTensor (ι := ι) (G := G)).Tensor ![]) :
+    (conjScalar t).toField = star t.toField := by
+  rw [conjScalar, toField_permT]
+  rw [toField_eq_repr, toField_eq_repr]
+  change componentMap (S := chiralTensor (ι := ι) (G := G))
+      (chiralConjStructure.bar ∘ ![]) (chiralConjStructure.conjT t) (fun j => Fin.elim0 j) =
+    star ((basis (S := chiralTensor (ι := ι) (G := G)) ![]).repr t (fun j => Fin.elim0 j))
+  rw [TensorSpecies.Conj.componentMap_conjT (cj := chiralConjStructure)]
+  rfl
+
+/-- Component formula for the holomorphic covector conjugate: the `![I]` basis component of
+`conjChiralCovector t` is the complex conjugate of the `![I]` component of `t`. -/
+theorem repr_conjChiralCovector
+    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) (I : ι) :
+    (basis (S := chiralTensor (ι := ι) (G := G)) ![antiDown]).repr
+        (conjChiralCovector t) ![I] =
+      star ((basis (S := chiralTensor (ι := ι) (G := G)) ![chiralDown]).repr t ![I]) := by
+  rw [conjChiralCovector, permT_basis_repr_symm_apply]
+  change componentMap (S := chiralTensor (ι := ι) (G := G))
+      (chiralConjStructure.bar ∘ ![chiralDown]) (chiralConjStructure.conjT t) _ = _
+  rw [TensorSpecies.Conj.componentMap_conjT (cj := chiralConjStructure)]
+  apply congrArg star
+  apply congrArg (fun idx => componentMap (S := chiralTensor (ι := ι) (G := G))
+    ![chiralDown] t idx)
+  funext i
+  fin_cases i
+  rfl
+
+/-- Conjugation of a holomorphic covector is additive. -/
+@[simp]
+theorem conjChiralCovector_add
+    (t₁ t₂ : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
+    conjChiralCovector (t₁ + t₂) = conjChiralCovector t₁ + conjChiralCovector t₂ := by
+  rw [conjChiralCovector, chiralConjStructure.conjT_add]
+  simp [conjChiralCovector, map_add]
+
+/-- Conjugation of a holomorphic covector is conjugate-linear: a scalar `r` pulls out as
+`star r`. -/
+@[simp]
+theorem conjChiralCovector_smul (r : ℂ)
+    (t : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown]) :
+    conjChiralCovector (r • t) = star r • conjChiralCovector t := by
+  rw [conjChiralCovector, chiralConjStructure.conjT_smul]
+  simp [conjChiralCovector]
+
+end Conjugation
 
 end SUSY.N1
 

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -18,11 +18,14 @@ public import Physlib.Relativity.Tensors.Conjugation.Basic
 This file fixes the data that indexes the scalars of the N=1 chiral sector,
 makes their contractions type-safe, and equips them with conjugation.
 
-A single finite type `ι` indexes the chiral scalars; it appears as
-`ChiralIndexingType` in the signatures. It is the only index type. Variance
-(upper versus lower) and holomorphy (a scalar versus its complex conjugate) are
-not separate index types but the two axes of a four-element type `ChiralColor`,
-the product of `chiral`/`anti` with `up`/`down`.
+A single finite type `ι` indexes the chiral scalars (written `ChiralIndexingType`
+in signatures) — the only index type. Variance (upper versus lower) and holomorphy
+(a scalar versus its complex conjugate) are not separate index types but the two
+axes of a four-element type `ChiralColor`, the product of `chiral`/`anti` with
+`up`/`down`. Each axis is realized as a genuine carrier distinction, not a label:
+variance as a module versus its dual (`ι → ℂ` versus `Module.Dual ℂ (ι → ℂ)`),
+holomorphy as a module versus its complex conjugate (`ConjModule`, where `i` acts
+as `−i`).
 
 The dual-colour involution `τ` flips variance and preserves holomorphy. Two
 indices may contract exactly when their colours are `τ`-related, so a holomorphic
@@ -36,19 +39,15 @@ The physical field content is the configuration `ChiralScalarConfiguration ι =
 scalars are the complex conjugates of this data, never an independent
 configuration.
 
-The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`. The four colours carry four
-distinct carriers, recording both axes as genuine type data: the holomorphic vectors `ι → ℂ` (up)
-and their dual `Module.Dual ℂ (ι → ℂ)` (down) on the chiral side, and the conjugate modules
-`ConjModule …` of each on the anti side, where `i` acts as `−i`. Variance is thus the vector/dual
-distinction and holomorphy the conjugate-module distinction, so an upper index pairs only with a
-lower one of the same holomorphy. Complex conjugation is the conjugate-linear identity
-`conjEquiv : M ≃ₛₗ[starRingEnd ℂ] ConjModule M` on each carrier (anti basis = `Basis.conj`), and the
-species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Each colour carries the
-trivial representation over the trivial group `Unit`, so the chiral scalars hold no charge.
-Contracting a colour against its `τ`-dual is the dot product of the two coordinate vectors, the
-Kronecker `δ_{IJ}` on basis labels: `contr` is that pairing `V c ⊗ V (τ c) → ℂ`, `unit` its cap in
-`V (τ c) ⊗ V c`, and `metric` the cap `∑_I b_I ⊗ b_I` in `V c ⊗ V c`. Supplying this instance equips
-the chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
+The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`, each colour carrying its
+distinct carrier from above. Complex conjugation is the conjugate-linear identity
+`conjEquiv : M ≃ₛₗ[starRingEnd ℂ] ConjModule M` on each carrier (anti basis `Basis.conj`); the
+species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Every
+colour carries the trivial representation over the trivial group `Unit`, so the chiral scalars hold
+no charge. Contracting a colour against its `τ`-dual is the dot product of the two coordinate
+vectors, the Kronecker `δ_{IJ}` on basis labels: `contr` is that pairing `V c ⊗ V (τ c) → ℂ`, `unit`
+its cap in `V (τ c) ⊗ V c`, and `metric` the cap `∑_I b_I ⊗ b_I` in `V c ⊗ V c`. This instance equips
+the chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, …).
 
 Conjugation is intrinsic species data: a `ConjTensorSpecies` is a `TensorSpecies`
 extended with the conjugate-colour involution `ChiralColor.bar` and its coherence. The framework then supplies the
@@ -79,7 +78,7 @@ is real. The species can express none of these alone.
 - B. The chiral colours and the dual involution
 - C. Carrier, representation, and basis
 - D. The δ structure on based finite modules
-  - D.1. The bilinear form and the cap
+  - D.1. The cap
   - D.2. The δ pairing across two based modules
 - E. The chiral-index tensor species
 - F. Conjugation
@@ -101,7 +100,8 @@ namespace SUSY.N1
 
 /-- The chiral scalar configuration: a complex value for each chiral label. This is
 the sector's only field data. Declared as an `abbrev` so that unification sees
-through it to `α → ℂ` and applies Mathlib's function-space calculus lemmas directly. -/
+through it to `ChiralIndexingType → ℂ` and applies Mathlib's function-space calculus
+lemmas directly. -/
 abbrev ChiralScalarConfiguration (ChiralIndexingType : Type*) := ChiralIndexingType → ℂ
 
 variable (ι : Type) [Fintype ι] [DecidableEq ι]
@@ -180,7 +180,8 @@ scalars carry no charge in this sector. -/
 def chiralRep : (c : ChiralColor) → Representation ℂ Unit (chiralModule (ι := ι) c) :=
   fun _ => Representation.trivial ℂ Unit _
 
-/-- The standard basis of the chiral carrier `ι → ℂ` (the indicator functions). -/
+/-- The standard basis of the vector carrier `ι → ℂ` (the indicator functions); the basis of
+`chiralUp` and the reference basis for the δ pairing. -/
 def piBasis : Basis ι ℂ (ι → ℂ) := Pi.basisFun ℂ ι
 
 /-- The basis of each colour's carrier, all indexed by `ι`: `piBasis` on the holomorphic vectors,
@@ -195,32 +196,21 @@ noncomputable def chiralBasis : (c : ChiralColor) → Basis ι ℂ (chiralModule
 /-!
 ## D. The δ structure on based finite modules
 
-The contraction, unit, and metric are one δ structure in basis coordinates. A contraction pairs a
+The contraction, unit, and metric are one δ structure in basis coordinates. Here `metric` is the
+`TensorSpecies` field of that name — the δ index-raising tensor `δ^{IJ}` — and is *not* the physical
+Kähler metric `g_{IJ̄}`, which is built downstream on top of this sector. A contraction pairs a
 colour with its variance dual `τ c`, whose carriers are *distinct* (a module and its dual, or their
 conjugates) but share the index `ι`, so the pairing is the dot product *across two based modules*
 `(M, b)` and `(N, b')`, `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, with cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. The
 single-module case `b = b'` (§D.1) is what `metric c` uses, since its two slots are the same colour;
 the genuinely two-module pairing (§D.2) is what `contr` and `unit` use. The δ data stays within one
-holomorphy and needs no conjugation; conjugation is carried instead by the tensor `conjT` and the
-anti-holomorphic Wirtinger derivatives that produce barred components.
+holomorphy and needs no conjugation; conjugation is carried instead by the tensor `conjT` (§F).
 
-### D.1. The bilinear form and the cap
+### D.1. The cap
 
 -/
 
 variable {M : Type*} [AddCommGroup M] [Module ℂ M]
-
-/-- The δ bilinear form: the bilinear form whose Gram matrix in the basis `b` is the identity,
-`Matrix.toBilin b 1`. On coordinates it is the dot product `(x, y) ↦ ∑_I (b x)_I (b y)_I`
-(`deltaBil_apply`), i.e. the form for which `b` is orthonormal. -/
-def deltaBil (b : Basis ι ℂ M) : M →ₗ[ℂ] M →ₗ[ℂ] ℂ := Matrix.toBilin b 1
-
-/-- `deltaBil b x y = ∑_I (b x)_I (b y)_I`: the identity Gram matrix collapses the double sum of
-`Matrix.toBilin_apply` to the dot product of the coordinate vectors. -/
-lemma deltaBil_apply (b : Basis ι ℂ M) (x y : M) :
-    deltaBil b x y = ∑ I, b.equivFun x I * b.equivFun y I := by
-  rw [deltaBil, Matrix.toBilin_apply]
-  simp [Matrix.one_apply, mul_ite, mul_zero, Finset.sum_ite_eq, Basis.equivFun_apply]
 
 /-- The δ cap `∑_I b_I ⊗ b_I`: the rank-2 tensor in `M ⊗ M` with two upper indices, whose
 components in the basis `b` are `δⁱʲ`. It is an element of `M ⊗ M` (the inverse-metric "cap"),
@@ -243,17 +233,20 @@ the species demands of them, proved here once over abstract `(M, b)`, `(N, b')`.
 variable {N : Type*} [AddCommGroup N] [Module ℂ N]
 
 /-- The δ pairing between two based modules sharing the index `ι`: the dot product of coordinate
-vectors `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, built by reading both sides into `ι → ℂ` and applying the
-reference dot product `deltaBil piBasis`. Equals `deltaBil b` when `b = b'`. -/
+vectors `(x, y) ↦ ∑_I (b x)_I (b' y)_I`. Built from Mathlib's `Basis.toDual b` (the canonical δ map
+`M → Module.Dual M`, sending `b` to its dual basis) precomposed on the second slot with the basis
+transport `b' ≃ b`. -/
 def deltaBil₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M →ₗ[ℂ] N →ₗ[ℂ] ℂ :=
-  ((deltaBil piBasis).comp b.equivFun.toLinearMap).compl₂ b'.equivFun.toLinearMap
+  b.toDual.compl₂ (b'.equiv b (Equiv.refl ι)).toLinearMap
 
 /-- `deltaBil₂ b b' x y = ∑_I (b x)_I (b' y)_I`. -/
 lemma deltaBil₂_apply (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (y : N) :
     deltaBil₂ b b' x y = ∑ I, b.equivFun x I * b'.equivFun y I := by
-  rw [deltaBil₂, LinearMap.compl₂_apply, LinearMap.comp_apply, LinearEquiv.coe_coe,
-    LinearEquiv.coe_coe, deltaBil_apply]
-  simp only [piBasis, Pi.basisFun_equivFun, LinearEquiv.refl_apply]
+  rw [deltaBil₂, LinearMap.compl₂_apply, LinearEquiv.coe_coe]
+  conv_lhs => rw [← b'.sum_equivFun y]
+  simp_rw [map_sum, map_smul, Basis.equiv_apply, Equiv.refl_apply, Basis.toDual_eq_equivFun,
+    smul_eq_mul]
+  exact Finset.sum_congr rfl fun J _ => mul_comm _ _
 
 /-- The two-module δ contraction `M ⊗ N → ℂ`. -/
 def deltaContr₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M ⊗[ℂ] N →ₗ[ℂ] ℂ :=

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -46,12 +46,12 @@ species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Every
 colour carries the trivial representation over the trivial group `Unit`, so the chiral scalars hold
 no charge. Contracting a colour against its `τ`-dual is the dot product of the two coordinate
 vectors, the Kronecker `δ_{IJ}` on basis labels: `contr` is that pairing `V c ⊗ V (τ c) → ℂ`, `unit`
-its cap in `V (τ c) ⊗ V c`, and `metric` the cap `∑_I b_I ⊗ b_I` in `V c ⊗ V c`. This instance equips
-the chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, …).
+its cap in `V (τ c) ⊗ V c`, and `metric` the cap `∑_I b_I ⊗ b_I` in `V c ⊗ V c`. This instance
+equips the chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, …).
 
 Conjugation is intrinsic species data: a `ConjTensorSpecies` is a `TensorSpecies`
-extended with the conjugate-colour involution `ChiralColor.bar` and its coherence. The framework then supplies the
-map `conjT` (conjugate the components and flip each index's holomorphy by `bar`)
+extended with the conjugate-colour involution `ChiralColor.bar` and its coherence. The framework
+then supplies the map `conjT` (conjugate the components and flip each index's holomorphy by `bar`)
 and its laws. `bar` is the holomorphy dual, distinct from and commuting with the
 variance dual `τ`; it is not used in contraction.
 
@@ -324,14 +324,15 @@ across those two carriers; `metric c` is the single-colour δ cap `∑_I b_I ⊗
 `TensorSpecies` coherence law reduces, by case analysis on the colour, to the corresponding abstract
 two-module δ lemma of §D. The conjugation flips holomorphy (`ChiralColor.bar`) while preserving
 variance; every basis is indexed by `ι`, so `barIdx_eq` is `rfl`, and `conj_contrComm` is
-`star δ = δ`. Instantiating `ConjTensorSpecies` this way gives the chiral sector both the framework's
-generic tensor API and its conjugation API (`conjT` and its laws) on one object. -/
+`star δ = δ`. Instantiating `ConjTensorSpecies` this way gives the chiral sector both
+the framework's generic tensor API and its conjugation API (`conjT` and its laws) on one object. -/
 def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := ι)) (fun _ => ι)
     (chiralRep (ι := ι)) (chiralBasis (ι := ι)) where
   τ := ChiralColor.tau
   τ_involution c := by cases c <;> rfl
-  -- `contr` pairs a colour with its variance dual `τ c` (distinct carriers, e.g. `ι → ℂ` against its
-  -- dual); `unit` is the δ cap across those two carriers; `metric` the δ cap of a colour with itself.
+  -- `contr` pairs a colour with its variance dual `τ c` (distinct carriers, e.g. `ι → ℂ`
+  -- against its dual); `unit` is the δ cap across those two carriers; `metric` the δ cap of a
+  -- colour with itself.
   contr c := { deltaContr₂ (chiralBasis c) (chiralBasis (ChiralColor.tau c)) with
       isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
   unit c := { LinearMap.toSpanSingleton ℂ _
@@ -339,7 +340,8 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := �
       isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap₂] }
   metric c := { LinearMap.toSpanSingleton ℂ _ (deltaCap (chiralBasis c)) with
       isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-  -- Each coherence law reduces, by case analysis on `c`, to the matching abstract two-module δ lemma.
+  -- Each coherence law reduces, by case analysis on `c`, to the matching abstract two-module
+  -- δ lemma.
   contr_tmul_symm c x y := by cases c <;> exact deltaContr₂_comm _ _ _ _
   unit_symm c := by cases c <;> exact deltaUnit₂_symm _ _
   contr_unit c x := by cases c <;> exact deltaContr₂_unit _ _ x
@@ -353,7 +355,8 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := �
     intro d x₁ x₂
     -- The contraction at every colour is the real δ pairing of two `ι`-bases, so `star` fixes it.
     -- The `key` lemma evaluates both sides by `deltaContr₂_basis_basis` (a syntactic rewrite to
-    -- `if x₁ = x₂ then 1 else 0`), so the heavy `Basis.conj`/`dualBasis` carriers are never `whnf`'d.
+    -- `if x₁ = x₂ then 1 else 0`), so the heavy `Basis.conj`/`dualBasis` carriers are never
+    -- `whnf`'d.
     have key : ∀ {M₁ M₁' M₂ M₂' : Type} [AddCommGroup M₁] [Module ℂ M₁] [AddCommGroup M₁']
         [Module ℂ M₁'] [AddCommGroup M₂] [Module ℂ M₂] [AddCommGroup M₂'] [Module ℂ M₂']
         (B₁ : Basis ι ℂ M₁) (B₁' : Basis ι ℂ M₁') (B₂ : Basis ι ℂ M₂) (B₂' : Basis ι ℂ M₂'),

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -5,18 +5,8 @@ Authors: Andrea Pari
 -/
 module
 
-public import Physlib.Relativity.Tensors.TensorSpecies.Basic
-public import Mathlib.RepresentationTheory.Basic
-public import Mathlib.RepresentationTheory.Intertwining
 public import Mathlib.Data.Complex.Basic
-public import Mathlib.LinearAlgebra.Basis.Defs
-public import Mathlib.LinearAlgebra.StdBasis
-public import Mathlib.Algebra.Group.TransferInstance
-public import Mathlib.Algebra.Module.TransferInstance
-public import Mathlib.Algebra.Module.RingHom
--- Contraction machinery for the type-safety smoke test below. Public because the test lives
--- in the public section and references `TensorSpecies.Tensor` and `contrT`.
-public import Physlib.Relativity.Tensors.Contraction.Basic
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import Physlib.Relativity.Tensors.Conjugation.Basic
 
 /-!
@@ -93,8 +83,6 @@ is real. The species can express none of these alone.
   - D.4. The coherence laws in `toSpanSingleton` form
 - E. The chiral-index tensor species
 - F. Conjugation
-  - F.1. Smoke tests
-  - F.2. Scalar and covector helpers
 
 ## iv. References
 
@@ -220,18 +208,17 @@ anti-holomorphic Wirtinger derivatives that produce barred components.
 
 variable {M : Type*} [AddCommGroup M] [Module ℂ M]
 
-/-- The δ bilinear form: the dot product of coordinate vectors in a basis `b`,
-`(x, y) ↦ ∑_I (b x)_I (b y)_I`. -/
-def deltaBil (b : Basis ι ℂ M) : M →ₗ[ℂ] M →ₗ[ℂ] ℂ :=
-  LinearMap.mk₂ ℂ (fun x y => ∑ I, b.equivFun x I * b.equivFun y I)
-    (fun x x' y => by simp only [map_add, Pi.add_apply, add_mul, Finset.sum_add_distrib])
-    (fun a x y => by
-      simp only [map_smul, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
-      exact Finset.sum_congr rfl fun I _ => by ring)
-    (fun x y y' => by simp only [map_add, Pi.add_apply, mul_add, Finset.sum_add_distrib])
-    (fun a x y => by
-      simp only [map_smul, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
-      exact Finset.sum_congr rfl fun I _ => by ring)
+/-- The δ bilinear form: the bilinear form whose Gram matrix in the basis `b` is the identity,
+`Matrix.toBilin b 1`. On coordinates it is the dot product `(x, y) ↦ ∑_I (b x)_I (b y)_I`
+(`deltaBil_apply`), i.e. the form for which `b` is orthonormal. -/
+def deltaBil (b : Basis ι ℂ M) : M →ₗ[ℂ] M →ₗ[ℂ] ℂ := Matrix.toBilin b 1
+
+/-- `deltaBil b x y = ∑_I (b x)_I (b y)_I`: the identity Gram matrix collapses the double sum of
+`Matrix.toBilin_apply` to the dot product of the coordinate vectors. -/
+lemma deltaBil_apply (b : Basis ι ℂ M) (x y : M) :
+    deltaBil b x y = ∑ I, b.equivFun x I * b.equivFun y I := by
+  rw [deltaBil, Matrix.toBilin_apply]
+  simp [Matrix.one_apply, mul_ite, mul_zero, Finset.sum_ite_eq, Basis.equivFun_apply]
 
 /-- The δ contraction `M ⊗ M → ℂ`: the bilinear form `deltaBil` lifted to the tensor
 product. -/
@@ -259,12 +246,11 @@ contraction is symmetric in its arguments and that the cap is fixed by swapping 
 
 -/
 
-omit [DecidableEq ι] in
 /-- `deltaContr b (x ⊗ₜ y) = ∑_I x_I y_I`, the dot product of the coordinate vectors of `x` and
 `y` in the basis `b` (writing `x_I := (b.equivFun x) I`). -/
 lemma deltaContr_tmul (b : Basis ι ℂ M) (x y : M) :
     deltaContr b (x ⊗ₜ[ℂ] y) = ∑ I, b.equivFun x I * b.equivFun y I := by
-  simp only [deltaContr, TensorProduct.lift.tmul, deltaBil, LinearMap.mk₂_apply]
+  rw [deltaContr, TensorProduct.lift.tmul, deltaBil_apply]
 
 /-- `deltaContr b (x ⊗ₜ b J) = x_J`: pairing with the basis vector `b J` reads off the `J`-th
 coordinate `(b.equivFun x) J`. -/
@@ -278,7 +264,6 @@ lemma deltaContr_basis_basis (b : Basis ι ℂ M) (I J : ι) :
     deltaContr b (b I ⊗ₜ[ℂ] b J) = if I = J then 1 else 0 := by
   rw [deltaContr_tmul_basis, Basis.equivFun_self]
 
-omit [DecidableEq ι] in
 /-- `deltaContr b (x ⊗ₜ y) = deltaContr b (y ⊗ₜ x)`: the δ contraction is symmetric, since
 `∑_I x_I y_I = ∑_I y_I x_I`. -/
 lemma deltaContr_comm (b : Basis ι ℂ M) (x y : M) :
@@ -476,15 +461,6 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι))
           = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂)
       exact key (Basis.conj piBasis) piBasis
 
-/-- Type-safety smoke test. `chiralUp` and `chiralDown` are `τ`-dual, so a rank-2 tensor with
-those index colours admits the framework contraction `contrT`. A same-variance pair would
-fail the `τ`-hypothesis `S.τ (c I) = c J`, which is exactly the safety the species provides. -/
-example (t : (chiralTensor (ι := ι) (G := G)).Tensor
-      ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
-    (chiralTensor (ι := ι) (G := G)).Tensor
-      (![ChiralColor.chiralUp, ChiralColor.chiralDown] ∘ Fin.succSuccAbove 0 1) :=
-  TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t
-
 /-!
 ## F. Conjugation
 
@@ -503,33 +479,8 @@ section Conjugation
 open TensorSpecies TensorSpecies.Tensor ConjTensorSpecies ChiralColor
 
 /-!
-### F.1. Smoke tests
-
-Type-safety and behaviour checks for `chiralTensor`'s conjugation.
--/
-
-/-- Conjugating a metric-typed tensor `g : Tensor ![chiralDown, antiDown]` via `chiralTensor.conjT`
-lands in the conjugate-colour list `ChiralColor.bar ∘ ![chiralDown, antiDown]`, i.e.
-`![antiDown, chiralDown]`. This is purely a type-safety check. -/
-example (g : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown, antiDown]) :
-    (chiralTensor (ι := ι) (G := G)).Tensor (ChiralColor.bar ∘ ![chiralDown, antiDown]) :=
-  (chiralTensor (ι := ι) (G := G)).conjT g
-
-/-- `conjT_contrT` applies to a one-index contraction: conjugating first and then contracting
-equals contracting the conjugate. Checked at colour `![chiralUp, chiralDown]` contracted at
-slots `0` and `1`. -/
-example (t : (chiralTensor (ι := ι) (G := G)).Tensor
-    ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
-    (chiralTensor (ι := ι) (G := G)).conjT (TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t)
-      = TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩
-          ((chiralTensor (ι := ι) (G := G)).conjT t) :=
-  (chiralTensor (ι := ι) (G := G)).conjT_contrT 0 1 ⟨by decide, rfl⟩ t
-
-/-!
-### F.2. Scalar and covector helpers
-
-These two definitions normalize the output of `(chiralTensor (ι := ι) (G := G)).conjT` back to the canonical
-colour lists for scalar and anti-holomorphic covector tensors respectively.
+The following normalize the output of `(chiralTensor (ι := ι) (G := G)).conjT` back to the
+canonical colour lists for scalar and anti-holomorphic covector tensors respectively.
 
 -/
 

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -46,16 +46,16 @@ The physical field content is the configuration `ChiralScalarConfiguration ι =
 scalars are the complex conjugates of this data, never an independent
 configuration.
 
-The index data is packaged as a `TensorSpecies` over `ChiralColor`. Every colour
-shares the one carrier `ι → ℂ`; the four colours are labels recording variance
-and holomorphy, not distinct spaces. Each carries the trivial `G`-representation,
-so `G` acts as the identity and the chiral scalars hold no `G`-charge.
-Contracting a colour against its `τ`-dual is
-the dot product of their coordinate vectors in the fixed basis, which on basis
-labels is the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the
-same element, the δ "cap" `∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`.
-Supplying this instance equips the chiral sector with the framework's generic
-tensor API (`.Tensor`, `.contrT`, and so on).
+The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`. The chiral
+colours carry the standard carrier `ι → ℂ`; the anti colours carry its conjugate
+module `ConjModule (ι → ℂ)`, where `i` acts as `−i`, so anti-holomorphy is genuine
+carrier data and complex conjugation is an honest linear map between the two. Each
+carries the trivial `G`-representation, so `G` acts as the identity and the chiral
+scalars hold no `G`-charge. Contracting a colour against its `τ`-dual is the dot
+product of their coordinate vectors in that colour's basis, which on basis labels is
+the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the δ "cap"
+`∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`. Supplying this instance equips the
+chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
 
 Conjugation is intrinsic species data, bundled into the same object: `chiralTensor`
 is a `ConjTensorSpecies`, a `TensorSpecies` extended with the conjugate-colour
@@ -163,37 +163,45 @@ variable {ι G}
 ## C. Carrier, representation, and basis
 
 A `TensorSpecies` takes, for each colour `c`, a carrier module, a `G`-representation on it, and a
-basis. Here none of these depend on the colour: every colour gets the same carrier `ι → ℂ`, the
-trivial `G`-representation (no `G`-charge), and the indicator basis `piBasis`. So `chiralModule`,
-`chiralRep`, and `chiralBasis` are constant in `c`; the colour is only the bookkeeping label that
-`τ` and `bar` act on.
+basis. The carrier depends on holomorphy: chiral colours carry the standard `ι → ℂ`, anti colours
+its conjugate module `ConjModule (ι → ℂ)` (so anti-holomorphy is genuine carrier data). The
+`G`-representation is trivial (no `G`-charge) for every colour; the basis is the indicator basis
+`piBasis` on the chiral carrier and its conjugate `Basis.conj piBasis` on the anti carrier. Variance
+(`τ`) preserves holomorphy, so it never leaves a colour's carrier; conjugation (`bar`) flips
+holomorphy and so maps a carrier to its conjugate.
 
 -/
 
-/-- The carrier module of each colour: every colour shares the single carrier `ι → ℂ`. The
-distinctions between colours (variance and holomorphy) are recorded by the colour and the maps
-`τ`/`bar`, not by the carrier, so all four colours live in the same space. -/
-@[nolint unusedArguments]
-def chiralModule : ChiralColor → Type := fun _ => ι → ℂ
+/-- The carrier module of each colour. The chiral colours carry the standard `ι → ℂ`; the anti
+colours carry its conjugate module `ConjModule (ι → ℂ)`, where `i` acts as `−i`. This makes
+anti-holomorphy genuine carrier data — complex conjugation is an honest linear map into the
+conjugate carrier — rather than a label tracked separately. -/
+abbrev chiralModule : ChiralColor → Type
+  | .chiralUp | .chiralDown => ι → ℂ
+  | .antiUp | .antiDown => ConjModule (ι → ℂ)
 
-instance instAddCommGroupChiralModule (c : ChiralColor) :
-    AddCommGroup (chiralModule (ι := ι) c) := inferInstanceAs (AddCommGroup (ι → ℂ))
+instance instAddCommGroupChiralModule : ∀ c, AddCommGroup (chiralModule (ι := ι) c)
+  | .chiralUp | .chiralDown => inferInstance
+  | .antiUp | .antiDown => inferInstance
 
-noncomputable instance instModuleChiralModule (c : ChiralColor) :
-    Module ℂ (chiralModule (ι := ι) c) := inferInstanceAs (Module ℂ (ι → ℂ))
+noncomputable instance instModuleChiralModule : ∀ c, Module ℂ (chiralModule (ι := ι) c)
+  | .chiralUp | .chiralDown => inferInstance
+  | .antiUp | .antiDown => inferInstance
 
 /-- The `G`-representation on each colour, taken trivial: the chiral scalars carry no
 `G`-charge in this sector. -/
 def chiralRep : (c : ChiralColor) → Representation ℂ G (chiralModule (ι := ι) c) :=
   fun _ => Representation.trivial ℂ G _
 
-/-- The standard basis of the carrier `ι → ℂ` (the indicator functions). -/
+/-- The standard basis of the chiral carrier `ι → ℂ` (the indicator functions). -/
 def piBasis : Basis ι ℂ (ι → ℂ) := Pi.basisFun ℂ ι
 
-/-- The standard basis of each colour's carrier: every colour shares the carrier `ι → ℂ`, hence
-the basis `piBasis`. -/
-def chiralBasis : (c : ChiralColor) → Basis ι ℂ (chiralModule (ι := ι) c) :=
-  fun _ => piBasis
+/-- The basis of each colour's carrier: the chiral colours use the indicator basis `piBasis`; the
+anti colours use its conjugate `Basis.conj piBasis`, whose coordinates are the `star` of the
+indicator coordinates. -/
+noncomputable def chiralBasis : (c : ChiralColor) → Basis ι ℂ (chiralModule (ι := ι) c)
+  | .chiralUp | .chiralDown => piBasis
+  | .antiUp | .antiDown => Basis.conj piBasis
 
 /-!
 ## D. The δ structure on a based finite module
@@ -403,24 +411,35 @@ lemma deltaContr_metric (b : Basis ι ℂ M) :
 -/
 
 /-- The chiral-index tensor species, bundled with its conjugation. Its colours are
-`chiral`/`anti` × `up`/`down`, all carried by `ι → ℂ`, and every colour contracts by the bare δ
-pairing with the δ cap serving as both metric and unit. Each `TensorSpecies` coherence law reduces,
-by case analysis on the colour, to the corresponding abstract δ lemma above. The conjugation flips
-holomorphy (`ChiralColor.bar`) while preserving variance; since every colour shares the index type
-`ι`, the identification `barIdx_eq` is `rfl`, and `conj_contrComm` is `star δ = δ`. Instantiating
+`chiral`/`anti` × `up`/`down`; the chiral carriers are `ι → ℂ`, the anti carriers their conjugate
+module `ConjModule (ι → ℂ)`. Every colour contracts by the δ pairing at its own basis (the conjugate
+basis on the anti side), with the δ cap serving as both metric and unit. Each `TensorSpecies`
+coherence law reduces, by case analysis on the colour, to the corresponding abstract δ lemma above.
+The conjugation flips holomorphy (`ChiralColor.bar`) while preserving variance; the index type `ι`
+is shared, so `barIdx_eq` is `rfl`, and `conj_contrComm` is `star δ = δ`. Instantiating
 `ConjTensorSpecies` this way gives the chiral sector both the framework's generic tensor API and
 its conjugation API (`conjT` and its laws) on one object. -/
 def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι)) (fun _ => ι)
     (chiralRep (ι := ι) (G := G)) (chiralBasis (ι := ι)) where
   τ := ChiralColor.tau
   τ_involution c := by cases c <;> rfl
-  -- The carrier is `ι → ℂ` for every colour, so the data fields are uniform in `c`.
-  contr _ := { deltaContr piBasis with
-      isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
-  unit _ := { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
-      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-  metric _ := { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
-      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+  -- The δ data at each colour's own basis: `piBasis` on the chiral carrier, `Basis.conj piBasis`
+  -- on the anti carrier. `τ` preserves holomorphy, so both contracted slots share the carrier.
+  contr c := match c with
+    | .chiralUp | .chiralDown => { deltaContr piBasis with
+        isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
+    | .antiUp | .antiDown => { deltaContr (Basis.conj piBasis) with
+        isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
+  unit c := match c with
+    | .chiralUp | .chiralDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
+        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+    | .antiUp | .antiDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap (Basis.conj piBasis)) with
+        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+  metric c := match c with
+    | .chiralUp | .chiralDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
+        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+    | .antiUp | .antiDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap (Basis.conj piBasis)) with
+        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
   -- Each coherence law reduces, by case analysis on `c`, to the matching abstract δ lemma.
   contr_tmul_symm c x y := by cases c <;> exact deltaContr_comm _ _ _
   unit_symm c := by cases c <;> exact deltaUnit_symm _
@@ -433,12 +452,29 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor G (chiralModule (ι := ι))
   barIdx_eq _ := rfl
   conj_contrComm := by
     intro d x₁ x₂
-    -- Every colour's contraction is the real δ, so `star` fixes it; the `bar`-side casts are `rfl`,
-    -- so each case reduces by defeq to this single fact.
-    have h : star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
-        = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂) := by
-      rw [deltaContr_basis_basis]; split <;> simp
-    cases d <;> exact h
+    -- The contraction at every colour is the real δ at that colour's basis, so `star` fixes it. Each
+    -- case is restated (`show`) in `deltaContr`-at-basis form — cheap, since the `IntertwiningMap`
+    -- coercion is `rfl` and the `bar`-side casts (`barIdx_eq`/`bar_tau`) are `rfl`. Then the *lemma*
+    -- `deltaContr_basis_basis` evaluates both sides by a syntactic rewrite, so the heavy `Basis.conj`
+    -- is never `whnf`'d (which is what made `exact`/unification time out).
+    have key : ∀ {M₁ M₂ : Type} [AddCommGroup M₁] [Module ℂ M₁] [AddCommGroup M₂] [Module ℂ M₂]
+        (B₁ : Basis ι ℂ M₁) (B₂ : Basis ι ℂ M₂),
+        star (deltaContr B₁ (B₁ x₁ ⊗ₜ[ℂ] B₁ x₂)) = deltaContr B₂ (B₂ x₁ ⊗ₜ[ℂ] B₂ x₂) := by
+      intro M₁ M₂ _ _ _ _ B₁ B₂
+      rw [deltaContr_basis_basis, deltaContr_basis_basis]; split <;> simp
+    cases d
+    · show star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
+          = deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂)
+      exact key piBasis (Basis.conj piBasis)
+    · show star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
+          = deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂)
+      exact key piBasis (Basis.conj piBasis)
+    · show star (deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂))
+          = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂)
+      exact key (Basis.conj piBasis) piBasis
+    · show star (deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂))
+          = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂)
+      exact key (Basis.conj piBasis) piBasis
 
 /-- Type-safety smoke test. `chiralUp` and `chiralDown` are `τ`-dual, so a rank-2 tensor with
 those index colours admits the framework contraction `contrT`. A same-variance pair would

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -6,7 +6,6 @@ Authors: Andrea Pari
 module
 
 public import Mathlib.Data.Complex.Basic
-public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import Physlib.Relativity.Tensors.Conjugation.Basic
 
 /-!

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -178,6 +178,7 @@ trivial `G`-representation (no `G`-charge), and the indicator basis `piBasis`. S
 /-- The carrier module of each colour: every colour shares the single carrier `ι → ℂ`. The
 distinctions between colours (variance and holomorphy) are recorded by the colour and the maps
 `τ`/`bar`, not by the carrier, so all four colours live in the same space. -/
+@[nolint unusedArguments]
 def chiralModule : ChiralColor → Type := fun _ => ι → ℂ
 
 instance instAddCommGroupChiralModule (c : ChiralColor) :
@@ -333,8 +334,8 @@ lemma deltaContr_deltaCap (b : Basis ι ℂ M) (x : M) :
   rw [TensorProduct.assoc_symm_tmul, LinearMap.rTensor_tmul, TensorProduct.lid_tmul,
     deltaContr_tmul_basis]
 
-/-- `∑_{IJ} (b_I · b_J) b_I ⊗ b_J = ∑_I b_I ⊗ b_I = deltaCap b` (the `contr_metric` law): contracting
-the two inner legs of `deltaCap b ⊗ deltaCap b` collapses it to a single cap, using
+/-- `∑_{IJ} (b_I · b_J) b_I ⊗ b_J = ∑_I b_I ⊗ b_I = deltaCap b` (the `contr_metric` law):
+contracting the two inner legs of `deltaCap b ⊗ deltaCap b` collapses it to a single cap, using
 `b_I · b_J = δ_{IJ}`. -/
 lemma deltaCap_contr_deltaCap (b : Basis ι ℂ M) :
     (TensorProduct.comm ℂ M M ((TensorProduct.lid ℂ M).lTensor M
@@ -493,7 +494,8 @@ example (g : (chiralTensor (ι := ι) (G := G)).Tensor ![chiralDown, antiDown]) 
 /-- `conjT_contrT` applies to a one-index contraction: conjugating first and then contracting
 equals contracting the conjugate. Checked at colour `![chiralUp, chiralDown]` contracted at
 slots `0` and `1`. -/
-example (t : (chiralTensor (ι := ι) (G := G)).Tensor ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
+example (t : (chiralTensor (ι := ι) (G := G)).Tensor
+    ![ChiralColor.chiralUp, ChiralColor.chiralDown]) :
     chiralConjStructure.conjT (TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ t)
       = TensorSpecies.Tensor.contrT 0 0 1 ⟨by decide, rfl⟩ (chiralConjStructure.conjT t) :=
   chiralConjStructure.conjT_contrT 0 1 ⟨by decide, rfl⟩ t

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -36,18 +36,19 @@ The physical field content is the configuration `ChiralScalarConfiguration ι =
 scalars are the complex conjugates of this data, never an independent
 configuration.
 
-The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`. The chiral
-colours carry the standard carrier `ι → ℂ`; the anti colours carry its conjugate
-module `ConjModule (ι → ℂ)`, where `i` acts as `−i`, so anti-holomorphy is genuine
-carrier data. Complex conjugation is then the conjugate-linear identity
-`conjEquiv : (ι → ℂ) ≃ₛₗ[starRingEnd ℂ] ConjModule (ι → ℂ)`: the anti basis is its transport
-`Basis.conj piBasis`, and the species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Each
-colour carries the trivial representation over the trivial group `Unit`, so the chiral scalars hold no
-charge. Contracting a colour against its `τ`-dual is the dot
-product of their coordinate vectors in that colour's basis, which on basis labels is
-the Kronecker `δ_{IJ}`. The `metric` and `unit` fields are both the δ "cap"
-`∑_I b_I ⊗ b_I` whose components are `δ^{IJ}`. Supplying this instance equips the
-chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
+The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`. The four colours carry four
+distinct carriers, recording both axes as genuine type data: the holomorphic vectors `ι → ℂ` (up)
+and their dual `Module.Dual ℂ (ι → ℂ)` (down) on the chiral side, and the conjugate modules
+`ConjModule …` of each on the anti side, where `i` acts as `−i`. Variance is thus the vector/dual
+distinction and holomorphy the conjugate-module distinction, so an upper index pairs only with a
+lower one of the same holomorphy. Complex conjugation is the conjugate-linear identity
+`conjEquiv : M ≃ₛₗ[starRingEnd ℂ] ConjModule M` on each carrier (anti basis = `Basis.conj`), and the
+species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Each colour carries the
+trivial representation over the trivial group `Unit`, so the chiral scalars hold no charge.
+Contracting a colour against its `τ`-dual is the dot product of the two coordinate vectors, the
+Kronecker `δ_{IJ}` on basis labels: `contr` is that pairing `V c ⊗ V (τ c) → ℂ`, `unit` its cap in
+`V (τ c) ⊗ V c`, and `metric` the cap `∑_I b_I ⊗ b_I` in `V c ⊗ V c`. Supplying this instance equips
+the chiral sector with the framework's generic tensor API (`.Tensor`, `.contrT`, and so on).
 
 Conjugation is intrinsic species data: a `ConjTensorSpecies` is a `TensorSpecies`
 extended with the conjugate-colour involution `ChiralColor.bar` and its coherence. The framework then supplies the
@@ -77,11 +78,9 @@ is real. The species can express none of these alone.
 - A. The chiral scalar configuration
 - B. The chiral colours and the dual involution
 - C. Carrier, representation, and basis
-- D. The δ structure on a based finite module
-  - D.1. The bilinear form, contraction, and cap
-  - D.2. Computation lemmas
-  - D.3. The coherence laws
-  - D.4. The coherence laws in `toSpanSingleton` form
+- D. The δ structure on based finite modules
+  - D.1. The bilinear form and the cap
+  - D.2. The δ pairing across two based modules
 - E. The chiral-index tensor species
 - F. Conjugation
 
@@ -151,30 +150,30 @@ variable {ι}
 ## C. Carrier, representation, and basis
 
 A `TensorSpecies` takes, for each colour `c`, a carrier module, a group representation on it, and a
-basis. The carrier depends on holomorphy: chiral colours carry the standard `ι → ℂ`, anti colours
-its conjugate module `ConjModule (ι → ℂ)` (so anti-holomorphy is genuine carrier data). The
-representation is trivial over the trivial group `Unit` (no charge) for every colour; the basis is the indicator basis
-`piBasis` on the chiral carrier and its conjugate `Basis.conj piBasis` on the anti carrier. Variance
-(`τ`) preserves holomorphy, so it never leaves a colour's carrier; conjugation (`bar`) flips
-holomorphy and so maps a carrier to its conjugate.
+basis. The carrier depends on *both* axes: variance gives the vector/dual distinction (`ι → ℂ`
+versus `Module.Dual ℂ (ι → ℂ)`) and holomorphy the conjugate-module distinction (`ConjModule …`,
+where `i` acts as `−i`), so all four colours have distinct carriers. The representation is trivial
+over the trivial group `Unit` (no charge) for every colour; each basis is indexed by `ι` —
+`piBasis`, its dual `piBasis.dualBasis`, and the `Basis.conj` of each. Variance (`τ`) sends a
+carrier to its dual; conjugation (`bar`) sends it to its conjugate module.
 
 -/
 
-/-- The carrier module of each colour. The chiral colours carry the standard `ι → ℂ`; the anti
-colours carry its conjugate module `ConjModule (ι → ℂ)`, where `i` acts as `−i`. This makes
-anti-holomorphy genuine carrier data — complex conjugation is an honest linear map into the
-conjugate carrier — rather than a label tracked separately. -/
+/-- The carrier module of each colour, distinct for all four: the holomorphic vectors `ι → ℂ` and
+their dual `Module.Dual ℂ (ι → ℂ)` on the chiral side, and the conjugate module `ConjModule …` of
+each (where `i` acts as `−i`) on the anti side. Variance is the vector/dual axis, holomorphy the
+conjugate-module axis; both are genuine carrier data, not labels tracked separately. -/
 abbrev chiralModule : ChiralColor → Type
-  | .chiralUp | .chiralDown => ι → ℂ
-  | .antiUp | .antiDown => ConjModule (ι → ℂ)
+  | .chiralUp   => ι → ℂ
+  | .chiralDown => Module.Dual ℂ (ι → ℂ)
+  | .antiUp     => ConjModule (ι → ℂ)
+  | .antiDown   => ConjModule (Module.Dual ℂ (ι → ℂ))
 
 instance instAddCommGroupChiralModule : ∀ c, AddCommGroup (chiralModule (ι := ι) c)
-  | .chiralUp | .chiralDown => inferInstance
-  | .antiUp | .antiDown => inferInstance
+  | .chiralUp | .chiralDown | .antiUp | .antiDown => inferInstance
 
 noncomputable instance instModuleChiralModule : ∀ c, Module ℂ (chiralModule (ι := ι) c)
-  | .chiralUp | .chiralDown => inferInstance
-  | .antiUp | .antiDown => inferInstance
+  | .chiralUp | .chiralDown | .antiUp | .antiDown => inferInstance
 
 /-- The representation on each colour, taken trivial over the trivial group `Unit`: the chiral
 scalars carry no charge in this sector. -/
@@ -184,25 +183,28 @@ def chiralRep : (c : ChiralColor) → Representation ℂ Unit (chiralModule (ι 
 /-- The standard basis of the chiral carrier `ι → ℂ` (the indicator functions). -/
 def piBasis : Basis ι ℂ (ι → ℂ) := Pi.basisFun ℂ ι
 
-/-- The basis of each colour's carrier: the chiral colours use the indicator basis `piBasis`; the
-anti colours use its conjugate `Basis.conj piBasis`, whose coordinates are the `star` of the
-indicator coordinates. -/
+/-- The basis of each colour's carrier, all indexed by `ι`: `piBasis` on the holomorphic vectors,
+its dual `piBasis.dualBasis` on the holomorphic covectors, and the `Basis.conj` of each on the
+anti-holomorphic side (coordinates `star`-ed). -/
 noncomputable def chiralBasis : (c : ChiralColor) → Basis ι ℂ (chiralModule (ι := ι) c)
-  | .chiralUp | .chiralDown => piBasis
-  | .antiUp | .antiDown => Basis.conj piBasis
+  | .chiralUp   => piBasis
+  | .chiralDown => piBasis.dualBasis
+  | .antiUp     => Basis.conj piBasis
+  | .antiDown   => Basis.conj piBasis.dualBasis
 
 /-!
-## D. The δ structure on a based finite module
+## D. The δ structure on based finite modules
 
-The contraction, unit, and metric are the same δ structure, written in basis coordinates: the
-contraction is the Kronecker δ pairing `(x, y) ↦ ∑_I x_I y_I`, while the unit and metric are both
-the matching δ "cap" `∑_I b_I ⊗ b_I`. They are defined once below over an abstract based module
-`(M, b)`, then used at `piBasis` to build the species' fields in §E. A contraction only ever pairs
-a colour with its `τ`-dual (same holomorphy, opposite variance), so it stays within one holomorphy
-and needs no conjugation; conjugation is carried instead by the tensor `conjT` and the
+The contraction, unit, and metric are one δ structure in basis coordinates. A contraction pairs a
+colour with its variance dual `τ c`, whose carriers are *distinct* (a module and its dual, or their
+conjugates) but share the index `ι`, so the pairing is the dot product *across two based modules*
+`(M, b)` and `(N, b')`, `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, with cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. The
+single-module case `b = b'` (§D.1) is what `metric c` uses, since its two slots are the same colour;
+the genuinely two-module pairing (§D.2) is what `contr` and `unit` use. The δ data stays within one
+holomorphy and needs no conjugation; conjugation is carried instead by the tensor `conjT` and the
 anti-holomorphic Wirtinger derivatives that produce barred components.
 
-### D.1. The bilinear form, contraction, and cap
+### D.1. The bilinear form and the cap
 
 -/
 
@@ -220,216 +222,155 @@ lemma deltaBil_apply (b : Basis ι ℂ M) (x y : M) :
   rw [deltaBil, Matrix.toBilin_apply]
   simp [Matrix.one_apply, mul_ite, mul_zero, Finset.sum_ite_eq, Basis.equivFun_apply]
 
-/-- The δ contraction `M ⊗ M → ℂ`: the bilinear form `deltaBil` lifted to the tensor
-product. -/
-def deltaContr (b : Basis ι ℂ M) : M ⊗[ℂ] M →ₗ[ℂ] ℂ := TensorProduct.lift (deltaBil b)
-
 /-- The δ cap `∑_I b_I ⊗ b_I`: the rank-2 tensor in `M ⊗ M` with two upper indices, whose
-components in the basis `b` are `δⁱʲ`. It is an element of `M ⊗ M` (the inverse-metric "cap"
-dual to `deltaContr`), not a linear map, and serves as both the metric and the unit of the
-species. -/
+components in the basis `b` are `δⁱʲ`. It is an element of `M ⊗ M` (the inverse-metric "cap"),
+not a linear map, and serves as the `metric` field of the species (whose two slots share a
+colour). -/
 def deltaCap (b : Basis ι ℂ M) : M ⊗[ℂ] M := ∑ I, b I ⊗ₜ[ℂ] b I
 
 /-!
-### D.2. Computation lemmas
+### D.2. The δ pairing across two based modules
 
-Rewrite rules that evaluate the abstractly-defined `deltaContr` and `deltaCap` on concrete
-inputs, together with their two symmetries. They are the only place that unfolds the δ
-definitions and the basis coordinate facts; the coherence laws of §D.3 are assembled entirely
-from them.
-
-`deltaContr_tmul` is the base rule, `deltaContr b (x ⊗ₜ y) = ∑_I x_I y_I`. Specializing the
-second argument to a basis vector (`deltaContr_tmul_basis`) reads off one coordinate, and
-specializing both (`deltaContr_basis_basis`) gives the Kronecker `δ_{IJ}`, i.e. the basis is
-orthonormal for the δ pairing. `deltaContr_comm` and `deltaCap_comm` record that the
-contraction is symmetric in its arguments and that the cap is fixed by swapping its factors.
+A contraction pairs a colour with its variance dual `τ c`, whose carriers are *distinct* types —
+e.g. the holomorphic vectors `ι → ℂ` and the holomorphic covectors `Module.Dual ℂ (ι → ℂ)` — so the
+δ pairing runs between two based modules `(M, b)` and `(N, b')` sharing the index `ι`:
+`(x, y) ↦ ∑_I (b x)_I (b' y)_I`, with cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. Setting `b = b'` recovers §D.1.
+This is the data of `contr` (the pairing `M ⊗ N → ℂ`) and `unit` (the cap), and the coherence laws
+the species demands of them, proved here once over abstract `(M, b)`, `(N, b')`.
 
 -/
 
-/-- `deltaContr b (x ⊗ₜ y) = ∑_I x_I y_I`, the dot product of the coordinate vectors of `x` and
-`y` in the basis `b` (writing `x_I := (b.equivFun x) I`). -/
-lemma deltaContr_tmul (b : Basis ι ℂ M) (x y : M) :
-    deltaContr b (x ⊗ₜ[ℂ] y) = ∑ I, b.equivFun x I * b.equivFun y I := by
-  rw [deltaContr, TensorProduct.lift.tmul, deltaBil_apply]
+variable {N : Type*} [AddCommGroup N] [Module ℂ N]
 
-/-- `deltaContr b (x ⊗ₜ b J) = x_J`: pairing with the basis vector `b J` reads off the `J`-th
-coordinate `(b.equivFun x) J`. -/
-lemma deltaContr_tmul_basis (b : Basis ι ℂ M) (x : M) (J : ι) :
-    deltaContr b (x ⊗ₜ[ℂ] b J) = b.equivFun x J := by
-  simp [deltaContr_tmul, Basis.equivFun_self]
+omit [DecidableEq ι] in
+/-- `piBasis.equivFun` is the identity readout of coordinates: `(piBasis.equivFun v) I = v I`. -/
+lemma piBasis_equivFun (v : ι → ℂ) (I : ι) : (piBasis (ι := ι)).equivFun v I = v I := by
+  simp [piBasis]
 
-/-- `deltaContr b (b I ⊗ₜ b J) = δ_{IJ}` (`if I = J then 1 else 0`): the basis vectors are
-orthonormal for the δ pairing. -/
-lemma deltaContr_basis_basis (b : Basis ι ℂ M) (I J : ι) :
-    deltaContr b (b I ⊗ₜ[ℂ] b J) = if I = J then 1 else 0 := by
-  rw [deltaContr_tmul_basis, Basis.equivFun_self]
+/-- The δ pairing between two based modules sharing the index `ι`: the dot product of coordinate
+vectors `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, built by reading both sides into `ι → ℂ` and applying the
+reference dot product `deltaBil piBasis`. Equals `deltaBil b` when `b = b'`. -/
+def deltaBil₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M →ₗ[ℂ] N →ₗ[ℂ] ℂ :=
+  ((deltaBil piBasis).comp b.equivFun.toLinearMap).compl₂ b'.equivFun.toLinearMap
 
-/-- `deltaContr b (x ⊗ₜ y) = deltaContr b (y ⊗ₜ x)`: the δ contraction is symmetric, since
-`∑_I x_I y_I = ∑_I y_I x_I`. -/
-lemma deltaContr_comm (b : Basis ι ℂ M) (x y : M) :
-    deltaContr b (x ⊗ₜ[ℂ] y) = deltaContr b (y ⊗ₜ[ℂ] x) := by
-  rw [deltaContr_tmul, deltaContr_tmul]
+/-- `deltaBil₂ b b' x y = ∑_I (b x)_I (b' y)_I`. -/
+lemma deltaBil₂_apply (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (y : N) :
+    deltaBil₂ b b' x y = ∑ I, b.equivFun x I * b'.equivFun y I := by
+  rw [deltaBil₂, LinearMap.compl₂_apply, LinearMap.comp_apply, LinearEquiv.coe_coe,
+    LinearEquiv.coe_coe, deltaBil_apply]
+  exact Finset.sum_congr rfl fun I _ => by rw [piBasis_equivFun, piBasis_equivFun]
+
+/-- The two-module δ contraction `M ⊗ N → ℂ`. -/
+def deltaContr₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M ⊗[ℂ] N →ₗ[ℂ] ℂ :=
+  TensorProduct.lift (deltaBil₂ b b')
+
+/-- `deltaContr₂ b b' (x ⊗ₜ y) = ∑_I (b x)_I (b' y)_I`. -/
+lemma deltaContr₂_tmul (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (y : N) :
+    deltaContr₂ b b' (x ⊗ₜ[ℂ] y) = ∑ I, b.equivFun x I * b'.equivFun y I := by
+  rw [deltaContr₂, TensorProduct.lift.tmul, deltaBil₂_apply]
+
+/-- `deltaContr₂ b b' (x ⊗ₜ b' J) = x_J`: pairing with the second basis reads off a coordinate. -/
+lemma deltaContr₂_tmul_basis (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (J : ι) :
+    deltaContr₂ b b' (x ⊗ₜ[ℂ] b' J) = b.equivFun x J := by
+  simp [deltaContr₂_tmul, Basis.equivFun_self]
+
+/-- `deltaContr₂ b b' (b I ⊗ₜ b' J) = δ_{IJ}`: the two bases are δ-dual. -/
+lemma deltaContr₂_basis_basis (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (I J : ι) :
+    deltaContr₂ b b' (b I ⊗ₜ[ℂ] b' J) = if I = J then 1 else 0 := by
+  rw [deltaContr₂_tmul_basis, Basis.equivFun_self]
+
+/-- `deltaContr₂ b b' (x ⊗ₜ y) = deltaContr₂ b' b (y ⊗ₜ x)`: swapping slots swaps the two bases. -/
+lemma deltaContr₂_comm (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (y : N) :
+    deltaContr₂ b b' (x ⊗ₜ[ℂ] y) = deltaContr₂ b' b (y ⊗ₜ[ℂ] x) := by
+  rw [deltaContr₂_tmul, deltaContr₂_tmul]
   exact Finset.sum_congr rfl fun I _ => mul_comm _ _
 
+/-- The two-module δ cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. -/
+def deltaCap₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M ⊗[ℂ] N := ∑ I, b I ⊗ₜ[ℂ] b' I
+
 omit [DecidableEq ι] in
-/-- `comm (deltaCap b) = deltaCap b`: swapping the two tensor factors fixes the cap, since
-every summand `b_I ⊗ b_I` is symmetric. -/
-lemma deltaCap_comm (b : Basis ι ℂ M) :
-    TensorProduct.comm ℂ M M (deltaCap b) = deltaCap b := by
-  rw [deltaCap, map_sum]
+/-- `comm (deltaCap₂ b b') = deltaCap₂ b' b`: swapping the two factors swaps the two bases. -/
+lemma deltaCap₂_comm (b : Basis ι ℂ M) (b' : Basis ι ℂ N) :
+    TensorProduct.comm ℂ M N (deltaCap₂ b b') = deltaCap₂ b' b := by
+  rw [deltaCap₂, map_sum]
   exact Finset.sum_congr rfl fun I _ => by rw [TensorProduct.comm_tmul]
 
-/-!
-### D.3. The coherence laws
-
-The three nontrivial axioms a `TensorSpecies` demands of its `unit`, `contr`, and `metric`,
-proved here for the δ structure over an abstract based module `(M, b)` so that every colour
-inherits them. Each corresponds to one species field:
-
-- `deltaCap_unit_symm` (`unit_symm`): the cap is unchanged by swapping its factors;
-- `deltaContr_deltaCap` (`contr_unit`): the snake identity, contracting the cap against a
-  vector returns that vector;
-- `deltaCap_contr_deltaCap` (`contr_metric`): contracting two adjacent caps yields one cap.
-
-The fourth axiom, `contr_tmul_symm`, is just `deltaContr_comm` from §D.2 and is not repeated
-here. These statements use `deltaCap`/`deltaContr` directly; §D.4 repackages them into the
-`toSpanSingleton` form the species fields literally require.
-
--/
-
 omit [DecidableEq ι] in
-/-- The `unit_symm` law for the δ cap: `deltaCap b = lTensor M id (comm (deltaCap b))`.
-On the right, `comm` swaps the cap's two tensor factors and `lTensor M id` applies the identity
-to the left factor (it is the identity because `τ` here keeps the carrier fixed, so the
-species' type-cast is trivial). Both operations leave the cap alone, so the law reduces to
-`comm (deltaCap b) = deltaCap b` (`deltaCap_comm`): swapping the two legs of `∑_I b_I ⊗ b_I`
-leaves it unchanged. -/
-lemma deltaCap_unit_symm (b : Basis ι ℂ M) :
-    deltaCap b = LinearMap.lTensor M (LinearEquiv.refl ℂ M).toLinearMap
-      (TensorProduct.comm ℂ M M (deltaCap b)) := by
-  simp only [deltaCap_comm, LinearEquiv.refl_toLinearMap, LinearMap.lTensor_id, LinearMap.id_coe,
-    id_eq]
+/-- The `unit_symm` law (two-module, `toSpanSingleton` form): `deltaCap₂ b' b` is the swap of
+`deltaCap₂ b b'`. -/
+lemma deltaUnit₂_symm (b : Basis ι ℂ M) (b' : Basis ι ℂ N) :
+    LinearMap.toSpanSingleton ℂ _ (deltaCap₂ b' b) 1 =
+      LinearMap.lTensor N (LinearEquiv.refl ℂ M).toLinearMap
+        (TensorProduct.comm ℂ M N (LinearMap.toSpanSingleton ℂ _ (deltaCap₂ b b') 1)) := by
+  simp only [LinearMap.toSpanSingleton_apply_one]
+  rw [deltaCap₂_comm]
+  simp only [LinearEquiv.refl_toLinearMap, LinearMap.lTensor_id, LinearMap.id_coe, id_eq]
 
-/-- The snake identity `∑_I (x · b_I) b_I = ∑_I x_I b_I = x` (the `contr_unit` law): contracting
-`x` into the left leg of the cap `∑_I b_I ⊗ b_I` and keeping the right leg returns `x`. The
-displayed term is the framework's spelling of this via `assoc`/`lid`. -/
-lemma deltaContr_deltaCap (b : Basis ι ℂ M) (x : M) :
-    (TensorProduct.lid ℂ M) ((deltaContr b).rTensor M
-      ((TensorProduct.assoc ℂ M M M).symm (x ⊗ₜ[ℂ] deltaCap b))) = x := by
-  rw [deltaCap, TensorProduct.tmul_sum, map_sum, map_sum, map_sum]
+/-- The snake identity (two-module, `contr_unit` law): contracting `x ∈ M` into the `M`-leg of
+`deltaCap₂ b' b ∈ N ⊗ M` returns `x`. -/
+lemma deltaContr₂_unit (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) :
+    (TensorProduct.lid ℂ M) ((deltaContr₂ b b').rTensor M
+      ((TensorProduct.assoc ℂ M N M).symm
+        (x ⊗ₜ[ℂ] LinearMap.toSpanSingleton ℂ _ (deltaCap₂ b' b) 1))) = x := by
+  rw [LinearMap.toSpanSingleton_apply_one, deltaCap₂, TensorProduct.tmul_sum, map_sum, map_sum,
+    map_sum]
   conv_rhs => rw [← b.sum_equivFun x]
   refine Finset.sum_congr rfl fun I _ => ?_
   rw [TensorProduct.assoc_symm_tmul, LinearMap.rTensor_tmul, TensorProduct.lid_tmul,
-    deltaContr_tmul_basis]
+    deltaContr₂_tmul_basis]
 
-/-- `∑_{IJ} (b_I · b_J) b_I ⊗ b_J = ∑_I b_I ⊗ b_I = deltaCap b` (the `contr_metric` law):
-contracting the two inner legs of `deltaCap b ⊗ deltaCap b` collapses it to a single cap, using
-`b_I · b_J = δ_{IJ}`. -/
-lemma deltaCap_contr_deltaCap (b : Basis ι ℂ M) :
-    (TensorProduct.comm ℂ M M ((TensorProduct.lid ℂ M).lTensor M
-      (((deltaContr b).rTensor M).lTensor M
-        (((TensorProduct.assoc ℂ M M M).symm.toLinearMap.lTensor M)
-          ((TensorProduct.assoc ℂ M M (M ⊗[ℂ] M))
-            (deltaCap b ⊗ₜ[ℂ] deltaCap b)))))) = deltaCap b := by
-  conv_lhs => rw [deltaCap, TensorProduct.sum_tmul]
-  conv_rhs => rw [deltaCap]
+/-- The `contr_metric` law (two-module): contracting the inner `M`/`N` legs of
+`deltaCap b ⊗ deltaCap b'` yields `deltaCap₂ b' b`. -/
+lemma deltaContr₂_metric (b : Basis ι ℂ M) (b' : Basis ι ℂ N) :
+    (TensorProduct.comm ℂ M N ((TensorProduct.lid ℂ N).lTensor M
+      (((deltaContr₂ b b').rTensor N).lTensor M
+        (((TensorProduct.assoc ℂ M N N).symm.toLinearMap.lTensor M)
+          ((TensorProduct.assoc ℂ M M (N ⊗[ℂ] N))
+            (LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 ⊗ₜ[ℂ]
+              LinearMap.toSpanSingleton ℂ _ (deltaCap b') 1)))))) =
+      LinearMap.toSpanSingleton ℂ _ (deltaCap₂ b' b) 1 := by
+  rw [LinearMap.toSpanSingleton_apply_one, LinearMap.toSpanSingleton_apply_one,
+    LinearMap.toSpanSingleton_apply_one]
+  conv_lhs => rw [deltaCap, deltaCap, TensorProduct.sum_tmul]
+  conv_rhs => rw [deltaCap₂]
   simp only [TensorProduct.tmul_sum, map_sum]
   simp [TensorProduct.assoc_tmul, LinearEquiv.lTensor_tmul, LinearMap.lTensor_tmul,
     TensorProduct.assoc_symm_tmul, LinearMap.rTensor_tmul, TensorProduct.lid_tmul,
-    TensorProduct.comm_tmul, deltaContr_basis_basis, ite_smul]
+    TensorProduct.comm_tmul, deltaContr₂_basis_basis, ite_smul]
   simp [TensorProduct.ite_tmul, Finset.sum_ite_eq]
-
-/-!
-### D.4. The coherence laws in `toSpanSingleton` form
-
-The species' `unit` and `metric` fields are not the bare element `deltaCap b` but the map
-`toSpanSingleton ℂ _ (deltaCap b)` sending `1 ↦ deltaCap b`, so the coherence goals mention
-`toSpanSingleton _ (deltaCap b) 1` wherever §D.3 has `deltaCap b`. These three lemmas bridge
-that gap: each rewrites `toSpanSingleton_apply_one` (`toSpanSingleton _ v 1 = v`) and then
-applies the matching §D.3 law, restating it in the exact shape the fields require.
-
-- `deltaUnit_symm` ← `deltaCap_unit_symm` (`unit_symm`);
-- `deltaContr_unit` ← `deltaContr_deltaCap` (`contr_unit`);
-- `deltaContr_metric` ← `deltaCap_contr_deltaCap` (`contr_metric`).
-
-Stated abstractly over `(M, b)`, they reduce each coherence field of `chiralTensor` to a single
-`cases c <;> exact …`. The fourth law, `contr_tmul_symm`, needs no adapter and uses
-`deltaContr_comm` from §D.2 directly.
-
--/
-
-omit [DecidableEq ι] in
-/-- The `unit_symm` law with `unit = toSpanSingleton _ (deltaCap b)`: evaluated at `1` it is
-`deltaCap b = lTensor M id (comm (deltaCap b))` (`deltaCap_unit_symm`). -/
-lemma deltaUnit_symm (b : Basis ι ℂ M) :
-    LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 =
-      LinearMap.lTensor M (LinearEquiv.refl ℂ M).toLinearMap
-        (TensorProduct.comm ℂ M M (LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1)) := by
-  simp only [LinearMap.toSpanSingleton_apply_one]
-  exact deltaCap_unit_symm b
-
-/-- The `contr_unit` law with the cap as `toSpanSingleton _ (deltaCap b)`: at `1` it is
-`∑_I (x · b_I) b_I = x` (`deltaContr_deltaCap`). -/
-lemma deltaContr_unit (b : Basis ι ℂ M) (x : M) :
-    (TensorProduct.lid ℂ M) ((deltaContr b).rTensor M
-      ((TensorProduct.assoc ℂ M M M).symm
-        (x ⊗ₜ[ℂ] LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1))) = x := by
-  rw [LinearMap.toSpanSingleton_apply_one]
-  exact deltaContr_deltaCap b x
-
-/-- The `contr_metric` law with the metric as `toSpanSingleton _ (deltaCap b)`: at `1` it is
-`∑_{IJ} (b_I · b_J) b_I ⊗ b_J = deltaCap b` (`deltaCap_contr_deltaCap`). -/
-lemma deltaContr_metric (b : Basis ι ℂ M) :
-    (TensorProduct.comm ℂ M M ((TensorProduct.lid ℂ M).lTensor M
-      (((deltaContr b).rTensor M).lTensor M
-        (((TensorProduct.assoc ℂ M M M).symm.toLinearMap.lTensor M)
-          ((TensorProduct.assoc ℂ M M (M ⊗[ℂ] M))
-            (LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 ⊗ₜ[ℂ]
-              LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1)))))) =
-      LinearMap.toSpanSingleton ℂ _ (deltaCap b) 1 := by
-  rw [LinearMap.toSpanSingleton_apply_one]
-  exact deltaCap_contr_deltaCap b
 
 /-!
 ## E. The chiral-index tensor species
 
 -/
 
-/-- The chiral-index tensor species, bundled with its conjugation. Its colours are
-`chiral`/`anti` × `up`/`down`; the chiral carriers are `ι → ℂ`, the anti carriers their conjugate
-module `ConjModule (ι → ℂ)`. Every colour contracts by the δ pairing at its own basis (the conjugate
-basis on the anti side), with the δ cap serving as both metric and unit. Each `TensorSpecies`
-coherence law reduces, by case analysis on the colour, to the corresponding abstract δ lemma above.
-The conjugation flips holomorphy (`ChiralColor.bar`) while preserving variance; the index type `ι`
-is shared, so `barIdx_eq` is `rfl`, and `conj_contrComm` is `star δ = δ`. Instantiating
-`ConjTensorSpecies` this way gives the chiral sector both the framework's generic tensor API and
-its conjugation API (`conjT` and its laws) on one object. -/
+/-- The chiral-index tensor species, bundled with its conjugation. Its four colours
+`chiral`/`anti` × `up`/`down` carry the four distinct carriers of §C. `contr c` is the two-module δ
+pairing of a colour against its variance dual `τ c` (`V c ⊗ V (τ c) → ℂ`); `unit c` is the δ cap
+across those two carriers; `metric c` is the single-colour δ cap `∑_I b_I ⊗ b_I`. Each
+`TensorSpecies` coherence law reduces, by case analysis on the colour, to the corresponding abstract
+two-module δ lemma of §D.2. The conjugation flips holomorphy (`ChiralColor.bar`) while preserving
+variance; every basis is indexed by `ι`, so `barIdx_eq` is `rfl`, and `conj_contrComm` is
+`star δ = δ`. Instantiating `ConjTensorSpecies` this way gives the chiral sector both the framework's
+generic tensor API and its conjugation API (`conjT` and its laws) on one object. -/
 def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := ι)) (fun _ => ι)
     (chiralRep (ι := ι)) (chiralBasis (ι := ι)) where
   τ := ChiralColor.tau
   τ_involution c := by cases c <;> rfl
-  -- The δ data at each colour's own basis: `piBasis` on the chiral carrier, `Basis.conj piBasis`
-  -- on the anti carrier. `τ` preserves holomorphy, so both contracted slots share the carrier.
-  contr c := match c with
-    | .chiralUp | .chiralDown => { deltaContr piBasis with
-        isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
-    | .antiUp | .antiDown => { deltaContr (Basis.conj piBasis) with
-        isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
-  unit c := match c with
-    | .chiralUp | .chiralDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
-        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-    | .antiUp | .antiDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap (Basis.conj piBasis)) with
-        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-  metric c := match c with
-    | .chiralUp | .chiralDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap piBasis) with
-        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-    | .antiUp | .antiDown => { LinearMap.toSpanSingleton ℂ _ (deltaCap (Basis.conj piBasis)) with
-        isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
-  -- Each coherence law reduces, by case analysis on `c`, to the matching abstract δ lemma.
-  contr_tmul_symm c x y := by cases c <;> exact deltaContr_comm _ _ _
-  unit_symm c := by cases c <;> exact deltaUnit_symm _
-  contr_unit c x := by cases c <;> exact deltaContr_unit _ x
-  contr_metric c := by cases c <;> exact deltaContr_metric _
+  -- `contr` pairs a colour with its variance dual `τ c` (distinct carriers, e.g. `ι → ℂ` against its
+  -- dual); `unit` is the δ cap across those two carriers; `metric` the δ cap of a colour with itself.
+  contr c := { deltaContr₂ (chiralBasis c) (chiralBasis (ChiralColor.tau c)) with
+      isIntertwining' g := by ext v; simp [Representation.tprod_apply, chiralRep] }
+  unit c := { LinearMap.toSpanSingleton ℂ _
+        (deltaCap₂ (chiralBasis (ChiralColor.tau c)) (chiralBasis c)) with
+      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap₂] }
+  metric c := { LinearMap.toSpanSingleton ℂ _ (deltaCap (chiralBasis c)) with
+      isIntertwining' g := by ext; simp [Representation.tprod_apply, chiralRep, deltaCap] }
+  -- Each coherence law reduces, by case analysis on `c`, to the matching abstract two-module δ lemma.
+  contr_tmul_symm c x y := by cases c <;> exact deltaContr₂_comm _ _ _ _
+  unit_symm c := by cases c <;> exact deltaUnit₂_symm _ _
+  contr_unit c x := by cases c <;> exact deltaContr₂_unit _ _ x
+  contr_metric c := by cases c <;> exact deltaContr₂_metric _ _
   -- Conjugation data: `bar` flips holomorphy, the index set is shared (`rfl`), `star δ = δ`.
   bar := ChiralColor.bar
   bar_involution := ChiralColor.bar_bar
@@ -437,29 +378,17 @@ def chiralTensor : ConjTensorSpecies ℂ ChiralColor Unit (chiralModule (ι := �
   barIdx_eq _ := rfl
   conj_contrComm := by
     intro d x₁ x₂
-    -- The contraction at every colour is the real δ at that colour's basis, so `star` fixes it. Each
-    -- case is restated (`show`) in `deltaContr`-at-basis form — cheap, since the `IntertwiningMap`
-    -- coercion is `rfl` and the `bar`-side casts (`barIdx_eq`/`bar_tau`) are `rfl`. Then the *lemma*
-    -- `deltaContr_basis_basis` evaluates both sides by a syntactic rewrite, so the heavy `Basis.conj`
-    -- is never `whnf`'d (which is what made `exact`/unification time out).
-    have key : ∀ {M₁ M₂ : Type} [AddCommGroup M₁] [Module ℂ M₁] [AddCommGroup M₂] [Module ℂ M₂]
-        (B₁ : Basis ι ℂ M₁) (B₂ : Basis ι ℂ M₂),
-        star (deltaContr B₁ (B₁ x₁ ⊗ₜ[ℂ] B₁ x₂)) = deltaContr B₂ (B₂ x₁ ⊗ₜ[ℂ] B₂ x₂) := by
-      intro M₁ M₂ _ _ _ _ B₁ B₂
-      rw [deltaContr_basis_basis, deltaContr_basis_basis]; split <;> simp
-    cases d
-    · show star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
-          = deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂)
-      exact key piBasis (Basis.conj piBasis)
-    · show star (deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂))
-          = deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂)
-      exact key piBasis (Basis.conj piBasis)
-    · show star (deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂))
-          = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂)
-      exact key (Basis.conj piBasis) piBasis
-    · show star (deltaContr (Basis.conj piBasis) (Basis.conj piBasis x₁ ⊗ₜ[ℂ] Basis.conj piBasis x₂))
-          = deltaContr piBasis (piBasis x₁ ⊗ₜ[ℂ] piBasis x₂)
-      exact key (Basis.conj piBasis) piBasis
+    -- The contraction at every colour is the real δ pairing of two `ι`-bases, so `star` fixes it.
+    -- The `key` lemma evaluates both sides by `deltaContr₂_basis_basis` (a syntactic rewrite to
+    -- `if x₁ = x₂ then 1 else 0`), so the heavy `Basis.conj`/`dualBasis` carriers are never `whnf`'d.
+    have key : ∀ {M₁ M₁' M₂ M₂' : Type} [AddCommGroup M₁] [Module ℂ M₁] [AddCommGroup M₁']
+        [Module ℂ M₁'] [AddCommGroup M₂] [Module ℂ M₂] [AddCommGroup M₂'] [Module ℂ M₂']
+        (B₁ : Basis ι ℂ M₁) (B₁' : Basis ι ℂ M₁') (B₂ : Basis ι ℂ M₂) (B₂' : Basis ι ℂ M₂'),
+        star (deltaContr₂ B₁ B₁' (B₁ x₁ ⊗ₜ[ℂ] B₁' x₂))
+          = deltaContr₂ B₂ B₂' (B₂ x₁ ⊗ₜ[ℂ] B₂' x₂) := by
+      intro M₁ M₁' M₂ M₂' _ _ _ _ _ _ _ _ B₁ B₁' B₂ B₂'
+      rw [deltaContr₂_basis_basis, deltaContr₂_basis_basis]; split <;> simp
+    cases d <;> exact key _ _ _ _
 
 /-!
 ## F. Conjugation

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -78,8 +78,6 @@ is real. The species can express none of these alone.
 - B. The chiral colours and the dual involution
 - C. Carrier, representation, and basis
 - D. The δ structure on based finite modules
-  - D.1. The cap
-  - D.2. The δ pairing across two based modules
 - E. The chiral-index tensor species
 - F. Conjugation
 
@@ -202,11 +200,10 @@ Kähler metric `g_{IJ̄}`, which is built downstream on top of this sector. A co
 colour with its variance dual `τ c`, whose carriers are *distinct* (a module and its dual, or their
 conjugates) but share the index `ι`, so the pairing is the dot product *across two based modules*
 `(M, b)` and `(N, b')`, `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, with cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. The
-single-module case `b = b'` (§D.1) is what `metric c` uses, since its two slots are the same colour;
-the genuinely two-module pairing (§D.2) is what `contr` and `unit` use. The δ data stays within one
-holomorphy and needs no conjugation; conjugation is carried instead by the tensor `conjT` (§F).
-
-### D.1. The cap
+single-colour cap `deltaCap` (`b = b'`) is what `metric c` uses, since its two slots are the same
+colour; the two-module pairing `deltaContr₂`/`deltaCap₂` is what `contr` and `unit` use. The δ data
+stays within one holomorphy and needs no conjugation; conjugation is carried instead by the tensor
+`conjT` (§F).
 
 -/
 
@@ -217,18 +214,6 @@ components in the basis `b` are `δⁱʲ`. It is an element of `M ⊗ M` (the in
 not a linear map, and serves as the `metric` field of the species (whose two slots share a
 colour). -/
 def deltaCap (b : Basis ι ℂ M) : M ⊗[ℂ] M := ∑ I, b I ⊗ₜ[ℂ] b I
-
-/-!
-### D.2. The δ pairing across two based modules
-
-A contraction pairs a colour with its variance dual `τ c`, whose carriers are *distinct* types —
-e.g. the holomorphic vectors `ι → ℂ` and the holomorphic covectors `Module.Dual ℂ (ι → ℂ)` — so the
-δ pairing runs between two based modules `(M, b)` and `(N, b')` sharing the index `ι`:
-`(x, y) ↦ ∑_I (b x)_I (b' y)_I`, with cap `∑_I b_I ⊗ b'_I ∈ M ⊗ N`. Setting `b = b'` recovers §D.1.
-This is the data of `contr` (the pairing `M ⊗ N → ℂ`) and `unit` (the cap), and the coherence laws
-the species demands of them, proved here once over abstract `(M, b)`, `(N, b')`.
-
--/
 
 variable {N : Type*} [AddCommGroup N] [Module ℂ N]
 
@@ -337,7 +322,7 @@ lemma deltaContr₂_metric (b : Basis ι ℂ M) (b' : Basis ι ℂ N) :
 pairing of a colour against its variance dual `τ c` (`V c ⊗ V (τ c) → ℂ`); `unit c` is the δ cap
 across those two carriers; `metric c` is the single-colour δ cap `∑_I b_I ⊗ b_I`. Each
 `TensorSpecies` coherence law reduces, by case analysis on the colour, to the corresponding abstract
-two-module δ lemma of §D.2. The conjugation flips holomorphy (`ChiralColor.bar`) while preserving
+two-module δ lemma of §D. The conjugation flips holomorphy (`ChiralColor.bar`) while preserving
 variance; every basis is indexed by `ι`, so `barIdx_eq` is `rfl`, and `conj_contrComm` is
 `star δ = δ`. Instantiating `ConjTensorSpecies` this way gives the chiral sector both the framework's
 generic tensor API and its conjugation API (`conjT` and its laws) on one object. -/

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -41,7 +41,7 @@ configuration.
 The index data is packaged as a `ConjTensorSpecies` over `ChiralColor`, each colour carrying its
 distinct carrier from above. Complex conjugation is the conjugate-linear identity
 `conjEquiv : M ≃ₛₗ[starRingEnd ℂ] ConjModule M` on each carrier (anti basis `Basis.conj`); the
-species' holomorphy flip (`slotConj`, hence `conjT`) is built from it. Every
+species' holomorphy flip (`conjEquiv`, hence `conjT`) is built from it. Every
 colour carries the trivial representation over the trivial group `Unit`, so the chiral scalars hold
 no charge. Contracting a colour against its `τ`-dual is the dot product of the two coordinate
 vectors, the Kronecker `δ_{IJ}` on basis labels: `contr` is that pairing `V c ⊗ V (τ c) → ℂ`, `unit`

--- a/Physlib/Particles/SuperSymmetry/N1/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/N1/Basic.lean
@@ -242,11 +242,6 @@ the species demands of them, proved here once over abstract `(M, b)`, `(N, b')`.
 
 variable {N : Type*} [AddCommGroup N] [Module ℂ N]
 
-omit [DecidableEq ι] in
-/-- `piBasis.equivFun` is the identity readout of coordinates: `(piBasis.equivFun v) I = v I`. -/
-lemma piBasis_equivFun (v : ι → ℂ) (I : ι) : (piBasis (ι := ι)).equivFun v I = v I := by
-  simp [piBasis]
-
 /-- The δ pairing between two based modules sharing the index `ι`: the dot product of coordinate
 vectors `(x, y) ↦ ∑_I (b x)_I (b' y)_I`, built by reading both sides into `ι → ℂ` and applying the
 reference dot product `deltaBil piBasis`. Equals `deltaBil b` when `b = b'`. -/
@@ -258,7 +253,7 @@ lemma deltaBil₂_apply (b : Basis ι ℂ M) (b' : Basis ι ℂ N) (x : M) (y : 
     deltaBil₂ b b' x y = ∑ I, b.equivFun x I * b'.equivFun y I := by
   rw [deltaBil₂, LinearMap.compl₂_apply, LinearMap.comp_apply, LinearEquiv.coe_coe,
     LinearEquiv.coe_coe, deltaBil_apply]
-  exact Finset.sum_congr rfl fun I _ => by rw [piBasis_equivFun, piBasis_equivFun]
+  simp only [piBasis, Pi.basisFun_equivFun, LinearEquiv.refl_apply]
 
 /-- The two-module δ contraction `M ⊗ N → ℂ`. -/
 def deltaContr₂ (b : Basis ι ℂ M) (b' : Basis ι ℂ N) : M ⊗[ℂ] N →ₗ[ℂ] ℂ :=

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -411,6 +411,17 @@ lemma induction_on_basis {n : ℕ} {c : Fin n → C} {P : S.Tensor c → Prop}
   · intro r t ht
     exact fun a => hsmul r t a
 
+/-- `componentMap` is the basis representation `(basis c).repr` definitionally; this bridges the two
+notations wherever a component computation meets a `repr` rewrite. -/
+lemma componentMap_eq_repr {n : ℕ} (c : Fin n → C) (t : S.Tensor c)
+    (ψ : ComponentIdx (S := S) c) : componentMap c t ψ = (basis c).repr t ψ := rfl
+
+/-- Two tensors with the same colour sequence are equal when all their components agree. -/
+lemma componentMap_ext {n : ℕ} {c : Fin n → C} {t₁ t₂ : S.Tensor c}
+    (h : ∀ b, componentMap c t₁ b = componentMap c t₂ b) : t₁ = t₂ := by
+  rw [← ofComponents_componentMap c t₁, ← ofComponents_componentMap c t₂]
+  congr 1; funext b; exact h b
+
 end Basis
 
 /-!

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 Andrea Pari. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrea Pari
+-/
+module
+
+public import Physlib.Relativity.Tensors.Contraction.Basic
+public import Physlib.Relativity.Tensors.Contraction.Basis
+public import Mathlib.Algebra.Star.Basic
+
+/-!
+
+# Conjugation structure on a tensor species
+
+## i. Overview
+
+The components of a complex tensor are complex numbers, and conjugating them is a basic operation.
+On a tensor it does more than conjugate numbers: each index carries a colour naming the
+representation it transforms in, and conjugation sends every index to the conjugate
+representation. For spinor colours this swaps, for instance, left- and right-handed indices.
+
+Reality and Hermiticity conditions are expressed through this operation: a tensor is real when
+conjugation fixes it, and a metric is Hermitian when conjugating it swaps its two indices. We
+package conjugation abstractly so these conditions can be stated once for any tensor species.
+
+There are two places one could define this conjugation: on the abstract tensor, or on its
+components. At the tensor level it would be an antilinear map on `S.Tensor c`, built through the
+tensor product without reference to a basis. At the basis level it is just "`star` the components":
+read a tensor's coordinates in the basis the species carries, conjugate each, and reinterpret them
+at the conjugate colours. We take the basis level. It is the concrete, direct one, and the
+basis-free construction, though possible, is heavier machinery that buys nothing here.
+Conjugate-linearity, `conjT (r • t) = star r • conjT t`, then follows for free from `star`.
+
+The rest of `Conj` is what that recipe needs to be well-defined. A component sits at a basis label
+of a colour `c`; after `star`-ing it we file it at the same label of the conjugate colour `bar c`,
+so `bar c` must carry the same labels as `c` (`barIdx_eq`). Contraction sums products of components
+weighted by the contraction coefficients, so for `star`-ing the components to commute with
+contracting them, those coefficients must be unchanged by conjugation (`conj_contrComm`); for the
+Kronecker-δ contractions here that is immediate. From this we build the `conj`-semilinear map
+`conjT` and prove its two laws: conjugation is an involution, and it commutes with contraction. The
+second makes reality and Hermiticity compatible with raising and lowering indices, which are
+contractions against a metric.
+
+## ii. Key results
+
+- `Conj` is the conjugation structure on a tensor species.
+- `Conj.conjT` is the conjugation of a tensor.
+- `Conj.conjT_conjT` proves that conjugation is an involution.
+- `Conj.conjT_contrT` proves that conjugation commutes with contraction.
+- `Conj.conjT_eq_permT_iff` is the componentwise criterion for `conjT t = permT σ h t'`, the
+  workhorse for proving reality and Hermiticity conditions.
+
+## iii. Table of contents
+
+- A. The conjugation structure
+- B. Conjugation of tensors
+- C. The involution law
+- D. Commutation with contraction
+
+-/
+
+@[expose] public section
+noncomputable section
+
+namespace TensorSpecies
+
+open Module Tensor
+
+variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
+    {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
+    {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
+    {rep : (c : C) → Representation k G (V c)} {b : (c : C) → Basis (basisIdx c) k (V c)}
+
+/-!
+
+## A. The conjugation structure
+
+We define `Conj`. Conjugation could be put directly on `S.Tensor c` as an antilinear map built
+through the tensor product, but we define it at the basis level instead, where it is simply
+"`star` the components" (§B) in the basis the species carries; the coordinate definition is the
+concrete one. The structure records what that recipe needs. Beyond `bar` (which colour is the conjugate of which) and its compatibility with
+the variance dual `τ`, it carries `barIdx_eq`, that a colour and its conjugate share basis labels so
+a `star`-ed component can be filed at the same label of the conjugate colour, and `conj_contrComm`,
+that the contraction coefficients are unchanged by `star`, the single condition that makes
+conjugation commute with contraction. Only `conj_contrComm` touches the scalars; the others are
+bookkeeping on colours.
+
+-/
+
+/-- A conjugation on a tensor species. Carries the conjugate-colour involution `bar`, the
+index-set identification `barIdx_eq`, and the contraction-coherence `conj_contrComm`. Also carries
+`bar_involution` and `bar_tau` (that `bar` is involutive and commutes with the variance dual). -/
+structure Conj (S : TensorSpecies k C G V basisIdx rep b) where
+  /-- The conjugate colour: flips holomorphy, preserves variance. -/
+  bar : C → C
+  /-- `bar` is an involution. -/
+  bar_involution : Function.Involutive bar
+  /-- `bar` commutes with the variance dual `τ`. -/
+  bar_tau : ∀ c, bar (S.τ c) = S.τ (bar c)
+  /-- Conjugation fixes the index set: the conjugate colour reuses the same basis labels.
+  Conjugation conjugates components in an adapted basis; it never permutes labels, so the label
+  sets of `c` and `bar c` coincide. -/
+  barIdx_eq : ∀ c, basisIdx (bar c) = basisIdx c
+  /-- Conjugation is compatible with contraction at the basis level: `star` of the contraction
+  coefficient at colour `d` equals the coefficient at the conjugate colour `bar d`, with basis
+  labels carried over by `barIdx_eq`. For a real (δ) contraction this is `star δ = δ`. -/
+  conj_contrComm : ∀ (d : C) (x₁ : basisIdx d) (x₂ : basisIdx (S.τ d)),
+      star (S.contr d (b d x₁ ⊗ₜ[k] b (S.τ d) x₂))
+        = S.contr (bar d) (b (bar d) ((Equiv.cast (barIdx_eq d)).symm x₁) ⊗ₜ[k]
+            b (S.τ (bar d)) (basisIdxCongr (bar_tau d) ((Equiv.cast (barIdx_eq (S.τ d))).symm x₂)))
+
+variable {S : TensorSpecies k C G V basisIdx rep b} (cj : Conj S)
+
+/-!
+
+## B. Conjugation of tensors
+
+We define the conjugation map `conjT` through its action on components, record that it conjugates
+components in place (`componentMap_conjT`), and show it is `conj`-semilinear and additive.
+
+-/
+
+/-- Reindex component labels of `bar ∘ c` back to `c`, slotwise via the cast `barIdx_eq`. -/
+def Conj.componentReindex {n : ℕ} (c : Fin n → C) :
+    ComponentIdx (S := S) (cj.bar ∘ c) ≃ ComponentIdx (S := S) c :=
+  Equiv.piCongrRight fun i => Equiv.cast (cj.barIdx_eq (c i))
+
+/-- Conjugation of a tensor: conjugate the components and reindex the basis to the conjugate
+colours. `conj`-semilinear by construction (see `conjT_smul`). -/
+def Conj.conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) : S.Tensor (cj.bar ∘ c) :=
+  ofComponents (cj.bar ∘ c)
+    (fun b => star (componentMap c t (cj.componentReindex c b)))
+
+/-- Components of a conjugated tensor: the `star` of the original components, reindexed. -/
+@[simp] lemma Conj.componentMap_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c)
+    (b : ComponentIdx (S := S) (cj.bar ∘ c)) :
+    componentMap (cj.bar ∘ c) (cj.conjT t) b
+      = star (componentMap c t (cj.componentReindex c b)) := by
+  simp only [Conj.conjT, componentMap_ofComponents]
+
+omit [StarRing k] in
+/-- `componentMap` is the basis representation `(Tensor.basis c).repr` definitionally; this bridges
+the two notations in the contraction and involution proofs below, and in the consuming reality and
+Hermiticity proofs. -/
+lemma componentMap_eq_repr {n : ℕ} (c : Fin n → C) (t : S.Tensor c)
+    (ψ : ComponentIdx (S := S) c) : componentMap c t ψ = (Tensor.basis c).repr t ψ := rfl
+
+omit [StarRing k] in
+/-- Two tensors with the same colour sequence are equal when all their components agree. -/
+private lemma Conj.componentMap_ext {n : ℕ} {c : Fin n → C} {t₁ t₂ : S.Tensor c}
+    (h : ∀ b, componentMap c t₁ b = componentMap c t₂ b) : t₁ = t₂ := by
+  rw [← ofComponents_componentMap c t₁, ← ofComponents_componentMap c t₂]
+  congr 1; funext b; exact h b
+
+/-- Conjugation is semilinear: scalar multiplication pulls out as `star r`. -/
+@[simp] lemma Conj.conjT_smul {n : ℕ} {c : Fin n → C} (r : k) (t : S.Tensor c) :
+    cj.conjT (r • t) = star r • cj.conjT t := by
+  apply Conj.componentMap_ext
+  intro b
+  simp only [componentMap_conjT, map_smul, Pi.smul_apply, smul_eq_mul, star_mul']
+
+/-- Conjugation is additive. -/
+@[simp] lemma Conj.conjT_add {n : ℕ} {c : Fin n → C} (t₁ t₂ : S.Tensor c) :
+    cj.conjT (t₁ + t₂) = cj.conjT t₁ + cj.conjT t₂ := by
+  apply Conj.componentMap_ext
+  intro b
+  simp only [componentMap_conjT, map_add, Pi.add_apply, star_add]
+
+/-- Componentwise criterion for `conjT t = permT σ h t'`. The conjugate of `t` equals the
+recolouring `permT σ h t'` exactly when, at every component, the `star`-conjugated reindexed
+component of `t` matches the corresponding component of `permT σ h t'`. This packages the
+`componentMap_conjT` expansion and the `repr`/`componentMap` bridge that the reality and Hermiticity
+proofs downstream would otherwise repeat by hand; the caller is left only with the species-specific
+permutation bookkeeping on the right-hand side. -/
+lemma Conj.conjT_eq_permT_iff {n m : ℕ} {c : Fin n → C} {c' : Fin m → C}
+    {σ : Fin n → Fin m} (h : PermCond c' (cj.bar ∘ c) σ)
+    (t : S.Tensor c) (t' : S.Tensor c') :
+    cj.conjT t = permT σ h t' ↔
+      ∀ φ : ComponentIdx (S := S) (cj.bar ∘ c),
+        star (componentMap c t (cj.componentReindex c φ))
+          = (Tensor.basis (cj.bar ∘ c)).repr (permT σ h t') φ := by
+  constructor
+  · intro H φ
+    rw [← H, ← componentMap_eq_repr, componentMap_conjT]
+  · intro H
+    apply Conj.componentMap_ext
+    intro φ
+    rw [componentMap_conjT]
+    exact H φ
+
+/-!
+
+## C. The involution law
+
+We prove `conjT_conjT`: conjugating a tensor twice returns it, up to the identity recolouring
+`bar ∘ bar ∘ c = c`. The supporting lemmas reconcile the iterated basis-label casts.
+
+-/
+
+omit [StarRing k] [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)] in
+/-- `basisIdxCongr` only depends on its endpoints up to `HEq` of the arguments: equal target
+colours and heterogeneously equal labels give equal casts. -/
+private lemma basisIdxCongr_heq_arg {c₁ c₂ d : C} (h₁ : c₁ = d) (h₂ : c₂ = d)
+    {x : basisIdx c₁} {y : basisIdx c₂} (hxy : HEq x y) :
+    basisIdxCongr h₁ x = basisIdxCongr h₂ y := by
+  subst h₁; subst h₂; cases hxy; rfl
+
+/-- Undoing the two cast reindexings (at `bar c` then at `c`) on a label of the doubly-conjugated
+colour returns the `bar_involution` cast. Free from `barIdx_eq` by `cast_cast` + proof
+irrelevance, with no coherence field needed. -/
+private lemma Conj.barIdx_involutive_symm (c : C) (y : basisIdx (cj.bar (cj.bar c))) :
+    Equiv.cast (cj.barIdx_eq c) (Equiv.cast (cj.barIdx_eq (cj.bar c)) y)
+      = basisIdxCongr (cj.bar_involution c) y := by
+  simp only [basisIdxCongr, Equiv.cast_apply, cast_cast]
+
+/-- The identity permutation satisfies `PermCond` from `c` to `bar ∘ bar ∘ c`, as `bar` is an
+involution. -/
+lemma Conj.permCond_bar_bar {n : ℕ} (c : Fin n → C) :
+    PermCond c (cj.bar ∘ cj.bar ∘ c) (id : Fin n → Fin n) :=
+  ⟨Function.bijective_id, fun i => (cj.bar_involution (c i)).symm⟩
+
+/-- Conjugation is an involution: conjugating twice returns the original tensor, up to the
+`bar_involution` recolouring (the identity permutation `permT`). -/
+lemma Conj.conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
+    cj.conjT (cj.conjT t)
+      = permT id (cj.permCond_bar_bar c) t := by
+  apply Conj.componentMap_ext
+  intro φ
+  rw [Conj.componentMap_conjT, Conj.componentMap_conjT, star_star]
+  rw [componentMap_eq_repr (cj.bar ∘ cj.bar ∘ c), permT_basis_repr_symm_apply,
+    ← componentMap_eq_repr c]
+  refine congrArg (fun ψ => (componentMap c) t ψ) ?_
+  funext i
+  have hinv : (PermCond.inv id (cj.permCond_bar_bar c)) i = i :=
+    PermCond.inv_apply_apply id _ i
+  show Equiv.cast (cj.barIdx_eq (c i)) (Equiv.cast (cj.barIdx_eq (cj.bar (c i))) (φ i)) = _
+  rw [cj.barIdx_involutive_symm]
+  exact basisIdxCongr_heq_arg _ _ (by rw [hinv]; exact HEq.rfl)
+
+/-!
+
+## D. Commutation with contraction
+
+We prove `conjT_contrT`: conjugation commutes with contracting two dual-coloured slots. The
+contraction expands as a sum over the contracted index pair, and `conj_contrComm` matches the
+conjugated coefficients to those on the `bar`-images.
+
+-/
+
+/-- Slots with dual colour in `c` have dual colour in `bar ∘ c`, as `bar` commutes with `τ`. -/
+lemma Conj.contrCond_bar {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
+    (h : i ≠ j ∧ S.τ (c i) = c j) :
+    i ≠ j ∧ S.τ ((cj.bar ∘ c) i) = (cj.bar ∘ c) j :=
+  ⟨h.1, by rw [Function.comp_apply, Function.comp_apply, ← cj.bar_tau, h.2]⟩
+
+/-- Conjugation commutes with contraction: conjugating a contracted tensor equals contracting the
+conjugate on the `bar`-images of the same two slots. -/
+lemma Conj.conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
+    (h : i ≠ j ∧ S.τ (c i) = c j) (t : S.Tensor c) :
+    cj.conjT (contrT n i j h t)
+      = contrT n i j (cj.contrCond_bar h) (cj.conjT t) := by
+  apply Conj.componentMap_ext
+  intro φ
+  rw [Conj.componentMap_conjT, componentMap_eq_repr, Tensor.contrT_basis_repr_apply]
+  have hrhs := Tensor.contrT_basis_repr_apply (S := S) (c := cj.bar ∘ c) (i := i) (j := j)
+    (cj.contrCond_bar h) (cj.conjT t) φ
+  rw [componentMap_eq_repr]
+  refine Eq.trans ?_ hrhs.symm
+  rw [star_sum]
+  -- `componentReindex` carries the `bar`-side contraction section onto the `c`-side one: it
+  -- commutes with `dropPair` definitionally, so the section bijection is just `subtypeEquiv`.
+  have hmem : ∀ a : ComponentIdx (cj.bar ∘ c),
+      a ∈ ComponentIdx.DropPairSection φ ↔
+        cj.componentReindex c a ∈
+          ComponentIdx.DropPairSection (cj.componentReindex (c ∘ i.succSuccAbove j) φ) := by
+    intro a
+    simp only [ComponentIdx.DropPairSection, Finset.mem_filter, Finset.mem_univ, true_and]
+    exact (Equiv.apply_eq_iff_eq (cj.componentReindex (c ∘ i.succSuccAbove j))).symm
+  refine (Finset.sum_equiv (Equiv.subtypeEquiv (cj.componentReindex c) hmem)
+    (fun _ => by simp) ?_).symm
+  intro b'' _
+  simp only [Equiv.subtypeEquiv_apply]
+  rw [← componentMap_eq_repr (cj.bar ∘ c), Conj.componentMap_conjT, componentMap_eq_repr c t,
+    star_mul']
+  congr 1
+  rw [cj.conj_contrComm (c i) ((cj.componentReindex c b''.1) i)
+        (basisIdxCongr (by rw [h.2]) ((cj.componentReindex c b''.1) j)),
+    show (cj.componentReindex c b''.1) i = Equiv.cast (cj.barIdx_eq (c i)) (b''.1 i) from rfl,
+    show (cj.componentReindex c b''.1) j = Equiv.cast (cj.barIdx_eq (c j)) (b''.1 j) from rfl,
+    Equiv.symm_apply_apply]
+  congr 2
+  exact congrArg (b (S.τ (cj.bar (c i)))) (basisIdxCongr_heq_arg _ _
+    (HEq.symm ((cast_heq _ _).trans ((cast_heq _ _).trans (cast_heq _ _)))))
+
+end TensorSpecies
+end
+end

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -26,19 +26,22 @@ chiral sector `bar` swaps chiral and anti-chiral indices.
 `conjT` conjugates a tensor at the basis level: `star` each coordinate in the species basis and
 place it at the conjugate colour. Reality and Hermiticity are stated through it, a tensor is real
 when conjugation fixes it and a metric is Hermitian when conjugating it swaps its two indices.
-`Conj` records what the recipe needs: `bar c` shares basis labels with `c` (`barIdx_eq`) and the
-contraction coefficients survive `star` (`conj_contrComm`), which together make conjugation commute
-with contraction. `conjT` is then `conj`-semilinear, involutive, and commutes with contraction; the
+
+Conjugation is intrinsic species data, not a detachable add-on: a `ConjTensorSpecies` is a
+`TensorSpecies` bundled (`extends`) with the conjugate-colour involution `bar` and the coherence
+the recipe needs. `bar c` shares basis labels with `c` (`barIdx_eq`) and the contraction
+coefficients survive `star` (`conj_contrComm`), which together make conjugation commute with
+contraction. `conjT` is then `conj`-semilinear, involutive, and commutes with contraction; the
 last makes reality and Hermiticity compatible with raising and lowering indices.
 
 ## ii. Key results
 
-- `Conj` is the conjugation structure on a tensor species.
-- `Conj.conjT` is the conjugation of a tensor.
-- `Conj.conjT_conjT` proves that conjugation is an involution.
-- `Conj.conjT_contrT` proves that conjugation commutes with contraction.
-- `Conj.conjT_eq_permT_iff` is the componentwise criterion for `conjT t = permT σ h t'`, the
-  workhorse for proving reality and Hermiticity conditions.
+- `ConjTensorSpecies` is a tensor species bundled with its conjugation.
+- `ConjTensorSpecies.conjT` is the conjugation of a tensor.
+- `ConjTensorSpecies.conjT_conjT` proves that conjugation is an involution.
+- `ConjTensorSpecies.conjT_contrT` proves that conjugation commutes with contraction.
+- `ConjTensorSpecies.conjT_eq_permT_iff` is the componentwise criterion for `conjT t = permT σ h t'`,
+  the workhorse for proving reality and Hermiticity conditions.
 
 ## iii. Table of contents
 
@@ -52,38 +55,37 @@ last makes reality and Hermiticity compatible with raising and lowering indices.
 @[expose] public section
 noncomputable section
 
-namespace TensorSpecies
-
-open Module Tensor
-
-variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
-    {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
-    {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
-    {rep : (c : C) → Representation k G (V c)} {b : (c : C) → Basis (basisIdx c) k (V c)}
+open Module TensorSpecies TensorSpecies.Tensor
 
 /-!
 
 ## A. The conjugation structure
 
-We define `Conj` at the basis level, where conjugation is "`star` the components" (§B). Four of its
-fields are bookkeeping on colours and index sets, trivial to supply per instance: `bar` (the
-conjugate-colour involution), `bar_involution`, `bar_tau` (it commutes with `τ`), and `barIdx_eq`
-(a colour and its conjugate share basis labels). The one substantive field is `conj_contrComm`, that
-the contraction coefficients are unchanged by `star`; this is what makes conjugation commute with
-contraction (§D), and here it is `star δ = δ`.
+A `ConjTensorSpecies` bundles a `TensorSpecies` (`extends`) with the conjugation data. Conjugation is
+defined at the basis level, where it is "`star` the components" (§B). Four of the new fields are
+bookkeeping on colours and index sets, trivial to supply per instance: `bar` (the conjugate-colour
+involution), `bar_involution`, `bar_tau` (it commutes with `τ`), and `barIdx_eq` (a colour and its
+conjugate share basis labels). The one substantive field is `conj_contrComm`, that the contraction
+coefficients are unchanged by `star`; this is what makes conjugation commute with contraction (§D),
+and for a real (δ) contraction it is `star δ = δ`.
 
 -/
 
-/-- A conjugation on a tensor species. Carries the conjugate-colour involution `bar`, the
-index-set identification `barIdx_eq`, and the contraction-coherence `conj_contrComm`. Also carries
-`bar_involution` and `bar_tau` (that `bar` is involutive and commutes with the variance dual). -/
-structure Conj (S : TensorSpecies k C G V basisIdx rep b) where
+/-- A tensor species bundled with a conjugation. Beyond the `TensorSpecies` it `extends`, it carries
+the conjugate-colour involution `bar`, the index-set identification `barIdx_eq`, and the
+contraction-coherence `conj_contrComm`. Also carries `bar_involution` and `bar_tau` (that `bar` is
+involutive and commutes with the variance dual). -/
+structure ConjTensorSpecies (k : Type) [CommRing k] [StarRing k] (C : Type) (G : Type) [Group G]
+    (V : C → Type) [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
+    (basisIdx : C → Type) [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
+    (rep : (c : C) → Representation k G (V c)) (b : (c : C) → Basis (basisIdx c) k (V c))
+    extends TensorSpecies k C G V basisIdx rep b where
   /-- The conjugate colour: flips holomorphy, preserves variance. -/
   bar : C → C
   /-- `bar` is an involution. -/
   bar_involution : Function.Involutive bar
   /-- `bar` commutes with the variance dual `τ`. -/
-  bar_tau : ∀ c, bar (S.τ c) = S.τ (bar c)
+  bar_tau : ∀ c, bar (toTensorSpecies.τ c) = toTensorSpecies.τ (bar c)
   /-- Conjugation fixes the index set: the conjugate colour reuses the same basis labels.
   Conjugation conjugates components in an adapted basis; it never permutes labels, so the label
   sets of `c` and `bar c` coincide. -/
@@ -91,12 +93,45 @@ structure Conj (S : TensorSpecies k C G V basisIdx rep b) where
   /-- Conjugation is compatible with contraction at the basis level: `star` of the contraction
   coefficient at colour `d` equals the coefficient at the conjugate colour `bar d`, with basis
   labels carried over by `barIdx_eq`. For a real (δ) contraction this is `star δ = δ`. -/
-  conj_contrComm : ∀ (d : C) (x₁ : basisIdx d) (x₂ : basisIdx (S.τ d)),
-      star (S.contr d (b d x₁ ⊗ₜ[k] b (S.τ d) x₂))
-        = S.contr (bar d) (b (bar d) ((Equiv.cast (barIdx_eq d)).symm x₁) ⊗ₜ[k]
-            b (S.τ (bar d)) (basisIdxCongr (bar_tau d) ((Equiv.cast (barIdx_eq (S.τ d))).symm x₂)))
+  conj_contrComm : ∀ (d : C) (x₁ : basisIdx d) (x₂ : basisIdx (toTensorSpecies.τ d)),
+      star (toTensorSpecies.contr d (b d x₁ ⊗ₜ[k] b (toTensorSpecies.τ d) x₂))
+        = toTensorSpecies.contr (bar d) (b (bar d) ((Equiv.cast (barIdx_eq d)).symm x₁) ⊗ₜ[k]
+            b (toTensorSpecies.τ (bar d)) (basisIdxCongr (bar_tau d)
+              ((Equiv.cast (barIdx_eq (toTensorSpecies.τ d))).symm x₂)))
 
-variable {S : TensorSpecies k C G V basisIdx rep b} (cj : Conj S)
+namespace TensorSpecies
+
+variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
+    {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
+    {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
+    {rep : (c : C) → Representation k G (V c)} {b : (c : C) → Basis (basisIdx c) k (V c)}
+    {S : TensorSpecies k C G V basisIdx rep b}
+
+omit [StarRing k] in
+/-- `componentMap` is the basis representation `(Tensor.basis c).repr` definitionally; this bridges
+the two notations in the contraction and involution proofs below, and in the consuming reality and
+Hermiticity proofs. -/
+lemma componentMap_eq_repr {n : ℕ} (c : Fin n → C) (t : S.Tensor c)
+    (ψ : ComponentIdx (S := S) c) : componentMap c t ψ = (Tensor.basis c).repr t ψ := rfl
+
+omit [StarRing k] in
+/-- Two tensors with the same colour sequence are equal when all their components agree. -/
+private lemma componentMap_ext {n : ℕ} {c : Fin n → C} {t₁ t₂ : S.Tensor c}
+    (h : ∀ b, componentMap c t₁ b = componentMap c t₂ b) : t₁ = t₂ := by
+  rw [← ofComponents_componentMap c t₁, ← ofComponents_componentMap c t₂]
+  congr 1; funext b; exact h b
+
+end TensorSpecies
+
+namespace ConjTensorSpecies
+
+open Tensor
+
+variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
+    {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
+    {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
+    {rep : (c : C) → Representation k G (V c)} {b : (c : C) → Basis (basisIdx c) k (V c)}
+    (S : ConjTensorSpecies k C G V basisIdx rep b)
 
 /-!
 
@@ -108,48 +143,34 @@ components in place (`componentMap_conjT`), and show it is `conj`-semilinear and
 -/
 
 /-- Reindex component labels of `bar ∘ c` back to `c`, slotwise via the cast `barIdx_eq`. -/
-def Conj.componentReindex {n : ℕ} (c : Fin n → C) :
-    ComponentIdx (S := S) (cj.bar ∘ c) ≃ ComponentIdx (S := S) c :=
-  Equiv.piCongrRight fun i => Equiv.cast (cj.barIdx_eq (c i))
+def componentReindex {n : ℕ} (c : Fin n → C) :
+    ComponentIdx (S := S.toTensorSpecies) (S.bar ∘ c) ≃ ComponentIdx (S := S.toTensorSpecies) c :=
+  Equiv.piCongrRight fun i => Equiv.cast (S.barIdx_eq (c i))
 
 /-- Conjugation of a tensor: conjugate the components and reindex the basis to the conjugate
 colours. `conj`-semilinear by construction (see `conjT_smul`). -/
-def Conj.conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) : S.Tensor (cj.bar ∘ c) :=
-  ofComponents (cj.bar ∘ c)
-    (fun b => star (componentMap c t (cj.componentReindex c b)))
+def conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) : S.Tensor (S.bar ∘ c) :=
+  ofComponents (S.bar ∘ c)
+    (fun b => star (componentMap c t (S.componentReindex c b)))
 
 /-- Components of a conjugated tensor: the `star` of the original components, reindexed. -/
-@[simp] lemma Conj.componentMap_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c)
-    (b : ComponentIdx (S := S) (cj.bar ∘ c)) :
-    componentMap (cj.bar ∘ c) (cj.conjT t) b
-      = star (componentMap c t (cj.componentReindex c b)) := by
-  simp only [Conj.conjT, componentMap_ofComponents]
-
-omit [StarRing k] in
-/-- `componentMap` is the basis representation `(Tensor.basis c).repr` definitionally; this bridges
-the two notations in the contraction and involution proofs below, and in the consuming reality and
-Hermiticity proofs. -/
-lemma componentMap_eq_repr {n : ℕ} (c : Fin n → C) (t : S.Tensor c)
-    (ψ : ComponentIdx (S := S) c) : componentMap c t ψ = (Tensor.basis c).repr t ψ := rfl
-
-omit [StarRing k] in
-/-- Two tensors with the same colour sequence are equal when all their components agree. -/
-private lemma Conj.componentMap_ext {n : ℕ} {c : Fin n → C} {t₁ t₂ : S.Tensor c}
-    (h : ∀ b, componentMap c t₁ b = componentMap c t₂ b) : t₁ = t₂ := by
-  rw [← ofComponents_componentMap c t₁, ← ofComponents_componentMap c t₂]
-  congr 1; funext b; exact h b
+@[simp] lemma componentMap_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c)
+    (b : ComponentIdx (S := S.toTensorSpecies) (S.bar ∘ c)) :
+    componentMap (S.bar ∘ c) (S.conjT t) b
+      = star (componentMap c t (S.componentReindex c b)) := by
+  simp only [conjT, componentMap_ofComponents]
 
 /-- Conjugation is semilinear: scalar multiplication pulls out as `star r`. -/
-@[simp] lemma Conj.conjT_smul {n : ℕ} {c : Fin n → C} (r : k) (t : S.Tensor c) :
-    cj.conjT (r • t) = star r • cj.conjT t := by
-  apply Conj.componentMap_ext
+@[simp] lemma conjT_smul {n : ℕ} {c : Fin n → C} (r : k) (t : S.Tensor c) :
+    S.conjT (r • t) = star r • S.conjT t := by
+  apply TensorSpecies.componentMap_ext
   intro b
   simp only [componentMap_conjT, map_smul, Pi.smul_apply, smul_eq_mul, star_mul']
 
 /-- Conjugation is additive. -/
-@[simp] lemma Conj.conjT_add {n : ℕ} {c : Fin n → C} (t₁ t₂ : S.Tensor c) :
-    cj.conjT (t₁ + t₂) = cj.conjT t₁ + cj.conjT t₂ := by
-  apply Conj.componentMap_ext
+@[simp] lemma conjT_add {n : ℕ} {c : Fin n → C} (t₁ t₂ : S.Tensor c) :
+    S.conjT (t₁ + t₂) = S.conjT t₁ + S.conjT t₂ := by
+  apply TensorSpecies.componentMap_ext
   intro b
   simp only [componentMap_conjT, map_add, Pi.add_apply, star_add]
 
@@ -159,18 +180,18 @@ component of `t` matches the corresponding component of `permT σ h t'`. This pa
 `componentMap_conjT` expansion and the `repr`/`componentMap` bridge that the reality and Hermiticity
 proofs downstream would otherwise repeat by hand; the caller is left only with the species-specific
 permutation bookkeeping on the right-hand side. -/
-lemma Conj.conjT_eq_permT_iff {n m : ℕ} {c : Fin n → C} {c' : Fin m → C}
-    {σ : Fin n → Fin m} (h : PermCond c' (cj.bar ∘ c) σ)
+lemma conjT_eq_permT_iff {n m : ℕ} {c : Fin n → C} {c' : Fin m → C}
+    {σ : Fin n → Fin m} (h : PermCond c' (S.bar ∘ c) σ)
     (t : S.Tensor c) (t' : S.Tensor c') :
-    cj.conjT t = permT σ h t' ↔
-      ∀ φ : ComponentIdx (S := S) (cj.bar ∘ c),
-        star (componentMap c t (cj.componentReindex c φ))
-          = (Tensor.basis (cj.bar ∘ c)).repr (permT σ h t') φ := by
+    S.conjT t = permT σ h t' ↔
+      ∀ φ : ComponentIdx (S := S.toTensorSpecies) (S.bar ∘ c),
+        star (componentMap c t (S.componentReindex c φ))
+          = (Tensor.basis (S.bar ∘ c)).repr (permT σ h t') φ := by
   constructor
   · intro H φ
     rw [← H, ← componentMap_eq_repr, componentMap_conjT]
   · intro H
-    apply Conj.componentMap_ext
+    apply TensorSpecies.componentMap_ext
     intro φ
     rw [componentMap_conjT]
     exact H φ
@@ -187,33 +208,33 @@ We prove `conjT_conjT`: conjugating a tensor twice returns it, up to the identit
 /-- Undoing the two cast reindexings (at `bar c` then at `c`) on a label of the doubly-conjugated
 colour returns the `bar_involution` cast. Free from `barIdx_eq` by `cast_cast` + proof
 irrelevance, with no coherence field needed. -/
-private lemma Conj.barIdx_involutive_symm (c : C) (y : basisIdx (cj.bar (cj.bar c))) :
-    Equiv.cast (cj.barIdx_eq c) (Equiv.cast (cj.barIdx_eq (cj.bar c)) y)
-      = basisIdxCongr (cj.bar_involution c) y := by
+private lemma barIdx_involutive_symm (c : C) (y : basisIdx (S.bar (S.bar c))) :
+    Equiv.cast (S.barIdx_eq c) (Equiv.cast (S.barIdx_eq (S.bar c)) y)
+      = basisIdxCongr (S.bar_involution c) y := by
   simp only [basisIdxCongr, Equiv.cast_apply, cast_cast]
 
 /-- The identity permutation satisfies `PermCond` from `c` to `bar ∘ bar ∘ c`, as `bar` is an
 involution. -/
-lemma Conj.permCond_bar_bar {n : ℕ} (c : Fin n → C) :
-    PermCond c (cj.bar ∘ cj.bar ∘ c) (id : Fin n → Fin n) :=
-  ⟨Function.bijective_id, fun i => (cj.bar_involution (c i)).symm⟩
+lemma permCond_bar_bar {n : ℕ} (c : Fin n → C) :
+    PermCond c (S.bar ∘ S.bar ∘ c) (id : Fin n → Fin n) :=
+  ⟨Function.bijective_id, fun i => (S.bar_involution (c i)).symm⟩
 
 /-- Conjugation is an involution: conjugating twice returns the original tensor, up to the
 `bar_involution` recolouring (the identity permutation `permT`). -/
-lemma Conj.conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
-    cj.conjT (cj.conjT t)
-      = permT id (cj.permCond_bar_bar c) t := by
-  apply Conj.componentMap_ext
+lemma conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
+    S.conjT (S.conjT t)
+      = permT id (S.permCond_bar_bar c) t := by
+  apply TensorSpecies.componentMap_ext
   intro φ
-  rw [Conj.componentMap_conjT, Conj.componentMap_conjT, star_star]
-  rw [componentMap_eq_repr (cj.bar ∘ cj.bar ∘ c), permT_basis_repr_symm_apply,
+  rw [componentMap_conjT, componentMap_conjT, star_star]
+  rw [componentMap_eq_repr (S.bar ∘ S.bar ∘ c), permT_basis_repr_symm_apply,
     ← componentMap_eq_repr c]
   refine congrArg (fun ψ => (componentMap c) t ψ) ?_
   funext i
-  have hinv : (PermCond.inv id (cj.permCond_bar_bar c)) i = i :=
+  have hinv : (PermCond.inv id (S.permCond_bar_bar c)) i = i :=
     PermCond.inv_apply_apply id _ i
-  show Equiv.cast (cj.barIdx_eq (c i)) (Equiv.cast (cj.barIdx_eq (cj.bar (c i))) (φ i)) = _
-  rw [cj.barIdx_involutive_symm]
+  show Equiv.cast (S.barIdx_eq (c i)) (Equiv.cast (S.barIdx_eq (S.bar (c i))) (φ i)) = _
+  rw [S.barIdx_involutive_symm]
   exact basisIdxCongr_heq_arg _ _ (by rw [hinv]; exact HEq.rfl)
 
 /-!
@@ -227,50 +248,50 @@ conjugated coefficients to those on the `bar`-images.
 -/
 
 /-- Slots with dual colour in `c` have dual colour in `bar ∘ c`, as `bar` commutes with `τ`. -/
-lemma Conj.contrCond_bar {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
+lemma contrCond_bar {n : ℕ} {c : Fin (n + 1 + 1) → C} {i j : Fin (n + 1 + 1)}
     (h : i ≠ j ∧ S.τ (c i) = c j) :
-    i ≠ j ∧ S.τ ((cj.bar ∘ c) i) = (cj.bar ∘ c) j :=
-  ⟨h.1, by rw [Function.comp_apply, Function.comp_apply, ← cj.bar_tau, h.2]⟩
+    i ≠ j ∧ S.τ ((S.bar ∘ c) i) = (S.bar ∘ c) j :=
+  ⟨h.1, by rw [Function.comp_apply, Function.comp_apply, ← S.bar_tau, h.2]⟩
 
 /-- Conjugation commutes with contraction: conjugating a contracted tensor equals contracting the
 conjugate on the `bar`-images of the same two slots. -/
-lemma Conj.conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
+lemma conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
     (h : i ≠ j ∧ S.τ (c i) = c j) (t : S.Tensor c) :
-    cj.conjT (contrT n i j h t)
-      = contrT n i j (cj.contrCond_bar h) (cj.conjT t) := by
-  apply Conj.componentMap_ext
+    S.conjT (contrT n i j h t)
+      = contrT n i j (S.contrCond_bar h) (S.conjT t) := by
+  apply TensorSpecies.componentMap_ext
   intro φ
-  rw [Conj.componentMap_conjT, componentMap_eq_repr, Tensor.contrT_basis_repr_apply]
-  have hrhs := Tensor.contrT_basis_repr_apply (S := S) (c := cj.bar ∘ c) (i := i) (j := j)
-    (cj.contrCond_bar h) (cj.conjT t) φ
+  rw [componentMap_conjT, componentMap_eq_repr, Tensor.contrT_basis_repr_apply]
+  have hrhs := Tensor.contrT_basis_repr_apply (S := S.toTensorSpecies) (c := S.bar ∘ c)
+    (i := i) (j := j) (S.contrCond_bar h) (S.conjT t) φ
   rw [componentMap_eq_repr]
   refine Eq.trans ?_ hrhs.symm
   rw [star_sum]
   -- `componentReindex` carries the `bar`-side contraction section onto the `c`-side one: it
   -- commutes with `dropPair` definitionally, so the section bijection is just `subtypeEquiv`.
-  have hmem : ∀ a : ComponentIdx (cj.bar ∘ c),
+  have hmem : ∀ a : ComponentIdx (S := S.toTensorSpecies) (S.bar ∘ c),
       a ∈ ComponentIdx.DropPairSection φ ↔
-        cj.componentReindex c a ∈
-          ComponentIdx.DropPairSection (cj.componentReindex (c ∘ i.succSuccAbove j) φ) := by
+        S.componentReindex c a ∈
+          ComponentIdx.DropPairSection (S.componentReindex (c ∘ i.succSuccAbove j) φ) := by
     intro a
     simp only [ComponentIdx.DropPairSection, Finset.mem_filter, Finset.mem_univ, true_and]
-    exact (Equiv.apply_eq_iff_eq (cj.componentReindex (c ∘ i.succSuccAbove j))).symm
-  refine (Finset.sum_equiv (Equiv.subtypeEquiv (cj.componentReindex c) hmem)
+    exact (Equiv.apply_eq_iff_eq (S.componentReindex (c ∘ i.succSuccAbove j))).symm
+  refine (Finset.sum_equiv (Equiv.subtypeEquiv (S.componentReindex c) hmem)
     (fun _ => by simp) ?_).symm
   intro b'' _
   simp only [Equiv.subtypeEquiv_apply]
-  rw [← componentMap_eq_repr (cj.bar ∘ c), Conj.componentMap_conjT, componentMap_eq_repr c t,
+  rw [← componentMap_eq_repr (S.bar ∘ c), componentMap_conjT, componentMap_eq_repr c t,
     star_mul']
   congr 1
-  rw [cj.conj_contrComm (c i) ((cj.componentReindex c b''.1) i)
-        (basisIdxCongr (by rw [h.2]) ((cj.componentReindex c b''.1) j)),
-    show (cj.componentReindex c b''.1) i = Equiv.cast (cj.barIdx_eq (c i)) (b''.1 i) from rfl,
-    show (cj.componentReindex c b''.1) j = Equiv.cast (cj.barIdx_eq (c j)) (b''.1 j) from rfl,
+  rw [S.conj_contrComm (c i) ((S.componentReindex c b''.1) i)
+        (basisIdxCongr (by rw [h.2]) ((S.componentReindex c b''.1) j)),
+    show (S.componentReindex c b''.1) i = Equiv.cast (S.barIdx_eq (c i)) (b''.1 i) from rfl,
+    show (S.componentReindex c b''.1) j = Equiv.cast (S.barIdx_eq (c j)) (b''.1 j) from rfl,
     Equiv.symm_apply_apply]
   congr 2
-  exact congrArg (b (S.τ (cj.bar (c i)))) (basisIdxCongr_heq_arg _ _
+  exact congrArg (b (S.τ (S.bar (c i)))) (basisIdxCongr_heq_arg _ _
     (HEq.symm ((cast_heq _ _).trans ((cast_heq _ _).trans (cast_heq _ _)))))
 
-end TensorSpecies
+end ConjTensorSpecies
 end
 end

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -172,7 +172,7 @@ component of `t` matches the corresponding component of `permT σ h t'`. This pa
 proofs downstream would otherwise repeat by hand; the caller is left only with the species-specific
 permutation bookkeeping on the right-hand side. -/
 lemma conjT_eq_permT_iff {n m : ℕ} {c : Fin n → C} {c' : Fin m → C}
-    {σ : Fin n → Fin m} (h : PermCond c' (S.bar ∘ c) σ)
+    {σ : Fin n → Fin m} (h : IsReindexing c' (S.bar ∘ c) σ)
     (t : S.Tensor c) (t' : S.Tensor c') :
     S.conjT t = permT σ h t' ↔
       ∀ φ : ComponentIdx (S := S.toTensorSpecies) (S.bar ∘ c),
@@ -204,17 +204,17 @@ private lemma barIdx_involutive_symm (c : C) (y : basisIdx (S.bar (S.bar c))) :
       = basisIdxCongr (S.bar_involution c) y := by
   simp only [basisIdxCongr, Equiv.cast_apply, cast_cast]
 
-/-- The identity permutation satisfies `PermCond` from `c` to `bar ∘ bar ∘ c`, as `bar` is an
+/-- The identity permutation satisfies `IsReindexing` from `c` to `bar ∘ bar ∘ c`, as `bar` is an
 involution. -/
-lemma permCond_bar_bar {n : ℕ} (c : Fin n → C) :
-    PermCond c (S.bar ∘ S.bar ∘ c) (id : Fin n → Fin n) :=
+lemma isReindexing_bar_bar {n : ℕ} (c : Fin n → C) :
+    IsReindexing c (S.bar ∘ S.bar ∘ c) (id : Fin n → Fin n) :=
   ⟨Function.bijective_id, fun i => (S.bar_involution (c i)).symm⟩
 
 /-- Conjugation is an involution: conjugating twice returns the original tensor, up to the
 `bar_involution` recolouring (the identity permutation `permT`). -/
 lemma conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
     S.conjT (S.conjT t)
-      = permT id (S.permCond_bar_bar c) t := by
+      = permT id (S.isReindexing_bar_bar c) t := by
   apply componentMap_ext
   intro φ
   rw [componentMap_conjT, componentMap_conjT, star_star]
@@ -222,8 +222,8 @@ lemma conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
     ← componentMap_eq_repr c]
   refine congrArg (fun ψ => (componentMap c) t ψ) ?_
   funext i
-  have hinv : (PermCond.inv id (S.permCond_bar_bar c)) i = i :=
-    PermCond.inv_apply_apply id _ i
+  have hinv : (IsReindexing.inv id (S.isReindexing_bar_bar c)) i = i :=
+    IsReindexing.inv_apply_apply id _ i
   show Equiv.cast (S.barIdx_eq (c i)) (Equiv.cast (S.barIdx_eq (S.bar (c i))) (φ i)) = _
   rw [S.barIdx_involutive_symm]
   exact basisIdxCongr_heq_arg _ _ (by rw [hinv]; exact HEq.rfl)

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -49,8 +49,8 @@ genuinely bilinear and `IsHermitian` an honest conjugate-transpose.
 - `ConjTensorSpecies.conjT` is the conjugation of a tensor.
 - `ConjTensorSpecies.conjT_conjT` proves that conjugation is an involution.
 - `ConjTensorSpecies.conjT_contrT` proves that conjugation commutes with contraction.
-- `ConjTensorSpecies.conjT_eq_permT_iff` is the componentwise criterion for `conjT t = permT σ h t'`,
-  the workhorse for proving reality and Hermiticity conditions.
+- `ConjTensorSpecies.conjT_eq_permT_iff` is the componentwise criterion for
+  `conjT t = permT σ h t'`, the workhorse for proving reality and Hermiticity conditions.
 - `ConjTensorSpecies.slotConj` is the single-slot conjugate-linear isomorphism `V c ≃ₛₗ V (bar c)`.
 - `ConjTensorSpecies.IsHermitian` is the structural conjugate-transpose condition on a metric slot.
 
@@ -74,8 +74,9 @@ open Module TensorSpecies TensorSpecies.Tensor
 
 ## A. The conjugation structure
 
-A `ConjTensorSpecies` bundles a `TensorSpecies` (`extends`) with the conjugation data. Conjugation is
-defined at the basis level, where it is "`star` the components" (§B). Four of the new fields are
+A `ConjTensorSpecies` bundles a `TensorSpecies` (`extends`) with the conjugation data.
+Conjugation is defined at the basis level, where it is "`star` the components" (§B). Four of the
+new fields are
 bookkeeping on colours and index sets, trivial to supply per instance: `bar` (the conjugate-colour
 involution), `bar_involution`, `bar_tau` (it commutes with `τ`), and `barIdx_eq` (a colour and its
 conjugate share basis labels). The one substantive field is `conj_contrComm`, that the contraction

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -36,6 +36,13 @@ coefficients survive `star` (`conj_contrComm`), which together make conjugation 
 contraction. `conjT` is then `conj`-semilinear, involutive, and commutes with contraction; the
 last makes reality and Hermiticity compatible with raising and lowering indices.
 
+At the single-index level, `slotConj : V c ≃ₛₗ V (bar c)` realises this conjugation: it reads a
+vector's coordinates, conjugates them with `ConjModule.starFinsupp`, and re-seats them at the
+conjugate colour. It rests on the conjugate module `ConjModule` (`Physlib.Mathematics.ConjModule`),
+the same vectors with the scalar action twisted by conjugation (`i` acts as `−i`). Equipping the
+conjugate colours with such conjugate-module carriers is what makes a metric `V c ⊗ V (bar c) → k`
+genuinely bilinear and `IsHermitian` an honest conjugate-transpose.
+
 ## ii. Key results
 
 - `ConjTensorSpecies` is a tensor species bundled with its conjugation.
@@ -82,7 +89,8 @@ structure ConjTensorSpecies (k : Type) [CommRing k] [StarRing k] (C : Type) (G :
     (basisIdx : C → Type) [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
     (rep : (c : C) → Representation k G (V c)) (b : (c : C) → Basis (basisIdx c) k (V c))
     extends TensorSpecies k C G V basisIdx rep b where
-  /-- The conjugate colour: flips holomorphy, preserves variance. -/
+  /-- The conjugate colour: the colour an index transforms in under complex conjugation; preserves
+  variance (commutes with `τ`). -/
   bar : C → C
   /-- `bar` is an involution. -/
   bar_involution : Function.Involutive bar
@@ -323,11 +331,11 @@ basis coordinates of `b c i` are the indicator at `i` and `star` fixes `0` and `
 
 ## F. Hermitian pairings
 
-A metric slot pairs a colour `c` with its conjugate `bar c` (e.g. a chiral index with the
-anti-chiral one). `IsHermitian` is the structural form of `g_{IJ̄} = conj g_{JĪ}`: conjugating and
-swapping the two slots through `slotConj` returns `g`'s `star`. Because `V c` and `V (bar c)` are
-genuinely different modules this is the honest conjugate-transpose, not a bare `g = g.flip`. The
-seam is locked here as `IsHermitian`; the Kähler-metric layer instantiates it for the δ pairing.
+A metric slot pairs a colour `c` with its conjugate `bar c`. `IsHermitian` is the structural form of
+`g_{IJ̄} = conj g_{JĪ}`: conjugating and swapping the two slots through `slotConj` returns `g`'s
+`star`. Because `V c` and `V (bar c)` are genuinely different modules this is the honest
+conjugate-transpose, not a bare `g = g.flip`. The seam is locked here as `IsHermitian`; a downstream
+metric layer instantiates it for a concrete pairing.
 
 -/
 

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -36,7 +36,7 @@ coefficients survive `star` (`conj_contrComm`), which together make conjugation 
 contraction. `conjT` is then `conj`-semilinear, involutive, and commutes with contraction; the
 last makes reality and Hermiticity compatible with raising and lowering indices.
 
-At the single-index level, `slotConj : V c ≃ₛₗ V (bar c)` realises this conjugation: it reads a
+At the single-index level, `conjEquiv : V c ≃ₛₗ V (bar c)` realises this conjugation: it reads a
 vector's coordinates, conjugates them with `ConjModule.starFinsupp`, and re-seats them at the
 conjugate colour. It rests on the conjugate module `ConjModule` (`Physlib.Mathematics.ConjModule`),
 the same vectors with the scalar action twisted by conjugation (`i` acts as `−i`). Equipping the
@@ -51,7 +51,7 @@ genuinely bilinear and `IsHermitian` an honest conjugate-transpose.
 - `ConjTensorSpecies.conjT_contrT` proves that conjugation commutes with contraction.
 - `ConjTensorSpecies.conjT_eq_permT_iff` is the componentwise criterion for
   `conjT t = permT σ h t'`, the workhorse for proving reality and Hermiticity conditions.
-- `ConjTensorSpecies.slotConj` is the single-slot conjugate-linear isomorphism `V c ≃ₛₗ V (bar c)`.
+- `ConjTensorSpecies.conjEquiv` is the single-slot conjugate-linear isomorphism `V c ≃ₛₗ V (bar c)`.
 - `ConjTensorSpecies.IsHermitian` is the structural conjugate-transpose condition on a metric slot.
 
 ## iii. Table of contents
@@ -114,30 +114,6 @@ structure ConjTensorSpecies (k : Type) [CommRing k] [StarRing k] (C : Type) (G :
             b (toTensorSpecies.τ (bar d)) (basisIdxCongr (bar_tau d)
               ((Equiv.cast (barIdx_eq (toTensorSpecies.τ d))).symm x₂)))
 
-namespace TensorSpecies
-
-variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
-    {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
-    {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]
-    {rep : (c : C) → Representation k G (V c)} {b : (c : C) → Basis (basisIdx c) k (V c)}
-    {S : TensorSpecies k C G V basisIdx rep b}
-
-omit [StarRing k] in
-/-- `componentMap` is the basis representation `(Tensor.basis c).repr` definitionally; this bridges
-the two notations in the contraction and involution proofs below, and in the consuming reality and
-Hermiticity proofs. -/
-lemma componentMap_eq_repr {n : ℕ} (c : Fin n → C) (t : S.Tensor c)
-    (ψ : ComponentIdx (S := S) c) : componentMap c t ψ = (Tensor.basis c).repr t ψ := rfl
-
-omit [StarRing k] in
-/-- Two tensors with the same colour sequence are equal when all their components agree. -/
-private lemma componentMap_ext {n : ℕ} {c : Fin n → C} {t₁ t₂ : S.Tensor c}
-    (h : ∀ b, componentMap c t₁ b = componentMap c t₂ b) : t₁ = t₂ := by
-  rw [← ofComponents_componentMap c t₁, ← ofComponents_componentMap c t₂]
-  congr 1; funext b; exact h b
-
-end TensorSpecies
-
 namespace ConjTensorSpecies
 
 open Tensor
@@ -178,14 +154,14 @@ def conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) : S.Tensor (S.bar ∘ c) 
 /-- Conjugation is semilinear: scalar multiplication pulls out as `star r`. -/
 @[simp] lemma conjT_smul {n : ℕ} {c : Fin n → C} (r : k) (t : S.Tensor c) :
     S.conjT (r • t) = star r • S.conjT t := by
-  apply TensorSpecies.componentMap_ext
+  apply componentMap_ext
   intro b
   simp only [componentMap_conjT, map_smul, Pi.smul_apply, smul_eq_mul, star_mul']
 
 /-- Conjugation is additive. -/
 @[simp] lemma conjT_add {n : ℕ} {c : Fin n → C} (t₁ t₂ : S.Tensor c) :
     S.conjT (t₁ + t₂) = S.conjT t₁ + S.conjT t₂ := by
-  apply TensorSpecies.componentMap_ext
+  apply componentMap_ext
   intro b
   simp only [componentMap_conjT, map_add, Pi.add_apply, star_add]
 
@@ -206,7 +182,7 @@ lemma conjT_eq_permT_iff {n m : ℕ} {c : Fin n → C} {c' : Fin m → C}
   · intro H φ
     rw [← H, ← componentMap_eq_repr, componentMap_conjT]
   · intro H
-    apply TensorSpecies.componentMap_ext
+    apply componentMap_ext
     intro φ
     rw [componentMap_conjT]
     exact H φ
@@ -239,7 +215,7 @@ lemma permCond_bar_bar {n : ℕ} (c : Fin n → C) :
 lemma conjT_conjT {n : ℕ} {c : Fin n → C} (t : S.Tensor c) :
     S.conjT (S.conjT t)
       = permT id (S.permCond_bar_bar c) t := by
-  apply TensorSpecies.componentMap_ext
+  apply componentMap_ext
   intro φ
   rw [componentMap_conjT, componentMap_conjT, star_star]
   rw [componentMap_eq_repr (S.bar ∘ S.bar ∘ c), permT_basis_repr_symm_apply,
@@ -274,7 +250,7 @@ lemma conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
     (h : i ≠ j ∧ S.τ (c i) = c j) (t : S.Tensor c) :
     S.conjT (contrT n i j h t)
       = contrT n i j (S.contrCond_bar h) (S.conjT t) := by
-  apply TensorSpecies.componentMap_ext
+  apply componentMap_ext
   intro φ
   rw [componentMap_conjT, componentMap_eq_repr, Tensor.contrT_basis_repr_apply]
   have hrhs := Tensor.contrT_basis_repr_apply (S := S.toTensorSpecies) (c := S.bar ∘ c)
@@ -311,7 +287,7 @@ lemma conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
 
 ## E. The slot conjugation
 
-`slotConj` is the conjugate-linear isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: read off the
+`conjEquiv` is the conjugate-linear isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: read off the
 coordinates of a vector in the species basis, conjugate them (`star`), and re-seat them as the
 coordinates at the conjugate colour (the index sets agree by `barIdx_eq`). It is the single-slot
 shadow of `conjT`, packaged as a bundled equivalence so the Hermitian-metric layer can apply it to a
@@ -322,22 +298,22 @@ involutivity together with `bar`'s.
 
 /-- The conjugate-linear slot isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: conjugate the
 coordinates in the species basis and relabel to the conjugate colour via `barIdx_eq`. -/
-def slotConj {c : C} : V c ≃ₛₗ[starRingEnd k] V (S.bar c) :=
+def conjEquiv {c : C} : V c ≃ₛₗ[starRingEnd k] V (S.bar c) :=
   ((b c).repr.trans (ConjModule.starFinsupp (k := k))).trans
     ((Finsupp.domLCongr (Equiv.cast (S.barIdx_eq c).symm)).trans (b (S.bar c)).repr.symm)
 
-/-- `slotConj` on a basis vector: `b c i ↦ b (bar c) i` (relabelled through `barIdx_eq`), since the
+/-- `conjEquiv` on a basis vector: `b c i ↦ b (bar c) i` (relabelled through `barIdx_eq`), since the
 basis coordinates of `b c i` are the indicator at `i` and `star` fixes `0` and `1`. -/
-@[simp] lemma slotConj_basis {c : C} (i : basisIdx c) :
-    S.slotConj (b c i) = b (S.bar c) (Equiv.cast (S.barIdx_eq c).symm i) := by
-  simp [slotConj, ConjModule.starFinsupp, Finsupp.domLCongr_apply, Finsupp.mapRange_single]
+@[simp] lemma conjEquiv_basis {c : C} (i : basisIdx c) :
+    S.conjEquiv (b c i) = b (S.bar c) (Equiv.cast (S.barIdx_eq c).symm i) := by
+  simp [conjEquiv, ConjModule.starFinsupp, Finsupp.domLCongr_apply, Finsupp.mapRange_single]
 
 /-!
 
 ## F. Hermitian pairings
 
 A metric slot pairs a colour `c` with its conjugate `bar c`. `IsHermitian` is the structural form of
-`g_{IJ̄} = conj g_{JĪ}`: conjugating and swapping the two slots through `slotConj` returns `g`'s
+`g_{IJ̄} = conj g_{JĪ}`: conjugating and swapping the two slots through `conjEquiv` returns `g`'s
 `star`. Because `V c` and `V (bar c)` are genuinely different modules this is the honest
 conjugate-transpose, not a bare `g = g.flip`. The condition is fixed here as `IsHermitian`; a
 downstream metric layer instantiates it for a concrete pairing.
@@ -346,10 +322,10 @@ downstream metric layer instantiates it for a concrete pairing.
 
 open scoped TensorProduct in
 /-- A pairing `g : V c ⊗ V (bar c) → k` is Hermitian when conjugating and swapping its two slots
-via `slotConj` returns its `star`: `g (x ⊗ y) = star (g (slotConj.symm y ⊗ slotConj x))`. -/
+via `conjEquiv` returns its `star`: `g (x ⊗ y) = star (g (conjEquiv.symm y ⊗ conjEquiv x))`. -/
 def IsHermitian {c : C} (g : V c ⊗[k] V (S.bar c) →ₗ[k] k) : Prop :=
   ∀ (x : V c) (y : V (S.bar c)),
-    g (x ⊗ₜ[k] y) = star (g (S.slotConj.symm y ⊗ₜ[k] S.slotConj x))
+    g (x ⊗ₜ[k] y) = star (g (S.conjEquiv.symm y ⊗ₜ[k] S.conjEquiv x))
 
 end ConjTensorSpecies
 end

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -26,8 +26,8 @@ while fixing a real vector colour. Variance is untouched, so `bar` commutes with
 chiral sector `bar` swaps chiral and anti-chiral indices.
 
 `conjT` conjugates a tensor at the basis level: `star` each coordinate in the species basis and
-place it at the conjugate colour. Reality and Hermiticity are stated through it, a tensor is real
-when conjugation fixes it and a metric is Hermitian when conjugating it swaps its two indices.
+place it at the conjugate colour. Reality and Hermiticity are stated through it: a tensor is real
+when conjugation fixes it, and a metric is Hermitian when conjugating it swaps its two indices.
 
 Conjugation is intrinsic species data, not a detachable add-on: a `ConjTensorSpecies` is a
 `TensorSpecies` bundled (`extends`) with the conjugate-colour involution `bar` and the coherence
@@ -51,6 +51,8 @@ genuinely bilinear and `IsHermitian` an honest conjugate-transpose.
 - `ConjTensorSpecies.conjT_contrT` proves that conjugation commutes with contraction.
 - `ConjTensorSpecies.conjT_eq_permT_iff` is the componentwise criterion for `conjT t = permT σ h t'`,
   the workhorse for proving reality and Hermiticity conditions.
+- `ConjTensorSpecies.slotConj` is the single-slot conjugate-linear isomorphism `V c ≃ₛₗ V (bar c)`.
+- `ConjTensorSpecies.IsHermitian` is the structural conjugate-transpose condition on a metric slot.
 
 ## iii. Table of contents
 
@@ -58,6 +60,8 @@ genuinely bilinear and `IsHermitian` an honest conjugate-transpose.
 - B. Conjugation of tensors
 - C. The involution law
 - D. Commutation with contraction
+- E. The slot conjugation
+- F. Hermitian pairings
 
 -/
 
@@ -317,7 +321,7 @@ involutivity together with `bar`'s.
 
 /-- The conjugate-linear slot isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: conjugate the
 coordinates in the species basis and relabel to the conjugate colour via `barIdx_eq`. -/
-noncomputable def slotConj {c : C} : V c ≃ₛₗ[starRingEnd k] V (S.bar c) :=
+def slotConj {c : C} : V c ≃ₛₗ[starRingEnd k] V (S.bar c) :=
   ((b c).repr.trans (ConjModule.starFinsupp (k := k))).trans
     ((Finsupp.domLCongr (Equiv.cast (S.barIdx_eq c).symm)).trans (b (S.bar c)).repr.symm)
 
@@ -334,8 +338,8 @@ basis coordinates of `b c i` are the indicator at `i` and `star` fixes `0` and `
 A metric slot pairs a colour `c` with its conjugate `bar c`. `IsHermitian` is the structural form of
 `g_{IJ̄} = conj g_{JĪ}`: conjugating and swapping the two slots through `slotConj` returns `g`'s
 `star`. Because `V c` and `V (bar c)` are genuinely different modules this is the honest
-conjugate-transpose, not a bare `g = g.flip`. The seam is locked here as `IsHermitian`; a downstream
-metric layer instantiates it for a concrete pairing.
+conjugate-transpose, not a bare `g = g.flip`. The condition is fixed here as `IsHermitian`; a
+downstream metric layer instantiates it for a concrete pairing.
 
 -/
 

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -79,8 +79,9 @@ variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
 We define `Conj`. Conjugation could be put directly on `S.Tensor c` as an antilinear map built
 through the tensor product, but we define it at the basis level instead, where it is simply
 "`star` the components" (§B) in the basis the species carries; the coordinate definition is the
-concrete one. The structure records what that recipe needs. Beyond `bar` (which colour is the conjugate of which) and its compatibility with
-the variance dual `τ`, it carries `barIdx_eq`, that a colour and its conjugate share basis labels so
+concrete one. The structure records what that recipe needs. Beyond `bar` (which colour is the
+conjugate of which) and its compatibility with the variance dual `τ`, it carries `barIdx_eq`, that a
+colour and its conjugate share basis labels so
 a `star`-ed component can be filed at the same label of the conjugate colour, and `conj_contrComm`,
 that the contraction coefficients are unchanged by `star`, the single condition that makes
 conjugation commute with contraction. Only `conj_contrComm` touches the scalars; the others are

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -15,32 +15,21 @@ public import Mathlib.Algebra.Star.Basic
 
 ## i. Overview
 
-The components of a complex tensor are complex numbers, and conjugating them is a basic operation.
-On a tensor it does more than conjugate numbers: each index carries a colour naming the
-representation it transforms in, and conjugation sends every index to the conjugate
-representation. For spinor colours this swaps, for instance, left- and right-handed indices.
+Each index of a tensor carries a colour naming the representation it transforms in. A species
+already has the variance dual `τ c`, the colour an index must meet to contract. Conjugation adds a
+second involution, the conjugate colour `bar c`: the colour an index transforms in after complex
+conjugation. A spinor index is the textbook example: complex conjugation sends a left-handed Weyl
+spinor to a right-handed one, `(ψ_α)* = ψ̄_α̇`, so `bar` swaps the left- and right-handed colours
+while fixing a real vector colour. Variance is untouched, so `bar` commutes with `τ`. In an N=1
+chiral sector `bar` swaps chiral and anti-chiral indices.
 
-Reality and Hermiticity conditions are expressed through this operation: a tensor is real when
-conjugation fixes it, and a metric is Hermitian when conjugating it swaps its two indices. We
-package conjugation abstractly so these conditions can be stated once for any tensor species.
-
-There are two places one could define this conjugation: on the abstract tensor, or on its
-components. At the tensor level it would be an antilinear map on `S.Tensor c`, built through the
-tensor product without reference to a basis. At the basis level it is just "`star` the components":
-read a tensor's coordinates in the basis the species carries, conjugate each, and reinterpret them
-at the conjugate colours. We take the basis level. It is the concrete, direct one, and the
-basis-free construction, though possible, is heavier machinery that buys nothing here.
-Conjugate-linearity, `conjT (r • t) = star r • conjT t`, then follows for free from `star`.
-
-The rest of `Conj` is what that recipe needs to be well-defined. A component sits at a basis label
-of a colour `c`; after `star`-ing it we file it at the same label of the conjugate colour `bar c`,
-so `bar c` must carry the same labels as `c` (`barIdx_eq`). Contraction sums products of components
-weighted by the contraction coefficients, so for `star`-ing the components to commute with
-contracting them, those coefficients must be unchanged by conjugation (`conj_contrComm`); for the
-Kronecker-δ contractions here that is immediate. From this we build the `conj`-semilinear map
-`conjT` and prove its two laws: conjugation is an involution, and it commutes with contraction. The
-second makes reality and Hermiticity compatible with raising and lowering indices, which are
-contractions against a metric.
+`conjT` conjugates a tensor at the basis level: `star` each coordinate in the species basis and
+place it at the conjugate colour. Reality and Hermiticity are stated through it, a tensor is real
+when conjugation fixes it and a metric is Hermitian when conjugating it swaps its two indices.
+`Conj` records what the recipe needs: `bar c` shares basis labels with `c` (`barIdx_eq`) and the
+contraction coefficients survive `star` (`conj_contrComm`), which together make conjugation commute
+with contraction. `conjT` is then `conj`-semilinear, involutive, and commutes with contraction; the
+last makes reality and Hermiticity compatible with raising and lowering indices.
 
 ## ii. Key results
 
@@ -76,16 +65,12 @@ variable {k : Type} [CommRing k] [StarRing k] {C : Type} {G : Type} [Group G]
 
 ## A. The conjugation structure
 
-We define `Conj`. Conjugation could be put directly on `S.Tensor c` as an antilinear map built
-through the tensor product, but we define it at the basis level instead, where it is simply
-"`star` the components" (§B) in the basis the species carries; the coordinate definition is the
-concrete one. The structure records what that recipe needs. Beyond `bar` (which colour is the
-conjugate of which) and its compatibility with the variance dual `τ`, it carries `barIdx_eq`, that a
-colour and its conjugate share basis labels so
-a `star`-ed component can be filed at the same label of the conjugate colour, and `conj_contrComm`,
-that the contraction coefficients are unchanged by `star`, the single condition that makes
-conjugation commute with contraction. Only `conj_contrComm` touches the scalars; the others are
-bookkeeping on colours.
+We define `Conj` at the basis level, where conjugation is "`star` the components" (§B). Four of its
+fields are bookkeeping on colours and index sets, trivial to supply per instance: `bar` (the
+conjugate-colour involution), `bar_involution`, `bar_tau` (it commutes with `τ`), and `barIdx_eq`
+(a colour and its conjugate share basis labels). The one substantive field is `conj_contrComm`, that
+the contraction coefficients are unchanged by `star`; this is what makes conjugation commute with
+contraction (§D), and here it is `star δ = δ`.
 
 -/
 
@@ -198,14 +183,6 @@ We prove `conjT_conjT`: conjugating a tensor twice returns it, up to the identit
 `bar ∘ bar ∘ c = c`. The supporting lemmas reconcile the iterated basis-label casts.
 
 -/
-
-omit [StarRing k] [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)] in
-/-- `basisIdxCongr` only depends on its endpoints up to `HEq` of the arguments: equal target
-colours and heterogeneously equal labels give equal casts. -/
-private lemma basisIdxCongr_heq_arg {c₁ c₂ d : C} (h₁ : c₁ = d) (h₂ : c₂ = d)
-    {x : basisIdx c₁} {y : basisIdx c₂} (hxy : HEq x y) :
-    basisIdxCongr h₁ x = basisIdxCongr h₂ y := by
-  subst h₁; subst h₂; cases hxy; rfl
 
 /-- Undoing the two cast reindexings (at `bar c` then at `c`) on a label of the doubly-conjugated
 colour returns the `bar_involution` cast. Free from `barIdx_eq` by `cast_cast` + proof

--- a/Physlib/Relativity/Tensors/Conjugation/Basic.lean
+++ b/Physlib/Relativity/Tensors/Conjugation/Basic.lean
@@ -7,7 +7,9 @@ module
 
 public import Physlib.Relativity.Tensors.Contraction.Basic
 public import Physlib.Relativity.Tensors.Contraction.Basis
+public import Physlib.Mathematics.ConjModule
 public import Mathlib.Algebra.Star.Basic
+public import Mathlib.LinearAlgebra.Finsupp.LSum
 
 /-!
 
@@ -291,6 +293,50 @@ lemma conjT_contrT {n : ℕ} {c : Fin (n + 1 + 1) → C} (i j : Fin (n + 1 + 1))
   congr 2
   exact congrArg (b (S.τ (S.bar (c i)))) (basisIdxCongr_heq_arg _ _
     (HEq.symm ((cast_heq _ _).trans ((cast_heq _ _).trans (cast_heq _ _)))))
+
+/-!
+
+## E. The slot conjugation
+
+`slotConj` is the conjugate-linear isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: read off the
+coordinates of a vector in the species basis, conjugate them (`star`), and re-seat them as the
+coordinates at the conjugate colour (the index sets agree by `barIdx_eq`). It is the single-slot
+shadow of `conjT`, packaged as a bundled equivalence so the Hermitian-metric layer can apply it to a
+metric slot. Semilinearity is built in via the coordinate `star`; invertibility is `star`'s
+involutivity together with `bar`'s.
+
+-/
+
+/-- The conjugate-linear slot isomorphism `V c ≃ₛₗ[starRingEnd k] V (bar c)`: conjugate the
+coordinates in the species basis and relabel to the conjugate colour via `barIdx_eq`. -/
+noncomputable def slotConj {c : C} : V c ≃ₛₗ[starRingEnd k] V (S.bar c) :=
+  ((b c).repr.trans (ConjModule.starFinsupp (k := k))).trans
+    ((Finsupp.domLCongr (Equiv.cast (S.barIdx_eq c).symm)).trans (b (S.bar c)).repr.symm)
+
+/-- `slotConj` on a basis vector: `b c i ↦ b (bar c) i` (relabelled through `barIdx_eq`), since the
+basis coordinates of `b c i` are the indicator at `i` and `star` fixes `0` and `1`. -/
+@[simp] lemma slotConj_basis {c : C} (i : basisIdx c) :
+    S.slotConj (b c i) = b (S.bar c) (Equiv.cast (S.barIdx_eq c).symm i) := by
+  simp [slotConj, ConjModule.starFinsupp, Finsupp.domLCongr_apply, Finsupp.mapRange_single]
+
+/-!
+
+## F. Hermitian pairings
+
+A metric slot pairs a colour `c` with its conjugate `bar c` (e.g. a chiral index with the
+anti-chiral one). `IsHermitian` is the structural form of `g_{IJ̄} = conj g_{JĪ}`: conjugating and
+swapping the two slots through `slotConj` returns `g`'s `star`. Because `V c` and `V (bar c)` are
+genuinely different modules this is the honest conjugate-transpose, not a bare `g = g.flip`. The
+seam is locked here as `IsHermitian`; the Kähler-metric layer instantiates it for the δ pairing.
+
+-/
+
+open scoped TensorProduct in
+/-- A pairing `g : V c ⊗ V (bar c) → k` is Hermitian when conjugating and swapping its two slots
+via `slotConj` returns its `star`: `g (x ⊗ y) = star (g (slotConj.symm y ⊗ slotConj x))`. -/
+def IsHermitian {c : C} (g : V c ⊗[k] V (S.bar c) →ₗ[k] k) : Prop :=
+  ∀ (x : V c) (y : V (S.bar c)),
+    g (x ⊗ₜ[k] y) = star (g (S.slotConj.symm y ⊗ₜ[k] S.slotConj x))
 
 end ConjTensorSpecies
 end

--- a/Physlib/Relativity/Tensors/TensorSpecies/Basic.lean
+++ b/Physlib/Relativity/Tensors/TensorSpecies/Basic.lean
@@ -93,6 +93,13 @@ lemma basisIdxCongr_apply_apply {c c1 c2 : C} (h1 : c = c1) (h2 : c1 = c2) (i : 
     basisIdxCongr h2 (basisIdxCongr h1 i) = basisIdxCongr (by simp [h1, h2]) i := by
   simp [basisIdxCongr]
 
+/-- `basisIdxCongr` only depends on its endpoints up to `HEq` of the arguments: equal target
+colours and heterogeneously equal labels give equal casts. -/
+lemma basisIdxCongr_heq_arg {c1 c2 d : C} (h1 : c1 = d) (h2 : c2 = d)
+    {x : basisIdx c1} {y : basisIdx c2} (hxy : HEq x y) :
+    basisIdxCongr h1 x = basisIdxCongr h2 y := by
+  subst h1; subst h2; cases hxy; rfl
+
 variable {k : Type} [CommRing k] {C : Type} {G : Type} [Group G]
     {V : C → Type} [∀ c, AddCommGroup (V c)] [∀ c, Module k (V c)]
     {basisIdx : C → Type} [∀ c, Fintype (basisIdx c)] [∀ c, DecidableEq (basisIdx c)]


### PR DESCRIPTION
## Contents

Two files: a reusable conjugation layer for the tensor framework, and the N=1
chiral-sector indexing foundation rebuilt on top of it.

**`Relativity/Tensors/Conjugation/Basic.lean`** (new) — the abstract conjugation
structure for an arbitrary `TensorSpecies`. A `TensorSpecies.Conj` packages a
conjugation as basis-level data, and the file derives from it the conjugation map
`conjT` and its laws (involution, commutation with contraction).

**`Particles/SuperSymmetry/N1/Basic.lean`** (supersedes the current `Model`
foundation) — rebuilds the chiral-sector indexing data as a `TensorSpecies` over
a four-element colour type, and instantiates the conjugation structure on it.

## Motivation

The N=1 chiral sector needs a type-safe contraction `g^{IJ̄} D_I W D̄_J̄ W̄` and a
notion of complex conjugation in which reality and Hermiticity are phrased — the
Kähler metric is Hermitian, and the anti-chiral sector is the complex conjugate
of the chiral one. The previous `Model C A` data carried chiral and anti-chiral
labels as two distinct index types tied by an equivalence. This PR replaces that
with a single `TensorSpecies` over a colour type, where variance and holomorphy
are tracked by the colour and the involutions `τ` / `bar`, and adds the reusable
conjugation layer the sector is stated against.

## Scope

Foundational layer only. The downstream layers that build on this foundation live
on a separate branch and are not part of this PR. The conjugation layer is general.
This supersedes the `Model`-based `N1/Basic.lean` currently on master. Nothing
else on master imports that module, so the replacement is self-contained.

## AI disclosure

AI (Claude Code) was used extensively to draft definitions, proofs, and
documentation under my direction. I reviewed every declaration and take full
responsibility for the content.

## Author responsibility

I am a PhD student in theoretical physics. The development proves no novel
mathematics: the conjugation map is "`star` the components in a fixed basis", its
laws reduce to the reality of the contraction coefficients, and the chiral
species is the standard Kronecker-δ structure on `ι → ℂ`. Correctness rests on
Mathlib's tensor and basis API and on the machine-checked `TensorSpecies`
coherence laws. The whole development compiles under the kernel with no `sorry`
and no new axioms.

## Lemmas and definitions added

### `Relativity/Tensors/Conjugation/Basic.lean`

**The structure (§A)**
- `TensorSpecies.Conj` — a conjugation on a tensor species: the conjugate-colour
  involution `bar` (with `bar_involution`, and `bar_tau` that it commutes with
  the variance dual `τ`), the basis-label identification `barIdx_eq`, and the
  contraction coherence `conj_contrComm` (`star` of a contraction coefficient at
  `d` equals the coefficient at `bar d`).

**Conjugation of tensors (§B)**
- `Conj.componentReindex` — slotwise reindexing of component labels from
  `bar ∘ c` back to `c`.
- `Conj.conjT` — the conjugation map `Tensor c → Tensor (bar ∘ c)`: `star` the
  components and recolour by `bar`.
- `Conj.componentMap_conjT` — the components of `conjT t` are the `star` of those
  of `t`, reindexed.
- `componentMap_eq_repr` — `componentMap` is the basis representation
  `(Tensor.basis c).repr` definitionally; bridges the two notations.
- `Conj.conjT_smul`, `Conj.conjT_add` — conjugate-semilinearity (`star r` pulls
  out) and additivity.
- `Conj.conjT_eq_permT_iff` — componentwise criterion for `conjT t = permT σ h t'`;
  packages the `componentMap_conjT` expansion that reality and Hermiticity proofs
  would otherwise repeat by hand.

**The involution law (§C)**
- `Conj.permCond_bar_bar` — the identity permutation satisfies `PermCond` from `c`
  to `bar ∘ bar ∘ c`.
- `Conj.conjT_conjT` — conjugating twice returns the tensor, up to the
  `bar`-involution recolouring.

**Commutation with contraction (§D)**
- `Conj.contrCond_bar` — dual-coloured slots stay dual under `bar`.
- `Conj.conjT_contrT` — conjugation commutes with contracting two dual slots.

### `Particles/SuperSymmetry/N1/Basic.lean`

**Configuration and colours (§A, §B)**
- `ChiralScalarConfiguration ι = ι → ℂ` — the sector's only field data (retained).
- `ChiralColor` — the four colours chiral/anti × up/down, with the variance dual
  `tau` and the conjugate-colour involution `bar` (and `bar_bar`, `bar_tau`).

**Carrier, representation, basis (§C)**
- `chiralModule`, `chiralRep`, `chiralBasis` — constant families of the colour:
  every colour shares the carrier `ι → ℂ`, the trivial `G`-representation, and the
  indicator basis `piBasis`.

**The δ structure (§D)**
- `deltaBil`, `deltaContr`, `deltaCap` — the Kronecker-δ bilinear form,
  contraction, and cap over an abstract based module, with their computation
  lemmas (`deltaContr_tmul`, `_tmul_basis`, `_basis_basis`, `_comm`,
  `deltaCap_comm`) and the coherence laws feeding the species fields
  (`deltaUnit_symm`, `deltaContr_unit`, `deltaContr_metric`, and their underlying
  `deltaCap` / `deltaContr` forms).

**The species and its conjugation (§E, §F)**
- `chiralTensor` — the `TensorSpecies` over `ChiralColor`: every colour contracts
  by the δ pairing, with the δ cap as both metric and unit.
- `chiralTensor_contr_chiralBasis` — the contraction coefficient on basis vectors
  is the Kronecker δ.
- `chiralConjStructure` — the `TensorSpecies.Conj` instance for `chiralTensor`.
- `conjScalar`, `conjChiralCovector` — conjugation normalized back to the scalar
  `![]` and anti-covector `![antiDown]` colour lists, with `toField_conjScalar`,
  `repr_conjChiralCovector`, and `conjChiralCovector_add` / `_smul`.
