### PR TITLE
refactor(Mathematics): golf succAbove_succAbove_predAboveI proof

### DIFF
--- a/Physlib/Mathematics/Fin.lean
+++ b/Physlib/Mathematics/Fin.lean
@@ -90,75 +90,10 @@ lemma predAboveI_ge {i x : Fin n.succ.succ} (h : i.val < x.val) :
 lemma succAbove_succAbove_predAboveI (i : Fin n.succ.succ) (j : Fin n.succ) (x : Fin n) :
     i.succAbove (j.succAbove x) =
     (i.succAbove j).succAbove ((predAboveI (i.succAbove j) i).succAbove x) := by
-  by_cases h1 : j.castSucc < i
-  · have hx := Fin.succAbove_of_castSucc_lt _ _ h1
-    rw [hx, predAboveI_ge h1]
-    by_cases hx1 : x.castSucc < j
-    · rw [Fin.succAbove_of_castSucc_lt _ _ hx1, Fin.succAbove_of_castSucc_lt]
-      · nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          exact hx1
-        · rw [Fin.lt_def] at h1 hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc]
-          omega
-      · exact Nat.lt_trans hx1 h1
-    · simp only [not_lt] at hx1
-      rw [Fin.le_def] at hx1
-      rw [Fin.lt_def] at h1
-      rw [Fin.succAbove_of_le_castSucc _ _ hx1]
-      by_cases hx2 : x.succ.castSucc < i
-      · rw [Fin.succAbove_of_castSucc_lt _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_le_castSucc]
-          · rfl
-          · assumption
-        · rw [Fin.lt_def] at hx2 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-          omega
-      · simp only [not_lt] at hx2
-        rw [Fin.succAbove_of_le_castSucc _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_le_castSucc]
-        · rw [Fin.succAbove_of_le_castSucc]
-          rw [Fin.le_def]
-          exact Nat.le_succ_of_le hx1
-        · rw [Fin.le_def] at hx2 ⊢
-          simp_all
-  · simp only [Nat.succ_eq_add_one, not_lt] at h1
-    have hx := Fin.succAbove_of_le_castSucc _ _ h1
-    rw [hx, predAboveI_lt (Nat.lt_add_one_of_le h1)]
-    by_cases hx1 : j ≤ x.castSucc
-    · rw [Fin.succAbove_of_le_castSucc _ _ hx1, Fin.succAbove_of_le_castSucc _ _]
-      · nth_rewrite 2 [Fin.succAbove_of_le_castSucc _ _]
-        · rw [Fin.succAbove_of_le_castSucc]
-          rw [Fin.le_def] at hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ, add_le_add_iff_right]
-        · rw [Fin.le_def] at h1 hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc]
-          omega
-      · rw [Fin.le_def] at hx1 h1 ⊢
-        simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-        omega
-    · simp only [Nat.succ_eq_add_one, not_le] at hx1
-      rw [Fin.lt_def] at hx1
-      rw [Fin.le_def] at h1
-      rw [Fin.succAbove_of_castSucc_lt _ _ hx1]
-      by_cases hx2 : x.castSucc.castSucc < i
-      · rw [Fin.succAbove_of_castSucc_lt _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          rw [Fin.lt_def] at hx2 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-          omega
-        · rw [Fin.lt_def] at hx2 ⊢
-          simp_all
-      · simp only [not_lt] at hx2
-        rw [Fin.succAbove_of_le_castSucc _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_le_castSucc]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          · rfl
-          exact Fin.castSucc_lt_succ_iff.mpr hx1
-        · rw [Fin.le_def] at hx2 ⊢
-          simp_all
+  apply Fin.ext
+  simp only [Fin.succAbove, predAboveI, Fin.lt_def, Fin.val_castSucc, Fin.val_succ,
+    apply_dite Fin.val, apply_ite Fin.val]
+  split_ifs <;> omega
 
 /-- The equivalence between `Fin n.succ` and `Fin 1 ⊕ Fin n` extracting the
   `i`th component. -/


### PR DESCRIPTION
## Summary

Golfs the proof of `succAbove_succAbove_predAboveI` in
`Physlib/Mathematics/Fin.lean` (namespace `Physlib.Fin`).

The lemma statement (name, binders, type) is unchanged — only the proof term
was rewritten.

## What changed

The original proof was a **69-line** manual case analysis: nested `by_cases`
on `j.castSucc < i`, `x.castSucc < j`, `x.succ.castSucc < i`, etc., each branch
rewriting with `Fin.succAbove_of_castSucc_lt` / `Fin.succAbove_of_le_castSucc`,
plus `nth_rewrite`, and closing leaves with repeated
`rw [Fin.lt_def/le_def] at … ⊢; simp_all only […]; omega` boilerplate.

Since both sides of the equation are elements of `Fin _` whose values are
completely determined by the underlying `Nat`, the whole thing collapses to a
single arithmetic decision:

```lean
lemma succAbove_succAbove_predAboveI (i : Fin n.succ.succ) (j : Fin n.succ) (x : Fin n) :
    i.succAbove (j.succAbove x) =
    (i.succAbove j).succAbove ((predAboveI (i.succAbove j) i).succAbove x) := by
  apply Fin.ext
  simp only [Fin.succAbove, predAboveI, Fin.lt_def, Fin.val_castSucc, Fin.val_succ,
    apply_dite Fin.val, apply_ite Fin.val]
  split_ifs <;> omega
```

- `apply Fin.ext` reduces the `Fin` equality to an equality of `.val`s.
- `simp only [Fin.succAbove, predAboveI, …, apply_dite Fin.val, apply_ite Fin.val]`
  unfolds the `succAbove`/`predAboveI` `if`/`dite`s and pushes `Fin.val`
  through them, turning every condition and branch into plain `Nat`
  expressions (`Fin.lt_def`, `Fin.val_castSucc`, `Fin.val_succ`).
- `split_ifs <;> omega` then discharges every resulting case (including the
  contradictory ones) by linear arithmetic over `Nat`.

## Improvements

- **Length:** 69 lines → 4 lines, eliminating all the repeated
  `rw … ; simp_all only … ; omega` boilerplate and the bespoke branch lemmas.
- **Speed:** the module builds in ~2.4s and the proof elaborates well within
  default heartbeats; the work is a single targeted `simp only` followed by
  `split_ifs <;> omega` instead of many separate `simp_all`/`rw` invocations.
- **Structure:** the proof now reflects the actual mathematical content — the
  identity is true purely by `Nat` arithmetic on the underlying values — rather
  than burying it in a manual case tree.

## Verification

- `lake build Physlib.Mathematics.Fin` succeeds (2.4s).
- `lake build Physlib` succeeds (4234 jobs).
- No `sorry`, no errors, no new warnings.
- Axioms unchanged: only `propext` and `Quot.sound`.
