### PR TITLE
auto-task(MicroCanonicalEnsemble): add API-map.yaml tracking the microcanonical ensemble API

### DIFF
--- a/Physlib/StatisticalMechanics/MicroCanonicalEnsemble/API-map.yaml
+++ b/Physlib/StatisticalMechanics/MicroCanonicalEnsemble/API-map.yaml
@@ -1,0 +1,89 @@
+version: v0.1
+
+Title: Microcanonical ensemble
+
+Overview: |
+    The microcanonical ensemble API is built around `MicroHamiltonian`, a Hamiltonian
+    written as a measurable energy function (valued in `WithTop ℝ`, with `⊤` excluding a
+    configuration) on a phase space of finitely many continuous degrees of freedom,
+    parameterized by extrinsic data `D`; the `NVEHamiltonian` specialization fixes that
+    data to the particle number `N` and volume `V`. The API defines the partition
+    function and the thermodynamic quantities derived from it (internal energy, Helmholtz
+    free energy, entropy, pressure), and instantiates the ideal gas, computing its
+    partition function and proving the ideal gas law `PV = nRT`.
+
+ParentAPIs: []
+
+References: []
+
+Requirements:
+
+  - description: >
+      The key input data structure `MicroHamiltonian` (a measurable, `WithTop ℝ`-valued
+      energy function on a finite-dimensional phase space parameterized by extrinsic data
+      `D`) is defined.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/Basic.lean (MicroHamiltonian)
+
+  - description: >
+      The standard particle-number/volume specialization of the Hamiltonian is defined,
+      with accessors for the particle number `N` and volume `V`.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/Basic.lean (NVEHamiltonian, NVEHamiltonian.N, NVEHamiltonian.V)
+
+  - description: >
+      The partition function `Z` is defined as an integral of the Boltzmann weight over
+      phase space, both as a function of the thermodynamic `β` and of the temperature `T`.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (partitionZ, partitionZT)
+
+  - description: >
+      The partition function is complexified as a Laplace transform with its convergence
+      domain, and is shown to be smooth on the interior of that domain.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (PartitionZComplex, ZComplexConvergenceDomain, contDiffAt_partitionZ_of_mem_interior_convergenceDomain)
+
+  - description: >
+      The thermodynamic quantities derived from the partition function are defined:
+      internal energy, Helmholtz free energy, and the entropy expressed both as a function
+      of `T` and of `β`.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (internalU, helmholtzA, entropyS, entropySβ)
+
+  - description: >
+      The two definitions of the entropy (via `T` from the Helmholtz free energy, and via
+      `β` as `ln Z + β U`) are proved equivalent.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (entropy_A_eq_entropy_Z)
+
+  - description: >
+      The thermodynamic definition of temperature `1/T = ∂S/∂U` (at constant extrinsic
+      data) is proved.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (β_eq_deriv_S_U)
+
+  - description: >
+      Integrability conditions for the partition function are defined: `ZIntegrable` at a
+      given `β`, and `PositiveβIntegrable` for integrability at all positive `β`.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (ZIntegrable, PositiveβIntegrable)
+
+  - description: The pressure is defined as the variable conjugate to the volume.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/ThermoQuantities.lean (pressure)
+
+  - description: >
+      The ideal gas is instantiated as an `NVEHamiltonian` and its partition function is
+      computed in closed form.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/IdealGas.lean (IdealGas, partitionZ_eq)
+
+  - description: >
+      The Helmholtz free energy of the ideal gas is computed in closed form, and the ideal
+      gas is shown to be `ZIntegrable` at positive `β`.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/IdealGas.lean (helmholtzA_eq, ZIntegrable)
+
+  - description: The ideal gas law `PV = nRT` (with `R = 1` in the unitless system) is proved.
+    done: true
+    location: Physlib/StatisticalMechanics/MicroCanonicalEnsemble/IdealGas.lean (ideal_gas_law)


### PR DESCRIPTION
## What this PR does

Adds a single new file, `Physlib/StatisticalMechanics/MicroCanonicalEnsemble/API-map.yaml`,
tracking the **microcanonical ensemble** API (key data structure: `MicroHamiltonian`).

- **No Lean source is changed.** The only file added is the `API-map.yaml`. `git status`
  shows just the one new file.
- The map is **generated from the directory's own Lean files**
  (`Basic.lean`, `ThermoQuantities.lean`, `IdealGas.lean`), not copied from anywhere.
