### PR TITLE
auto-task(adiabatic_relation_prod): rename from variable-name-based name

### DIFF
--- a/Physlib/Thermodynamics/IdealGas/Basic.lean
+++ b/Physlib/Thermodynamics/IdealGas/Basic.lean
@@ -72,7 +72,7 @@ theorem adiabatic_relation_log
     then (Ua/Ub)^c * (Va/Vb) = 1.
 -/
 
-theorem adiabatic_relation_UaUbVaVb
+theorem adiabatic_relation_prod
     {s0 U0 V0 N0 c R : ℝ}
     {Ua Ub Va Vb N : ℝ}
     (hUa : 0 < Ua) (hUb : 0 < Ub)


### PR DESCRIPTION
## Summary

Renames the theorem `adiabatic_relation_UaUbVaVb` to `adiabatic_relation_prod`
in `Physlib/Thermodynamics/IdealGas/Basic.lean`. Only the name changes; the
statement and proof are untouched.

## Why

The old name `adiabatic_relation_UaUbVaVb` embeds the raw bound-variable names
(`Ua`, `Ub`, `Va`, `Vb`) directly into the theorem name. [Mathlib naming
conventions](https://leanprover-community.github.io/contribute/naming.html) say
a declaration name should describe *what the result says*, not list the
variables that appear in it, so `UaUbVaVb` is a poor, cryptic suffix.

The theorem proves the adiabatic relation in **product form**,
`(Ua/Ub)^c * (Va/Vb) = 1`. Its own docstring already describes it as the
"Adiabatic relation in product form", and the sibling theorem in the same file,
`adiabatic_relation_log`, proves the logarithmic form
`c * log (Ua/Ub) + log (Va/Vb) = 0`. The new name `adiabatic_relation_prod`
mirrors that sibling, follows Mathlib conventions, and accurately names the
mathematical content.

## Changes

- `Physlib/Thermodynamics/IdealGas/Basic.lean`: renamed
  `adiabatic_relation_UaUbVaVb` → `adiabatic_relation_prod`.

The theorem was not referenced anywhere else in the repository (no other
`.lean`, `.md`, or `.yaml` file mentions it), so no other updates were needed.

## Verification

- `lake build Physlib.Thermodynamics.IdealGas.Basic` succeeds (1980/1980 jobs).
- No remaining references to the old name anywhere in the repo.
- The renamed theorem uses only the standard axioms
  (`propext`, `Classical.choice`, `Quot.sound`) — no `sorry`, no new axioms,
  no new warnings.
