### PR TITLE
Prove free particle conservation lemmas

### DIFF
--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -5,8 +5,8 @@ Authors: Pranav Magdum
 -/
 module
 
-public import Physlib.Meta.Sorry
 public import Physlib.SpaceAndTime.Time.Derivatives
+public import Mathlib.Analysis.Calculus.MeanValue
 /-!
 # The Free Particle
 
@@ -152,15 +152,27 @@ More precisely, if the second derivative of the trajectory is zero
 for all times, then there exists a constant `v₀` such that the
 velocity is equal to `v₀` at every time.
 
-The continuity assumption on `deriv q` is included to apply standard
-results from real analysis relating vanishing derivatives to constant
-functions.
+The second-order differentiability assumption is included to apply
+standard results from real analysis relating vanishing derivatives to
+constant functions.
 -/
-@[sorryful]
 lemma velocity_const_of_zero_acc (q : Time → ℝ) (h : ∀ t, deriv (deriv q) t = 0)
-    (hcont : ContDiff ℝ 1 q) : ∃ v₀, ∀ t, deriv q t = v₀ := by
-  -- this is a standard analysis result (related to `is_const_of_fderiv_eq_zero`)
-  sorry
+    (hcont : ContDiff ℝ 2 q) : ∃ v₀, ∀ t, deriv q t = v₀ := by
+  refine ⟨deriv q 0, fun t => ?_⟩
+  refine is_const_of_fderiv_eq_zero (𝕜 := ℝ) (f := deriv q) ?_ ?_ t 0
+  · unfold Time.deriv
+    change Differentiable ℝ ((fun L : Time →L[ℝ] ℝ => L 1) ∘ fun t => fderiv ℝ q t)
+    fun_prop
+  · intro t
+    ext p
+    simp only [ContinuousLinearMap.zero_apply]
+    have hp : p = p.val • (1 : Time) := by
+      ext
+      simp
+    rw [hp]
+    simp only [map_smul, smul_eq_mul, mul_eq_zero]
+    right
+    simpa [Time.deriv_eq] using h t
 
 /--
 If a free-particle trajectory has constant velocity, then its linear momentum is constant.
@@ -179,9 +191,8 @@ A free particle satisfying the equation of motion conserves linear momentum.
 Newton's second law implies that the acceleration vanishes, so the velocity is constant.
 Since the particle mass is fixed, the linear momentum is constant in time.
 -/
-@[sorryful]
 theorem linearMomentum_conserved (s : FreeParticle) (q : Trajectory)
-    (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 1 q) :
+    (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 2 q) :
     ∃ p, ∀ t, s.linearMomentum q t = p := by
   have h_acc : ∀ t, deriv (deriv q) t = 0 :=
     accel_zero s q h
@@ -197,13 +208,12 @@ turn implies that the velocity is constant. Since the kinetic energy
 depends only on the square of the velocity, it follows that the kinetic
 energy is constant in time.
 -/
-@[sorryful]
 theorem kineticEnergy_conserved (s : FreeParticle) (q : Trajectory)
-    (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 1 q) :
+    (h : ∀ t, s.NewtonsSecondLaw q t) (hcont : ContDiff ℝ 2 q) :
     ∃ E, ∀ t, s.kineticEnergy q t = E := by
   -- get q'' = 0
   have h_acc : ∀ t, deriv (deriv q) t = 0 :=
-  accel_zero s q h
+    accel_zero s q h
   -- get constant velocity
   rcases velocity_const_of_zero_acc q h_acc hcont with ⟨v₀, hv⟩
   -- energy is constant

--- a/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/FreeParticle/Basic.lean
@@ -160,8 +160,7 @@ lemma velocity_const_of_zero_acc (q : Time → ℝ) (h : ∀ t, deriv (deriv q) 
     (hcont : ContDiff ℝ 2 q) : ∃ v₀, ∀ t, deriv q t = v₀ := by
   refine ⟨deriv q 0, fun t => ?_⟩
   refine is_const_of_fderiv_eq_zero (𝕜 := ℝ) (f := deriv q) ?_ ?_ t 0
-  · unfold Time.deriv
-    change Differentiable ℝ ((fun L : Time →L[ℝ] ℝ => L 1) ∘ fun t => fderiv ℝ q t)
+  · change Differentiable ℝ ((fun L : Time →L[ℝ] ℝ => L 1) ∘ fun t => fderiv ℝ q t)
     fun_prop
   · intro t
     ext p


### PR DESCRIPTION
## Summary
- Prove the previously `@[sorryful]` constant-velocity lemma for zero acceleration of a free-particle trajectory.
- Use that result to discharge the `@[sorryful]` proofs of linear momentum and kinetic energy conservation.
- Strengthen the affected regularity hypotheses from `ContDiff ℝ 1 q` to `ContDiff ℝ 2 q`, matching the proof's second-derivative requirement.

## Declarations
No declarations are added or removed.

Changed in `Physlib/ClassicalMechanics/FreeParticle/Basic.lean`:
- `velocity_const_of_zero_acc`: removes `@[sorryful]`, proves the statement using `is_const_of_fderiv_eq_zero`, and changes the regularity assumption to `ContDiff ℝ 2 q`.
- `linearMomentum_conserved`: removes `@[sorryful]` and updates the regularity assumption to `ContDiff ℝ 2 q`.
- `kineticEnergy_conserved`: removes `@[sorryful]` and updates the regularity assumption to `ContDiff ℝ 2 q`.

## Reviewer Map
1. Check `velocity_const_of_zero_acc`; this is the only analytic proof in the PR.
2. Then check `linearMomentum_conserved` and `kineticEnergy_conserved`, which package the constant-velocity result.

## Checks
- `lake exe cache get`
- `lake build`
- `lake build Physlib.ClassicalMechanics.FreeParticle.Basic`
- `lake exe lint_all` (exit code 0; output includes repository-wide style/transitive-import diagnostics)
- `./scripts/lint-style.sh`
