### PR TITLE
auto-task(traceNorm_eq_one): rename traceNorm_eq_1 to spell out the numeral

### DIFF
--- a/QuantumInfo/States/Mixed/MState.lean
+++ b/QuantumInfo/States/Mixed/MState.lean
@@ -1228,7 +1228,7 @@ theorem traceRight_right_assoc' (ρ : MState (d₁ × d₂ × d₃)) :
   simp [assoc']
 
 @[simp]
-theorem traceNorm_eq_1 (ρ : MState d) : ρ.m.traceNorm = 1 :=
+theorem traceNorm_eq_one (ρ : MState d) : ρ.m.traceNorm = 1 :=
   have := calc (ρ.m.traceNorm : ℂ)
     _ = ρ.m.trace := ρ.psd.traceNorm_eq_trace
     _ = 1 := ρ.tr'

--- a/QuantumInfo/States/Mixed/TraceDistance.lean
+++ b/QuantumInfo/States/Mixed/TraceDistance.lean
@@ -47,7 +47,7 @@ theorem ge_zero : 0 ≤ TrDistance ρ σ := by
 theorem le_one : TrDistance ρ σ ≤ 1 := by
   have htri := Matrix.traceNorm_add_le ρ.m (-σ.m)
   simp [TrDistance, sub_eq_add_neg, Matrix.traceNorm_neg,
-    ρ.traceNorm_eq_1, σ.traceNorm_eq_1] at htri ⊢
+    ρ.traceNorm_eq_one, σ.traceNorm_eq_one] at htri ⊢
   linarith
 
 /-- The trace distance, as a `Prob` probability with value between 0 and 1. -/


### PR DESCRIPTION
## Summary

Renames the theorem `MState.traceNorm_eq_1` to `MState.traceNorm_eq_one`.

## Motivation

[Mathlib naming conventions](https://leanprover-community.github.io/contribute/naming.html)
require numerals appearing in declaration names to be spelled out as words
(`zero`, `one`, `two`, …) rather than written as digits. The existing name
`traceNorm_eq_1` uses the digit `1`, whereas the overwhelmingly common Mathlib
spelling for a lemma whose right-hand side is `1` is `..._eq_one`.

The theorem states `ρ.m.traceNorm = 1`, so `traceNorm_eq_one` both follows the
convention and accurately describes the result.

## Changes

- `QuantumInfo/States/Mixed/MState.lean`: renamed the theorem
  `traceNorm_eq_1` → `traceNorm_eq_one`. Its statement, type, `@[simp]`
  attribute, and proof are unchanged.
- `QuantumInfo/States/Mixed/TraceDistance.lean`: updated the single use of the
  old name (the dot-notation calls `ρ.traceNorm_eq_1` and `σ.traceNorm_eq_1` in
  the proof of `TrDistance.le_one`) to the new name.

No other declarations, statements, proofs, imports, or formatting were touched.

## Verification

`lake build QuantumInfo` completes successfully (8636 jobs) with no errors,
no warnings, no `sorry`, and no new axioms. There are no remaining references to
the old name anywhere in the repository.