### PR TITLE
feat(TimeAndSpace): add coordinate type, projections, and Euclidean action (addresses #939)

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -430,6 +430,7 @@ public import Physlib.SpaceAndTime.Time.TimeTransMan
 public import Physlib.SpaceAndTime.Time.TimeUnit
 public import Physlib.SpaceAndTime.TimeAndSpace.Basic
 public import Physlib.SpaceAndTime.TimeAndSpace.ConstantTimeDist
+public import Physlib.SpaceAndTime.TimeAndSpace.EuclideanGroup.Action
 public import Physlib.StatisticalMechanics.BoltzmannConstant
 public import Physlib.StatisticalMechanics.CanonicalEnsemble.Basic
 public import Physlib.StatisticalMechanics.CanonicalEnsemble.Finite

--- a/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Zhi Kai Pong, Joseph Tooby-Smith
+Authors: Zhi Kai Pong, Joseph Tooby-Smith, Rob Sneiderman
 -/
 module
 
@@ -12,13 +12,16 @@ public import Physlib.SpaceAndTime.Space.Derivatives.Curl
 
 ## i. Overview
 
-In this module we define and prove basic lemmas about derivatives of functions and
-distributions on both `Time` and `Space d`.
+In this module we define `TimeAndSpace d` as the product of `Time` and `Space d`, and
+prove basic lemmas about derivatives of functions and distributions on both coordinates.
 
-We put these results in the namespace `Space` by convention.
+The derivative and distribution results are in the namespace `Space` by convention.
 
 ## ii. Key results
 
+- `TimeAndSpace d` : Euclidean spacetime as the product of time and space.
+- `TimeAndSpace.time` : The projection from `TimeAndSpace d` to `Time`.
+- `TimeAndSpace.space` : The projection from `TimeAndSpace d` to `Space d`.
 - `distTimeDeriv` : The derivative of a distribution on `Time × Space d` along the
   temporal coordinate.
 - `distSpaceDeriv` : The derivative of a distribution on `Time × Space d` along the
@@ -29,13 +32,14 @@ We put these results in the namespace `Space` by convention.
 
 ## iii. Table of contents
 
-- A. Derivatives involving time and space
-  - A.1. Space and time derivatives in terms of curried functions
-  - A.2. Commuting time and space derivatives
-  - A.3. Differentiablity conditions
-  - A.4. Time derivative commute with curl
-  - A.5. Constant of time deriative and space derivatives zero
-  - A.6. Equal up to a constant of time and space derivatives equal
+- A. The coordinate product and derivatives involving time and space
+  - A.1. The `TimeAndSpace` coordinate product
+  - A.2. Space and time derivatives in terms of curried functions
+  - A.3. Commuting time and space derivatives
+  - A.4. Differentiablity conditions
+  - A.5. Time derivative commute with curl
+  - A.6. Constant of time deriative and space derivatives zero
+  - A.7. Equal up to a constant of time and space derivatives equal
 - B. Derivatives of distributions on Time × Space d
   - B.1. Time derivatives
     - B.1.1. Composition with a CLM
@@ -55,17 +59,62 @@ We put these results in the namespace `Space` by convention.
 
 open Physlib
 
-namespace Space
-
 /-!
 
-## A. Derivatives involving time and space
+## A. The coordinate product and derivatives involving time and space
 
 -/
 
 /-!
 
-### A.1. Space and time derivatives in terms of curried functions
+### A.1. The `TimeAndSpace` coordinate product
+
+-/
+
+/-- Euclidean spacetime as the product of time and `d`-dimensional space. -/
+abbrev TimeAndSpace (d : ℕ := 3) := Time × Space d
+
+namespace TimeAndSpace
+
+variable {d : ℕ}
+
+/-- The time-coordinate projection from `TimeAndSpace d`. -/
+noncomputable def time {d : ℕ} : TimeAndSpace d →L[ℝ] Time :=
+  ContinuousLinearMap.fst ℝ Time (Space d)
+
+/-- The spatial-coordinate projection from `TimeAndSpace d`. -/
+noncomputable def space {d : ℕ} : TimeAndSpace d →L[ℝ] Space d :=
+  ContinuousLinearMap.snd ℝ Time (Space d)
+
+@[simp]
+lemma time_apply (tx : TimeAndSpace d) :
+    time tx = tx.1 := rfl
+
+@[simp]
+lemma space_apply (tx : TimeAndSpace d) :
+    space tx = tx.2 := rfl
+
+/-- The time projection is nonexpanding for the product metric. -/
+lemma dist_time_le (tx ty : TimeAndSpace d) :
+    dist (time tx) (time ty) ≤ dist tx ty := by
+  change dist tx.1 ty.1 ≤ dist tx ty
+  rw [Prod.dist_eq]
+  exact le_max_left (dist tx.1 ty.1) (dist tx.2 ty.2)
+
+/-- The spatial projection is nonexpanding for the product metric. -/
+lemma dist_space_le (tx ty : TimeAndSpace d) :
+    dist (space tx) (space ty) ≤ dist tx ty := by
+  change dist tx.2 ty.2 ≤ dist tx ty
+  rw [Prod.dist_eq]
+  exact le_max_right (dist tx.1 ty.1) (dist tx.2 ty.2)
+
+end TimeAndSpace
+
+namespace Space
+
+/-!
+
+### A.2. Space and time derivatives in terms of curried functions
 
 -/
 
@@ -95,7 +144,7 @@ lemma fderiv_time_eq_fderiv_curry {M} [NormedAddCommGroup M] [NormedSpace ℝ M]
 
 /-!
 
-### A.2. Commuting time and space derivatives
+### A.3. Commuting time and space derivatives
 
 -/
 
@@ -147,7 +196,7 @@ lemma time_deriv_comm_space_deriv {d i} {M} [NormedAddCommGroup M] [NormedSpace 
 
 /-!
 
-### A.3. Differentiablity conditions
+### A.4. Differentiablity conditions
 
 -/
 
@@ -207,7 +256,7 @@ lemma curl_differentiable_time
 
 /-!
 
-### A.4. Time derivative commute with curl
+### A.5. Time derivative commute with curl
 
 -/
 open Time
@@ -243,7 +292,7 @@ lemma time_deriv_curl_commute (fₜ : Time → Space → EuclideanSpace ℝ (Fin
 
 /-!
 
-### A.5. Constant of time deriative and space derivatives zero
+### A.6. Constant of time deriative and space derivatives zero
 
 -/
 
@@ -310,7 +359,7 @@ lemma const_of_time_deriv_space_deriv_eq_zero {d} {M} [NormedAddCommGroup M] [No
 
 /-!
 
-### A.6. Equal up to a constant of time and space derivatives equal
+### A.7. Equal up to a constant of time and space derivatives equal
 
 -/
 

--- a/Physlib/SpaceAndTime/TimeAndSpace/EuclideanGroup/Action.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/EuclideanGroup/Action.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Rob Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rob Sneiderman
+-/
+module
+
+public import Physlib.SpaceAndTime.Space.EuclideanGroup.Action
+public import Physlib.SpaceAndTime.TimeAndSpace.Basic
+/-!
+
+# The action of the Euclidean group on `TimeAndSpace`
+
+## i. Overview
+
+In this file we define the action of the Euclidean group on `TimeAndSpace d`. The action fixes
+the time coordinate and acts on the space coordinate by the usual Euclidean-group action on
+`Space d`.
+
+## ii. Key results
+
+- `TimeAndSpace.instMulActionEuclideanGroup` : The action of the Euclidean group on
+  `TimeAndSpace d`.
+- `TimeAndSpace.dist_smul` : The Euclidean group action on `TimeAndSpace d` preserves distance.
+
+## iii. Table of contents
+
+- A. The Euclidean group action
+
+## iv. References
+
+-/
+
+@[expose] public section
+
+namespace TimeAndSpace
+
+variable {d : ℕ}
+
+/-!
+
+## A. The Euclidean group action
+
+-/
+
+/-- The Euclidean group acts on `TimeAndSpace d` by fixing time and acting on space. -/
+noncomputable instance instMulActionEuclideanGroup :
+    MulAction (EuclideanGroup d) (TimeAndSpace d) where
+  smul g tx := (tx.1, g • tx.2)
+  one_smul tx := by
+    rcases tx with ⟨t, x⟩
+    show ((t, (1 : EuclideanGroup d) • x) : TimeAndSpace d) = (t, x)
+    simp
+  mul_smul g h tx := by
+    rcases tx with ⟨t, x⟩
+    show ((t, (g * h) • x) : TimeAndSpace d) = (t, g • h • x)
+    simp [mul_smul]
+
+/-- Coordinate formula for the Euclidean-group action on `TimeAndSpace d`. -/
+@[simp]
+lemma smul_mk (g : EuclideanGroup d) (t : Time) (x : Space d) :
+    g • ((t, x) : TimeAndSpace d) = (t, g • x) := by
+  show ((t, g • x) : TimeAndSpace d) = (t, g • x)
+  rfl
+
+/-- The Euclidean-group action fixes the first coordinate. -/
+@[simp]
+lemma fst_smul (g : EuclideanGroup d) (tx : TimeAndSpace d) :
+    (g • tx).1 = tx.1 := by
+  rcases tx with ⟨t, x⟩
+  rw [smul_mk]
+
+/-- The Euclidean-group action applies to the second coordinate. -/
+@[simp]
+lemma snd_smul (g : EuclideanGroup d) (tx : TimeAndSpace d) :
+    (g • tx).2 = g • tx.2 := by
+  rcases tx with ⟨t, x⟩
+  rw [smul_mk]
+
+/-- The Euclidean-group action fixes the time projection. -/
+lemma time_smul (g : EuclideanGroup d) (tx : TimeAndSpace d) :
+    time (g • tx) = time tx := by
+  simp [time]
+
+/-- The Euclidean-group action applies to the space projection. -/
+lemma space_smul (g : EuclideanGroup d) (tx : TimeAndSpace d) :
+    space (g • tx) = g • space tx := by
+  simp [space]
+
+/-- The Euclidean-group action on `TimeAndSpace d` preserves product distance. -/
+lemma dist_smul (g : EuclideanGroup d) (tx ty : TimeAndSpace d) :
+    dist (g • tx) (g • ty) = dist tx ty := by
+  rcases tx with ⟨t, x⟩
+  rcases ty with ⟨t', x'⟩
+  show dist ((t, g • x) : TimeAndSpace d) (t', g • x') = dist (t, x) (t', x')
+  rw [Prod.dist_eq, Prod.dist_eq, EuclideanGroup.dist_smul]
+
+end TimeAndSpace


### PR DESCRIPTION
## Summary

Partially addresses #939 by adding the base Euclidean coordinate-product API for
`TimeAndSpace d`.

This PR does not add the Schwartz-map action requested later in #939.

## Changes

`Physlib.SpaceAndTime.TimeAndSpace.Basic`
- `TimeAndSpace`: abbreviation for `Time x Space d`.
- `TimeAndSpace.time`: continuous linear projection to `Time`.
- `TimeAndSpace.space`: continuous linear projection to `Space d`.
- `TimeAndSpace.time_apply`: simp lemma for the time projection.
- `TimeAndSpace.space_apply`: simp lemma for the space projection.
- `TimeAndSpace.dist_time_le`: the time projection is nonexpanding for the product metric.
- `TimeAndSpace.dist_space_le`: the spatial projection is nonexpanding for the product metric.

`Physlib.SpaceAndTime.TimeAndSpace.EuclideanGroup.Action`
- `TimeAndSpace.instMulActionEuclideanGroup`: Euclidean-group action on `TimeAndSpace d`
  fixing time and acting on space.
- `TimeAndSpace.smul_mk`: how the action evaluates on a pair `(t, x)`.
- `TimeAndSpace.fst_smul`: the action fixes the first coordinate.
- `TimeAndSpace.snd_smul`: the action sends the second coordinate to `g • x`.
- `TimeAndSpace.time_smul`: the time projection is unchanged.
- `TimeAndSpace.space_smul`: the space projection transforms by `g`.
- `TimeAndSpace.dist_smul`: the action preserves product distance.

## Reviewer map

1. Start with `TimeAndSpace.Basic` for the named product type and projections.
2. Then read `TimeAndSpace.EuclideanGroup.Action` for the induced Euclidean action.
3. `Physlib.lean` only adds the new action-module import.

## Verification

- `lake exe cache get`
- `lake build Physlib.SpaceAndTime.TimeAndSpace.Basic Physlib.SpaceAndTime.TimeAndSpace.EuclideanGroup.Action Physlib.SpaceAndTime.TimeAndSpace.ConstantTimeDist`
- Stdin Lean probe for the `MulAction` instance, projection simp behavior, and `TimeAndSpace.dist_smul`
- `lake exe lint_all`

Note: local `lake exe lint_all` reported pre-existing style/transitive-import messages in
unrelated files, but the build/import/sorry checks passed and the Lean linter passed for
`Physlib`.
