### PR TITLE
auto-task(take_insert_gt): weaken index hypothesis from n < m to n ≤ m

### DIFF
--- a/Physlib/Mathematics/List/InsertIdx.lean
+++ b/Physlib/Mathematics/List/InsertIdx.lean
@@ -169,14 +169,14 @@ lemma drop_eraseIdx_succ {I : Type} :
     refine drop_eraseIdx_succ n as _
 
 lemma take_insert_gt {I : Type} (i : I) :
-    (n m : ℕ) → (h : n < m) → (r : List I) →
+    (n m : ℕ) → (h : n ≤ m) → (r : List I) →
     List.take n (List.insertIdx r m i) = List.take n r
   | 0, 0, _, _ => by simp
   | 0, m + 1, _, _ => by simp
   | n+1, m + 1, _, [] => by simp
   | n+1, m + 1, h, a::as => by
     simp only [List.insertIdx_succ_cons, List.take_succ_cons, List.cons.injEq, true_and]
-    refine take_insert_gt i n m (Nat.succ_lt_succ_iff.mp h) as
+    refine take_insert_gt i n m (Nat.succ_le_succ_iff.mp h) as
 
 lemma take_insert_let {I : Type} (i : I) :
     (n m : ℕ) → (h : m ≤ n) → (r : List I) → (hm : m ≤ r.length) →

--- a/Physlib/QFT/PerturbationTheory/FieldStatistics/Basic.lean
+++ b/Physlib/QFT/PerturbationTheory/FieldStatistics/Basic.lean
@@ -282,7 +282,7 @@ lemma ofList_take_succ_cons (n : ℕ) (φ1 : 𝓕) (φs : List 𝓕) :
 
 lemma ofList_take_insertIdx_gt (n m : ℕ) (φ1 : 𝓕) (φs : List 𝓕) (hn : n < m) :
     ofList q ((List.insertIdx φs m φ1).take n) = ofList q (φs.take n) := by
-  rw [take_insert_gt φ1 n m hn φs]
+  rw [take_insert_gt φ1 n m hn.le φs]
 
 lemma ofList_insert_lt_eq (n m : ℕ) (φ1 : 𝓕) (φs : List 𝓕) (hn : m ≤ n)
     (hm : m ≤ φs.length) :


### PR DESCRIPTION
## Summary

Generalizes the list lemma `take_insert_gt` by weakening its index hypothesis
from the strict inequality `n < m` to the non-strict `n ≤ m`.

`take_insert_gt` states that taking the first `n` elements of a list after
inserting an element at index `m` is the same as taking the first `n` elements
of the original list:

```
List.take n (List.insertIdx r m i) = List.take n r
```

This holds whenever the insertion happens at index `m ≥ n`, including the
boundary case `n = m`: an element inserted at index `n` lands *after* the first
`n` positions, so `take n` is unaffected. The strict hypothesis `n < m` was
therefore stronger than the proof needs.

## Change

`Physlib/Mathematics/List/InsertIdx.lean` — the chosen lemma:

Before:
```lean
lemma take_insert_gt {I : Type} (i : I) :
    (n m : ℕ) → (h : n < m) → (r : List I) →
    List.take n (List.insertIdx r m i) = List.take n r
  | 0, 0, _, _ => by simp
  | 0, m + 1, _, _ => by simp
  | n+1, m + 1, _, [] => by simp
  | n+1, m + 1, h, a::as => by
    simp only [List.insertIdx_succ_cons, List.take_succ_cons, List.cons.injEq, true_and]
    refine take_insert_gt i n m (Nat.succ_lt_succ_iff.mp h) as
```

After:
```lean
lemma take_insert_gt {I : Type} (i : I) :
    (n m : ℕ) → (h : n ≤ m) → (r : List I) →
    List.take n (List.insertIdx r m i) = List.take n r
  | 0, 0, _, _ => by simp
  | 0, m + 1, _, _ => by simp
  | n+1, m + 1, _, [] => by simp
  | n+1, m + 1, h, a::as => by
    simp only [List.insertIdx_succ_cons, List.take_succ_cons, List.cons.injEq, true_and]
    refine take_insert_gt i n m (Nat.succ_le_succ_iff.mp h) as
```

Only the hypothesis type and the matching recursion step (`Nat.succ_lt_succ_iff`
→ `Nat.succ_le_succ_iff`) changed. The `(n+1, 0)` case remains automatically
impossible (`n + 1 ≤ 0` is empty), and the now-reachable `(0, 0)` branch is
closed by the existing `simp`.

## Downstream fix

`Physlib/QFT/PerturbationTheory/FieldStatistics/Basic.lean` — the single caller
`ofList_take_insertIdx_gt` passed its hypothesis `hn : n < m` directly to
`take_insert_gt`. Since the expected argument is now `n ≤ m`, the call supplies
`hn.le` instead of `hn`. No statements other than `take_insert_gt` were changed.

## Verification

`lake build Physlib` completes successfully (4322 jobs), with no `sorry`, no new
axioms, and no new errors or warnings.
