### PR TITLE
refactor(classical-mechanics): characterize special times of harmonic oscillator trajectories

### DIFF
--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -51,11 +51,15 @@ prove that they satisfy the equation of motion, and prove some properties of the
   - E.2. Conversion to standard initial conditions
   - E.3. The trajectory in normal form
   - E.4. Recovering the amplitude and phase
-- F. The trajectories at zero velocity
-  - F.1. The times at which the velocity is zero
-  - F.2. A time when the velocity is zero
+- F. Special conditions of the trajectory
+  - F.1. Normal form for standard initial conditions
+  - F.2. Times at which the velocity is zero
   - F.3. The position when the velocity is zero
-- G. Some open TODOs
+  - F.4. Times at which the trajectory passes through zero
+- G. Periodicity and recurrence
+  - G.1. The period
+  - G.2. Periodicity of the trajectory
+  - G.3. Return to the initial state
 
 ## iv. References
 
@@ -1118,6 +1122,25 @@ lemma trajectory_eq_zero_iff_exists_int (IC : InitialConditions)
 
 end InitialConditions
 
+/-!
+
+## G. Periodicity and recurrence
+
+Every trajectory is a shifted cosine of angular frequency `ω`, so it repeats after a fixed period
+`T = 2π / ω`. We record the period, show the trajectory is periodic, and prove that — for
+non-trivial initial data — the trajectory returns to its initial position and velocity exactly at
+integer multiples of the period.
+
+-/
+
+/-!
+
+### G.1. The period
+
+The period `T = 2π / ω` is the time for one complete oscillation; it is positive since `ω > 0`.
+
+-/
+
 /--
 The period of a harmonic oscillator is `2 * π / ω`.
 -/
@@ -1133,6 +1156,15 @@ lemma period_pos : 0 < T S := by
   rw [period_eq]
   positivity
 
+/-!
+
+### G.2. Periodicity of the trajectory
+
+The trajectory satisfies `x(t + T) = x(t)`: advancing time by one period shifts the phase `ω t`
+by `2π`, leaving `cos` and `sin` unchanged.
+
+-/
+
 /--
 The trajectory of the harmonic oscillator is periodic with period of `2 * π / ω`.
 -/
@@ -1143,6 +1175,15 @@ lemma trajectory_periodic (IC : InitialConditions) :
     ring_nf; field_simp
   rw [InitialConditions.trajectory, add_val, period_eq, h, cos_add_two_pi, sin_add_two_pi]
   rfl
+
+/-!
+
+### G.3. Return to the initial state
+
+For non-trivial initial data, the trajectory returns to its initial position and velocity only at
+integer multiples of the period.
+
+-/
 
 /--
 Assuming that the initial coordinate and velocity are not simultaneously zero,
@@ -1227,8 +1268,6 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
     _ = (S.ω * t) / S.ω := by rw [hn]
     _ = t * (S.ω / S.ω) := by ring_nf
     _ = t := by simp only [ne_eq, S.ω_ne_zero, not_false_eq_true, div_self, mul_one]
-
-
 end HarmonicOscillator
 
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -889,9 +889,15 @@ namespace InitialConditions
 
 /-!
 
-## F. The trajectories at zero velocity
+## F. Special conditions of the trajectory
 
-We study the properties of the trajectories when the velocity is zero.
+We use the amplitude-phase parametrization from section E to describe the special times of a
+trajectory. After converting arbitrary initial conditions to amplitude and phase, every trajectory
+has the form `x(t) = A cos (ω t - φ)` and its velocity has the form `v(t) = -Aω sin (ω t - φ)`.
+
+Thus the turning points of the motion are controlled by the zeros of `sin (ω t - φ)`, while the
+times at which the trajectory passes through the origin are controlled by the zeros of
+`cos (ω t - φ)`.
 
 -/
 
@@ -928,129 +934,188 @@ lemma trajectory_velocity_eq_sin (IC : InitialConditions) (t : Time) :
 
 /-!
 
-### F.2. A time when the velocity is zero
+### F.2. Times at which the velocity is zero
 
