### PR TITLE
feat(ClassicalMechanics): add amplitude–phase parametrization of the harmonic oscillator

### DIFF
--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -589,7 +589,7 @@ end InitialConditions
 
 /-!
 
-## D.1. Correctness of InitialConditionsAtTime conversion
+### D.1. Correctness of InitialConditionsAtTime conversion
 
 We now prove the correctness lemmas for the `InitialConditionsAtTime.toInitialConditions`
 conversion function. These show that the conversion produces a trajectory that passes through
@@ -648,7 +648,7 @@ end InitialConditionsAtTime
 
 /-!
 
-## D.2. Correctness of InitialConditionsFromTwoPositions conversion
+### D.2. Correctness of InitialConditionsFromTwoPositions conversion
 
 The conversion recovers the initial conditions only when `sin (S.ω * (t₂ - t₁)) ≠ 0`. This
 condition fails exactly when `ω·(t₂ - t₁) = n·π` for some integer `n`, i.e. when `t₂ - t₁` is an
@@ -690,7 +690,7 @@ end InitialConditionsFromTwoPositions
 
 /-!
 
-## D.3. Correctness of InitialConditionsFromTwoVelocities conversion
+### D.3. Correctness of InitialConditionsFromTwoVelocities conversion
 
 The conversion recovers the initial conditions only when `sin (S.ω * (t₂ - t₁)) ≠ 0`. Under this
 nondegeneracy condition, we prove that the resulting trajectory has velocity `v_t₁` at `t₁` and

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -6,6 +6,7 @@ Authors: Nathaneal Sajan, Joseph Tooby-Smith, Lode Vermeulen
 module
 
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
+public import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 /-!
 
 # Solutions to the classical harmonic oscillator
@@ -45,11 +46,16 @@ prove that they satisfy the equation of motion, and prove some properties of the
   - D.1. Correctness of InitialConditionsAtTime conversion
   - D.2. Correctness of InitialConditionsFromTwoPositions conversion
   - D.3. Correctness of InitialConditionsFromTwoVelocities conversion
-- E. The trajectories at zero velocity
-  - E.1. The times at which the velocity is zero
-  - E.2. A time when the velocity is zero
-  - E.3. The position when the velocity is zero
-- F. Some open TODOs
+- E. Amplitude–phase parametrization
+  - E.1. The amplitude–phase initial conditions
+  - E.2. Conversion to standard initial conditions
+  - E.3. The trajectory in normal form
+  - E.4. Recovering the amplitude and phase
+- F. The trajectories at zero velocity
+  - F.1. The times at which the velocity is zero
+  - F.2. A time when the velocity is zero
+  - F.3. The position when the velocity is zero
+- G. Some open TODOs
 
 ## iv. References
 
@@ -115,9 +121,8 @@ Currently implemented:
   distinct times `t₁` and `t₂` that satisfy the non-degeneracy condition.
 - **Initial conditions from two velocities at different times**: Specify the velocity at two
   distinct times `t₁` and `t₂` that satisfy the non-degeneracy condition.
-
-Future work (to be added in separate PRs) :
-- Amplitude-phase parametrization
+- **Amplitude–phase parametrization**: Specify the solution as a single shifted cosine
+  `x(t) = A cos (ω t - φ)` with amplitude `A` and phase `φ`.
 
 All alternative forms can be converted to the standard `InitialConditions` type via conversion
 functions, and we prove that the converted initial conditions produce trajectories that satisfy
@@ -723,11 +728,168 @@ lemma toInitialConditions_velocity_at_t₂ (S : HarmonicOscillator)
 
 end InitialConditionsFromTwoVelocities
 
