### PR TITLE
auto-task(spectrum_subset_of_isOpen): flatten auto-generated proof scaffolding

### DIFF
--- a/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
+++ b/QuantumInfo/ForMathlib/HermitianMat/CFC.lean
@@ -640,75 +640,68 @@ set_option maxHeartbeats 400000 in
 lemma spectrum_subset_of_isOpen (A₀ : HermitianMat d ℂ) (U : Set ℝ)
     (hU : IsOpen U) (hAU : spectrum ℝ A₀.mat ⊆ U) :
     ∀ᶠ B in nhds A₀, spectrum ℝ B.mat ⊆ U := by
-  -- Let $M = \|A₀\| + 1$. For $B$ in a ball of radius $1$ around $A₀$, $\|B\| \leq M$, so $\sigma(B) \subseteq \overline{B(0, M)}$.
-  obtain ⟨M, hM⟩ : ∃ M : ℝ, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < 1 → spectrum ℝ B.mat ⊆ Metric.closedBall 0 M := by
+  -- Let `M = ‖A₀‖ + 1`. For `B` with `‖B - A₀‖ < 1` we get `‖B‖ ≤ M`, so `σ(B) ⊆ closedBall 0 M`.
+  obtain ⟨M, hM⟩ : ∃ M : ℝ, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < 1 →
+      spectrum ℝ B.mat ⊆ Metric.closedBall 0 M := by
     use ‖A₀‖ + 1
     intro B hB
     have h_norm : ‖B‖ ≤ ‖A₀‖ + 1 := by
