### PR TITLE
refactor: change Space.dsucc to Space d in remaining files and surfaces (3 of 3)

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/SolidSphere.lean
@@ -43,12 +43,11 @@ noncomputable def solidSphere (d : ℕ) (m R : ℝ≥0) : RigidBody d where
       rw [integral_const_mul]
       ring⟩
 
-lemma solidSphere_mass {d : ℕ} (m R : ℝ≥0) (hr : R ≠ 0) : (solidSphere d.succ m R).mass = m := by
+lemma solidSphere_mass {d : ℕ} (m R : ℝ≥0) (hr : R ≠ 0) : (solidSphere d m R).mass = m := by
   simp only [mass, solidSphere]
-  simp only [Nat.succ_eq_add_one, LinearMap.coe_mk, AddHom.coe_mk, ContMDiffMap.coeFn_mk,
-    integral_const, MeasurableSet.univ, measureReal_restrict_apply, Set.univ_inter, smul_eq_mul,
-    mul_one]
-  have h1 : (@volume (Space d.succ) measureSpaceOfInnerProductSpace).real
+  simp only [LinearMap.coe_mk, AddHom.coe_mk, ContMDiffMap.coeFn_mk, integral_const,
+    MeasurableSet.univ, measureReal_restrict_apply, Set.univ_inter, smul_eq_mul, mul_one]
+  have h1 : (@volume (Space d) measureSpaceOfInnerProductSpace).real
       (Metric.closedBall 0 R) ≠ 0 := by
     refine (measureReal_ne_zero_iff ?_).mpr ?_
     · apply measure_closedBall_lt_top.ne