+/-!
+
+## E. Amplitude–phase parametrization
+
+The state of the harmonic oscillator at `t = 0` is captured by `InitialConditions` as a position
+`x₀` and a velocity `v₀`. An equivalent and often more physical description writes the solution as
+a single shifted cosine of amplitude `A` and phase `φ`:
+  `x(t) = A cos (ω t - φ)`.
+
+Expanding with the angle-subtraction identity,
+  `A cos (ω t - φ) = (A cos φ) cos (ω t) + (A sin φ) sin (ω t)`,
+and matching coefficients against the standard solution
+  `x(t) = cos (ω t) x₀ + (sin (ω t) / ω) v₀`
+gives the change of coordinates
+  `x₀ = A cos φ`,   `v₀ = A ω sin φ`.
+
+We implement the forward map `(A, φ) ↦ (x₀, v₀)` as `toInitialConditions`, prove the resulting
+trajectory is the cosine normal form above (with velocity `-A ω sin (ω t - φ)`), and implement the
+inverse map `(x₀, v₀) ↦ (A, φ)` as `fromInitialConditions`, recovering `A` and `φ` as the polar
+coordinates of the phase vector `(x₀, v₀ / ω)`.
+
+-/
+
+/-!
+
+### E.1. The amplitude–phase initial conditions
+
+We define a type for initial conditions specified by an amplitude `A` and a phase angle `φ`. Being
+an amplitude and an angle, these are stored as scalars, rather than as vectors as for the other
+initial-condition types.
+
+-/
+
+/-- Initial conditions for the harmonic oscillator specified by an amplitude `A` and a phase
+  offset `φ`, describing the solution `x(t) = A cos (ω t - φ)`.
+
+  The conditions can be converted to the standard `InitialConditions` format using the
+  `toInitialConditions` function. -/
+@[ext] structure AmplitudePhase where
+  /-- The amplitude of the oscillation. -/
+  A : ℝ
+  /-- The phase offset of the oscillation. -/
+  φ : ℝ
+
+namespace AmplitudePhase
+
+/-!
+
+### E.2. Conversion to standard initial conditions
+
+Using `x₀ = A cos φ` and `v₀ = A ω sin φ`, we convert amplitude–phase data to the standard initial
+position and velocity at `t = 0`.
+
+-/
+
+/-- Convert amplitude–phase initial conditions to standard initial conditions at `t = 0`, via
+  `x₀ = A cos φ` and `v₀ = A ω sin φ`.
+
+  See `toInitialConditions_trajectory_eq_cos` and `toInitialConditions_velocity_eq_sin` in
+  section E.3 for the correctness proofs. -/
+noncomputable def toInitialConditions (S : HarmonicOscillator) (IC : AmplitudePhase) :
+    InitialConditions where
+  x₀ := EuclideanSpace.single 0 (IC.A * cos IC.φ)
+  v₀ := EuclideanSpace.single 0 (IC.A * S.ω * sin IC.φ)
+
+/-!
+
+### E.3. The trajectory in normal form
+
+The trajectory built from amplitude–phase data is exactly the single cosine
+`x(t) = A cos (ω t - φ)`, with velocity `v(t) = -A ω sin (ω t - φ)`. In the position identity the
+factor `1 / ω` of the standard solution cancels the `ω` in `v₀ = A ω sin φ`, which uses `ω ≠ 0`.
+
+-/
+
+/-- The trajectory of amplitude–phase initial conditions is the cosine normal form
+  `x(t) = A cos (ω t - φ)`. -/
+lemma toInitialConditions_trajectory_eq_cos (S : HarmonicOscillator) (IC : AmplitudePhase)
+    (t : Time) :
+    (IC.toInitialConditions S).trajectory S t
+      = EuclideanSpace.single 0 (IC.A * cos (S.ω * t - IC.φ)) := by
+  rw [InitialConditions.trajectory_eq, toInitialConditions]
+  ext i
+  fin_cases i
+  simp [Real.cos_sub]
+  field_simp [S.ω_ne_zero]
+
+/-- The velocity of the amplitude–phase trajectory is `v(t) = -A ω sin (ω t - φ)`. -/
+lemma toInitialConditions_velocity_eq_sin (S : HarmonicOscillator) (IC : AmplitudePhase)
+    (t : Time) :
+    ∂ₜ ((IC.toInitialConditions S).trajectory S) t
+      = EuclideanSpace.single 0 (-(IC.A * S.ω * sin (S.ω * t.val - IC.φ))) := by
+  rw [InitialConditions.trajectory_velocity, toInitialConditions]
+  ext i
+  fin_cases i
+  simp [Real.sin_sub]
+  ring
+
+/-!
+
+### E.4. Recovering the amplitude and phase
+
+The inverse map `(x₀, v₀) ↦ (A, φ)` must solve `x₀ = A cos φ` and `v₀ / ω = A sin φ`. Recovering
+the angle with the real `arctan` covers only `(-π/2, π/2)` and forces a case split at `x₀ = 0`; we
+instead embed the phase vector as the complex number `z = x₀ + (v₀ / ω) i` and read off `A = ‖z‖`
+and `φ = Complex.arg z`, with `arg` in the canonical range `(-π, π]`. The degenerate state
+`x₀ = v₀ = 0` is covered by the convention `arg 0 = 0`, so no case split is needed.
+
+We prove that converting initial conditions to amplitude–phase form and back returns the original
+initial conditions.
+
+-/
+
+/-- Recover amplitude–phase data from standard initial conditions, as the polar coordinates of the
+  phase vector `(x₀, v₀ / ω)` embedded as `z = x₀ + (v₀ / ω) i`: the amplitude is `‖z‖` and the
+  phase is `Complex.arg z`.
+
+  See `toInitialConditions_fromInitialConditions` for the right-inverse identity. -/
+noncomputable def fromInitialConditions (S : HarmonicOscillator) (IC : InitialConditions) :
+    AmplitudePhase where
+  A := ‖(⟨IC.x₀ 0, IC.v₀ 0 / S.ω⟩ : ℂ)‖
+  φ := Complex.arg (⟨IC.x₀ 0, IC.v₀ 0 / S.ω⟩ : ℂ)
+
+/-- `fromInitialConditions` is a right inverse of `toInitialConditions`: converting initial
+  conditions to amplitude–phase form and back recovers them exactly. -/
+lemma toInitialConditions_fromInitialConditions (S : HarmonicOscillator)
+    (IC : InitialConditions) :
+    (fromInitialConditions S IC).toInitialConditions S = IC := by
+  have hω : S.ω ≠ 0 := S.ω_ne_zero
+  set z : ℂ := (⟨IC.x₀ 0, IC.v₀ 0 / S.ω⟩ : ℂ)
+  -- polar identities
+  have hcos : ‖z‖ * cos (Complex.arg z) = z.re := by
+    rcases eq_or_ne z 0 with h | h
+    · simp [h]
+    · rw [Complex.cos_arg h]; field_simp
+  have hsin : ‖z‖ * sin (Complex.arg z) = z.im := by
+    rcases eq_or_ne z 0 with h | h
+    · simp [h]
+    · rw [Complex.sin_arg]; field_simp
+  -- By construction the parts of `z` are exactly the original data.
+  have hre : z.re = IC.x₀ 0 := rfl
+  have him : z.im = IC.v₀ 0 / S.ω := rfl
+  apply InitialConditions.ext
+  · -- Position: `‖z‖ cos (arg z) = Re z = IC.x₀ 0`, and `single 0 (IC.x₀ 0) = IC.x₀`.
+    show EuclideanSpace.single 0 (‖z‖ * cos (Complex.arg z)) = IC.x₀
+    rw [hcos, hre]
+    ext i; fin_cases i; simp
+  · -- Velocity: `‖z‖ ω sin (arg z) = ω · Im z = ω · (v₀ / ω) = IC.v₀ 0`, then reassemble.
+    show EuclideanSpace.single 0 (‖z‖ * S.ω * sin (Complex.arg z)) = IC.v₀
+    have hv : ‖z‖ * S.ω * sin (Complex.arg z) = IC.v₀ 0 := by
+      rw [mul_right_comm, hsin, him]; field_simp
+    rw [hv]
+    ext i; fin_cases i; simp
+
+end AmplitudePhase
+
+
 namespace InitialConditions
 
 /-!
 
