### PR TITLE
auto-task(BlochSphere): drop unused BargmannInvariant import

### DIFF
--- a/QuantumInfo/States/Pure/BlochSphere.lean
+++ b/QuantumInfo/States/Pure/BlochSphere.lean
@@ -5,7 +5,6 @@ Authors: Anand Nambakam
 -/
 module
 
-public import QuantumInfo.States.Pure.BargmannInvariant
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 


### PR DESCRIPTION
# Minimize imports of `QuantumInfo/States/Pure/BlochSphere.lean`

## What changed

Removed one unused import from `QuantumInfo/States/Pure/BlochSphere.lean`:

- `public import QuantumInfo.States.Pure.BargmannInvariant`

The file defines `BlochSphere`, `blochPoint`, `solidAngle`, and the
supporting lemmas purely in terms of Mathlib's `EuclideanSpace`,
`WithLp.equiv`, `Matrix.crossProduct` (the `⨯₃` notation), `dotProduct`,
and `Complex`/`Real` API. It references no declaration from
`QuantumInfo.States.Pure.BargmannInvariant` (or its transitive
`Braket` content), so that import is dead weight.

## What was kept and why

Both remaining imports are used directly and are required for the build:

- `Mathlib.LinearAlgebra.CrossProduct` — provides the `⨯₃` cross-product
  notation used in `solidAngle`. Removing it breaks parsing.
- `Mathlib.Analysis.InnerProductSpace.PiL2` — provides `EuclideanSpace`,
  `WithLp.equiv`, `EuclideanSpace.dist_eq`/`norm_eq`. Removing it makes
  `EuclideanSpace` unknown.

I verified each by removing it individually and confirming the build fails,
so no further import could be trimmed.

## Downstream impact

None. `BlochSphere.lean` has no importers in the repository, so no
downstream file needed a compensating import.

## Verification

`lake build QuantumInfo` completes successfully (8636 jobs) with no
`sorry`, no new axioms, and no new errors or warnings. Only `import`
lines were touched; no code, docstrings, or declarations were modified.