-We show that as long as the initial position is non-zero, then at
-the time `arctan (IC.v₀ 0 / (S.ω * IC.x₀ 0)) / S.ω` the velocity is zero.
+In amplitude-phase form the velocity is `v(t) = -Aω sin (ω t - φ)`. For nonzero amplitude this
+vanishes exactly when `sin (ω t - φ) = 0`, equivalently when `ω t - φ` is an
+integer multiple of `π`.
 
 -/
 
-lemma trajectory_velocity_eq_zero_at_arctan (IC : InitialConditions) (hx : IC.x₀ ≠ 0) :
-    (∂ₜ (IC.trajectory S)) (arctan (IC.v₀ 0 / (S.ω * IC.x₀ 0)) / S.ω) = 0 := by
-  rw [trajectory_velocity]
-  simp [neg_smul]
-  have hx' : S.ω ≠ 0 := by exact ω_ne_zero S
-  field_simp
-  rw [Real.sin_arctan, Real.cos_arctan]
-  ext i
-  simp [one_div]
-  trans (-(S.ω * (IC.v₀ 0 / (S.ω * IC.x₀ 0) * IC.x₀ 0)) + IC.v₀ 0) *
-    (√(1 + (IC.v₀ 0 / (S.ω * IC.x₀ 0)) ^ 2))⁻¹
-  · fin_cases i
-    simp only [Fin.isValue, Fin.zero_eta]
-    ring
-  simp [mul_eq_zero, inv_eq_zero]
-  left
-  field_simp
-  have hx : IC.x₀ 0 ≠ 0 := by
-    intro hn
-    apply hx
+/-- For nonzero amplitude, the velocity vanishes exactly when the sine factor in
+  amplitude-phase form vanishes. -/
+lemma trajectory_velocity_eq_zero_iff_sin_eq_zero (IC : InitialConditions)
+    (hA : (AmplitudePhase.fromInitialConditions S IC).A ≠ 0) (t : Time) :
+    ∂ₜ (IC.trajectory S) t = 0 ↔
+      sin (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ) = 0 := by
+  rw [trajectory_velocity_eq_sin]
+  constructor
+  · intro h
+    have hscalar :
+        -((AmplitudePhase.fromInitialConditions S IC).A * S.ω *
+          sin (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ)) = 0 := by
+      simpa using congrArg (fun x : EuclideanSpace ℝ (Fin 1) => x 0) h
+    have hprod :
+        (AmplitudePhase.fromInitialConditions S IC).A * S.ω *
+          sin (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ) = 0 := by
+      simpa only [neg_eq_zero] using hscalar
+    rcases mul_eq_zero.mp hprod with hAω | hsin
+    · rcases mul_eq_zero.mp hAω with hA0 | hω
+      · exact (hA hA0).elim
+      · exact (S.ω_ne_zero hω).elim
+    · exact hsin
+  · intro h
     ext i
     fin_cases i
-    simp [hn]
-  field_simp
-  ring
+    simp [h]
+
+/-- For nonzero amplitude, the velocity is zero exactly at phase times `φ + nπ`. -/
+lemma trajectory_velocity_eq_zero_iff_exists_int (IC : InitialConditions)
+    (hA : (AmplitudePhase.fromInitialConditions S IC).A ≠ 0) (t : Time) :
+    ∂ₜ (IC.trajectory S) t = 0 ↔
+      ∃ n : ℤ,
+        (t : ℝ) =
+          ((AmplitudePhase.fromInitialConditions S IC).φ + n * π) / S.ω := by
+  rw [trajectory_velocity_eq_zero_iff_sin_eq_zero S IC hA t]
+  constructor
+  · intro h
+    obtain ⟨n, hn⟩ := Real.sin_eq_zero_iff.mp h
+    use n
+    have hω : S.ω ≠ 0 := S.ω_ne_zero
+    have ht :
+        S.ω * t.val = (AmplitudePhase.fromInitialConditions S IC).φ + n * π := by
+      linarith
+    calc
+      (t : ℝ) = (S.ω * t) / S.ω := by field_simp [hω]
+      _ = ((AmplitudePhase.fromInitialConditions S IC).φ + n * π) / S.ω := by
+        rw [ht]
+  · intro h
+    obtain ⟨n, hn⟩ := h
+    rw [Real.sin_eq_zero_iff]
+    use n
+    have hω : S.ω ≠ 0 := S.ω_ne_zero
+    rw [hn]
+    field_simp [hω]
+    ring
 
 /-!
 
 ### F.3. The position when the velocity is zero
 
