### PR TITLE
refactor(QuantumMechanics): golf orthogonal_exp_of_mem_orthogonal proof

### DIFF
--- a/Physlib/QuantumMechanics/OneDimension/HarmonicOscillator/Completeness.lean
+++ b/Physlib/QuantumMechanics/OneDimension/HarmonicOscillator/Completeness.lean
@@ -274,23 +274,9 @@ lemma orthogonal_exp_of_mem_orthogonal (f : ℝ → ℂ) (hf : MemHS f)
         (Complex.I * ↑c * ↑y) ^ r / r ! * (f y * Real.exp (- y^2 / (2 * Q.ξ^2))))
       Filter.atTop (nhds (Complex.exp (Complex.I * c * y) *
       (f y * Real.exp (- y^2 / (2 * Q.ξ^2))))) := by
-    have h11 : (fun n => ∑ r ∈ range n,
-        (Complex.I * ↑c * ↑y) ^ r / r !
-        * (f y * Real.exp (- y^2 / (2 * Q.ξ^2)))) =
-        fun n => (∑ r ∈ range n,
-        (Complex.I * ↑c * ↑y) ^ r / r !)
-        * ((f y * Real.exp (- y^2 / (2 * Q.ξ^2)))) := by
-      funext s
-      simp [Finset.sum_mul]
-    rw [h11]
-    have h12 : (Complex.exp (Complex.I * c * y) * (f y * Real.exp (- y^2 / (2 * Q.ξ^2))))
-      = (Complex.exp (Complex.I * c * y)) * (f y * Real.exp (- y^2 / (2 * Q.ξ^2))) := by
-      simp
-    rw [h12]
+    simp_rw [← Finset.sum_mul]
     apply Filter.Tendsto.mul_const
     simp only [Complex.exp, Complex.exp']
-    haveI hi : CauSeq.IsComplete ℂ norm :=
-      inferInstanceAs (CauSeq.IsComplete ℂ norm)
     exact CauSeq.tendsto_limit (Complex.exp' (Complex.I * c * y))
   /- End of rewriting the integrand as a limit. -/
   /- Rewriting the integral as a limit using dominated_convergence -/
@@ -302,34 +288,9 @@ lemma orthogonal_exp_of_mem_orthogonal (f : ℝ → ℂ) (hf : MemHS f)
       (Real.exp (- x ^ 2 / (2 * Q.ξ^2)))
     apply MeasureTheory.tendsto_integral_of_dominated_convergence bound
     · intro n
-      refine aestronglyMeasurable_fun_sum (range n) ?_
-      intro r hr
-      have h1 : (fun a => (Complex.I * ↑c * ↑a) ^ r / ↑r ! *
-        (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2)))))
-        = fun a => (Complex.I * ↑c) ^ r / ↑r ! *
-        (f a * Complex.ofReal (a ^ r * (Real.exp (- a ^ 2 / (2 * Q.ξ^2))))) := by
-        funext a
-        simp only [Complex.ofReal_exp, Complex.ofReal_div, Complex.ofReal_neg,
-          Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_ofNat]
-        ring
-      rw [h1]
-      apply MeasureTheory.AEStronglyMeasurable.const_mul
-      apply MeasureTheory.AEStronglyMeasurable.mul
-      · exact aeStronglyMeasurable_of_memHS hf
-      · apply MeasureTheory.Integrable.aestronglyMeasurable
-        apply MeasureTheory.Integrable.ofReal
-        change Integrable (fun x => (x ^ r) * (Real.exp (- x ^ 2 / (2 * Q.ξ^2))))
-        have h1 : (fun x => (x ^ r)*(Real.exp (- x ^ 2 / (2 * Q.ξ^2)))) =
-            (fun x => (Polynomial.X ^ r : Polynomial ℤ).aeval x *
-            (Real.exp (- (1/ (2* Q.ξ^2)) * x ^ 2))) := by
-          funext x
-          simp only [neg_mul, map_pow, Polynomial.aeval_X, mul_eq_mul_left_iff, Real.exp_eq_exp,
-            pow_eq_zero_iff', ne_eq]
-          left
-          field_simp
-        rw [h1]
-        apply guassian_integrable_polynomial
-        simp
+      refine aestronglyMeasurable_fun_sum (range n) fun r _ => ?_
+      exact (Continuous.aestronglyMeasurable (by fun_prop)).mul
+        ((aeStronglyMeasurable_of_memHS hf).mul (Continuous.aestronglyMeasurable (by fun_prop)))
     · /- Prove the bound is integrable. -/
       have hbound : bound = (fun x => Real.exp |c * x| * norm (f x) *
           Real.exp (-(1/ (2 * Q.ξ^2)) * x ^ 2)) := by
@@ -388,34 +349,23 @@ lemma orthogonal_exp_of_mem_orthogonal (f : ℝ → ℂ) (hf : MemHS f)
   have h3b : (fun n => ∫ y : ℝ, ∑ r ∈ range n,
       (Complex.I * ↑c * ↑y) ^ r / r ! *
       (f y * Real.exp (- y^2 / (2 * Q.ξ^2)))) = fun (n : ℕ) => 0 := by
-    funext n
-    rw [MeasureTheory.integral_finsetSum]
-    · apply Finset.sum_eq_zero
-      intro r hr
-      have hf' : (fun a => (Complex.I * ↑c * ↑a) ^ r / ↑r ! *
+    have key (r : ℕ) : (fun a => (Complex.I * ↑c * ↑a) ^ r / ↑r ! *
         (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2)))))
         = fun a => ((Complex.I * ↑c) ^ r / ↑r !) *