-      have := norm_sub_norm_le B A₀; linarith!;
-    generalize_proofs at *; (exact spectrum_subset_closedBall B |> fun h => h.trans <| Metric.closedBall_subset_closedBall h_norm)
-  generalize_proofs at *; (
-  -- Let $K = \overline{B(0, M)} \setminus U$. Then $K$ is compact and $K \cap \sigma(A₀) = \emptyset$.
+      have := norm_sub_norm_le B A₀; linarith
+    exact (spectrum_subset_closedBall B).trans (Metric.closedBall_subset_closedBall h_norm)
+  -- `K = closedBall 0 M \ U` is compact and disjoint from `σ(A₀)`.
   set K : Set ℝ := Metric.closedBall 0 M \ U
-  have hK_compact : IsCompact K := by
-    exact IsCompact.diff ( ProperSpace.isCompact_closedBall _ _ ) hU
-  have hK_disjoint : K ∩ spectrum ℝ A₀.mat = ∅ := by
-    exact Set.eq_empty_of_forall_notMem fun x hx => hx.1.2 <| hAU hx.2
-  generalize_proofs at *; (
-  -- For each $t \in K$, there exist $\delta_t > 0$ and $\epsilon_t > 0$ such that for $\|B - A₀\| < \delta_t$ and $|s - t| < \epsilon_t$, $B.mat - algebraMap ℝ _ s$ is a unit.
-  have h_unitary : ∀ t ∈ K, ∃ δ_t > 0, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ_t → ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
+  have hK_compact : IsCompact K := IsCompact.diff (ProperSpace.isCompact_closedBall _ _) hU
+  have hK_disjoint : K ∩ spectrum ℝ A₀.mat = ∅ :=
+    Set.eq_empty_of_forall_notMem fun x hx => hx.1.2 <| hAU hx.2
+  -- For each `t ∈ K` there are `δ_t, ε_t > 0` such that `‖B - A₀‖ < δ_t` and `|s - t| < ε_t`
+  -- make `B.mat - s` a unit: units are open and `A₀.mat - t` is one.
+  have h_unitary : ∀ t ∈ K, ∃ δ_t > 0, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ_t →
+      ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
     intro t ht
     have h_unitary : IsUnit (A₀.mat - algebraMap ℝ (Matrix d d ℂ) t) := by
-      simp_all [ Set.ext_iff, spectrum.mem_iff ];
+      simp_all [Set.ext_iff, spectrum.mem_iff]
       simpa using hK_disjoint t ht |> IsUnit.neg |> IsUnit.mul <| isUnit_one
-    generalize_proofs at *; (
-    -- The set of units is open in the space of matrices.
-    have h_unitary_open : IsOpen {B : Matrix d d ℂ | IsUnit B} := by
-      exact Units.isOpen
-    generalize_proofs at *; (
-    have h_unitary_cont : Continuous (fun p : HermitianMat d ℂ × ℝ => p.1.mat - algebraMap ℝ (Matrix d d ℂ) p.2) := by
+    have h_unitary_open : IsOpen {B : Matrix d d ℂ | IsUnit B} := Units.isOpen
+    have h_unitary_cont : Continuous (fun p : HermitianMat d ℂ × ℝ =>
+        p.1.mat - algebraMap ℝ (Matrix d d ℂ) p.2) := by
       refine' Continuous.sub _ _ <;> fun_prop (disch := solve_by_elim)
-    generalize_proofs at *; (
-    have := Metric.isOpen_iff.mp ( h_unitary_open.preimage h_unitary_cont ) ( A₀, t ) h_unitary
-    generalize_proofs at *; (
-    obtain ⟨ ε, ε_pos, hε ⟩ := this; exact ⟨ ε, ε_pos, ε, ε_pos, fun B hB s hs => hε ( show ( B, s ) ∈ Metric.ball ( A₀, t ) ε from by
-      simp only [Metric.mem_ball, Prod.dist_eq,]
+    obtain ⟨ε, ε_pos, hε⟩ :=
+      Metric.isOpen_iff.mp (h_unitary_open.preimage h_unitary_cont) (A₀, t) h_unitary
+    exact ⟨ε, ε_pos, ε, ε_pos, fun B hB s hs => hε (show (B, s) ∈ Metric.ball (A₀, t) ε from by
+      simp only [Metric.mem_ball, Prod.dist_eq]
       refine max_lt ?_ ?_
       · simpa [dist_eq_norm] using hB
-      · simpa [dist_eq_norm] using hs) ⟩ ;))))
-  generalize_proofs at *; (
-  -- By compactness of $K$, finitely many $\epsilon$-balls cover $K$. Take $\delta = \min(1, \min_j \delta_j)$.
-  obtain ⟨δ, hδ_pos, hδ⟩ : ∃ δ > 0, ∀ t ∈ K, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ → ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
+      · simpa [dist_eq_norm] using hs)⟩
+  -- Compactness gives a finite subcover of `ε`-balls; set `δ = min 1 (min_j δ_j)`.
+  obtain ⟨δ, hδ_pos, hδ⟩ : ∃ δ > 0, ∀ t ∈ K, ∃ ε_t > 0, ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ →
+      ∀ s : ℝ, |s - t| < ε_t → IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) s) := by
     choose! δ hδ ε hε h using h_unitary
-    generalize_proofs at *; (
-    have := hK_compact.elim_nhds_subcover ( fun t => Metric.ball t ( ε t ) ) fun t ht => Metric.ball_mem_nhds t ( hε t ht ) ; simp_all [ Set.subset_def ] ; (
-    obtain ⟨ t, ht₁, ht₂ ⟩ := this
-    generalize_proofs at *; (
-    -- Let $\delta = \min(1, \min_{i \in t} \delta_i)$.
+    have := hK_compact.elim_nhds_subcover (fun t => Metric.ball t (ε t))
+      fun t ht => Metric.ball_mem_nhds t (hε t ht)
+    simp_all [Set.subset_def]
+    obtain ⟨t, ht₁, ht₂⟩ := this
     obtain ⟨δ_min, hδ_min_pos, hδ_min⟩ : ∃ δ_min > 0, ∀ i ∈ t, δ_min ≤ δ i := by
-      by_cases ht : t.Nonempty <;> simp_all [ Finset.Nonempty ];
-      · exact ⟨ Finset.min' ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩, by have := Finset.min'_mem ( t.image δ ) ⟨ _, Finset.mem_image_of_mem δ ht.choose_spec ⟩ ; aesop, fun i hi => Finset.min'_le _ _ ( Finset.mem_image_of_mem δ hi ) ⟩;
-      · exact ⟨ 1, zero_lt_one ⟩
-    generalize_proofs at *; (
-    refine' ⟨ Min.min δ_min 1, lt_min hδ_min_pos zero_lt_one, fun x hx => _ ⟩
-    generalize_proofs at *; (
-    obtain ⟨ i, hi, hi' ⟩ := ht₂ x hx
-    generalize_proofs at *; (
-    exact ⟨ ε i - |x - i|, sub_pos.mpr ( by simp_all [ abs_sub_comm ]; exact hi' ), fun B hB s hs => h i ( ht₁ i hi ) B ( lt_of_lt_of_le hB ( min_le_of_left_le ( hδ_min i hi ) ) ) s ( by rw [ abs_lt ] at *; constructor <;> linarith [ abs_le.mp ( show |x - i| ≤ |x - i| by rfl ) ] ) ⟩))))))
-  generalize_proofs at *; (
-  -- For any $B$ with $\|B - A₀\| < \delta$, if $t \in \sigma(B)$, then $t \notin K$.
+      by_cases ht : t.Nonempty <;> simp_all [Finset.Nonempty]
+      · exact ⟨Finset.min' (t.image δ) ⟨_, Finset.mem_image_of_mem δ ht.choose_spec⟩,
+          by have := Finset.min'_mem (t.image δ) ⟨_, Finset.mem_image_of_mem δ ht.choose_spec⟩; aesop,
+          fun i hi => Finset.min'_le _ _ (Finset.mem_image_of_mem δ hi)⟩
+      · exact ⟨1, zero_lt_one⟩
+    refine' ⟨Min.min δ_min 1, lt_min hδ_min_pos zero_lt_one, fun x hx => _⟩
+    obtain ⟨i, hi, hi'⟩ := ht₂ x hx
+    exact ⟨ε i - |x - i|, sub_pos.mpr (by simp_all [abs_sub_comm]; exact hi'),
+      fun B hB s hs => h i (ht₁ i hi) B (lt_of_lt_of_le hB (min_le_of_left_le (hδ_min i hi))) s
+        (by rw [abs_lt] at *; constructor <;> linarith [abs_le.mp (show |x - i| ≤ |x - i| by rfl)])⟩
+  -- For `B` with `‖B - A₀‖ < δ`, any `t ∈ σ(B)` lies outside `K`.
   have h_not_in_K : ∀ B : HermitianMat d ℂ, ‖B - A₀‖ < δ → ∀ t ∈ spectrum ℝ B.mat, t ∉ K := by
     intro B hB t ht htK
     obtain ⟨ε_t, hε_t_pos, hε_t⟩ := hδ t htK
-    have h_unit : IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) t) := by
-      exact hε_t B hB t ( by simpa using hε_t_pos )
-    generalize_proofs at *; (
-    exact ht ( by have h1 := h_unit.neg; simp_all; exact h1 ))
-  generalize_proofs at *; (
-  filter_upwards [ Metric.ball_mem_nhds A₀ ( show 0 < Min.min δ 1 by positivity ) ] with B hB using fun t ht =>
-      Classical.not_not.1 fun h => h_not_in_K B
-      ( lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) ( min_le_left _ _ ) ) t ht
-      ⟨ hM B ( lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) ( min_le_right _ _ ) ) ht, h ⟩)))))
+    have h_unit : IsUnit (B.mat - algebraMap ℝ (Matrix d d ℂ) t) :=
+      hε_t B hB t (by simpa using hε_t_pos)
+    exact ht (by have h1 := h_unit.neg; simp_all; exact h1)
+  filter_upwards [Metric.ball_mem_nhds A₀ (show 0 < Min.min δ 1 by positivity)] with B hB using
+    fun t ht => Classical.not_not.1 fun h => h_not_in_K B
+      (lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) (min_le_left _ _)) t ht
+      ⟨hM B (lt_of_lt_of_le (by simpa [dist_eq_norm] using hB) (min_le_right _ _)) ht, h⟩
 
 /-
 PROBLEM


### PR DESCRIPTION
## Summary

Golfs the proof of `HermitianMat.spectrum_subset_of_isOpen` in
`QuantumInfo/ForMathlib/HermitianMat/CFC.lean`. Only the tactic block is
touched — the lemma statement (name, binders, type) is byte-for-byte
identical.

The original proof was machine-generated and carried a large amount of
scaffolding: **15** separate `generalize_proofs at *; (` invocations wrapping
nearly every step, together with a corresponding 5-level-deep tail of `)))))`.
Each `generalize_proofs at *` rescans the entire local context, but none of the
hypotheses here have proof terms embedded in their *types*, so every one of
these passes is a no-op.

## What changed

- **Removed all 15 redundant `generalize_proofs at *` passes** and the matching
  paren nesting, turning a deeply nested expression into a flat sequence of
  `have`/`obtain` steps. This is the bulk of the win on all three axes:
  - *speed* — no longer rescans the whole context 15 times during elaboration;
  - *length* — `47 insertions(+), 54 deletions(-)`;
  - *structure* — the proof now reads top-to-bottom instead of as a wall of
    `generalize_proofs at *; (` lines closed by a single `)))))`.
- Minor idiomatic cleanups, all behaviour-preserving:
  - dropped redundant `by exact` wrappers (`hK_compact`, `hK_disjoint`,
    `h_unitary_open`, `h_unit`) in favour of direct terms;
  - `spectrum_subset_closedBall B |> fun h => h.trans <| …` written as the
    direct `(spectrum_subset_closedBall B).trans …`;
  - `linarith!` → `linarith` (the goal is purely real-linear);
  - merged the `have := Metric.isOpen_iff.mp …` / `obtain … := this` pair into a
    single `obtain`;
  - rewrapped over-long lines and removed stray trailing `;`/`,`.

The mathematically load-bearing steps (the `simp_all`/`simpa` units argument,
the compactness subcover, the `min'` bound, the final `filter_upwards`) are kept
verbatim.

## Verification

- `lake build QuantumInfo.ForMathlib.HermitianMat.CFC` succeeds with no errors
  and no warnings.
- LSP diagnostics for the file are empty.
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — no
  `sorryAx`, no new axioms.
