### PR TITLE
refactor(QFT): golf bosonicProjF_mem_ideal proof

### DIFF
--- a/Physlib/QFT/PerturbationTheory/WickAlgebra/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/WickAlgebra/Basic.lean
@@ -309,114 +309,19 @@ lemma bosonicProjF_mem_ideal (x : FieldOpFreeAlgebra 𝓕)
     obtain ⟨d, hd, y, hy, rfl⟩ := Set.mem_mul.mp ha
     rw [bosonicProjF_mul, bosonicProjF_mul, fermionicProjF_mul]
     simp only [add_mul]
-    rcases fermionicProjF_mem_fieldOpIdealSet_or_zero y hy with hfy | hfy
-      <;> rcases bosonicProjF_mem_fieldOpIdealSet_or_zero y hy with hby | hby
-    · apply TwoSidedIdeal.add_mem
-      apply TwoSidedIdeal.add_mem
-      · /- boson, boson, boson mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(bosonicProjF d) * ↑(bosonicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use bosonicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (bosonicProjF y).1
-          simp [hby]
-        · aesop
-      · /- fermion, fermion, boson mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(fermionicProjF d) * ↑(fermionicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use fermionicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (fermionicProjF y).1
-          simp [hfy]
-        · aesop
-      apply TwoSidedIdeal.add_mem
-      · /- boson, fermion, fermion mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(bosonicProjF d) * ↑(fermionicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use bosonicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (fermionicProjF y).1
-          simp [hfy]
-        · aesop
-      · /- fermion, boson, fermion mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(fermionicProjF d) * ↑(bosonicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use fermionicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (bosonicProjF y).1
-          simp [hby]
-        · simp only [Set.mem_univ, mul_eq_mul_left_iff, mul_eq_zero, ZeroMemClass.coe_eq_zero,
-          true_and, exists_or_eq_left]
-    · simp only [hby, ZeroMemClass.coe_zero, mul_zero, zero_mul, zero_add, add_zero]
-      apply TwoSidedIdeal.add_mem
-      · /- fermion, fermion, boson mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(fermionicProjF d) * ↑(fermionicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use fermionicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (fermionicProjF y).1
-          simp [hfy]
-        · aesop
-      · /- boson, fermion, fermion mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(bosonicProjF d) * ↑(fermionicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use bosonicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (fermionicProjF y).1
-          simp [hfy]
-        · simp only [Set.mem_univ, mul_eq_mul_left_iff, mul_eq_zero, ZeroMemClass.coe_eq_zero,
-          true_and, exists_or_eq_left]
-    · simp only [hfy, ZeroMemClass.coe_zero, mul_zero, zero_mul, add_zero, zero_add]
-      apply TwoSidedIdeal.add_mem
-      · /- boson, boson, boson mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(bosonicProjF d) * ↑(bosonicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use bosonicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (bosonicProjF y).1
-          simp [hby]
-        · aesop
-      · /- fermion, boson, fermion mem-/
-        rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]
-        refine Set.mem_of_mem_of_subset ?_ AddSubgroup.subset_closure
-        apply Set.mem_mul.mpr
-        use ↑(fermionicProjF d) * ↑(bosonicProjF y)
-        apply And.intro
-        · apply Set.mem_mul.mpr
-          use fermionicProjF d
-          simp only [Set.mem_univ, mul_eq_mul_left_iff, ZeroMemClass.coe_eq_zero, true_and]
-          use (bosonicProjF y).1
-          simp [hby]
-        · aesop
-    · simp [hfy, hby]
+    have key {u w v : 𝓕.FieldOpFreeAlgebra}
+        (hv : v ∈ TwoSidedIdeal.span 𝓕.fieldOpIdealSet) :
+        u * v * w ∈ TwoSidedIdeal.span 𝓕.fieldOpIdealSet :=
+      TwoSidedIdeal.mul_mem_right _ _ _ (TwoSidedIdeal.mul_mem_left _ _ _ hv)
+    have hBy : ↑(bosonicProjF y) ∈ TwoSidedIdeal.span 𝓕.fieldOpIdealSet := by
+      rcases bosonicProjF_mem_fieldOpIdealSet_or_zero y hy with h | h
+      · exact TwoSidedIdeal.mem_span_iff.mpr fun I hI => hI h
+      · simp [h]
+    have hFy : ↑(fermionicProjF y) ∈ TwoSidedIdeal.span 𝓕.fieldOpIdealSet := by
+      rcases fermionicProjF_mem_fieldOpIdealSet_or_zero y hy with h | h
+      · exact TwoSidedIdeal.mem_span_iff.mpr fun I hI => hI h
+      · simp [h]
+    exact add_mem (add_mem (key hBy) (key hFy)) (add_mem (key hFy) (key hBy))
   · simp only [TwoSidedIdeal.mem_mk, map_zero, ZeroMemClass.coe_zero, p]
     exact (RingCon.eq (ringConGen fun a b => a - b ∈ 𝓕.fieldOpIdealSet)).mp rfl
   · intro x y hx hy hpx hpy


### PR DESCRIPTION
# Golf `bosonicProjF_mem_ideal`

Golfs the proof of `bosonicProjF_mem_ideal` in
`Physlib/QFT/PerturbationTheory/WickAlgebra/Basic.lean`. Only the tactic block of
this single lemma is changed; its statement (name, binders, type) is untouched, and
no other declaration, import, or file is modified.

## What changed

The lemma proves that the bosonic projection of an element of the two-sided ideal
`TwoSidedIdeal.span 𝓕.fieldOpIdealSet` stays in that ideal. The proof inducts on the
additive-subgroup closure (`AddSubgroup.closure_induction`); after expanding the
bosonic part of the generator `d * y * b` via `bosonicProjF_mul`/`fermionicProjF_mul`,
the membership goal becomes a sum of four terms, each of the form
`u * (projF y) * w` where the **middle** factor is either `↑(bosonicProjF y)` or
`↑(fermionicProjF y)`.

The original proof case-split (`rcases ... <;> rcases ...`) on whether each projection
lands in `fieldOpIdealSet` or is zero, and then spelled out the ideal membership of
each surviving summand by hand — six near-identical ~11-line blocks that unfold the
span to `AddSubgroup.closure (Set.univ * S * Set.univ)` and exhibit explicit witnesses.

The key observation is that the four-way case split is unnecessary: each middle factor
is **always** in the span — either it lies in `fieldOpIdealSet` (hence in the span), or
it is `0` (hence in the span trivially). Once that is established for both projections,
every summand is in the ideal by plain two-sided-ideal absorption
(`TwoSidedIdeal.mul_mem_left` / `mul_mem_right`), and the whole goal closes with a
single `add_mem` term.

The new proof:
- establishes `↑(bosonicProjF y), ↑(fermionicProjF y) ∈ span` once each (via
  `*_mem_fieldOpIdealSet_or_zero`);
- introduces a one-line local `key` lemma capturing the absorption
  `u * v * w ∈ span` from `v ∈ span`;
- closes the goal with
  `exact add_mem (add_mem (key hBy) (key hFy)) (add_mem (key hFy) (key hBy))`.

## Improvements

- **Length:** the lemma's tactic block shrinks from ~123 to ~19 lines
  (file diff: 13 insertions, 108 deletions). The six copy-pasted membership blocks and
  the four-way `rcases` are removed entirely.
- **Speed:** drops the repeated `rw [TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure]`
  unfoldings, the `Set.mem_mul`/`Set.mem_of_mem_of_subset` witness juggling, and several
  `aesop`/`simp` calls, replacing them with direct term-mode applications of the
  `TwoSidedIdeal` API.
- **Structure:** the proof now reflects the actual mathematical content (two-sided
  absorption of an ideal element) instead of re-deriving span membership from its
  additive-closure definition for each summand. The local `key` abbreviation removes
  duplication and makes the four summands' uniform treatment explicit.

## Verification

- `lake build` succeeds (whole project, all jobs).
- `#print axioms` for the lemma reports only `propext`, `Classical.choice`, `Quot.sound`
  — no `sorryAx`, no new axioms.
- No new errors or warnings introduced.
