### PR TITLE
refactor(Mathematics): extract symmetric bound helper in InnerProductSpace/Basic

### DIFF
--- a/Physlib/Mathematics/InnerProductSpace/Basic.lean
+++ b/Physlib/Mathematics/InnerProductSpace/Basic.lean
@@ -608,42 +608,23 @@ lemma _root_.isBoundedBilinearMap_inner' :
         rfl
       · rw [norm_withLp2_eq_norm2]
         rfl
-    · have h1 : |‖x‖₂| ≤ √ d * ‖x‖ := by
+    · have key (z : E) : |‖z‖₂| ≤ √ d * ‖z‖ := by
         apply le_of_sq_le_sq
         · simp [@mul_pow]
           rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
           simp only [re_to_real]
-          apply (h x).2.trans
+          apply (h z).2.trans
           apply le_of_eq
           simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
             pow_eq_zero_iff, norm_eq_zero]
           left
           refine Eq.symm (Real.sq_sqrt ?_)
           linarith
-        · apply mul_nonneg
-          · exact Real.sqrt_nonneg d
-          · exact norm_nonneg x
-      have h2 : |‖y‖₂| ≤ √ d * ‖y‖ := by
-        apply le_of_sq_le_sq
-        · simp [@mul_pow]
-          rw [norm₂_sq_eq_re_inner (𝕜 := ℝ)]
-          simp only [re_to_real]
-          apply (h y).2.trans
-          apply le_of_eq
-          simp only [mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-            pow_eq_zero_iff, norm_eq_zero]
-          left
-          refine Eq.symm (Real.sq_sqrt ?_)
-          linarith
-        · apply mul_nonneg
-          · exact Real.sqrt_nonneg d
-          · exact norm_nonneg y
+        · positivity
+      have h1 := key x
+      have h2 := key y
       trans (√ d * ‖x‖) * (√ d * ‖y‖)
-      · refine mul_le_mul_of_nonneg h1 h2 ?_ ?_
-        · exact abs_nonneg ‖x‖₂
-        · apply mul_nonneg
-          · exact Real.sqrt_nonneg d
-          · exact norm_nonneg y
+      · exact mul_le_mul_of_nonneg h1 h2 (by positivity) (by positivity)
       · apply le_of_eq
         ring_nf
         rw [Real.sq_sqrt]


### PR DESCRIPTION
## Summary
Deduplicates the `bound` proof of `isBoundedBilinearMap_inner'` in
`Physlib/Mathematics/InnerProductSpace/Basic.lean`. Its two `have` blocks (`h1` for `x`, `h2` for `y`)
were identical up to the `x ↔ y` symmetry, so they are replaced by a single local helper
`key (z : E) : |‖z‖₂| ≤ √ d * ‖z‖` instantiated at `x` and `y`. No lemma statement is changed.

> Builds on #353 (merged 2026-06-26, PR #1289), which cleared the `multiGoal` warnings in this file.

## Changes
| What | Detail |
|---|---|
| extract helper | `have key (z : E) : |‖z‖₂| ≤ √ d * ‖z‖` replaces the duplicated `h1`/`h2` blocks; then `h1 := key x`, `h2 := key y` |
| simplify side goals | the trailing nonnegativity goals are closed with `positivity` (removing the residual x/y asymmetry) |

## Effect
- Removes ~13 lines of verbatim x↔y duplication (the AGENTS.md "symmetry / general-then-specialize" extraction).
- `bound` proof **57 → 38 LOC** — now under the 50-LOC guideline.

## Scope — what is NOT changed
- No lemma statement, binder, type, or definition is changed; the proved theorem is identical.
- A local `have` (not a named lemma) is used deliberately: `key` closes over the proof-local `d` and `h`
  from `hE.inner_top_equiv_norm`, so it is proof plumbing, not reusable API.

## Verification
- `lake env lean -Dlinter.style.multiGoal=true -Dlinter.style.longLine=true …` → 0 warnings.
- `lake build Physlib.Mathematics.InnerProductSpace.Basic` succeeds; 0 errors.
- No `sorry`/`admit`; no trailing whitespace; diff is `+6 / −25`.

Follow-up to #353.
