### PR TITLE
refactor(QuantumMechanics): remove erw in momentumOperator_smul

### DIFF
--- a/Physlib/QuantumMechanics/OneDimension/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/OneDimension/Operators/Momentum.lean
@@ -58,9 +58,7 @@ lemma momentumOperator_smul {ψ : ℝ → ℂ} (hψ : Differentiable ℝ ψ) (c 
   simp only [neg_mul, Pi.smul_apply]
   rw [smul_comm]
   congr
-  erw [deriv_smul]
-  simp only [smul_eq_mul, deriv_const', zero_mul, add_zero]
-  fun_prop
+  rw [deriv_const_smul]
   fun_prop
 
 lemma momentumOperator_add {ψ1 ψ2 : ℝ → ℂ}


### PR DESCRIPTION
Replace erw [deriv_smul] with rw [deriv_const_smul] in momentumOperator_smul. Since the scalar is a constant, deriv_const_smul applies directly and rewrites to simp-normal form, dropping the spurious zero term the old proof had to clean up. Addresses #385.