### PR TITLE
refactor(Mathematics): remove multiGoal warnings in InnerProductSpace/Basic

### DIFF
--- a/Physlib/Mathematics/InnerProductSpace/Basic.lean
+++ b/Physlib/Mathematics/InnerProductSpace/Basic.lean
@@ -322,13 +322,13 @@ lemma inner_sum'{ι : Type*} [Fintype ι] (x : E) (g : ι → E) :
   have h1 := inner_sum (𝕜 := 𝕜) (E:=WithLp 2 E) (x := WithLp.toLp 2 x)
     (f := fun i => WithLp.toLp 2 (g i))
   convert h1 (Finset.univ)
-  rw [← ofLp_inner_left]
-  simp only
-  congr
-  change _ = (WithLp.linearEquiv 2 𝕜 E) _
-  simp only [map_sum, WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe,
-    EquivLike.coe_coe, WithLp.addEquiv_apply]
-  rfl
+  · rw [← ofLp_inner_left]
+    simp only
+    congr
+    change _ = (WithLp.linearEquiv 2 𝕜 E) _
+    simp only [map_sum, WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe,
+      EquivLike.coe_coe, WithLp.addEquiv_apply]
+  · rfl
 
 @[fun_prop]
 lemma Continuous.inner' {α} [TopologicalSpace α] (f g : α → E)
@@ -598,56 +598,56 @@ lemma _root_.isBoundedBilinearMap_inner' :
     simp_all
     intro x y
     trans |‖x‖₂| * |‖y‖₂|
-    change |@inner ℝ (WithLp 2 E) _ _ _| ≤ _
-    have h1 := norm_inner_le_norm (𝕜 := ℝ) (E := WithLp 2 E) (WithLp.toLp 2 x) (WithLp.toLp 2 y)
-    simp at h1
-    apply h1.trans
-    apply le_of_eq
-    congr
-    rw [norm_withLp2_eq_norm2]
-    rfl
-    rw [norm_withLp2_eq_norm2]
-    rfl
-    have h1 : |‖x‖₂| ≤ √ d * ‖x‖ := by
-      apply le_of_sq_le_sq
-      simp [@mul_pow]
-      rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
-      simp only [re_to_real]
-      apply (h x).2.trans
+    · change |@inner ℝ (WithLp 2 E) _ _ _| ≤ _
+      have h1 := norm_inner_le_norm (𝕜 := ℝ) (E := WithLp 2 E) (WithLp.toLp 2 x) (WithLp.toLp 2 y)
+      simp at h1
+      apply h1.trans
       apply le_of_eq
