### PR TITLE
refactor(Mathematics): remove erws from LieTrace

### DIFF
--- a/Physlib/Mathematics/DataStructures/Matrix/LieTrace.lean
+++ b/Physlib/Mathematics/DataStructures/Matrix/LieTrace.lean
@@ -158,7 +158,7 @@ lemma det_exp_of_blockTriangular_id {A : Matrix m m 𝕂} (hA : BlockTriangular 
     diag_exp_of_blockTriangular_id hA
   simp_rw [← diag_apply]
   simp_rw [h_diag_exp]
-  erw [← NormedSpace.exp_sum Finset.univ]
+  rw [← NormedSpace.exp_sum Finset.univ]
   congr 1
 
 /-- The trace is invariant under unitary conjugation. -/
@@ -202,9 +202,9 @@ theorem det_exp {𝕂 m : Type*} [RCLike 𝕂] [IsAlgClosed 𝕂] [Fintype m] [L
   have h_prop : T.val.IsUpperTriangular := T.property
   have h_conj : A = U * T * star U := schur_triangulation A
   have h_trace_invariant : A.trace = T.val.trace := by
-    erw [h_conj, trace_unitary_conj]
+    rw [h_conj, Unitary.coe_star, trace_unitary_conj]
   have h_det_invariant : (NormedSpace.exp A).det = (NormedSpace.exp T.val).det := by
-    erw [h_conj, det_exp_unitary_conj]
+    rw [h_conj, Unitary.coe_star, det_exp_unitary_conj]
   have h_triangular_case : (NormedSpace.exp T.val).det = NormedSpace.exp T.val.trace :=
     det_exp_of_blockTriangular_id h_prop
   rw [h_det_invariant, h_triangular_case, h_trace_invariant]
@@ -273,9 +273,7 @@ theorem det_exp_real {n : Type*} [Fintype n] [LinearOrder n]
   rw [h_trace_comm] at h_complex
   have h_exp_comm : Complex.exp ((algebraMap ℝ ℂ) A.trace) =
       (algebraMap ℝ ℂ) (Real.exp A.trace) := by
-    erw [← Complex.ofReal_exp]
-    simp_all only [Complex.coe_algebraMap, Algebra.algebraMap_self, RingHom.id_apply,
-      Complex.ofReal_exp, A_ℂ]
+    rw [Complex.coe_algebraMap, ← Complex.ofReal_exp]
   rw [h_exp_comm] at h_complex
   exact Complex.ofReal_injective h_complex
 


### PR DESCRIPTION
## Summary
Removes four `erw` calls in `Physlib/Mathematics/DataStructures/Matrix/LieTrace.lean` (toward #385),
replacing each with `rw`. **No statement is changed** — the edits are purely proof-internal coercion
normalizations.

## Changes
| Lemma | Fix |
|---|---|
| `det_exp_of_blockTriangular_id` | `erw [← NormedSpace.exp_sum …]` → plain `rw` (the `erw` was unnecessary) |
| `det_exp` | `erw [h_conj, trace_unitary_conj]` → `rw [h_conj, Unitary.coe_star, trace_unitary_conj]` (normalize `↑(star U)` vs `star ↑U`) |
| `det_exp` | `erw [h_conj, det_exp_unitary_conj]` → `rw [h_conj, Unitary.coe_star, det_exp_unitary_conj]` (same coercion) |
| `det_exp_real` | `erw [← Complex.ofReal_exp]` → `rw [Complex.coe_algebraMap, ← Complex.ofReal_exp]`; drops a now-redundant `simp_all only [...]` |

## Scope
- **Zero statement changes**; the two public theorems (`det_exp`, `det_exp_real`) and all helpers keep identical signatures. Diff is `+4 / −6`, one file.
- The bridging lemmas used are the canonical `@[simp, norm_cast]` ones: `Unitary.coe_star`, `Complex.coe_algebraMap`.

## Deliberately left (separate follow-up)
The file still has two `erw`s in `exp_map_algebraMap`. Removing them cleanly would require specializing the
private helper `map_tsum` from `AddMonoidHom` to `RingHom` — but its proof only uses additivity, so that
would weaken a general helper just to dodge a coercion. I'd rather leave those two for a dedicated
follow-up than regress the helper here. (Happy to do that follow-up if you'd like.)

## Verification (Lean v4.31.0)
- `lake build Physlib.Mathematics.DataStructures.Matrix.LieTrace` succeeds; 0 errors.
- `lake env lean -Dlinter.style.multiGoal=true -Dlinter.style.longLine=true …` → 0 warnings.
- No `sorry`/`admit`; no trailing whitespace.

Toward #385.
