### PR TITLE
refactor(Mathematics): remove erws from HasVarAdjDeriv

### DIFF
--- a/Physlib/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
+++ b/Physlib/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean
@@ -756,14 +756,14 @@ protected lemma fderiv (u : X → U) (dx : X) (hu : ContDiff ℝ ∞ u)
   · intro φ1 φ2 h1 h2
     funext x
     simp only [Pi.add_apply]
-    erw [fderiv_add]
+    rw [fderiv_add]
     simp only [add_apply]
     · exact (h1.differentiable (by simp)).differentiableAt
     · exact (h2.differentiable (by simp)).differentiableAt
   · intro c φ hφ
     funext x
     simp only [Pi.smul_apply]
-    erw [fderiv_const_smul]
+    rw [fderiv_const_smul]
     simp only [FunLike.coe_smul, Pi.smul_apply]
     exact (hφ.differentiable (by simp)).differentiableAt
   · intro φ hφ x


### PR DESCRIPTION
## Summary
Removes two `erw` calls in `Physlib/Mathematics/VariationalCalculus/HasVarAdjDeriv.lean` (toward #385),
replacing each with `rw`. **No statement is changed** — purely proof-internal.

## Changes
| Site | Fix |
|---|---|
| `HasVarAdjDerivAt.fderiv` (`add` obligation) | `erw [fderiv_add]` → `rw [fderiv_add]` |
| `HasVarAdjDerivAt.fderiv` (`smul` obligation) | `erw [fderiv_const_smul]` → `rw [fderiv_const_smul]` |

Both `fderiv_add` / `fderiv_const_smul` match by plain `rw` against the pinned mathlib, so the `erw`s were
carrying unnecessary up-to-defeq unification. The surrounding `simp only` / differentiability side-goals are
untouched. Diff `+2 / −2`.

## Deliberately left (out of scope)
Two `erw`s remain in this file; both were checked and are intentionally kept:
- `fderiv_uncurry_comp_fst` (line ~256): its LHS is stated via `Function.uncurry` (`↿f`) while the goal is the
  curried form — plain `rw` fails, and making it match would require restating a **shared named helper in
  another file** (`FDerivCurry.lean`) for one call site — an API change to dodge a coercion (the kind of
  generality regression flagged on PR #1296). Left as-is.
- `erw [h1]` inside a `conv` block (line ~938): the focused subterm matches the local hypothesis only up to
  defeq (`(φ s x).ofLp i` vs `EuclideanSpace.proj i …`); `rw` fails and `simp only [h1]` cascade-breaks the
  next `simp only`. Fragile local surgery for no net gain — left as-is.

## Verification (Lean v4.31.0)
- `lake build Physlib.Mathematics.VariationalCalculus.HasVarAdjDeriv` succeeds (3113 jobs, 0 errors).
- `lake env lean -Dlinter.style.longLine=true …` → 0 long-line warnings; `git diff --check` clean.
- No `sorry`/`admit`. (The file has pre-existing `multiGoal` warnings unrelated to this change — out of scope.)

Toward #385.
