### PR TITLE
chore: remove set_option backward.isDefEq.respectTransparency false

### DIFF
--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -523,7 +523,7 @@ lemma trajectories_unique (IC : InitialConditions) (x : Time → EuclideanSpace 
       ∂ₜ (fun t => f t - g t) = fun t => ∂ₜ f t - ∂ₜ g t := by
     intro f g hf hg
     funext t
-    simp only [Time.deriv_eq, fderiv_fun_sub (hf t) (hg t), ContinuousLinearMap.sub_apply]
+    simp only [Time.deriv_eq, fderiv_fun_sub (hf t) (hg t), sub_apply]
   -- The difference `y := x - traj` is smooth, again solves the equation of motion (the force is
   -- linear), and has vanishing initial data; energy conservation then forces `y = 0`.
   set y : Time → EuclideanSpace ℝ (Fin 1) := fun t => x t - IC.trajectory S t with hydef

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -122,8 +122,7 @@ lemma isTotalTimeDerivative_explicit {δL : Time → X → X → ℝ} :
        (1, ∂ₜ q t).2 = fderiv ℝ (fun t' => (tq q t').2) t 1 := by rfl
        _ = (∂ₜ (tq q) t).2 := by
         rw [fderiv.snd]
-        · simp only [ContinuousLinearMap.coe_comp', ContinuousLinearMap.coe_snd',
-              Function.comp_apply]
+        · simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_snd']
           rfl
         · apply ContDiffAt.differentiableAt
           · apply ContDiff.contDiffAt
@@ -135,7 +134,7 @@ lemma isTotalTimeDerivative_explicit {δL : Time → X → X → ℝ} :
     intro q F t hF hq
     change  fderiv ℝ ((↿F) ∘ (tq q)) t 1 = fderiv ℝ ↿F (t, q t) ((1 : Time), ∂ₜ q t)
     rw [fderiv_comp]
-    · simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+    · simp only [ContinuousLinearMap.comp_apply]
       rw [← Time.deriv_eq,h_tq_der]
       exact hq
     · apply ContDiffAt.differentiableAt

--- a/Physlib/Mathematics/Distribution/Basic.lean
+++ b/Physlib/Mathematics/Distribution/Basic.lean
@@ -121,7 +121,6 @@ on the size of `u` applied to `η`.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The construction of a distribution from the following data:
 1. We take a finite set `s` of pairs `(k, n) ∈ ℕ × ℕ` that will be explained later.
 2. We take a linear map `u` that evaluates the given Schwartz function `η`. At this stage we don't