-      simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-        pow_eq_zero_iff, norm_eq_zero]
-      left
-      refine Eq.symm (Real.sq_sqrt ?_)
-      linarith
-      apply mul_nonneg
-      exact Real.sqrt_nonneg d
-      exact norm_nonneg x
-    have h2 : |‖y‖₂| ≤ √ d * ‖y‖ := by
-      apply le_of_sq_le_sq
-      simp [@mul_pow]
-      rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
-      simp only [re_to_real]
-      apply (h y).2.trans
-      apply le_of_eq
-      simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-        pow_eq_zero_iff, norm_eq_zero]
-      left
-      refine Eq.symm (Real.sq_sqrt ?_)
-      linarith
-      apply mul_nonneg
-      exact Real.sqrt_nonneg d
-      exact norm_nonneg y
-    trans (√ d * ‖x‖) * (√ d * ‖y‖)
-    refine mul_le_mul_of_nonneg h1 h2 ?_ ?_
-    exact abs_nonneg ‖x‖₂
-    apply mul_nonneg
-    exact Real.sqrt_nonneg d
-    exact norm_nonneg y
-    apply le_of_eq
-    ring_nf
-    rw [Real.sq_sqrt]
-    ring
-    linarith
+      congr
+      · rw [norm_withLp2_eq_norm2]
+        rfl
+      · rw [norm_withLp2_eq_norm2]
+        rfl
+    · have h1 : |‖x‖₂| ≤ √ d * ‖x‖ := by
+        apply le_of_sq_le_sq
+        · simp [@mul_pow]
+          rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
+          simp only [re_to_real]
+          apply (h x).2.trans
+          apply le_of_eq
+          simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+            pow_eq_zero_iff, norm_eq_zero]
+          left
+          refine Eq.symm (Real.sq_sqrt ?_)
+          linarith
+        · apply mul_nonneg
+          · exact Real.sqrt_nonneg d
+          · exact norm_nonneg x
+      have h2 : |‖y‖₂| ≤ √ d * ‖y‖ := by
+        apply le_of_sq_le_sq
+        · simp [@mul_pow]
+          rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
+          simp only [re_to_real]
+          apply (h y).2.trans
+          apply le_of_eq
+          simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+            pow_eq_zero_iff, norm_eq_zero]
+          left
+          refine Eq.symm (Real.sq_sqrt ?_)
+          linarith
+        · apply mul_nonneg
+          · exact Real.sqrt_nonneg d
+          · exact norm_nonneg y
+      trans (√ d * ‖x‖) * (√ d * ‖y‖)
+      · refine mul_le_mul_of_nonneg h1 h2 ?_ ?_
+        · exact abs_nonneg ‖x‖₂
+        · apply mul_nonneg
+          · exact Real.sqrt_nonneg d
+          · exact norm_nonneg y
+      · apply le_of_eq
+        ring_nf
+        rw [Real.sq_sqrt]
+        · ring
+        · linarith
 
 end Constructions


### PR DESCRIPTION
## Summary
Clears all `linter.style.multiGoal` warnings in `Physlib/Mathematics/InnerProductSpace/Basic.lean` by
focusing post-split goals with `·` bullets. Pure proof-formatting change — no statement, definition,
docstring, or proof logic is altered. Toward #353.

## Changes
All warnings live in two proofs; only their tactic blocks are reformatted (one `·` per open goal):

| Lemma | Change |
|---|---|
| `inner_sum'` | focus the goals opened by `convert` with `·` bullets (5 warnings) |
| `isBoundedBilinearMap_inner'` | bullet the `trans` / `congr` / side-goal structure of the `bound` field (36 warnings) |

## Scope — what is NOT changed
- No lemma statement, binder, type, definition, or docstring is touched; no tactic is added or removed — only `·` focusing bullets and indentation.
- The global `lakefile.toml` linter flag is **not** flipped — the linter is enabled locally per file (the file-by-file approach for #353).
- Deliberately left for separate PRs: the lone `erw` at line 316 in `inner_self_eq_zero'` (an `erw`-removal / #385 concern) and the file's pre-existing missing `## A.` section header.

## Verification
- `lake env lean -Dlinter.style.multiGoal=true Physlib/Mathematics/InnerProductSpace/Basic.lean` → **41 warnings on master, 0 after** (equivalently `set_option linter.style.multiGoal true` at the top of the file).
- `lake build Physlib.Mathematics.InnerProductSpace.Basic` succeeds, no new errors/warnings.
- `lake env lean -Dlinter.style.longLine=true …` clean (no line > 100 chars introduced); `git diff --check` clean (no trailing whitespace).
- No `sorry`/`admit` introduced.

## Note for the reviewer
The `bound` proof of `isBoundedBilinearMap_inner'` is ~57 LOC (over the AGENTS.md 50-LOC guideline). Its
two `have` blocks (`h1` for `x`, `h2` for `y`) are identical up to the `x ↔ y` symmetry, so they could be
factored into a single helper `∀ z : E, |‖z‖₂| ≤ √ d * ‖z‖` (then `h1 := key x`, `h2 := key y`) — which
would also bring the proof under 50 LOC. I kept this PR strictly formatting-only to mirror #1277 (no logic
change / no statement change), and am happy to follow up with a scoped `refactor` PR doing that extraction
if you'd like.

Toward #353.