@@ -59,15 +58,15 @@ lemma solidSphere_mass {d : ℕ} (m R : ℝ≥0) (hr : R ≠ 0) : (solidSphere d
   field_simp
 
 /-- The center of mass of a solid sphere located at the origin is `0`. -/
-lemma solidSphere_centerOfMass {d : ℕ} (m R : ℝ≥0) : (solidSphere d.succ m R).centerOfMass = 0 := by
+lemma solidSphere_centerOfMass {d : ℕ} (m R : ℝ≥0) : (solidSphere d m R).centerOfMass = 0 := by
   ext i
-  simp only [Nat.succ_eq_add_one, centerOfMass, solidSphere, one_div, LinearMap.coe_mk,
-    AddHom.coe_mk, ContMDiffMap.coeFn_mk, smul_eq_mul, Space.zero_apply, mul_eq_zero, inv_eq_zero,
-    div_eq_zero_iff, coe_eq_zero]
+  simp only [centerOfMass, solidSphere, one_div, LinearMap.coe_mk, AddHom.coe_mk,
+    ContMDiffMap.coeFn_mk, smul_eq_mul, Space.zero_apply, mul_eq_zero, inv_eq_zero, div_eq_zero_iff,
+    coe_eq_zero]
   right
   right
-  suffices ∫ x in Metric.closedBall (0 : Space d.succ) R, x i ∂MeasureSpace.volume
-    = -∫ x in Metric.closedBall (0 : Space d.succ) R, x i ∂MeasureSpace.volume by linarith
+  suffices ∫ x in Metric.closedBall (0 : Space d) R, x i ∂MeasureSpace.volume
+    = -∫ x in Metric.closedBall (0 : Space d) R, x i ∂MeasureSpace.volume by linarith
   rw [← integral_neg]
   simp only [← integral_indicator measurableSet_closedBall, Set.indicator, Metric.mem_closedBall]
   rw [← integral_neg_eq_self]

--- a/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
+++ b/Physlib/SpaceAndTime/Space/Derivatives/Iterated.lean
@@ -107,9 +107,10 @@ lemma iteratedDeriv_zero [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
   simp [iteratedDeriv, Physlib.MultiIndex.toList_zero]
 
 @[simp]
-lemma iteratedDeriv_increment_zero [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
-    (I : MultiIndex d.succ) (f : Space d.succ → M) :
+lemma iteratedDeriv_increment_zero [NeZero d] [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
+    (I : MultiIndex d) (f : Space d → M) :
     ∂^[MultiIndex.increment I 0] f = ∂[0] (∂^[I] f) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne d)
   simp [iteratedDeriv, Physlib.MultiIndex.toList_increment_zero]
 
 @[simp]

--- a/Physlib/SpaceAndTime/Space/Translations.lean
+++ b/Physlib/SpaceAndTime/Space/Translations.lean
@@ -127,18 +127,18 @@ lemma distTranslate_distGrad {d : ℕ} (a : EuclideanSpace ℝ (Fin d))
   rw [fderiv_comp_add_right]
 
 open MeasureTheory
-lemma distTranslate_ofFunction {d : ℕ} (a : EuclideanSpace ℝ (Fin d.succ))
-    (f : Space d.succ → X) (hf : IsDistBounded f) :
+lemma distTranslate_ofFunction {d : ℕ} (a : EuclideanSpace ℝ (Fin d))
+    (f : Space d → X) (hf : IsDistBounded f) :
     distTranslate a (distOfFunction f hf) =
     distOfFunction (fun x => f (x - basis.repr.symm a))
     (IsDistBounded.comp_add_right hf (- basis.repr.symm a)) := by
   ext η
   rw [distTranslate_apply, distOfFunction_apply, distOfFunction_apply]
-  trans ∫ (x : Space d.succ), η ((x - basis.repr.symm a) + basis.repr.symm a) •
+  trans ∫ (x : Space d), η ((x - basis.repr.symm a) + basis.repr.symm a) •
     f (x - basis.repr.symm a); swap
   · simp
-  let f' := fun x : Space d.succ => η (x + basis.repr.symm a) • f (x)
-  change _ = ∫ (x : Space d.succ), f' (x - basis.repr.symm a)
+  let f' := fun x : Space d => η (x + basis.repr.symm a) • f (x)
+  change _ = ∫ (x : Space d), f' (x - basis.repr.symm a)
   rw [MeasureTheory.integral_sub_right_eq_self]
   congr
   funext x

--- a/Physlib/SpaceAndTime/TimeAndSpace/ConstantTimeDist.lean
+++ b/Physlib/SpaceAndTime/TimeAndSpace/ConstantTimeDist.lean
@@ -144,8 +144,6 @@ lemma continuous_time_integral {d} (η : 𝓢(Time × Space d, ℝ)) :
 
 -/
 
-set_option maxSynthPendingDepth 10000 in
-
 lemma time_integral_hasFDerivAt {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) (x₀ : Space d) :
     HasFDerivAt (fun x => ∫ (t : Time), η (t, x))
       (∫ (t : Time), fderiv ℝ (fun x : Space d => η (t, x)) x₀) x₀ := by
@@ -262,20 +260,6 @@ lemma time_integral_hasFDerivAt {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) (x�
         rw [norm_iteratedFDerivWithin_one]
         rw [fderivWithin_univ]
         exact uniqueDiffWithinAt_univ
-      have h0 : ‖(0 : Space d.succ →L[ℝ] Time).prod
-          (ContinuousLinearMap.id ℝ (Space d.succ))‖ ≠ 0 := by
-        rw [@norm_ne_zero_iff]
-        simp only [Nat.succ_eq_add_one, ne_eq]
-        rw [@ContinuousLinearMap.ext_iff]
-        simp only [ContinuousLinearMap.prod_apply, _root_.zero_apply,
-          ContinuousLinearMap.coe_id', id_eq, Prod.mk_eq_zero, true_and, not_forall]
-        use Space.basis 0
-        by_contra hn
-        have ht : (basis 0 : Space d.succ) 0 = 0 := by
-          rw [hn]
-          simp
-        rw [basis_apply] at ht
-        simp at ht
       trans k * (|1 + ‖t‖| ^ rt)⁻¹ * ‖ContinuousLinearMap.prod (0 : Space d →L[ℝ] Time)
         (ContinuousLinearMap.id ℝ (Space d))‖
       swap
@@ -289,7 +273,6 @@ lemma time_integral_hasFDerivAt {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) (x�
       · rfl
       fun_prop
       fun_prop
-
       · apply Differentiable.differentiableAt
         exact η.smooth'.differentiable (by simp)
       fun_prop
@@ -307,7 +290,7 @@ lemma time_integral_hasFDerivAt {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) (x�
 
 -/
 
-lemma time_integral_differentiable {d : ℕ} (η : 𝓢(Time × Space d.succ, ℝ)) :
+lemma time_integral_differentiable {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) :
     Differentiable ℝ (fun x => ∫ (t : Time), η (t, x)) :=
   fun x => (time_integral_hasFDerivAt η x).differentiableAt
 
@@ -369,32 +352,15 @@ lemma integrable_fderiv_space {d : ℕ} (η : 𝓢(Time × Space d, ℝ)) (x : S
       k * ‖ContinuousLinearMap.prod (0 : Space d →L[ℝ] Time)
       (ContinuousLinearMap.id ℝ (Space d))‖ * (|1 + ‖t‖| ^ rt)⁻¹ := by
     intro x t
-    match d with
-    | 0 => simp
-    | .succ d =>
-      have h0 : ‖ContinuousLinearMap.prod (0 : Space d.succ →L[ℝ] Time)
-          (ContinuousLinearMap.id ℝ (Space d.succ))‖ ≠ 0 := by
-        rw [@norm_ne_zero_iff]
-        simp only [Nat.succ_eq_add_one, ne_eq]
-        rw [@ContinuousLinearMap.ext_iff]
-        simp only [ContinuousLinearMap.prod_apply, _root_.zero_apply,
-          ContinuousLinearMap.coe_id', id_eq, Prod.mk_eq_zero, true_and, not_forall]
-        use Space.basis 0
-        by_contra hn
-        have ht : (basis 0 : Space d.succ) 0 = 0 := by
-          rw [hn]
-          simp
-        rw [basis_apply] at ht
-        simp at ht
-      trans k * (|1 + ‖t‖| ^ rt)⁻¹ * ‖ContinuousLinearMap.prod (0 : Space d.succ →L[ℝ] Time)
-        (ContinuousLinearMap.id ℝ (Space d.succ))‖
-      swap
-      · apply le_of_eq
-        ring
-      refine mul_le_mul_of_nonneg ?_ ?_ (by positivity) (by positivity)
-      · convert! h1 x t
-        simp
-      · rfl
+    trans k * (|1 + ‖t‖| ^ rt)⁻¹ * ‖ContinuousLinearMap.prod (0 : Space d →L[ℝ] Time)
+      (ContinuousLinearMap.id ℝ (Space d))‖
+    swap
+    · apply le_of_eq
+      ring
+    refine mul_le_mul_of_nonneg ?_ ?_ (by positivity) (by positivity)
+    · convert! h1 x t
+      simp
+    · rfl
   have h2 : ∀ x : Space d, ∀ t : Time, ‖fderiv ℝ (fun x => η (t, x)) x‖ ≤
       k * ‖ContinuousLinearMap.prod (0 : Space d →L[ℝ] Time)
         (ContinuousLinearMap.id ℝ (Space d))‖ * (|1 + ‖t‖| ^ rt)⁻¹ := by
@@ -729,7 +695,7 @@ lemma time_integral_iteratedFDeriv_apply {d : ℕ} (n : ℕ) (η : 𝓢(Time × 
       | succ n ih2 =>
         intro x y
         rw [iteratedFDeriv_succ_eq_comp_left, iteratedFDeriv_succ_eq_comp_left]
-        simp only [Nat.succ_eq_add_one, Function.comp_apply,
+        simp only [Function.comp_apply,
           continuousMultilinearCurryLeftEquiv_symm_apply]
         trans ((fderiv ℝ (fun x => iteratedFDeriv ℝ n (fun x => η (t, x)) x (Fin.tail y)) x) (y 0))
         · rw [fderiv_continuousMultilinear_apply_const_apply]
@@ -1056,15 +1022,15 @@ lemma constantTime_distTimeDeriv {M : Type} [NormedAddCommGroup M] [NormedSpace 
       · simp
       · conv_lhs =>
           enter [t]
-          simp only [Nat.succ_eq_add_one, one_mul]
+          simp only [one_mul]
           change (fderiv ℝ (η ∘ fun t => (t, x)) t) 1
           rw [fderiv_comp _ (by
             apply Differentiable.differentiableAt
             exact η.smooth'.differentiable (by simp))
             (by fun_prop), DifferentiableAt.fderiv_prodMk (by fun_prop) (by fun_prop)]
-          simp only [Nat.succ_eq_add_one, fderiv_fun_id, fderiv_fun_const, Pi.zero_apply,
-            ContinuousLinearMap.coe_comp, Function.comp_apply, ContinuousLinearMap.prod_apply,
-            ContinuousLinearMap.coe_id', id_eq, _root_.zero_apply]
+          simp only [fderiv_fun_id, fderiv_fun_const, Pi.ofNat_apply,
+            ContinuousLinearMap.comp_apply, ContinuousLinearMap.prod_apply,
+            ContinuousLinearMap.id_apply, _root_.zero_apply]
         exact integrable_time_integral (LineDeriv.lineDerivOpCLM ℝ _ ((1, 0) : Time × Space d) η) x
       · simp
         exact integrable_time_integral η x

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Line.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Line.lean
@@ -29,37 +29,30 @@ open MeasureTheory Real
 
 -/
 
-/-- The coordinate line embedded in `Space d.succ.succ`. -/
-def line (d : ℕ) : ℝ → Space d.succ.succ := fun r =>
-  (slice (0 : Fin d.succ.succ)).symm (r, 0)
+/-- The coordinate line embedded in `Space d`. -/
+def line (d : ℕ) [NeZero d] : ℝ → Space d := fun r =>
+  r • basis (0 : Fin d)
 
-lemma line_eq (d : ℕ) :
-    line d = (slice (0 : Fin d.succ.succ)).symm ∘ (fun r : ℝ => (r, 0)) := rfl
+lemma line_eq_smul_basis (d : ℕ) [NeZero d] :
+  line d = fun r => r • basis (0 : Fin d) := rfl
 
-lemma line_injective (d : ℕ) : Function.Injective (line d) := by
+lemma line_injective (d : ℕ) [NeZero d] : Function.Injective (line d) := by
   intro x y h
-  have h0 := congrArg (fun p : Space d.succ.succ => p (0 : Fin d.succ.succ)) h
+  have h0 := congrArg (fun p : Space d => p (0 : Fin d)) h
   simpa [line] using h0
 
 @[fun_prop]
-lemma line_continuous (d : ℕ) : Continuous (line d) := by
-  rw [line_eq]
+lemma line_continuous (d : ℕ) [NeZero d] : Continuous (line d) := by
+  rw [line_eq_smul_basis]
   fun_prop
 
-lemma line_measurableEmbedding (d : ℕ) : MeasurableEmbedding (line d) :=
+lemma line_measurableEmbedding (d : ℕ) [NeZero d] : MeasurableEmbedding (line d) :=
   Continuous.measurableEmbedding (line_continuous d) (line_injective d)
 
 @[simp]
-lemma norm_line (d : ℕ) (r : ℝ) : ‖line d r‖ = ‖r‖ := by
-  rw [line, norm_slice_symm_eq]
-  simp [Real.sqrt_sq_eq_abs]
-
-lemma line_eq_smul_basis (d : ℕ) (r : ℝ) :
-    line d r = r • basis (0 : Fin d.succ.succ) := by
-  rw [line, basis_self_eq_slice]
-  change (slice (0 : Fin d.succ.succ)).symm (r, 0) =
-    r • (slice (0 : Fin d.succ.succ)).symm (1, 0)
-  simpa using ((slice (0 : Fin d.succ.succ)).symm.map_smul r (1, (0 : Space d.succ)))
+lemma norm_line (d : ℕ) [NeZero d] (r : ℝ) : ‖line d r‖ = ‖r‖ := by
+  rw [line, norm_smul]
+  simp
 
 /-!
 
@@ -67,11 +60,11 @@ lemma line_eq_smul_basis (d : ℕ) (r : ℝ) :
 
 -/
 
-/-- The measure on `Space d.succ.succ` corresponding to integration along a coordinate line. -/
-def lineMeasure (d : ℕ) : Measure (Space d.succ.succ) :=
+/-- The measure on `Space d` corresponding to integration along a coordinate line. -/
+def lineMeasure (d : ℕ) [NeZero d] : Measure (Space d) :=
   MeasureTheory.Measure.map (line d) volume
 
-instance lineMeasure_hasTemperateGrowth (d : ℕ) :
+instance lineMeasure_hasTemperateGrowth (d : ℕ) [NeZero d] :
     (lineMeasure d).HasTemperateGrowth := by
   rw [lineMeasure]
   refine { exists_integrable := ?_ }
@@ -89,17 +82,17 @@ instance lineMeasure_hasTemperateGrowth (d : ℕ) :
 
 -/
 
-/-- The distribution on `Space d.succ.succ` corresponding to integration along a coordinate line.
+/-- The distribution on `Space d` corresponding to integration along a coordinate line.
   One can roughly think of this distribution as taking a test function `f` to its integral against
   a mass, charge or current density concentrated on a line. -/
-def lineDist (d : ℕ) : (Space d.succ.succ) →d[ℝ] ℝ :=
+def lineDist (d : ℕ) [NeZero d] : (Space d) →d[ℝ] ℝ :=
   SchwartzMap.integralCLM ℝ (lineMeasure d)
 
-lemma lineDist_apply_eq_integral_lineMeasure (d : ℕ) (f : 𝓢(Space d.succ.succ, ℝ)) :
+lemma lineDist_apply_eq_integral_lineMeasure (d : ℕ) [NeZero d] (f : 𝓢(Space d, ℝ)) :
     lineDist d f = ∫ x, f x ∂lineMeasure d := by
   rw [lineDist, SchwartzMap.integralCLM_apply]
 
-lemma lineDist_apply_eq_integral_volume (d : ℕ) (f : 𝓢(Space d.succ.succ, ℝ)) :
+lemma lineDist_apply_eq_integral_volume (d : ℕ) [NeZero d] (f : 𝓢(Space d, ℝ)) :
     lineDist d f = ∫ r : ℝ, f (line d r) := by
   rw [lineDist_apply_eq_integral_lineMeasure, lineMeasure,
     MeasurableEmbedding.integral_map (line_measurableEmbedding d)]
@@ -110,34 +103,35 @@ lemma lineDist_apply_eq_integral_volume (d : ℕ) (f : 𝓢(Space d.succ.succ, �
 
 -/
 
-/-- The linear subspace spanned by the coordinate line in `Space d.succ.succ`. -/
-def lineSubmodule (d : ℕ) : Submodule ℝ (Space d.succ.succ) :=
-  ℝ ∙ basis (0 : Fin d.succ.succ)
+/-- The linear subspace spanned by the coordinate line in `Space d`. -/
+def lineSubmodule (d : ℕ) [NeZero d] : Submodule ℝ (Space d) :=
+  ℝ ∙ basis (0 : Fin d)
 
-lemma line_mem_lineSubmodule (d : ℕ) (r : ℝ) : line d r ∈ lineSubmodule d := by
+lemma line_mem_lineSubmodule (d : ℕ) [NeZero d] (r : ℝ) : line d r ∈ lineSubmodule d := by
   rw [line_eq_smul_basis]
-  exact Submodule.smul_mem _ r (Submodule.mem_span_singleton_self (basis (0 : Fin d.succ.succ)))
+  exact Submodule.smul_mem _ r (Submodule.mem_span_singleton_self (basis (0 : Fin d)))
 
-lemma range_line_subset_lineSubmodule (d : ℕ) :
-    Set.range (line d) ⊆ (lineSubmodule d : Set (Space d.succ.succ)) := by
+lemma range_line_subset_lineSubmodule (d : ℕ) [NeZero d] :
+    Set.range (line d) ⊆ (lineSubmodule d : Set (Space d)) := by
   rintro x ⟨r, rfl⟩
   exact line_mem_lineSubmodule d r
 
-lemma lineSubmodule_ne_top (d : ℕ) : lineSubmodule d ≠ ⊤ := by
+lemma lineSubmodule_ne_top (d : ℕ) [NeZero d] (hd : 2 ≤ d) : lineSubmodule d ≠ ⊤ := by
   intro htop
-  have hbasis : basis (1 : Fin d.succ.succ) ∈ lineSubmodule d := by
+  have hbasis : basis (1 : Fin d) ∈ lineSubmodule d := by
     rw [htop]
     exact Submodule.mem_top
   obtain ⟨c, hc⟩ := (Submodule.mem_span_singleton.mp hbasis)
-  have hcoord := congrArg (fun p : Space d.succ.succ => p (1 : Fin d.succ.succ)) hc
-  simp [basis_apply] at hcoord
+  have hcoord := congrArg (fun p : Space d => p (1 : Fin d)) hc
+  have hd1 : d ≠ 1 := by omega
+  simp [basis_apply, hd1] at hcoord
 
-lemma volume_line_range (d : ℕ) :
-    volume (Set.range (line d) : Set (Space d.succ.succ)) = 0 := by
+lemma volume_line_range (d : ℕ) [NeZero d] (hd : 2 ≤ d) :
+    volume (Set.range (line d) : Set (Space d)) = 0 := by
   refine measure_mono_null (range_line_subset_lineSubmodule d) ?_
   rw [volume_eq_addHaar]
   exact MeasureTheory.Measure.addHaar_submodule
-    (Space.basis.toBasis.addHaar : Measure (Space d.succ.succ))
-    (lineSubmodule d) (lineSubmodule_ne_top d)
+    (Space.basis.toBasis.addHaar : Measure (Space d))
+    (lineSubmodule d) (lineSubmodule_ne_top d hd)
 
 end Space

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Line.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Line.lean
@@ -34,7 +34,7 @@ def line (d : ℕ) [NeZero d] : ℝ → Space d := fun r =>
   r • basis (0 : Fin d)
 
 lemma line_eq_smul_basis (d : ℕ) [NeZero d] :
-  line d = fun r => r • basis (0 : Fin d) := rfl
+    line d = fun r => r • basis (0 : Fin d) := rfl
 
 lemma line_injective (d : ℕ) [NeZero d] : Function.Injective (line d) := by
   intro x y h

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/Ring.lean
@@ -29,11 +29,11 @@ open MeasureTheory Real
 
 -/
 
-/-- The map embedding the unit ring in `Space d.succ` into `Space d.succ`. -/
+/-- The embedding of the unit ring (a circle `S¹` in `Space 2`) into `Space 3`. -/
 def ring : Metric.sphere (0 : Space 2) 1 → Space 3 := fun x =>
-  (slice 2).symm (0, Space.sphericalShell 1 x)
+  (slice 2).symm (0, Space.sphericalShell 2 x)
 
-lemma ring_eq : ring = (slice 2).symm ∘ (fun x => (0, sphericalShell 1 x)) := rfl
+lemma ring_eq : ring = (slice 2).symm ∘ (fun x => (0, sphericalShell 2 x)) := rfl
 
 lemma ring_injective : Function.Injective ring := by
   intro x y h

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SolidCylinder.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SolidCylinder.lean
@@ -76,7 +76,7 @@ lemma norm_solidCylinder (x : Space 2 × ℝ) :
   pushforward of the product of the solid-sphere (closed unit disk) measure on `Space 2` with the
   line measure along the axis. -/
 def solidCylinderMeasure : Measure (Space 3) :=
-  MeasureTheory.Measure.map solidCylinder ((solidSphereMeasure 1).prod (volume (α := ℝ)))
+  MeasureTheory.Measure.map solidCylinder ((solidSphereMeasure 2).prod (volume (α := ℝ)))
 
 instance solidCylinderMeasure_hasTemperateGrowth :
     solidCylinderMeasure.HasTemperateGrowth := by
@@ -88,8 +88,8 @@ instance solidCylinderMeasure_hasTemperateGrowth :
   rw [MeasurableEmbedding.integrable_map_iff solidCylinder_measurableEmbedding]
   change Integrable
     (fun x : Space 2 × ℝ => (1 + ‖solidCylinder x‖) ^ (-(n : ℝ)))
-    ((solidSphereMeasure 1).prod (volume (α := ℝ)))
-  apply Integrable.mono' (hn.comp_snd (solidSphereMeasure 1))
+    ((solidSphereMeasure 2).prod (volume (α := ℝ)))
+  apply Integrable.mono' (hn.comp_snd (solidSphereMeasure 2))
   · apply AEMeasurable.aestronglyMeasurable
     exact ((continuous_const.add solidCylinder_continuous.norm).rpow_const
       (fun x => Or.inl (by positivity : (1 : ℝ) + ‖solidCylinder x‖ ≠ 0))).aemeasurable
@@ -105,7 +105,7 @@ instance solidCylinderMeasure_hasTemperateGrowth :
 
 instance solidCylinderMeasure_sFinite : SFinite solidCylinderMeasure := by
   rw [solidCylinderMeasure]
-  exact Measure.instSFiniteMap ((solidSphereMeasure 1).prod (volume (α := ℝ))) solidCylinder
+  exact Measure.instSFiniteMap ((solidSphereMeasure 2).prod (volume (α := ℝ))) solidCylinder
 
 /-!
 
@@ -125,7 +125,7 @@ lemma solidCylinderDist_apply_eq_integral_solidCylinderMeasure (f : 𝓢(Space 3
 
 lemma solidCylinderDist_apply_eq_integral_disk_volume (f : 𝓢(Space 3, ℝ)) :
     solidCylinderDist f =
-    ∫ x, f (solidCylinder x) ∂((solidSphereMeasure 1).prod (volume (α := ℝ))) := by
+    ∫ x, f (solidCylinder x) ∂((solidSphereMeasure 2).prod (volume (α := ℝ))) := by
   rw [solidCylinderDist_apply_eq_integral_solidCylinderMeasure, solidCylinderMeasure,
     MeasurableEmbedding.integral_map solidCylinder_measurableEmbedding]
 
@@ -138,7 +138,7 @@ lemma solidCylinderDist_apply_eq_integral_disk_volume (f : 𝓢(Space 3, ℝ)) :
 lemma solidCylinderMeasure_univ_pos : 0 < solidCylinderMeasure Set.univ := by
   rw [solidCylinderMeasure, Measure.map_apply solidCylinder_measurableEmbedding.measurable
     MeasurableSet.univ, Set.preimage_univ, ← Set.univ_prod_univ, Measure.prod_prod]
-  refine ENNReal.mul_pos (solidSphereMeasure_univ_pos 1).ne' ?_
+  refine ENNReal.mul_pos (solidSphereMeasure_univ_pos 2).ne' ?_
   simp
 
 end Space

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SolidSphere.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SolidSphere.lean
@@ -11,7 +11,7 @@ public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 
 ## Solid sphere surfaces in `Space d`
 
-The solid sphere is the closed unit ball in `Space d.succ`. Unlike the line or the spherical
+The solid sphere is the closed unit ball in `Space d`. Unlike the line or the spherical
 shell, it is a region of positive ambient volume, so the measure associated with it is the
 ambient volume restricted to the ball rather than a pushforward of a lower-dimensional measure.
 The requirement that the surface has ambient measure zero is therefore not applicable here, and
@@ -35,8 +35,8 @@ open MeasureTheory Real
 
 -/
 
-/-- The map embedding the closed unit ball in `Space d.succ` into `Space d.succ`. -/
-def solidSphere (d : ℕ) : Metric.closedBall (0 : Space d.succ) 1 → Space d.succ := fun x => x.1
+/-- The inclusion into `Space d` of its closed unit ball `B^d` (the subtype coercion `x ↦ x.1`). -/
+def solidSphere (d : ℕ) : Metric.closedBall (0 : Space d) 1 → Space d := fun x => x.1
 
 lemma solidSphere_injective (d : ℕ) : Function.Injective (solidSphere d) := by
   intro x y h
@@ -51,7 +51,7 @@ lemma solidSphere_measurableEmbedding (d : ℕ) : MeasurableEmbedding (solidSphe
   · exact solidSphere_injective d
 
 @[simp]
-lemma norm_solidSphere_le (d : ℕ) (x : Metric.closedBall (0 : Space d.succ) 1) :
+lemma norm_solidSphere_le (d : ℕ) (x : Metric.closedBall (0 : Space d) 1) :
     ‖solidSphere d x‖ ≤ 1 := by
   have hx := x.2
   rw [Metric.mem_closedBall, dist_eq_norm, sub_zero] at hx
@@ -63,10 +63,10 @@ lemma norm_solidSphere_le (d : ℕ) (x : Metric.closedBall (0 : Space d.succ) 1)
 
 -/
 
-/-- The measure on `Space d.succ` corresponding to integration over a solid sphere, i.e. the
+/-- The measure on `Space d` corresponding to integration over a solid sphere, i.e. the
   ambient volume measure restricted to the closed unit ball. -/
-def solidSphereMeasure (d : ℕ) : Measure (Space d.succ) :=
-  volume.restrict (Metric.closedBall (0 : Space d.succ) 1)
+def solidSphereMeasure (d : ℕ) : Measure (Space d) :=
+  volume.restrict (Metric.closedBall (0 : Space d) 1)
 
 instance solidSphereMeasure_isFiniteMeasure (d : ℕ) :
     IsFiniteMeasure (solidSphereMeasure d) := by
@@ -83,18 +83,18 @@ instance solidSphereMeasure_hasTemperateGrowth (d : ℕ) :
 
 -/
 
-/-- The distribution on `Space d.succ` corresponding to integration over a solid sphere.
+/-- The distribution on `Space d` corresponding to integration over a solid sphere.
   One can roughly think of this distribution as taking a test function `f` to its integral against
   a mass, charge or current density spread over a solid ball. -/
-def solidSphereDist (d : ℕ) : (Space d.succ) →d[ℝ] ℝ :=
+def solidSphereDist (d : ℕ) : (Space d) →d[ℝ] ℝ :=
   SchwartzMap.integralCLM ℝ (solidSphereMeasure d)
 
-lemma solidSphereDist_apply_eq_integral_solidSphereMeasure (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
+lemma solidSphereDist_apply_eq_integral_solidSphereMeasure (d : ℕ) (f : 𝓢(Space d, ℝ)) :
     solidSphereDist d f = ∫ x, f x ∂solidSphereMeasure d := by
   rw [solidSphereDist, SchwartzMap.integralCLM_apply]
 
-lemma solidSphereDist_apply_eq_integral_closedBall (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
-    solidSphereDist d f = ∫ x in Metric.closedBall (0 : Space d.succ) 1, f x := by
+lemma solidSphereDist_apply_eq_integral_closedBall (d : ℕ) (f : 𝓢(Space d, ℝ)) :
+    solidSphereDist d f = ∫ x in Metric.closedBall (0 : Space d) 1, f x := by
   rw [solidSphereDist_apply_eq_integral_solidSphereMeasure, solidSphereMeasure]
 
 /-!
@@ -104,8 +104,8 @@ lemma solidSphereDist_apply_eq_integral_closedBall (d : ℕ) (f : 𝓢(Space d.s
 -/
 
 lemma solidSphere_volume_pos (d : ℕ) :
-    0 < volume (Metric.closedBall (0 : Space d.succ) 1) := by
-  apply lt_of_lt_of_le (b := volume (Metric.ball (0 : Space d.succ) 1))
+    0 < volume (Metric.closedBall (0 : Space d) 1) := by
+  apply lt_of_lt_of_le (b := volume (Metric.ball (0 : Space d) 1))
   · exact (Metric.isOpen_ball).measure_pos volume (Metric.nonempty_ball.mpr one_pos)
   · exact measure_mono Metric.ball_subset_closedBall
 

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalCylinder.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalCylinder.lean
@@ -36,16 +36,16 @@ open MeasureTheory Real
 
 /-- The map embedding the unit circular shell extruded along the axis into `Space 3`. -/
 def sphericalCylinder : Metric.sphere (0 : Space 2) 1 × ℝ → Space 3 := fun x =>
-  (slice 2).symm (x.2, sphericalShell 1 x.1)
+  (slice 2).symm (x.2, sphericalShell 2 x.1)
 
 lemma sphericalCylinder_eq :
-    sphericalCylinder = (slice 2).symm ∘ (fun x => (x.2, sphericalShell 1 x.1)) := rfl
+    sphericalCylinder = (slice 2).symm ∘ (fun x => (x.2, sphericalShell 2 x.1)) := rfl
 
 lemma sphericalCylinder_injective : Function.Injective sphericalCylinder := by
   intro x y h
   have h' := congrArg (slice 2) h
   simp [sphericalCylinder] at h'
-  exact Prod.ext (sphericalShell_injective 1 h'.2) h'.1
+  exact Prod.ext (sphericalShell_injective 2 h'.2) h'.1
 
 @[fun_prop]
 lemma sphericalCylinder_continuous : Continuous sphericalCylinder := by

--- a/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalShell.lean
+++ b/PhyslibAlpha/SpaceAndTime/Space/Surfaces/SphericalShell.lean
@@ -31,8 +31,8 @@ open MeasureTheory Real
 
 -/
 
-/-- The map embedding the unit sphere in `Space d.succ` into `Space d.succ`. -/
-def sphericalShell (d : ℕ) : Metric.sphere (0 : Space d.succ) 1 → Space d.succ := fun x => x.1
+/-- The inclusion into `Space d` of its unit sphere `S^{d-1}` (the subtype coercion `x ↦ x.1`). -/
+def sphericalShell (d : ℕ) : Metric.sphere (0 : Space d) 1 → Space d := fun x => x.1
 
 lemma sphericalShell_injective (d : ℕ) : Function.Injective (sphericalShell d) := by
   intro x y h
@@ -47,7 +47,7 @@ lemma sphericalShell_measurableEmbedding (d : ℕ) : MeasurableEmbedding (spheri
   · exact sphericalShell_injective d
 
 @[simp]
-lemma norm_sphericalShell (d : ℕ) (x : Metric.sphere (0 : Space d.succ) 1) :
+lemma norm_sphericalShell (d : ℕ) (x : Metric.sphere (0 : Space d) 1) :
     ‖sphericalShell d x‖ = 1 := by
   simp [sphericalShell, Metric.sphere]
 
@@ -57,8 +57,8 @@ lemma norm_sphericalShell (d : ℕ) (x : Metric.sphere (0 : Space d.succ) 1) :
 
 -/
 
-/-- The measure on `Space d.succ` corresponding to integration around a spherical shell. -/
-def sphericalShellMeasure (d : ℕ) : Measure (Space d.succ) :=
+/-- The measure on `Space d` corresponding to integration around a spherical shell. -/
+def sphericalShellMeasure (d : ℕ) : Measure (Space d) :=
   MeasureTheory.Measure.map (sphericalShell d) (MeasureTheory.Measure.toSphere volume)
 
 instance sphericalShellMeasure_hasTemperateGrowth (d : ℕ) :
@@ -78,15 +78,15 @@ instance sphericalShellMeasure_hasTemperateGrowth (d : ℕ) :
   One can roughly think of this distribution as the distribution which
   takes test functions `f (r)` to `∫ d³r f(r) ρ(r)` where `ρ(r)` is the
   mass, charge or current etc. distribution. -/
-def sphericalShellDist (d : ℕ) : (Space d.succ) →d[ℝ] ℝ  :=
+def sphericalShellDist (d : ℕ) : (Space d) →d[ℝ] ℝ  :=
   SchwartzMap.integralCLM ℝ (sphericalShellMeasure d)
 
 
-lemma sphericalShellDist_apply_eq_integral_sphericalShellMeasure (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
+lemma sphericalShellDist_apply_eq_integral_sphericalShellMeasure (d : ℕ) (f : 𝓢(Space d, ℝ)) :
     sphericalShellDist d f = ∫ x, f x ∂sphericalShellMeasure d := by
   rw [sphericalShellDist, SchwartzMap.integralCLM_apply]
 
-lemma sphericalShellDist_apply_eq_integral_sphere_volume (d : ℕ) (f : 𝓢(Space d.succ, ℝ)) :
+lemma sphericalShellDist_apply_eq_integral_sphere_volume (d : ℕ) (f : 𝓢(Space d, ℝ)) :
     sphericalShellDist d f =
     ∫ x, f (sphericalShell d x) ∂(MeasureTheory.Measure.toSphere volume) := by
   rw [sphericalShellDist_apply_eq_integral_sphericalShellMeasure, sphericalShellMeasure,


### PR DESCRIPTION
## Summary

Continues the Space d.succ → Space d refactor (so d is the true dimension). Orthogonal to #1299 (the Space/Norm distributional migration) — touches a disjoint set of files, no shared changes.

Leaf lemmas → now fully general (no positivity hypothesis): Translations.distTranslate_ofFunction, RigidBody/SolidSphere mass/centre-of-mass, ConstantTimeDist.time_integral_differentiable (+ dead-code/simp cleanup), and Derivatives/Iterated.iteratedDeriv_increment_zero (now [NeZero d]).

Space/Surfaces/: SphericalShell/SolidSphere defs migrate fully general; Ring/SphericalCylinder/SolidCylinder get index bumps (surface index now = ambient dimension); Line is reformulated from slice to r • basis 0 so it lives over Space d ([NeZero d], with 2 ≤ d only on the measure-zero lemmas).

Space.slice is intentionally kept at .succ (a genuine Space d.succ ≃ ℝ × Space d coordinate-peel).

What's left: the axis-aligned Lorentz boosts (SpaceTime/Boosts, Kinematics/Boosts, LorentzGroup/Boosts/Basic) and HarmonicWave. These single out a boost/propagation axis 0 and need a Function.update / j ≠ 0 reformulation which is more involved, will leave this for now.

PR prepared by myself with checking and summary assisted by claude
