### PR TITLE
refactor(ULift): enable linters for QuantumInfo/ForMathlib/ULift.lean

### DIFF
--- a/QuantumInfo/ForMathlib/ULift.lean
+++ b/QuantumInfo/ForMathlib/ULift.lean
@@ -7,6 +7,15 @@ module
 
 public import Mathlib
 
+/-!
+# Typeclass instances for `ULift`
+
+This file equips `ULift` with algebraic and analytic typeclass instances lifted from the
+underlying type, including `Star`, `StarMul`, `StarRing`, `NormedField`, `DenselyNormedField`
+and `RCLike` structures, together with the corresponding `simp` lemmas relating operations on
+`ULift.{v, u} α` to operations on the underlying `α`.
+-/
+
 @[expose] public section
 
 open ComplexOrder
@@ -22,7 +31,8 @@ instance ULift.instStar {𝕜 : Type u} [Star 𝕜] : Star (ULift.{v,u} 𝕜) wh
 theorem ULift.star_eq {𝕜 : Type u} [Star 𝕜] (x : ULift.{v,u} 𝕜) : star x = .up (star x.down) := by
   rfl
 
-instance ULift.instInvolutiveStar {𝕜 : Type u} [InvolutiveStar 𝕜] : InvolutiveStar (ULift.{v,u} 𝕜) where
+instance ULift.instInvolutiveStar {𝕜 : Type u} [InvolutiveStar 𝕜] :
+    InvolutiveStar (ULift.{v,u} 𝕜) where
   star_involutive x := by simp
 
 instance ULift.instStarMul {𝕜 : Type u} [Mul 𝕜] [StarMul 𝕜] : StarMul (ULift.{v,u} 𝕜) where

--- a/scripts/LinterExemption.txt
+++ b/scripts/LinterExemption.txt
@@ -64,7 +64,6 @@ QuantumInfo/ForMathlib/SionMinimax.lean
 QuantumInfo/ForMathlib/Superadditive.lean
 QuantumInfo/ForMathlib/Tactic/Commutes.lean
 QuantumInfo/ForMathlib/Tactic/Commutes/Attribute.lean
-QuantumInfo/ForMathlib/ULift.lean
 QuantumInfo/ForMathlib/Unitary.lean
 QuantumInfo/Measurements/POVM.lean
 QuantumInfo/Operators/Unitary.lean


### PR DESCRIPTION
Note: this is a PR testing the script [here](https://github.com/jstoobysmith/PhyslibAITools). As such, I haven't modified the docstring that was generated by claude when the PR was created (though it is somewhat verbose, and it may be worth changing the prompt in the script to improve on this?).

Happy to make any other edits to the PR as needed:)

--- Below is the PR description that Claude generated ------

## Summary

Removes `QuantumInfo/ForMathlib/ULift.lean` from `scripts/LinterExemption.txt` so that
the required linters are now enforced on it, and fixes the issues that were keeping it
exempt.

## File

- `QuantumInfo/ForMathlib/ULift.lean`

## Linters that were failing

- **`./scripts/lint-style.sh`** (`lint-style.py`):
  - `ERR_MOD` — the file had no module docstring, so the first non-import line
    (`@[expose] public section`) tripped the "module docstring missing, or too late" check.
  - `ERR_LIN` — the `ULift.instInvolutiveStar` instance declaration was 104 characters,
    exceeding the 100-character line limit.

## Changes

- Added a `/-!` module docstring describing the typeclass instances the file provides for
  `ULift` (`Star`, `StarMul`, `StarRing`, `NormedField`, `DenselyNormedField`, `RCLike`).
- Wrapped the over-long `ULift.instInvolutiveStar` instance signature across two lines.
- Removed the file's entry from `scripts/LinterExemption.txt`.

No proof or definition meaning was changed.

## Verification

- `lake build QuantumInfo` — build completed successfully.
- `lake exe runPhyslibLinters` — linting passed for `Physlib` and `QuantumInfo`.
- `./scripts/lint-style.sh` — passed (exit 0).
