### PR TITLE
auto-golf(succAbove_succAbove_predAboveI): reduce Fin case-bash to simp + omega

### DIFF
--- a/Physlib/Mathematics/Fin.lean
+++ b/Physlib/Mathematics/Fin.lean
@@ -90,75 +90,9 @@ lemma predAboveI_ge {i x : Fin n.succ.succ} (h : i.val < x.val) :
 lemma succAbove_succAbove_predAboveI (i : Fin n.succ.succ) (j : Fin n.succ) (x : Fin n) :
     i.succAbove (j.succAbove x) =
     (i.succAbove j).succAbove ((predAboveI (i.succAbove j) i).succAbove x) := by
-  by_cases h1 : j.castSucc < i
-  · have hx := Fin.succAbove_of_castSucc_lt _ _ h1
-    rw [hx, predAboveI_ge h1]
-    by_cases hx1 : x.castSucc < j
-    · rw [Fin.succAbove_of_castSucc_lt _ _ hx1, Fin.succAbove_of_castSucc_lt]
-      · nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          exact hx1
-        · rw [Fin.lt_def] at h1 hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc]
-          omega
-      · exact Nat.lt_trans hx1 h1
-    · simp only [not_lt] at hx1
-      rw [Fin.le_def] at hx1
-      rw [Fin.lt_def] at h1
-      rw [Fin.succAbove_of_le_castSucc _ _ hx1]
-      by_cases hx2 : x.succ.castSucc < i
-      · rw [Fin.succAbove_of_castSucc_lt _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_le_castSucc]
-          · rfl
-          · assumption
-        · rw [Fin.lt_def] at hx2 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-          omega
-      · simp only [not_lt] at hx2
-        rw [Fin.succAbove_of_le_castSucc _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_le_castSucc]
-        · rw [Fin.succAbove_of_le_castSucc]
-          rw [Fin.le_def]
-          exact Nat.le_succ_of_le hx1
-        · rw [Fin.le_def] at hx2 ⊢
-          simp_all
-  · simp only [Nat.succ_eq_add_one, not_lt] at h1
-    have hx := Fin.succAbove_of_le_castSucc _ _ h1
-    rw [hx, predAboveI_lt (Nat.lt_add_one_of_le h1)]
-    by_cases hx1 : j ≤ x.castSucc
-    · rw [Fin.succAbove_of_le_castSucc _ _ hx1, Fin.succAbove_of_le_castSucc _ _]
-      · nth_rewrite 2 [Fin.succAbove_of_le_castSucc _ _]
-        · rw [Fin.succAbove_of_le_castSucc]
-          rw [Fin.le_def] at hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ, add_le_add_iff_right]
-        · rw [Fin.le_def] at h1 hx1 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc]
-          omega
-      · rw [Fin.le_def] at hx1 h1 ⊢
-        simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-        omega
-    · simp only [Nat.succ_eq_add_one, not_le] at hx1
-      rw [Fin.lt_def] at hx1
-      rw [Fin.le_def] at h1
-      rw [Fin.succAbove_of_castSucc_lt _ _ hx1]
-      by_cases hx2 : x.castSucc.castSucc < i
-      · rw [Fin.succAbove_of_castSucc_lt _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_castSucc_lt]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          rw [Fin.lt_def] at hx2 ⊢
-          simp_all only [Nat.succ_eq_add_one, Fin.val_castSucc, Fin.val_succ]
-          omega
-        · rw [Fin.lt_def] at hx2 ⊢
-          simp_all
-      · simp only [not_lt] at hx2
-        rw [Fin.succAbove_of_le_castSucc _ _ hx2]
-        nth_rewrite 2 [Fin.succAbove_of_le_castSucc]
-        · rw [Fin.succAbove_of_castSucc_lt]
-          · rfl
-          exact Fin.castSucc_lt_succ_iff.mpr hx1
-        · rw [Fin.le_def] at hx2 ⊢
-          simp_all
+  simp only [Fin.succAbove, predAboveI, Fin.lt_def, Fin.val_castSucc, Fin.val_succ, Fin.ext_iff,
+    apply_dite Fin.val, apply_ite Fin.val]
+  split_ifs <;> omega
 
 /-- The equivalence between `Fin n.succ` and `Fin 1 ⊕ Fin n` extracting the
   `i`th component. -/


### PR DESCRIPTION
## Summary

Golfs the proof of `Physlib.Fin.succAbove_succAbove_predAboveI` in
`Physlib/Mathematics/Fin.lean`.

The lemma is a simplicial-style identity in `Fin (n+2)`:

```lean
lemma succAbove_succAbove_predAboveI (i : Fin n.succ.succ) (j : Fin n.succ) (x : Fin n) :
    i.succAbove (j.succAbove x) =
    (i.succAbove j).succAbove ((predAboveI (i.succAbove j) i).succAbove x)
```

No statement (name, binders, or type) was changed — only the proof term.

## How it was golfed

The original proof was a 69-line nested case-bash: a `by_cases` on
`j.castSucc < i`, then nested `by_cases` on the relative orders of `x`, `j`,
and `i`, with each of the resulting branches discharged by a bespoke mix of
`Fin.succAbove_of_castSucc_lt` / `Fin.succAbove_of_le_castSucc` rewrites,
`nth_rewrite`, `Fin.lt_def`/`Fin.le_def` unfolding, and `simp_all`/`omega`.

Since both sides are elements of `Fin (n+2)`, the whole identity is just a fact
about the underlying `Nat` values. The new proof unfolds the two definitions
(`Fin.succAbove`, `predAboveI`) and pushes `Fin.val` through the resulting
`ite`/`dite` so the goal becomes a single (nested-`if`) statement about `Nat`,
then finishes by splitting the conditionals and calling `omega`:

```lean
  simp only [Fin.succAbove, predAboveI, Fin.lt_def, Fin.val_castSucc, Fin.val_succ, Fin.ext_iff,
    apply_dite Fin.val, apply_ite Fin.val]
  split_ifs <;> omega
```

Improvements along the three axes:

- **Length**: 69 lines → 3 lines, eliminating all the repeated branch-specific
  rewriting.
- **Speed**: the module builds in ~2.3s; the proof reduces to one `simp only`
  normalization followed by a uniform `split_ifs <;> omega`, replacing the many
  separate `simp_all`/`omega`/`nth_rewrite` invocations of the original.
- **Structure**: the proof now reflects the actual mathematical content — the
  identity is pure `Nat` arithmetic on the components — instead of obscuring it
  behind a manual case analysis.

## Verification

- `lake build Physlib` succeeds (all 4234 jobs), including the edited module and
  all downstream dependents of `Physlib/Mathematics/Fin.lean`.
- No `sorry`, no errors, no new warnings.
- `#print axioms` is unchanged: only `propext` and `Quot.sound`.