-## E. The trajectories at zero velocity
+## F. The trajectories at zero velocity
 
 We study the properties of the trajectories when the velocity is zero.
 
@@ -735,7 +897,7 @@ We study the properties of the trajectories when the velocity is zero.
 
 /-!
 
-### E.1. The times at which the velocity is zero
+### F.1. The times at which the velocity is zero
 
 We show that if the velocity of the trajectory is zero, then the time satisfies
 the condition that
@@ -783,7 +945,7 @@ lemma tan_time_eq_of_trajectory_velocity_eq_zero (IC : InitialConditions) (t : T
 
 /-!
 
-### E.2. A time when the velocity is zero
+### F.2. A time when the velocity is zero
 
 We show that as long as the initial position is non-zero, then at
 the time `arctan (IC.v₀ 0 / (S.ω * IC.x₀ 0)) / S.ω` the velocity is zero.
@@ -818,7 +980,7 @@ lemma trajectory_velocity_eq_zero_at_arctan (IC : InitialConditions) (hx : IC.x�
 
 /-!
 
-### E.3. The position when the velocity is zero
+### F.3. The position when the velocity is zero
 
 We show that the position is equal to `√(‖IC.x₀‖^2 + (‖IC.v₀‖/S.ω)^2) ` when
 the velocity is zero.
@@ -1021,7 +1183,7 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
 
 /-!
 
-## F. Some open TODOs
+## G. Some open TODOs
 
 We give some open TODOs for the classical harmonic oscillator.
 


### PR DESCRIPTION
Adds the amplitude–phase parametrization — the final alternate initial-condition form for the
harmonic oscillator. Lives in a new, self-contained **section E** of
`HarmonicOscillator/Solution.lean`; **no existing declarations are changed**.

### New API
The new section introduces `AmplitudePhase`, an initial-condition type carrying an amplitude
`A : ℝ` and a phase `φ : ℝ`. The forward conversion `toInitialConditions` maps `(A, φ)` to the
standard initial position and velocity `(A cos φ, A ω sin φ)`, and the lemmas
`toInitialConditions_trajectory_eq_cos` and `toInitialConditions_velocity_eq_sin` show the
resulting trajectory is the normal form `x(t) = A cos(ω t − φ)`, with velocity
`−A ω sin(ω t − φ)`. The reverse conversion `fromInitialConditions` recovers `(A, φ)` as the polar
coordinates of the phase vector `(x₀, v₀ / ω)` via `Complex.arg`, and
`toInitialConditions_fromInitialConditions` proves it is a right inverse — converting initial
conditions to amplitude–phase form and back recovers them.

### What to look at
1. **Scalars, not vectors** — `A`, `φ` are `ℝ` (a magnitude and an angle), unlike the
   `EuclideanSpace ℝ (Fin 1)` fields of the other IC types.
2. **`Complex.arg` in the reverse map only** — used to avoid the `arctan` quadrant case-split; the
   trajectory itself stays real-valued. First use of `Complex.arg` in `ClassicalMechanics`.

Minor (separate commit): §D.1–§D.3 headings promoted `##` → `###` to match the TOC.

---
*Developed with assistance from Claude (Anthropic); all mathematics and proofs were
reviewed and verified to compile.*
