### PR TITLE
auto-task(CanonicalEnsemble): add API-map.yaml tracking the canonical ensemble API

### DIFF
--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/API-map.yaml
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/API-map.yaml
@@ -1,0 +1,102 @@
+version: v0.1
+
+Title: Canonical ensemble
+
+Overview: |
+    The key data structure `CanonicalEnsemble` describes a system in thermal
+    equilibrium with a heat bath at fixed temperature `T`, given by a measurable type
+    of microstates, an energy function, and the semi-classical data (degrees of
+    freedom and phase-space unit) needed to form dimensionless thermodynamic
+    quantities. The API gives a measure-theoretic formalization (uniform over discrete
+    and continuous models) of the partition function, Boltzmann/probability measures,
+    mean energy, entropies, and Helmholtz free energy, together with the fundamental
+    identities `F = U - T S` and `U = -∂_β log Z`, the fluctuation-dissipation theorem,
+    and the composition of ensembles.
+
+ParentAPIs:
+  - Temperature (Physlib/Thermodynamics/Temperature)
+
+References:
+  - L. D. Landau & E. M. Lifshitz, Statistical Physics, Part 1 (§31).
+  - D. Tong, Lectures on Statistical Physics (Cambridge), https://www.damtp.cam.ac.uk/user/tong/statphys/one.pdf and https://www.damtp.cam.ac.uk/user/tong/statphys/two.pdf
+
+Requirements:
+
+  - description: >
+      The key data structure of the canonical ensemble (microstates type, energy
+      function, degrees of freedom, phase-space unit, and a σ-finite measure) is
+      defined, together with composition operations: addition of independent
+      ensembles, `n` non-interacting copies, and transport along measurable
+      equivalences.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (CanonicalEnsemble, HAdd instance, nsmul, congr)
+
+  - description: >
+      The API defines the (unnormalized) Boltzmann measure and the normalized
+      probability measure, and the pointwise mathematical and physical (dimensionless)
+      probability densities.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (μBolt, μProd, probability, physicalProbability)
+
+  - description: >
+      The API defines the mathematical partition function `∫ exp(-β E) dμ` and the
+      physical dimensionless partition function `Z = Z_math / h^dof`, with positivity
+      lemmas.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (mathematicalPartitionFunction, partitionFunction)
+
+  - description: >
+      The API defines the mean energy, mean-square energy, and energy variance, and
+      proves `Var(E) = <E²> - <E>²`.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (meanEnergy, meanSquareEnergy, energyVariance); Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean (energyVariance_eq_meanSquareEnergy_sub_meanEnergy_sq)
+
+  - description: The API defines the Helmholtz free energy `F = -kB T log Z`.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (helmholtzFreeEnergy)
+
+  - description: >
+      The API defines the differential entropy and the absolute thermodynamic entropy,
+      and (in the finite case) proves the thermodynamic entropy equals the Shannon
+      entropy `-kB ∑ p log p`.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Basic.lean (differentialEntropy, thermodynamicEntropy); Physlib/StatisticalMechanics/CanonicalEnsemble/Finite.lean (shannonEntropy, thermodynamicEntropy_eq_shannonEntropy)
+
+  - description: The API proves the fundamental thermodynamic identity `F = U - T S`.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean (helmholtzFreeEnergy_eq_meanEnergy_sub_temp_mul_thermodynamicEntropy)
+
+  - description: The API proves the mean energy is `U = -∂_β log Z`.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean (meanEnergy_eq_neg_deriv_log_Z_of_beta)
+
+  - description: >
+      The API defines the heat capacity and proves the fluctuation-dissipation theorem
+      `C_V = Var(E) / (kB T²)` for finite ensembles.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Lemmas.lean (heatCapacity, fluctuation_dissipation_energy_parametric); Physlib/StatisticalMechanics/CanonicalEnsemble/Finite.lean (fluctuation_dissipation_theorem_finite)
+
+  - description: >
+      The API specializes the framework to systems with finitely many discrete
+      microstates via the `IsFinite` class, reducing the integral definitions to finite
+      sums (e.g. `Z = ∑ᵢ exp(-β Eᵢ)`).
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/Finite.lean (IsFinite, partitionFunction_of_fintype, meanEnergy_of_fintype)
+
+  - description: >
+      The API constructs the concrete two-state ensemble and proves closed forms for
+      its partition function, state probabilities, and mean energy.
+    done: true
+    location: Physlib/StatisticalMechanics/CanonicalEnsemble/TwoState.lean (twoState, twoState_partitionFunction_apply, twoState_probability_fst, twoState_probability_snd, twoState_meanEnergy_eq)
+
+  - description: >
+      The API shall prove a closed-form simplification of the thermodynamic entropy of
+      the two-state ensemble.
+    done: false
+    location: N/A
+
+  - description: >
+      The API shall prove a closed-form simplification of the Helmholtz free energy of
+      the two-state ensemble.
+    done: false
+    location: N/A


### PR DESCRIPTION
## Summary

Adds `Physlib/StatisticalMechanics/CanonicalEnsemble/API-map.yaml`, a new
in-repository API tracker for the **canonical ensemble** API (the in-repo
replacement for the GitHub `API` issue tracking, cf. issue #892).

The map is generated from the directory's own Lean files (`Basic.lean`,
`Finite.lean`, `Lemmas.lean`, `TwoState.lean`), with issue #892 used only as a
reference for intended scope. No Lean source is touched — this is a YAML-only
addition.

## What the map records

- **Key data structure:** `CanonicalEnsemble` — a measure-theoretic, semi-classical
  formalization (uniform over discrete and continuous models) parameterized by a
  microstate type, an energy function, the degrees of freedom, the phase-space unit,
  and a σ-finite measure.
- **Parent API:** Temperature (`Physlib/Thermodynamics/Temperature`), which the
  directory imports and uses (matching issue #892's parent reference #861).
- **References:** Landau & Lifshitz, *Statistical Physics, Part 1*; D. Tong,
  *Lectures on Statistical Physics* — taken from the module docstrings' References
  sections.

## Requirements (13 total: 11 done, 2 not done)

`done: true` items (each pointing at a real declaration, confirmed to exist and be
sorry-free via `lean_verify` / grep): the `CanonicalEnsemble` structure and its
composition operations (`+`, `nsmul`, `congr`); the Boltzmann/probability measures
and probability densities; the mathematical and physical partition functions; mean
energy / mean-square energy / variance; Helmholtz free energy; differential and
thermodynamic entropies (with `thermodynamicEntropy = shannonEntropy` in the finite
case); the fundamental identity `F = U - T S`; `U = -∂_β log Z`; heat capacity and
the fluctuation-dissipation theorem `C_V = Var(E)/(kB T²)`; the finite specialization
`IsFinite`; and the concrete two-state ensemble with closed forms.

`done: false` items (the two `informal_lemma` placeholders still to be formalized in
`TwoState.lean`): closed-form simplifications of the two-state ensemble's entropy and
Helmholtz free energy.

## Verification

- File is valid YAML (`yaml.safe_load`) and uses exactly the schema's top-level
  fields.
- Every `done: true` location was confirmed against the source; the five headline
  theorems were checked with `lean_verify` (only standard axioms, no `sorry`).
- `lake build` completes successfully (YAML-only change, build unaffected).
