### PR TITLE
refactor: Golf adiabatic_relation_log proof in IdealGas/Basic

### DIFF
--- a/Physlib/Thermodynamics/IdealGas/Basic.lean
+++ b/Physlib/Thermodynamics/IdealGas/Basic.lean
@@ -55,115 +55,12 @@ theorem adiabatic_relation_log
       entropy c R s0 U0 V0 N0 Ua Va N =
       entropy c R s0 U0 V0 N0 Ub Vb N) :
     c * log (Ua / Ub) + log (Va / Vb) = 0 := by
-  -- Step 1: cancel `N * s0` and isolate the `N * R * (...)` pieces.
-  have h1 :
-      N * R *
-          (c * log (Ua / U0) +
-            log (Va / V0) -
-            (c + 1) * log (N / N0)) =
-        N * R *
-          (c * log (Ub / U0) +
-            log (Vb / V0) -
-            (c + 1) * log (N / N0)) := by
-    -- unfold entropy and use `add_left_cancel` to cancel `N * s0`
-    unfold entropy at hS
-    -- now `hS` is: N*s0 + N*R*(...) = N*s0 + N*R*(...)`
-    -- cancel `N*s0` from both sides
-    exact add_left_cancel hS
-
-  -- Step 2: cancel the common factor `N * R`.
-  have hNR : N * R ≠ 0 :=
-    mul_ne_zero (ne_of_gt hN) (ne_of_gt hR)
-  have h2 :
-      c * log (Ua / U0) +
-        log (Va / V0) -
-        (c + 1) * log (N / N0) =
-      c * log (Ub / U0) +
-        log (Vb / V0) -
-        (c + 1) * log (N / N0) :=
-    mul_left_cancel₀ hNR h1
-
-  -- Step 3: cancel the common `-(c+1) * log (N/N0)` term.
-  have h3 :
-      c * log (Ua / U0) + log (Va / V0) =
-      c * log (Ub / U0) + log (Vb / V0) := by
-
-    -- rewrite with `sub_eq_add_neg` so we can use `add_right_cancel`
-
-    have h2' :
-        c * log (Ua / U0) + log (Va / V0)
-          - (c + 1) * log (N / N0) =
-        c * log (Ub / U0) + log (Vb / V0)
-          - (c + 1) * log (N / N0) := by
-      simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-    -- now cancel the same term on the right
-    exact add_right_cancel h2'
-
-  -- Step 4: turn this equality into a “difference = 0” form
-  -- and rearrange algebraically.
-  have h4 :
-      c * (log (Ua / U0) - log (Ub / U0)) +
-        (log (Va / V0) - log (Vb / V0)) = 0 := by
-    -- from `a = b`, we get `a - b = 0`
-    have h4' :
-        (c * log (Ua / U0) + log (Va / V0)) -
-          (c * log (Ub / U0) + log (Vb / V0)) = 0 :=
-      sub_eq_zero.mpr h3
-    -- expand `a - b` and simplify
-    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc,
-          mul_add, add_mul, mul_comm, mul_left_comm, mul_assoc] using h4'
-
-  -- Step 5: use `log_div` to turn differences of logs into logs of ratios.
-  have hUaU0 : 0 < Ua / U0 := div_pos hUa hU0
-  have hUbU0 : 0 < Ub / U0 := div_pos hUb hU0
-  have hVaV0 : 0 < Va / V0 := div_pos hVa hV0
-  have hVbV0 : 0 < Vb / V0 := div_pos hVb hV0
-
-  have hU :
-      log (Ua / U0) - log (Ub / U0) =
-        log ((Ua / U0) / (Ub / U0)) := by
-    -- log_div hx hy : log (x / y) = log x - log y
-    -- log_div needs ≠ 0, not just positivity
-    have hneqx : Ua / U0 ≠ 0 := ne_of_gt hUaU0
-    have hneqy : Ub / U0 ≠ 0 := ne_of_gt hUbU0
-
-    have h := Real.log_div (x := Ua / U0) (y := Ub / U0) hneqx hneqy
-    -- we want "difference = log(ratio)", so flip and rewrite
-    simpa [sub_eq_add_neg] using h.symm
-
-  have hV :
-      log (Va / V0) - log (Vb / V0) =
-        log ((Va / V0) / (Vb / V0)) := by
-    -- log_div hx hy : log (x / y) = log x - log y
-    -- log_div needs ≠ 0, not just positivity
-    have hneqxV : Va / V0 ≠ 0 := ne_of_gt hVaV0
-    have hneqyV : Vb / V0 ≠ 0 := ne_of_gt hVbV0
-
-    have h := Real.log_div (x := Va / V0) (y := Vb / V0) hneqxV hneqyV
-
-    simpa [sub_eq_add_neg] using h.symm
-
-  have h5 :
-      c * log ((Ua / U0) / (Ub / U0)) +
-        log ((Va / V0) / (Vb / V0)) = 0 := by
-    simpa [hU, hV] using h4
-
-  -- Step 6: simplify the ratios to Ua/Ub and Va/Vb using `field_simp`.
-  have h_ratio_U :
-      (Ua / U0) / (Ub / U0) = Ua / Ub := by
-    -- `field_simp` uses the nonzero denominators in the context
-    field_simp [div_eq_mul_inv]
-
-  have h_ratio_V :
-      (Va / V0) / (Vb / V0) = Va / Vb := by
-    field_simp [div_eq_mul_inv]
-
-  have h6 :
-      c * log (Ua / Ub) + log (Va / Vb) = 0 := by
-    -- rewrite the log arguments using the two equalities above
-    simpa [h_ratio_U, h_ratio_V] using h5
-
-  exact h6
+  unfold entropy at hS
+  have h := mul_left_cancel₀ (mul_ne_zero hN.ne' hR.ne') (add_left_cancel hS)
+  rw [Real.log_div hUa.ne' hU0.ne', Real.log_div hUb.ne' hU0.ne',
+      Real.log_div hVa.ne' hV0.ne', Real.log_div hVb.ne' hV0.ne'] at h
+  rw [Real.log_div hUa.ne' hUb.ne', Real.log_div hVa.ne' hVb.ne']
+  linear_combination h
 
 /-- Adiabatic relation in product form:
     If S(Ua,Va,N) = S(Ub,Vb,N) with N fixed,


### PR DESCRIPTION
## Summary

Golfs the proof of `adiabatic_relation_log` in
`Physlib/Thermodynamics/IdealGas/Basic.lean`, reducing it from a 109-line
tactic block to 6 lines. The theorem statement (name, binders, type) is
unchanged.

## What the lemma says

Given `entropy c R s0 U0 V0 N0 U V N = N*s0 + N*R*(c*log(U/U0) + log(V/V0) - (c+1)*log(N/N0))`,
from `S(Ua,Va,N) = S(Ub,Vb,N)` conclude `c * log (Ua/Ub) + log (Va/Vb) = 0`.

## How it was golfed

The original proof walked through six labelled steps, each with several
nested `have`s: cancelling `N*s0` via `add_left_cancel`, cancelling `N*R`
via `mul_left_cancel₀`, cancelling the common `-(c+1)*log(N/N0)` term with
`add_right_cancel`, rearranging with repeated `simpa [...]` over long
`add_comm`/`mul_comm` lemma lists, expanding logs with auxiliary `hU`/`hV`
equalities, and finally simplifying ratios with `field_simp`.

The new proof keeps the same mathematical skeleton but expresses it directly:

```lean
  unfold entropy at hS
  have h := mul_left_cancel₀ (mul_ne_zero hN.ne' hR.ne') (add_left_cancel hS)
  rw [Real.log_div hUa.ne' hU0.ne', Real.log_div hUb.ne' hU0.ne',
      Real.log_div hVa.ne' hV0.ne', Real.log_div hVb.ne' hV0.ne'] at h
  rw [Real.log_div hUa.ne' hUb.ne', Real.log_div hVa.ne' hVb.ne']
  linear_combination h
```

- **Length:** 109 → 6 lines; the six intermediate lemmas and their
  restated goals are gone.
- **Speed:** drops the repeated heavy `simpa [...]` calls and `field_simp`
  in favour of targeted `Real.log_div` rewrites plus a single
  `linear_combination`. After expanding every `log (x/y)` into
  `log x - log y`, the goal follows from the cancelled hypothesis by a pure
  `ring` check, which `linear_combination h` discharges directly. The
  `log (N/N0)` term cancels automatically as a `ring` atom, so it never has
  to be handled explicitly. Module builds in ~2.8s.
- **Structure:** the proof now reads as the three real steps — cancel the
  common `N*s0` and `N*R` factors, turn quotient-logs into differences of
  logs, finish by linear combination — instead of being obscured by
  bookkeeping `have`s.

## Verification

- `lake build Physlib.Thermodynamics.IdealGas.Basic` succeeds (no errors,
  no warnings).
- Axioms unchanged: `propext`, `Classical.choice`, `Quot.sound` (no
  `sorryAx`, no new axioms).
