### PR TITLE
docs(QuantumInfo): add module docstring to ForMathlib/ContinuousLinearMap

### DIFF
--- a/QuantumInfo/ForMathlib/ContinuousLinearMap.lean
+++ b/QuantumInfo/ForMathlib/ContinuousLinearMap.lean
@@ -8,6 +8,21 @@ module
 public import Mathlib.Analysis.InnerProductSpace.Spectrum
 public import Mathlib.Order.CompletePartialOrder
 
+/-!
+# Continuous linear maps
+
+This file collects auxiliary results about `ContinuousLinearMap`s that are not (yet) available in
+Mathlib.
+
+## Main results
+
+* `ContinuousLinearMap.ker_mk`: the kernel of the continuous linear map built from a continuous
+  semilinear map `f` agrees with the kernel of `f`.
+* `ContinuousLinearMap.support_eq_sup_eigenspace_nonzero`: the range of a symmetric continuous
+  linear map on a finite-dimensional Euclidean space is the supremum of its eigenspaces for
+  nonzero eigenvalues.
+-/
+
 @[expose] public section
 
 namespace ContinuousLinearMap

--- a/scripts/LinterExemption.txt
+++ b/scripts/LinterExemption.txt
@@ -20,7 +20,6 @@ QuantumInfo/Entropy/Relative.lean
 QuantumInfo/Entropy/SSA.lean
 QuantumInfo/Entropy/VonNeumann.lean
 QuantumInfo/ForMathlib/ComplexLaplaceTransform.lean
-QuantumInfo/ForMathlib/ContinuousLinearMap.lean
 QuantumInfo/ForMathlib/ContinuousSup.lean
 QuantumInfo/ForMathlib/Filter.lean
 QuantumInfo/ForMathlib/HayataGroup/TraceInequality/BlockDiagonal.lean


### PR DESCRIPTION
## Summary

Adds a module docstring to `QuantumInfo/ForMathlib/ContinuousLinearMap.lean` and
removes the file from `scripts/LinterExemption.txt`, so it is now linted as part of CI.

This is a documentation-only change: no definition, statement, or proof is modified.

## Changes
- Add a `/-!` module docstring with a short summary and a "Main results" list covering
  `ContinuousLinearMap.ker_mk` and `ContinuousLinearMap.support_eq_sup_eigenspace_nonzero`.
- Remove `QuantumInfo/ForMathlib/ContinuousLinearMap.lean` from `scripts/LinterExemption.txt`.

## Verification
- `lake build` succeeds.
- `./scripts/lint-style.sh` passes.
- `lake exe runPhyslibLinters` passes for both `Physlib` and `QuantumInfo`.
