### PR TITLE
Add first-order local CFT API to PhyslibAlpha

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -4,6 +4,7 @@ public import PhyslibAlpha.Basic
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
 public import PhyslibAlpha.ClassicalFieldTheory.Local.Action
 public import PhyslibAlpha.ClassicalFieldTheory.Local.EulerLagrange
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstOrder
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Basic
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Criterion
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Density

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/FirstOrder.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/FirstOrder.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
+/-!
+# First-order local field theory
+
+## i. Overview
+
+This module provides a thin usability layer for first-order local field theory, i.e. the
+specialization of the local CFT stack to `k = 1`.
+
+The definitions here do not introduce a new theory. They are aliases and projections for the
+existing coordinate-readout stack:
+
+- first-order jet points are `JetPoint d m 1`,
+- first-order lagrangians are `Lagrangian d m 1`,
+- field values are still the zero-order jet coordinates,
+- first derivatives are the coordinates indexed by `MultiIndex.increment 0 i`.
+
+This keeps the general finite-order API as the source of truth while making the common first-order
+case easier to state in examples and later mechanics bridges.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.FirstOrderJetPoint`
+- `ClassicalFieldTheory.Local.FirstOrderLagrangian`
+- `ClassicalFieldTheory.Local.firstDerivativeIndex`
+- `ClassicalFieldTheory.Local.JetPoint.firstDerivCoord`
+- `ClassicalFieldTheory.Local.firstOrderJetAt`
+
+## iii. Table of contents
+
+- A. First-order aliases
+- B. First derivative indices
+- C. First-order jet projections
+- D. First-order evaluation and variational API
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  arXiv:1612.03100v2, Chapter 5.
+
+-/
+
+@[expose] public section
+
+open Physlib
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. First-order aliases
+
+-/
+
+/-- Coordinate data for first-order local jet points. -/
+abbrev FirstOrderJetCoordinates (d m : ℕ) := JetCoordinates d m 1
+
+/-- Coordinate-level first-order jet points. -/
+abbrev FirstOrderJetPoint (d m : ℕ) := JetPoint d m 1
+
+/-- Fiber-direction data for first-order jet points. -/
+abbrev FirstOrderJetFiberData (d m : ℕ) := JetFiberData d m 1
+
+/-- First-order local lagrangians. -/
+abbrev FirstOrderLagrangian (d m : ℕ) := Lagrangian d m 1
+
+/-!
+## B. First derivative indices
+
+-/
+
+/-- The first-derivative coordinate index in the source direction `i`. -/
+def firstDerivativeIndex (d : ℕ) (i : Fin d) : DerivativeIndex d 1 :=
+  ⟨Physlib.MultiIndex.increment 0 i, by simp⟩
+
+@[simp]
+lemma firstDerivativeIndex_coe (d : ℕ) (i : Fin d) :
+    ((firstDerivativeIndex d i : DerivativeIndex d 1) : MultiIndex d) =
+      Physlib.MultiIndex.increment 0 i := rfl
+
+lemma firstDerivativeIndex_order (d : ℕ) (i : Fin d) :
+    ((firstDerivativeIndex d i : DerivativeIndex d 1) : MultiIndex d).order = 1 := by
+  simp [firstDerivativeIndex]
+
+/-!
+## C. First-order jet projections
+
+-/
+
+namespace JetPoint
+
+variable {d m : ℕ}
+
+/-- The first derivative coordinate `u^a_i` of a first-order jet point. -/
+def firstDerivCoord (J : FirstOrderJetPoint d m) (i : Fin d) (a : Fin m) : ℝ :=
+  J.coord (firstDerivativeIndex d i) a
+
+/-- The bundled target vector of first derivative coordinates in the source direction `i`. -/
+def firstDerivVector (J : FirstOrderJetPoint d m) (i : Fin d) : EuclideanSpace ℝ (Fin m) :=
+  WithLp.toLp 2 fun a => J.firstDerivCoord i a
+
+@[simp]
+lemma firstDerivVector_apply (J : FirstOrderJetPoint d m) (i : Fin d) (a : Fin m) :
+    J.firstDerivVector i a = J.firstDerivCoord i a := by
+  simp [firstDerivVector]
+
+@[simp]
+lemma firstDerivCoord_ofBaseCoordinates (x : Space d) (u : FirstOrderJetCoordinates d m)
+    (i : Fin d) (a : Fin m) :
+    (JetPoint.ofBaseCoordinates x u).firstDerivCoord i a = u (firstDerivativeIndex d i) a := rfl
+
+end JetPoint
+
+/-!
+## D. First-order evaluation and variational API
+
+-/
+
+/-- The first-order coordinate-level jet point of a field at a point. -/
+noncomputable abbrev firstOrderJetAt (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    FirstOrderJetPoint d m :=
+  jetAt 1 f x
+
+@[simp]
+lemma firstOrderJetAt_base (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    (firstOrderJetAt f x).base = x := rfl
+
+lemma firstOrderJetAt_value (f : Space d → EuclideanSpace ℝ (Fin m)) (x : Space d) :
+    (firstOrderJetAt f x).value = f x := by
+  simp [firstOrderJetAt]
+
+@[simp]
+lemma firstOrderJetAt_firstDerivCoord (f : Space d → EuclideanSpace ℝ (Fin m))
+    (x : Space d) (i : Fin d) (a : Fin m) :
+    (firstOrderJetAt f x).firstDerivCoord i a =
+      ∂^[Physlib.MultiIndex.increment 0 i] (fun y => (f y) a) x := rfl
+
+/-- Evaluate a first-order local lagrangian along the first jets of a field. -/
+noncomputable abbrev firstOrderActionDensity (L : FirstOrderLagrangian d m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → ℝ :=
+  actionDensity L f
+
+/-- The action of a first-order local lagrangian. -/
+noncomputable abbrev firstOrderAction (L : FirstOrderLagrangian d m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : ℝ :=
+  action L f
+
+/-- The Euler-Lagrange operator of a first-order local lagrangian. -/
+noncomputable abbrev firstOrderEulerLagrangeOp (L : FirstOrderLagrangian d m)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Space d → EuclideanSpace ℝ (Fin m) :=
+  eulerLagrangeOp L f
+
+theorem firstOrder_isCritical_iff_eulerLagrange_zero
+    (L : FirstOrderLagrangian d m) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hLf : IsAdmissibleForAction L f)
+    (hL : Lagrangian.SmoothInCoordinates L) :
+    IsCritical L f ↔ firstOrderEulerLagrangeOp L f = 0 := by
+  exact isCritical_iff_eulerLagrange_zero_of_admissibleForAction_and_smoothInCoordinates L f hLf hL
+
+end Local
+end ClassicalFieldTheory


### PR DESCRIPTION
This PR adds a small first-order specialization layer for the local Classical Field Theory stack in `PhyslibAlpha`.

The development is based on the coordinate local setup used in Cortes--Haupt, [arXiv:1612.03100v2](https://arxiv.org/abs/1612.03100v2). The general finite-order Alpha stack was added in #1189; this PR does not replace that API, but provides convenient names and projections for the common first-order case `k = 1`.

## What This PR Adds

This PR adds `PhyslibAlpha/ClassicalFieldTheory/Local/FirstOrder.lean`, together with its import in `PhyslibAlpha.lean`.

Concretely, it provides:

- first-order aliases for jet coordinates, jet points, jet fiber data, and local Lagrangians;
- `firstDerivativeIndex`, the bounded derivative index corresponding to a first derivative in a source direction;
- first-order jet projections `JetPoint.firstDerivCoord` and `JetPoint.firstDerivVector`;
- first-order wrappers for `jetAt`, action density, action, and the Euler--Lagrange operator;
- a first-order specialization of the existing local Euler--Lagrange criticality criterion.

## Why This Is Needed

Most early examples and later bridges to classical mechanics use first-order Lagrangians.

The existing Alpha stack is intentionally general in the jet order `k`. This PR keeps that general API as the source of truth, while adding a readable first-order surface API that avoids exposing unnecessary finite-order generality in examples and follow-up developments.

## Scope Of This PR

This PR is intentionally limited to a usability layer for `k = 1`.

It does not introduce:

- a new jet-point object;
- a new Lagrangian definition;
- a new Euler--Lagrange operator;
- total divergences or equivalent Lagrangians;
- examples or mechanics bridge code.

Those will come in later small Alpha PRs.

## Build

Locally checked with:

- `lake build PhyslibAlpha.ClassicalFieldTheory.Local.FirstOrder`
- `lake build PhyslibAlpha`
- `lake exe runPhyslibAlphaLinters`
- `./scripts/PhyslibAlpha/alphaPythonLinters.sh`
- `python3 ./scripts/PhyslibAlpha/alphaFileImports.py`
- `python3 ./scripts/PhyslibAlpha/noAlphaImports.py`
