### PR TITLE
refactor(Thermodynamics): golf adiabatic_relation_log proof

### DIFF
--- a/Physlib/Thermodynamics/IdealGas/Basic.lean
+++ b/Physlib/Thermodynamics/IdealGas/Basic.lean
@@ -55,115 +55,17 @@ theorem adiabatic_relation_log
       entropy c R s0 U0 V0 N0 Ua Va N =
       entropy c R s0 U0 V0 N0 Ub Vb N) :
     c * log (Ua / Ub) + log (Va / Vb) = 0 := by
-  -- Step 1: cancel `N * s0` and isolate the `N * R * (...)` pieces.
-  have h1 :
-      N * R *
-          (c * log (Ua / U0) +
-            log (Va / V0) -
-            (c + 1) * log (N / N0)) =
-        N * R *
-          (c * log (Ub / U0) +
-            log (Vb / V0) -
-            (c + 1) * log (N / N0)) := by
-    -- unfold entropy and use `add_left_cancel` to cancel `N * s0`
-    unfold entropy at hS
-    -- now `hS` is: N*s0 + N*R*(...) = N*s0 + N*R*(...)`
-    -- cancel `N*s0` from both sides
-    exact add_left_cancel hS
-
-  -- Step 2: cancel the common factor `N * R`.
-  have hNR : N * R ≠ 0 :=
-    mul_ne_zero (ne_of_gt hN) (ne_of_gt hR)
-  have h2 :
-      c * log (Ua / U0) +
-        log (Va / V0) -
-        (c + 1) * log (N / N0) =
-      c * log (Ub / U0) +
-        log (Vb / V0) -
-        (c + 1) * log (N / N0) :=
-    mul_left_cancel₀ hNR h1
-
-  -- Step 3: cancel the common `-(c+1) * log (N/N0)` term.
-  have h3 :
-      c * log (Ua / U0) + log (Va / V0) =
-      c * log (Ub / U0) + log (Vb / V0) := by
-
-    -- rewrite with `sub_eq_add_neg` so we can use `add_right_cancel`
-
-    have h2' :
-        c * log (Ua / U0) + log (Va / V0)
-          - (c + 1) * log (N / N0) =
-        c * log (Ub / U0) + log (Vb / V0)
-          - (c + 1) * log (N / N0) := by
-      simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-    -- now cancel the same term on the right
-    exact add_right_cancel h2'
-
-  -- Step 4: turn this equality into a “difference = 0” form
-  -- and rearrange algebraically.
-  have h4 :
-      c * (log (Ua / U0) - log (Ub / U0)) +
-        (log (Va / V0) - log (Vb / V0)) = 0 := by
-    -- from `a = b`, we get `a - b = 0`
-    have h4' :
-        (c * log (Ua / U0) + log (Va / V0)) -
-          (c * log (Ub / U0) + log (Vb / V0)) = 0 :=
-      sub_eq_zero.mpr h3
-    -- expand `a - b` and simplify
-    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc,
-          mul_add, add_mul, mul_comm, mul_left_comm, mul_assoc] using h4'
-
-  -- Step 5: use `log_div` to turn differences of logs into logs of ratios.
-  have hUaU0 : 0 < Ua / U0 := div_pos hUa hU0
-  have hUbU0 : 0 < Ub / U0 := div_pos hUb hU0
-  have hVaV0 : 0 < Va / V0 := div_pos hVa hV0
-  have hVbV0 : 0 < Vb / V0 := div_pos hVb hV0
-
-  have hU :
-      log (Ua / U0) - log (Ub / U0) =
-        log ((Ua / U0) / (Ub / U0)) := by
-    -- log_div hx hy : log (x / y) = log x - log y
-    -- log_div needs ≠ 0, not just positivity
-    have hneqx : Ua / U0 ≠ 0 := ne_of_gt hUaU0
-    have hneqy : Ub / U0 ≠ 0 := ne_of_gt hUbU0
-
-    have h := Real.log_div (x := Ua / U0) (y := Ub / U0) hneqx hneqy
-    -- we want "difference = log(ratio)", so flip and rewrite
-    simpa [sub_eq_add_neg] using h.symm
-
-  have hV :
-      log (Va / V0) - log (Vb / V0) =
-        log ((Va / V0) / (Vb / V0)) := by
-    -- log_div hx hy : log (x / y) = log x - log y
-    -- log_div needs ≠ 0, not just positivity
-    have hneqxV : Va / V0 ≠ 0 := ne_of_gt hVaV0
-    have hneqyV : Vb / V0 ≠ 0 := ne_of_gt hVbV0
-
-    have h := Real.log_div (x := Va / V0) (y := Vb / V0) hneqxV hneqyV
-
-    simpa [sub_eq_add_neg] using h.symm
-
-  have h5 :
-      c * log ((Ua / U0) / (Ub / U0)) +
-        log ((Va / V0) / (Vb / V0)) = 0 := by
-    simpa [hU, hV] using h4
-
-  -- Step 6: simplify the ratios to Ua/Ub and Va/Vb using `field_simp`.
-  have h_ratio_U :
-      (Ua / U0) / (Ub / U0) = Ua / Ub := by
-    -- `field_simp` uses the nonzero denominators in the context
-    field_simp [div_eq_mul_inv]
-
-  have h_ratio_V :
-      (Va / V0) / (Vb / V0) = Va / Vb := by
-    field_simp [div_eq_mul_inv]
-
-  have h6 :
-      c * log (Ua / Ub) + log (Va / Vb) = 0 := by
-    -- rewrite the log arguments using the two equalities above
-    simpa [h_ratio_U, h_ratio_V] using h5
-
-  exact h6
+  -- Unfold `entropy`, then cancel the common summand `N * s0` and factor `N * R`
+  -- to isolate the bracketed expression, on which the two states agree.
+  unfold entropy at hS
+  have hNR : N * R ≠ 0 := mul_ne_zero hN.ne' hR.ne'
+  have key := mul_left_cancel₀ hNR (add_left_cancel hS)
+  -- Expand every `log (·/·)` into a difference of logs; the goal then differs
+  -- from `key` only by the common `(c + 1) * log (N / N0)` terms, which cancel.
+  rw [Real.log_div hUa.ne' hUb.ne', Real.log_div hVa.ne' hVb.ne']
+  rw [Real.log_div hUa.ne' hU0.ne', Real.log_div hUb.ne' hU0.ne',
+      Real.log_div hVa.ne' hV0.ne', Real.log_div hVb.ne' hV0.ne'] at key
+  linear_combination key
 
 /-- Adiabatic relation in product form:
     If S(Ua,Va,N) = S(Ub,Vb,N) with N fixed,


### PR DESCRIPTION

Made using @claude and test of the script: 

https://github.com/jstoobysmith/PhyslibAITools/blob/main/Scripts/auto-golf.sh

## Summary

Golfs the proof of `adiabatic_relation_log` in
`Physlib/Thermodynamics/IdealGas/Basic.lean`. The theorem statement
(name, binders, type) is unchanged; only the tactic block is rewritten.

## What changed

The previous proof was ~120 lines built from six intermediate `have`
blocks, each restating large `entropy` sub-expressions in full and
discharging cancellations with heavy `simpa [...]` calls (long
`add_comm`/`mul_comm`/`add_left_comm` rewrite sets) plus two `field_simp`
ratio simplifications.

The new proof is 9 tactic lines:

```lean
  unfold entropy at hS
  have hNR : N * R ≠ 0 := mul_ne_zero hN.ne' hR.ne'
  have key := mul_left_cancel₀ hNR (add_left_cancel hS)
  rw [Real.log_div hUa.ne' hUb.ne', Real.log_div hVa.ne' hVb.ne']
  rw [Real.log_div hUa.ne' hU0.ne', Real.log_div hUb.ne' hU0.ne',
      Real.log_div hVa.ne' hV0.ne', Real.log_div hVb.ne' hV0.ne'] at key
  linear_combination key
```

Idea: after unfolding `entropy`, cancel the common summand `N * s0`
(`add_left_cancel`) and the common factor `N * R` (`mul_left_cancel₀`) in
one step to obtain `key`, the equality of the bracketed expressions.
Expanding every `log (·/·)` into a difference of logs via `Real.log_div`
makes the goal and `key` agree up to the common `(c + 1) * log (N / N0)`
terms, so `linear_combination key` closes it directly — the leftover
terms cancel under the `ring` check.

## Improvements

- **Length:** ~120 lines → 9 lines; removes six nested `have` blocks and
  all the restated sub-expressions.
- **Speed:** replaces several broad `simpa [...]` rewrite-set calls and two
  `field_simp` calls with targeted `rw [Real.log_div ...]` and a single
  `linear_combination`. The file elaborates in ~2.2s.
- **Structure:** a clear linear narrative (cancel summand → cancel factor →
  expand logs → linear combination) using `.ne'` accessors, following
  Mathlib conventions.

## Verification

- `lake build Physlib.Thermodynamics.IdealGas.Basic` succeeds with no
  errors or warnings.
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`
  (no `sorry`, no new axioms).