-We show that the position is equal to `√(‖IC.x₀‖^2 + (‖IC.v₀‖/S.ω)^2) ` when
-the velocity is zero.
+The zeros of the velocity are the turning points of the oscillator. In amplitude-phase form,
+these are the times when `sin (ω t - φ) = 0`; equivalently, `cos (ω t - φ)` is `1` or `-1`.
+At exactly those times the trajectory has maximal norm, equal to the amplitude `A`.
+
+The statement also covers the degenerate case `A = 0`: then the trajectory and its velocity are
+identically zero, so both sides of the equivalence hold at every time.
 
 -/
 
-lemma trajectory_velocity_eq_zero_iff (IC : InitialConditions) (t : Time) :
+/-- The velocity vanishes exactly when the trajectory has norm equal to the amplitude. -/
+lemma trajectory_velocity_eq_zero_iff_norm_eq_amplitude (IC : InitialConditions)
+    (t : Time) :
     ∂ₜ (IC.trajectory S) t = 0 ↔
-    ‖(IC.trajectory S) t‖ = √(‖IC.x₀‖^2 + (‖IC.v₀‖/S.ω)^2) := by
-  have := by exact energy_eq S (trajectory S IC)
-  have h_energy_t := congrFun this t
-  simp only [kineticEnergy_eq, one_div, potentialEnergy_eq, smul_eq_mul] at h_energy_t
-  rw [real_inner_self_eq_norm_sq (trajectory S IC t)] at h_energy_t
-  have := by exact trajectory_energy S IC
-  have h_init := congrFun this t
-  have h_ω := by exact ω_sq S
+      ‖IC.trajectory S t‖ = (AmplitudePhase.fromInitialConditions S IC).A := by
+  by_cases hA : (AmplitudePhase.fromInitialConditions S IC).A = 0
+  · constructor
+    · intro _
+      rw [trajectory_eq_cos]
+      simp [hA]
+    · intro _
+      rw [trajectory_velocity_eq_sin]
+      ext i
+      fin_cases i
+      simp [hA]
+  rw [trajectory_velocity_eq_zero_iff_sin_eq_zero S IC hA t]
+  rw [trajectory_eq_cos]
+  set A := (AmplitudePhase.fromInitialConditions S IC).A
+  set θ := S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ
+  show sin θ = 0 ↔ ‖EuclideanSpace.single 0 (A * cos θ)‖ = A
+  have hA' : A ≠ 0 := by simpa [A] using hA
+  have hA_nonneg : 0 ≤ A := by
+    show 0 ≤ ‖(⟨IC.x₀ 0, IC.v₀ 0 / S.ω⟩ : ℂ)‖
+    exact norm_nonneg _
+  have hA_pos : 0 < A := lt_of_le_of_ne hA_nonneg (Ne.symm hA')
   constructor
-  · intro h_partial
-    rw [h_partial, inner_zero_left, mul_zero, zero_add] at h_energy_t
-    have h₁ : ‖trajectory S IC t‖ ^ 2 = S.energy (trajectory S IC) t * 2 * (1 / S.k) := by
-      simp [h_energy_t]
-      field_simp
-    symm
-    refine (sqrt_eq_iff_mul_self_eq ?_ ?_).mpr ?_
-    · apply add_nonneg <;> apply sq_nonneg
-    · apply norm_nonneg
-    rw [← pow_two]
-    rw [h₁, h_init]
-    ring_nf
-    rw [mul_assoc]
-    rw [mul_inv_cancel₀]
-    · rw [mul_one, inv_eq_one_div S.k, mul_assoc]
-      rw [mul_one_div S.m S.k, ← inverse_ω_sq]
-      ring
-    · exact k_ne_zero S
-  · intro h_norm
-    apply norm_eq_zero.mp
-    rw [real_inner_self_eq_norm_sq (∂ₜ (trajectory S IC) t)] at h_energy_t
-    have energies : S.energy (trajectory S IC) t = S.energy (trajectory S IC) t := by rfl
-    nth_rewrite 1 [h_energy_t] at energies
-    nth_rewrite 1 [h_init] at energies
-    rw [h_norm] at energies
-    have h₁ : S.m * ‖∂ₜ (trajectory S IC) t‖ ^ 2 + S.k * (√(‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2) ^ 2)
-            = S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2 := by
+  · intro hsin
+    rcases Real.sin_eq_zero_iff_cos_eq.mp hsin with hcos | hcos
+    · simp [hcos, abs_of_pos hA_pos]
+    · simp [hcos, abs_of_pos hA_pos]
+  · intro hnorm
+    have hnorm' : |A * cos θ| = A := by
+      simpa using hnorm
+    have hcos_abs : |cos θ| = 1 := by
       calc
-        S.m * ‖∂ₜ (trajectory S IC) t‖ ^ 2 + S.k * (√(‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2) ^ 2)
-            = 2 * (2⁻¹ * S.m * ‖∂ₜ (trajectory S IC) t‖ ^ 2
-            + 2⁻¹ * (S.k * √(‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2) ^ 2)) := by
-          simp [mul_add]
-          rw [← mul_assoc, ← mul_assoc]
-          rw [mul_inv_cancel_of_invertible 2, one_mul]
-      _ = 2 * (1 / 2 * (S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2)) := by rw [energies]
-      _ = S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2 := by simp
-    have h₂ : S.m * ‖∂ₜ (trajectory S IC) t‖ ^ 2 + S.k * (‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2)
-        = S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2 := by
-      rw [← h₁, sq_sqrt ?_]
-      apply add_nonneg
-      apply sq_nonneg
-      apply sq_nonneg
-    have h₃: ‖∂ₜ (trajectory S IC) t‖ ^ 2 = ‖IC.v₀‖ ^ 2 - (S.k / S.m) * (‖IC.v₀‖ / S.ω) ^ 2 := by
-      calc
-        ‖∂ₜ (trajectory S IC) t‖ ^ 2 = (1 / S.m) * (S.m * ‖∂ₜ (trajectory S IC) t‖ ^ 2
-        + S.k * (‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2) - S.k * (‖IC.x₀‖ ^ 2
-        + (‖IC.v₀‖ / S.ω) ^ 2)) := by simp
-        _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2
-          - S.k * (‖IC.x₀‖ ^ 2 + (‖IC.v₀‖ / S.ω) ^ 2)) := by rw [h₂]
-        _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2 + S.k * ‖IC.x₀‖ ^ 2
-          - S.k * ‖IC.x₀‖ ^ 2 - S.k * (‖IC.v₀‖ / S.ω) ^ 2) := by
-          rw [mul_add S.k (‖IC.x₀‖ ^ 2) ((‖IC.v₀‖ /S.ω) ^2)]
-          rw [← sub_sub_sub_eq (S.m * ‖IC.v₀‖ ^ 2) (S.k * ‖IC.x₀‖ ^ 2)
-          (S.k * (‖IC.v₀‖ / S.ω) ^ 2) (S.k * ‖IC.x₀‖ ^ 2)]
-          simp only [one_div, sub_sub_sub_cancel_right, add_sub_cancel_right]
-        _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2 - S.k * (‖IC.v₀‖ / S.ω) ^ 2) := by simp
-        _ = (1 / S.m) * (S.m * ‖IC.v₀‖ ^ 2) - (1 / S.m) * (S.k * (‖IC.v₀‖ / S.ω) ^ 2) := by
-          rw [mul_sub (1 / S.m) (S.m * ‖IC.v₀‖ ^ 2) (S.k * (‖IC.v₀‖ / S.ω) ^ 2)]
-        _ = ‖IC.v₀‖ ^ 2 - (S.k / S.m) * (‖IC.v₀‖ / S.ω) ^ 2 := by
-          simp only [one_div, ne_eq, m_ne_zero, not_false_eq_true, inv_mul_cancel_left₀,
-            sub_right_inj]
-          rw [← mul_assoc, inv_mul_eq_div S.m S.k]
-    rw [← ω_sq, div_pow ‖IC.v₀‖ S.ω 2] at h₃
-    rw [mul_div_cancel₀ (‖IC.v₀‖ ^ 2) ?_] at h₃
-    rw [sub_self (‖IC.v₀‖ ^ 2)] at h₃
-    rw [sq_eq_zero_iff] at h₃
-    exact h₃
-    rw [pow_ne_zero_iff ?_]
-    apply ω_ne_zero
-    exact Ne.symm (Nat.zero_ne_add_one 1)
+        |cos θ| = |A * cos θ| / A := by
+          rw [abs_mul, abs_of_pos hA_pos]
+          field_simp [hA']
+        _ = A / A := by rw [hnorm']
+        _ = 1 := by field_simp [hA']
+    obtain ⟨n, hn⟩ := Real.abs_cos_eq_one_iff.mp hcos_abs
+    exact Real.sin_eq_zero_iff.mpr ⟨n, hn⟩
+
+/-!
+
+### F.4. Times at which the trajectory passes through zero
+
+In amplitude-phase form the trajectory is `x(t) = A cos (ω t - φ).` For nonzero amplitude this
+vanishes exactly when `cos (ω t - φ) = 0`, equivalently when the phase is an odd multiple
+of `π / 2`.
+
+-/
+
+/-- For nonzero amplitude, the trajectory passes through zero exactly when the cosine factor in
+  amplitude-phase form vanishes. -/
+lemma trajectory_eq_zero_iff_cos_eq_zero (IC : InitialConditions)
+    (hA : (AmplitudePhase.fromInitialConditions S IC).A ≠ 0) (t : Time) :
+    IC.trajectory S t = 0 ↔
+      cos (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ) = 0 := by
+  rw [trajectory_eq_cos]
+  constructor
+  · intro h
+    have hscalar :
+        (AmplitudePhase.fromInitialConditions S IC).A *
+          cos (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ) = 0 := by
+      simpa using congrArg (fun x : EuclideanSpace ℝ (Fin 1) => x 0) h
+    rcases mul_eq_zero.mp hscalar with hA0 | hcos
+    · exact (hA hA0).elim
+    · exact hcos
+  · intro h
+    ext i
+    fin_cases i
+    simp [h]
+
+/-- For nonzero amplitude, the trajectory passes through zero exactly at phase times
+  `φ + (2n + 1)π / 2`. -/
+lemma trajectory_eq_zero_iff_exists_int (IC : InitialConditions)
+    (hA : (AmplitudePhase.fromInitialConditions S IC).A ≠ 0) (t : Time) :
+    IC.trajectory S t = 0 ↔
+      ∃ n : ℤ,
+        (t : ℝ) =
+          ((AmplitudePhase.fromInitialConditions S IC).φ + (2 * n + 1) * π / 2) / S.ω := by
+  rw [trajectory_eq_zero_iff_cos_eq_zero S IC hA t]
+  constructor
+  · intro h
+    obtain ⟨n, hn⟩ := Real.cos_eq_zero_iff.mp h
+    use n
+    have hω : S.ω ≠ 0 := S.ω_ne_zero
+    have ht :
+        S.ω * t.val =
+          (AmplitudePhase.fromInitialConditions S IC).φ + (2 * n + 1) * π / 2 := by
+      linarith
+    calc
+      (t : ℝ) = (S.ω * t) / S.ω := by field_simp [hω]
+      _ = ((AmplitudePhase.fromInitialConditions S IC).φ + (2 * n + 1) * π / 2) / S.ω := by
+        rw [ht]
+  · intro h
+    obtain ⟨n, hn⟩ := h
+    rw [Real.cos_eq_zero_iff]
+    use n
+    have hω : S.ω ≠ 0 := S.ω_ne_zero
+    rw [hn]
+    field_simp [hω]
+    ring
+
 end InitialConditions
 
 /--

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -897,51 +897,34 @@ We study the properties of the trajectories when the velocity is zero.
 
 /-!
 
-### F.1. The times at which the velocity is zero
+### F.1. Normal form for standard initial conditions
 
-We show that if the velocity of the trajectory is zero, then the time satisfies
-the condition that
-```
-tan (S.ω * t) = IC.v₀ 0 / (S.ω * IC.x₀ 0)
-```
+The amplitude-phase normal form was first proved for data already expressed as an
+`AmplitudePhase`. We now transport those identities back to ordinary `InitialConditions` using
+`AmplitudePhase.fromInitialConditions`.
 
 -/
-lemma tan_time_eq_of_trajectory_velocity_eq_zero (IC : InitialConditions) (t : Time)
-    (h : ∂ₜ (IC.trajectory S) t = 0) (hx : IC.x₀ ≠ 0 ∨ IC.v₀ ≠ 0) :
-    tan (S.ω * t) = IC.v₀ 0 / (S.ω * IC.x₀ 0) := by
-  rw [trajectory_velocity] at h
-  simp at h
-  have hx : S.ω ≠ 0 := by exact ω_ne_zero S
-  by_cases h1 : IC.x₀ ≠ 0
-  by_cases h2 : IC.v₀ ≠ 0
-  have h1' : IC.x₀ 0 ≠ 0 := by
-    intro hn
-    apply h1
-    ext i
-    fin_cases i
-    simp [hn]
-  have hcos : cos (S.ω * t.val) ≠ 0 := by
-    by_contra hn
-    rw [hn] at h
-    rw [Real.cos_eq_zero_iff_sin_eq] at hn
-    simp_all
-  rw [tan_eq_sin_div_cos]
-  field_simp
-  trans (sin (S.ω * t.val) * (S.ω * IC.x₀ 0)) +
-    (-(S.ω • sin (S.ω * t.val) • IC.x₀) + cos (S.ω * t.val) • IC.v₀) 0
-  · rw [h]
-    simp only [Fin.isValue, PiLp.zero_apply, add_zero]
-    ring_nf
-  · simp only [Fin.isValue, PiLp.add_apply, PiLp.neg_apply, PiLp.smul_apply, smul_eq_mul]
-    ring_nf
-  simp at h2
-  rw [h2] at h ⊢
-  simp_all
-  simp [tan_eq_sin_div_cos, h]
-  simp at h1
-  rw [h1] at h ⊢
-  simp_all
-  simp [tan_eq_sin_div_cos, h]
+
+/-- Every trajectory of the harmonic oscillator is a single shifted cosine after converting its
+  initial conditions to amplitude-phase form. -/
+lemma trajectory_eq_cos (IC : InitialConditions) (t : Time) :
+    IC.trajectory S t =
+      EuclideanSpace.single 0 ((AmplitudePhase.fromInitialConditions S IC).A *
+        cos (S.ω * t - (AmplitudePhase.fromInitialConditions S IC).φ)) := by
+  conv_lhs =>
+    rw [← AmplitudePhase.toInitialConditions_fromInitialConditions S IC]
+  exact AmplitudePhase.toInitialConditions_trajectory_eq_cos S
+    (AmplitudePhase.fromInitialConditions S IC) t
+
+/-- The velocity of every trajectory is the corresponding shifted sine in amplitude-phase form. -/
+lemma trajectory_velocity_eq_sin (IC : InitialConditions) (t : Time) :
+    ∂ₜ (IC.trajectory S) t =
+      EuclideanSpace.single 0 (-((AmplitudePhase.fromInitialConditions S IC).A * S.ω *
+        sin (S.ω * t.val - (AmplitudePhase.fromInitialConditions S IC).φ))) := by
+  conv_lhs =>
+    rw [← AmplitudePhase.toInitialConditions_fromInitialConditions S IC]
+  exact AmplitudePhase.toInitialConditions_velocity_eq_sin S
+    (AmplitudePhase.fromInitialConditions S IC) t
 
 /-!
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -1229,18 +1229,6 @@ lemma return_time (IC : InitialConditions) (non_trivial : IC.x₀ ≠ 0 ∨ IC.v
     _ = t := by simp only [ne_eq, S.ω_ne_zero, not_false_eq_true, div_self, mul_one]
 
 
-/-!
-
-## G. Some open TODOs
-
-We give some open TODOs for the classical harmonic oscillator.
-
--/
-
-
-TODO "For the classical harmonic oscillator find the times for
-  which it passes through zero."
-
 end HarmonicOscillator
 
 end ClassicalMechanics


### PR DESCRIPTION
Builds on the amplitude-phase parametrization from #1294 to characterize special times of a harmonic-oscillator trajectory in a new section F, and closes the open zero-crossing TODO. It also groups the existing periodicity declarations into a labelled section G.

### New API

Section F first transports the amplitude-phase normal form back to ordinary initial conditions:

- `trajectory_eq_cos` rewrites the trajectory as
  `x(t) = A cos(ω t - φ)`, where `A` and `φ` come from
  `AmplitudePhase.fromInitialConditions`.
- `trajectory_velocity_eq_sin` rewrites the velocity as
  `v(t) = -Aω sin(ω t - φ)`.

Using these two normal forms, section F then proves the special-time characterizations:

- `trajectory_velocity_eq_zero_iff_sin_eq_zero` says that, for nonzero amplitude, the velocity is
  zero exactly when the sine factor in the amplitude-phase velocity vanishes.
- `trajectory_velocity_eq_zero_iff_exists_int` converts this into the explicit time family
  `t = (φ + nπ) / ω`.
- `trajectory_velocity_eq_zero_iff_norm_eq_amplitude` identifies the velocity-zero times with the
  turning points of the motion: these are exactly the times when `‖x(t)‖ = A`.
- `trajectory_eq_zero_iff_cos_eq_zero` says that, for nonzero amplitude, the trajectory passes
  through the origin exactly when the cosine factor in the amplitude-phase trajectory vanishes.
- `trajectory_eq_zero_iff_exists_int` converts this into the explicit time family
  `t = (φ + (2n + 1)π / 2) / ω`.

Together these describe the velocity-zero times, the position at those times, and the zero-crossing times in terms of the phase `ω t - φ`.

### Removed API

The old zero-velocity section is replaced by the amplitude-phase formulation. The following lemmas are removed:

- `tan_time_eq_of_trajectory_velocity_eq_zero`
- `trajectory_velocity_eq_zero_at_arctan`
- `trajectory_velocity_eq_zero_iff`

The new statements give exact `iff` characterizations and integer parametrizations of the relevant times. The norm result is now stated directly as `‖x(t)‖ = A`.

### Motivation

In the raw initial-condition form, the special-time calculations involve tangent/arctangent algebra and separate case analysis. In amplitude-phase form, they reduce to standard zero sets of sine and cosine:

- velocity-zero times are zeros of `sin(ω t - φ)`;
- zero crossings are zeros of `cos(ω t - φ)`;
- turning-point norms follow from `|cos(ω t - φ)| = 1`.

This gives a smaller and more uniform API for later trajectory results.

### Section G

The existing declarations

- `period`
- `trajectory_periodic`
- `return_time`

are grouped under `G. Periodicity and recurrence` with section documentation. Their statements and proofs are unchanged.

### Reviewer map

1. Start with `trajectory_eq_cos` and `trajectory_velocity_eq_sin`.
2. Review the velocity-zero and turning-point lemmas in F.2-F.3.
3. Review the zero-crossing lemmas in F.4; these close the TODO.
4. Skim section G, which is documentation and organization only.

Developed with AI assistance; all mathematics and proofs were reviewed by the human author.