--- a/Physlib/Mathematics/List.lean
+++ b/Physlib/Mathematics/List.lean
@@ -371,10 +371,9 @@ lemma orderedInsertEquiv_succ {I : Type} (le1 : I → I → Prop) [DecidableRel 
   simp only [List.length_cons, orderedInsertEquiv, Nat.succ_eq_add_one, Equiv.trans_apply]
   match r with
   | [] =>
-    simp only [List.length_nil, Nat.reduceAdd, Fin.castOrderIso_refl, OrderIso.refl_toEquiv,
-      Fin.val_eq_zero, Fin.zero_eta, Fin.isValue, Equiv.symm_apply_apply, Fin.zero_succAbove,
-      Fin.succ_mk, Fin.cast_eq_self]
-    rfl
+    simp only [List.length_nil, Nat.reduceAdd, Fin.val_eq_zero, Fin.zero_eta, Fin.isValue,
+      Equiv.symm_apply_apply, OrderIso.coe_symm_toEquiv, Fin.symm_castOrderIso,
+      Fin.castOrderIso_apply, Fin.cast_mk, Fin.zero_succAbove, Fin.succ_mk]
   | r1 :: r =>
     simp only [List.length_cons]
     rw [finExtractOne_apply_neq]
@@ -391,10 +390,9 @@ lemma orderedInsertEquiv_fin_succ {I : Type} (le1 : I → I → Prop) [Decidable
   simp only [orderedInsertEquiv, Equiv.trans_apply]
   match r with
   | [] =>
-    simp only [List.length_cons, List.length_nil, Nat.reduceAdd, Fin.castOrderIso_refl,
-      OrderIso.refl_toEquiv, Fin.val_eq_zero, Fin.zero_eta, Fin.isValue, Equiv.symm_apply_apply,
-      Fin.eta, Fin.zero_succAbove, Fin.cast_eq_self]
-    rfl
+    simp only [List.length_cons, List.length_nil, Nat.reduceAdd, Fin.val_eq_zero, Fin.zero_eta,
+      Fin.isValue, Equiv.symm_apply_apply, OrderIso.coe_symm_toEquiv, Fin.symm_castOrderIso,
+      Fin.castOrderIso_apply, Fin.eta, Fin.zero_succAbove]
   | r1 :: r =>
     simp only [List.length_cons, Fin.eta]
     rw [finExtractOne_apply_neq]

--- a/Physlib/Mathematics/List.lean
+++ b/Physlib/Mathematics/List.lean
@@ -362,7 +362,6 @@ lemma orderedInsertEquiv_zero {I : Type} (le1 : I → I → Prop) [DecidableRel 
     (r0 : I) : orderedInsertEquiv le1 r r0 0 = orderedInsertPos le1 r r0 := by
   simp [orderedInsertEquiv]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma orderedInsertEquiv_succ {I : Type} (le1 : I → I → Prop) [DecidableRel le1] (r : List I)
     (r0 : I) (n : ℕ) (hn : Nat.succ n < (r0 :: r).length) :
     orderedInsertEquiv le1 r r0 ⟨Nat.succ n, hn⟩ =
@@ -384,7 +383,6 @@ lemma orderedInsertEquiv_succ {I : Type} (le1 : I → I → Prop) [DecidableRel 
     rfl
     exact ne_of_beq_false rfl
 
-set_option backward.isDefEq.respectTransparency false in
 lemma orderedInsertEquiv_fin_succ {I : Type} (le1 : I → I → Prop) [DecidableRel le1] (r : List I)
     (r0 : I) (n : Fin r.length) :
     orderedInsertEquiv le1 r r0 n.succ = Fin.cast (List.orderedInsert_length le1 r r0).symm

--- a/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/FamilyMaps.lean
+++ b/Physlib/Particles/BeyondTheStandardModel/RHN/AnomalyCancellation/FamilyMaps.lean
@@ -53,7 +53,6 @@ def speciesFamilyProj {m n : ℕ} (h : n ≤ m) :
 def familyProjection {m n : ℕ} (h : n ≤ m) : (SMνCharges m).Charges →ₗ[ℚ] (SMνCharges n).Charges :=
   chargesMapOfSpeciesMap (speciesFamilyProj h)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- For species, the embedding of the `m`-family charges onto the `n`-family charges, with all
 other charges zero. -/
 @[simps!]

--- a/Physlib/Particles/StandardModel/AnomalyCancellation/FamilyMaps.lean
+++ b/Physlib/Particles/StandardModel/AnomalyCancellation/FamilyMaps.lean
@@ -51,7 +51,6 @@ def speciesFamilyProj {m n : ℕ} (h : n ≤ m) :
 def familyProjection {m n : ℕ} (h : n ≤ m) : (SMCharges m).Charges →ₗ[ℚ] (SMCharges n).Charges :=
   chargesMapOfSpeciesMap (speciesFamilyProj h)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- For species, the embedding of the `m`-family charges onto the `n`-family charges, with all
 other charges zero. -/
 @[simps!]

--- a/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
@@ -253,7 +253,6 @@ lemma accYY_ext {S T : MSSMCharges.Charges}
   repeat rw [← Finset.mul_sum]
   simp_all
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The symmetric bilinear function used to define the quadratic ACC. -/
 @[simps!]
 def quadBiLin : BiLinearSymm MSSMCharges.Charges := BiLinearSymm.mk₂
@@ -364,7 +363,6 @@ lemma cubeTriLinToFun_map_add₁ (S T R L : MSSMCharges.Charges) :
   · rw [Hd.map_add, Hu.map_add]
     ring
 
-set_option backward.isDefEq.respectTransparency false in
 lemma cubeTriLinToFun_swap1 (S T R : MSSMCharges.Charges) :
     cubeTriLinToFun (S, T, R) = cubeTriLinToFun (T, S, R) := by
   simp only [cubeTriLinToFun, toSMSpecies_apply, Fin.isValue, Hd_apply, Fin.reduceFinMk, Hu_apply]
@@ -373,7 +371,6 @@ lemma cubeTriLinToFun_swap1 (S T R : MSSMCharges.Charges) :
     ring
   · ring
 
-set_option backward.isDefEq.respectTransparency false in
 lemma cubeTriLinToFun_swap2 (S T R : MSSMCharges.Charges) :
     cubeTriLinToFun (S, T, R) = cubeTriLinToFun (S, R, T) := by
   simp only [cubeTriLinToFun, toSMSpecies_apply, Fin.isValue, Hd_apply, Fin.reduceFinMk, Hu_apply]

--- a/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
+++ b/Physlib/Particles/SuperSymmetry/MSSMNu/AnomalyCancellation/Basic.lean
@@ -294,8 +294,7 @@ def quadBiLin : BiLinearSymm MSSMCharges.Charges := BiLinearSymm.mk₂
     simp only [toSMSpecies_apply, Fin.isValue, neg_mul, one_mul, Hd_apply, Fin.reduceFinMk,
       Hu_apply]
     congr 1
-    · simp only [reduceMul, Fin.isValue, sum_MSSMSpecies_numberCharges_eq_expand, Fin.zero_eta,
-      Fin.mk_one]
+    · simp only [reduceMul, Fin.isValue, sum_MSSMSpecies_numberCharges_eq_expand]
       ring
     · ring)
 

--- a/Physlib/QFT/QED/AnomalyCancellation/ConstAbs.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/ConstAbs.lean
@@ -211,7 +211,6 @@ theorem AFL_odd (A : (PureU1 (2 * n + 1)).LinSols) (h : ConstAbsSorted A.val) :
   apply ACCSystemLinear.LinSols.ext
   exact is_zero h (AFL_odd_zero h)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma AFL_even_Boundary {A : (PureU1 (2 * n.succ)).LinSols} (h : ConstAbsSorted A.val)
     (hA : A.val (0 : Fin (2 * n.succ)) ≠ 0) {k : Fin (2 * n + 1)} (hk : Boundary A.val k) :
     k.val = n := by

--- a/Physlib/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Even/BasisLinear.lean
@@ -782,7 +782,6 @@ lemma swap!_as_add {S S' : (PureU1 (2 * n.succ)).LinSols} (j : Fin n)
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma P_P_P!_accCube (g : Fin n.succ → ℚ) (j : Fin n) :
     accCubeTriLinSymm (P g) (P g) (basis!AsCharges j)
     = g (j.succ) ^ 2 - g (j.castSucc) ^ 2 := by
@@ -799,7 +798,6 @@ lemma P_P_P!_accCube (g : Fin n.succ → ℚ) (j : Fin n) :
     simp only [mul_zero, add_zero]
   · simp
 
-set_option backward.isDefEq.respectTransparency false in
 lemma P_P!_P!_accCube (g : Fin n → ℚ) (j : Fin n.succ) :
     accCubeTriLinSymm (P! g) (P! g) (basisAsCharges j)
     = (P! g (evenFst j))^2 - (P! g (evenSnd j))^2 := by

--- a/Physlib/QFT/QED/AnomalyCancellation/LineInPlaneCond.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/LineInPlaneCond.lean
@@ -118,7 +118,6 @@ theorem linesInPlane_constAbs {S : (PureU1 (n.succ.succ.succ.succ.succ)).LinSols
   · simp only [Nat.succ_eq_add_one, ne_eq, Decidable.not_not] at hij
     rw [hij]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma linesInPlane_four (S : (PureU1 4).Sols) (hS : LineInPlaneCond S.1.1) :
     ConstAbsProp (S.val (0 : Fin 4), S.val (1 : Fin 4)) := by
   simp only [ConstAbsProp, Fin.isValue]

--- a/Physlib/QFT/QED/AnomalyCancellation/Odd/BasisLinear.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Odd/BasisLinear.lean
@@ -753,7 +753,6 @@ theorem basis!_linear_independent : LinearIndependent ℚ (@basis! n) := by
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma P_P_P!_accCube (g : Fin n → ℚ) (j : Fin n) :
     accCubeTriLinSymm (P g) (P g) (basis!AsCharges j)
     = (P g (oddShiftFst j))^2 - (g j)^2 := by

--- a/Physlib/QFT/QED/AnomalyCancellation/Sorts.lean
+++ b/Physlib/QFT/QED/AnomalyCancellation/Sorts.lean
@@ -46,7 +46,6 @@ lemma sort_apply {n : ℕ} (S : (PureU1 n).Charges) (j : Fin n) :
     sort S j = S ((Tuple.sort S) j) := by
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 lemma sort_zero {n : ℕ} (S : (PureU1 n).Charges) (hS : sort S = 0) : S = 0 := by
   funext i
   have hj : ∀ j, sort S j = 0 := by

--- a/Physlib/SpaceAndTime/Space/Norm/Basic.lean
+++ b/Physlib/SpaceAndTime/Space/Norm/Basic.lean
@@ -1255,7 +1255,6 @@ We show that the divergence of `x ↦ ‖x‖ ^ (- d) • x` is equal to a multi
 at `0`.
 
 -/
-set_option backward.isDefEq.respectTransparency false in
 /-- Auxiliary lemma with dimension defined as d.succ to handle `homeomorphUnitSphereProd`.
 The dimension correct version is declared in `distDiv_inv_pow_eq_dim`. -/
 private lemma distDiv_inv_pow_eq_dim' {d : ℕ} :


### PR DESCRIPTION
  Files processed:        124
  Fully cleaned:          5
  Partially cleaned:      6
  Unchanged:              103
  Errors:                 10
  Lines removed:          15
  Lines kept:             267

ran scripts/rm_set_option.py, only 15 removed this version.

also fix some build warnings