-        (a^ r * (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2))))) := by
-        funext a
-        simp only [Complex.ofReal_exp, Complex.ofReal_div, Complex.ofReal_neg,
-          Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_ofNat]
-        ring
-      rw [hf']
-      rw [MeasureTheory.integral_const_mul]
-      rw [Q.orthogonal_power_of_mem_orthogonal f hf hOrth r]
+        (a ^ r * (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2))))) := by
+      funext a
+      simp only [Complex.ofReal_exp, Complex.ofReal_div, Complex.ofReal_neg,
+        Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_ofNat]
+      ring
+    funext n
+    rw [MeasureTheory.integral_finsetSum]
+    · refine Finset.sum_eq_zero fun r _ => ?_
+      rw [key r, MeasureTheory.integral_const_mul,
+        Q.orthogonal_power_of_mem_orthogonal f hf hOrth r]
       simp
-    · intro r hr
-      have hf' : (fun a => (Complex.I * ↑c * ↑a) ^ r / ↑r ! *
-        (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2)))))
-        = ((Complex.I * ↑c) ^ r / ↑r !) •
-        fun a => (a^ r * (f a * ↑(Real.exp (- a ^ 2 / (2 * Q.ξ^2))))) := by
-        funext a
-        simp only [Complex.ofReal_exp, Complex.ofReal_div, Complex.ofReal_neg,
-          Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_ofNat, Pi.smul_apply, smul_eq_mul]
-        ring
-      rw [hf']
-      apply MeasureTheory.Integrable.smul
-      exact Q.mul_power_integrable f hf r
+    · intro r _
+      rw [key r]
+      exact (Q.mul_power_integrable f hf r).const_mul _
   rw [h3b] at h1'
   apply tendsto_nhds_unique h1'
   rw [tendsto_const_nhds_iff]


### PR DESCRIPTION
# Golf `orthogonal_exp_of_mem_orthogonal`

Golfs the proof of `orthogonal_exp_of_mem_orthogonal` in
`Physlib/QuantumMechanics/OneDimension/HarmonicOscillator/Completeness.lean`.

The lemma statement (name, binders, type) is unchanged — only the tactic block
is rewritten. The proof shrinks from **154 to ~115 lines** (`+18 / −68` in the
diff).

## What changed

**1. Pointwise-limit step (`h1`).**
Removed two helper rewrites: `h11` (manual `funext … simp [Finset.sum_mul]`) is
replaced by a single `simp_rw [← Finset.sum_mul]`, and `h12` (which rewrote an
expression to a syntactically identical one — a no-op) is deleted. Also dropped a
redundant `haveI : CauSeq.IsComplete ℂ norm` that is already found by instance
resolution.

**2. Measurability obligation of dominated convergence.**
The original spent ~28 lines reshaping the summand into a real polynomial and
invoking `guassian_integrable_polynomial` just to get
`AEStronglyMeasurable`. Since the only non-continuous factor is `f` (measurable
via `aeStronglyMeasurable_of_memHS hf`), this collapses to a one-liner: the
product of two `Continuous.aestronglyMeasurable (by fun_prop)` factors with the
measurable `f`.

**3. Vanishing-integral step (`h3b`).**
The two near-identical `funext … simp only [Complex.ofReal_*] … ring` rewrites
(one in `*` form, one in `•` form) are unified into a single reusable
`key (r : ℕ)` equation. The integrability side goal now uses
`(Q.mul_power_integrable …).const_mul _` instead of an extra `•`-shaped rewrite
plus `Integrable.smul`.

## Improvements

- **Length:** −50 net lines; eliminates a no-op rewrite and a duplicated
  `simp only [Complex.ofReal_*]` block.
- **Speed:** the measurability goal is closed by lightweight continuity /
  `fun_prop` reasoning rather than constructing a `Polynomial ℤ` and routing
  through `guassian_integrable_polynomial`.
- **Structure:** the repeated integrand reshaping is factored into one named
  `key` lemma; redundant intermediate `have`s are gone, making the
  dominated-convergence argument read top-to-bottom.

## Verification

- `lake build Physlib.QuantumMechanics.OneDimension.HarmonicOscillator.Completeness`
  succeeds with no errors or warnings.
- No `sorry`; axiom set is unchanged (`propext`, `Classical.choice`,
  `Quot.sound`).
