### PR TITLE
refactor(IsMaximalSelfAdjoint): enable linters for QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean

### DIFF
--- a/QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean
+++ b/QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean
@@ -7,18 +7,35 @@ module
 
 public import Mathlib.Analysis.Matrix.Normed
 
+/-!
+# Maximal self-adjoint subrings
+
+This file introduces the `IsMaximalSelfAdjoint R α` typeclass, which records that the
+`TrivialStar` ring `R` carries the self-adjoint part of a star ring `α`. It bundles an
+additive, `R`-linear map `selfadjMap : α →+ R` that inverts `algebraMap R α` on self-adjoint
+elements. The guiding example is `R = ℝ`, `α = ℂ`: it lets a quantity such as the trace of a
+Hermitian matrix be valued in `ℝ` instead of `ℂ`, reflecting that physical observables are
+self-adjoint and take real expectation values.
+-/
+
 @[expose] public section
 
-/- We want to have `HermitianMat.trace` give 𝕜 when 𝕜 is already a TrivialStar field, but give the "clean" type
-otherwise -- for instance, ℝ when the input field is ℂ. This typeclass lets us do so. -/
+/-- `IsMaximalSelfAdjoint R α` witnesses that `R` is the maximal `TrivialStar` subring of the
+star ring `α`, via an additive map `selfadjMap : α →+ R` collecting the self-adjoint part of
+each element. This lets `HermitianMat.trace` return `𝕜` when `𝕜` already has a trivial star,
+and the "clean" underlying type otherwise, e.g. `ℝ` when the input field is `ℂ`. -/
 class IsMaximalSelfAdjoint (R : outParam Type*) (α : Type*) [Star α] [Star R] [CommSemiring R]
     [Semiring α] [TrivialStar R] [Algebra R α] where
+  /-- The additive map sending an element of `α` to its self-adjoint part in `R`. -/
   selfadjMap : α →+ R
+  /-- `selfadjMap` pulls scalar multiplication by `R` out of its argument. -/
   selfadj_smul : ∀ (r : R) (a : α), selfadjMap (r • a) = r * (selfadjMap a)
+  /-- On self-adjoint elements, `selfadjMap` is a section of `algebraMap R α`. -/
   selfadj_algebra : ∀ {a : α}, IsSelfAdjoint a → algebraMap _ _ (selfadjMap a) = a
 
 /-- Every `TrivialStar` `CommSemiring` is its own maximal self adjoints. -/
-instance instTrivialStar_IsMaximalSelfAdjoint {R} [Star R] [TrivialStar R] [CommSemiring R] : IsMaximalSelfAdjoint R R where
+instance instTrivialStar_IsMaximalSelfAdjoint {R} [Star R] [TrivialStar R] [CommSemiring R] :
+    IsMaximalSelfAdjoint R R where
   selfadjMap := AddMonoidHom.id R
   selfadj_smul _ __ := rfl
   selfadj_algebra {_} _ := rfl
@@ -36,7 +53,8 @@ namespace IsMaximalSelfAdjoint
 -- take care of proving that anyway.
 
 @[simp]
-theorem trivial_selfadjMap {R} [Star R] [TrivialStar R] [CommSemiring R] : (selfadjMap : R →+ R) = .id R := by
+theorem trivial_selfadjMap {R} [Star R] [TrivialStar R] [CommSemiring R] :
+    (selfadjMap : R →+ R) = .id R := by
   rfl
 
 @[simp]

--- a/scripts/LinterExemption.txt
+++ b/scripts/LinterExemption.txt
@@ -51,7 +51,6 @@ QuantumInfo/ForMathlib/HermitianMat/Schatten.lean
 QuantumInfo/ForMathlib/HermitianMat/Sqrt.lean
 QuantumInfo/ForMathlib/HermitianMat/Trace.lean
 QuantumInfo/ForMathlib/HermitianMat/Unitary.lean
-QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean
 QuantumInfo/ForMathlib/Isometry.lean
 QuantumInfo/ForMathlib/LimSupInf.lean
 QuantumInfo/ForMathlib/Majorization.lean


### PR DESCRIPTION
Enables the Physlib linters for `QuantumInfo/ForMathlib/IsMaximalSelfAdjoint.lean` and removes it from `scripts/LinterExemption.txt`.

The file was previously exempt from linting. This PR updates the file to satisfy the two required linters (`lake exe runPhyslibLinters` and `./scripts/lint-style.sh`) and drops its exemption line so the rules are now enforced on it.

Verified locally: the build succeeds and both required linters pass on the file.