- **No corresponding GitHub `API` issue exists** for this directory. The closest one,
  [#892 "API: Canonical Ensemble"](https://github.com/leanprover-community/physlib/issues/892),
  is a stub (`requirements-needed`, empty checklist) for the *sibling* `CanonicalEnsemble`
  directory, which is being mapped separately in #1266. There are **no `TODO` tags and no
  `sorry`s** in this directory, so every requirement is `done: true` and there are no
  speculative `done: false` items.
- Full `lake build` stays green (9107 jobs); the two deprecation warnings emitted are
  pre-existing and in unrelated files (`ClassicalMechanics/HarmonicOscillator/Solution.lean`,
  `ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean`).

## Reviewer checklist — every claim in the YAML vs. the repository

Each part of the YAML is below with the exact source it came from, so you can tick each box.

### Metadata fields

- [ ] **`Title: Microcanonical ensemble`** — matches the module docstrings.
  `Basic.lean:14` `## The Microcanonical Ensemble`;
  `ThermoQuantities.lean:16` `## The theormodynamical quantities of a microcanonical ensemble`.

- [ ] **`Overview`** — grounded in the `MicroHamiltonian` docstring (`Basic.lean:16-27`):
  *"We define Hamiltonians as an energy function on a real manifold, whose dimension n
  possibly depends on the data D. Energy is a WithTop ℝ, ⊤ is used to mean 'excluded as a
  possibility in phase space'."* and `Basic.lean:44-45`
  *"The standard microcanonical ensemble Hamiltonian, where the data is the particle number
  N and the volume V."* The thermodynamic quantities and ideal gas law are the contents of
  `ThermoQuantities.lean` / `IdealGas.lean` listed below.

- [ ] **`ParentAPIs: []`** — the only imports are Mathlib, `Physlib.Meta.Sorry`, and
  `QuantumInfo.ForMathlib.ComplexLaplaceTransform` (a ForMathlib helper). No physics or
  `Physlib/Mathematics/` API is imported or used.

- [ ] **`References: []`** — no module docstring contains a `References` section, and there
  is no GitHub issue to cite. (No citation invented.)

### Requirements (all `done: true`)

| # | Requirement | Location in YAML | Source to verify |
|---|---|---|---|
| 1 | Key data structure `MicroHamiltonian` | `Basic.lean (MicroHamiltonian)` | `Basic.lean:29` `structure MicroHamiltonian (D : Type) where` |
| 2 | N/V specialization + accessors | `Basic.lean (NVEHamiltonian, NVEHamiltonian.N, NVEHamiltonian.V)` | `Basic.lean:46` `abbrev NVEHamiltonian := MicroHamiltonian (ℕ × ℝ)`; `:49` `def NVEHamiltonian.N`; `:52` `def NVEHamiltonian.V` |
| 3 | Partition function (in `β` and `T`) | `ThermoQuantities.lean (partitionZ, partitionZT)` | `ThermoQuantities.lean:28` `def partitionZ (β : ℝ) : ℝ`; `:76` `def partitionZT (T : ℝ) : ℝ` |
| 4 | Complexified `Z` as Laplace transform + smoothness | `ThermoQuantities.lean (PartitionZComplex, ZComplexConvergenceDomain, contDiffAt_partitionZ_of_mem_interior_convergenceDomain)` | `:34` `def PartitionZComplex`; `:38` `def ZComplexConvergenceDomain`; `:65` `theorem contDiffAt_partitionZ_of_mem_interior_convergenceDomain` |
| 5 | Internal energy, Helmholtz free energy, entropy (in `T` and `β`) | `ThermoQuantities.lean (internalU, helmholtzA, entropyS, entropySβ)` | `:80` `def internalU`; `:85` `def helmholtzA`; `:89` `def entropyS`; `:93` `def entropySβ` |
| 6 | Two entropy definitions equivalent | `ThermoQuantities.lean (entropy_A_eq_entropy_Z)` | `:133` `theorem entropy_A_eq_entropy_Z` |
| 7 | Temperature `1/T = ∂S/∂U` | `ThermoQuantities.lean (β_eq_deriv_S_U)` | `:168` `theorem β_eq_deriv_S_U` |
| 8 | Integrability conditions | `ThermoQuantities.lean (ZIntegrable, PositiveβIntegrable)` | `:100` `def ZIntegrable`; `:109` `def PositiveβIntegrable` |
| 9 | Pressure as conjugate to volume | `ThermoQuantities.lean (pressure)` | `:225` `def pressure (T : ℝ) : ℝ` (namespace `NVEHamiltonian`) |
| 10 | Ideal gas instance + closed-form `Z` | `IdealGas.lean (IdealGas, partitionZ_eq)` | `IdealGas.lean:24` `def IdealGas : NVEHamiltonian`; `:64` `lemma partitionZ_eq` |
| 11 | Ideal gas Helmholtz energy + integrability | `IdealGas.lean (helmholtzA_eq, ZIntegrable)` | `:214` `lemma helmholtzA_eq`; `:221` `lemma ZIntegrable` |
| 12 | Ideal gas law `PV = nRT` | `IdealGas.lean (ideal_gas_law)` | `:232` `theorem ideal_gas_law` |

### How `done: true` was verified

- `grep` confirmed every cited declaration name exists at the line shown above.
- `lean_verify` (lean-lsp) confirmed the central theorems elaborate with only the standard
  axioms (`propext`, `Classical.choice`, `Quot.sound`) — **no `sorryAx`** — for
  `IdealGas.ideal_gas_law` and `MicroHamiltonian.entropy_A_eq_entropy_Z`.
- The whole directory compiles as part of a green `lake build`.
