### PR TITLE
auto-task(Fermion.Modules): add TODO to define Dirac fermion module

### DIFF
--- a/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Modules.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Modules.lean
@@ -211,5 +211,11 @@ end DualRightHandedWeyl
 
 end DualRightHanded
 
+TODO "Define the module in which Dirac fermions live, in the same style as `LeftHandedWeyl`
+  and `RightHandedWeyl`: a structure wrapping `Fin 4 → ℂ` (equivalently a pair of a
+  left-handed and a right-handed Weyl spinor) carrying `AddCommMonoid`, `AddCommGroup` and
+  `Module ℂ` instances and a linear equivalence to `Fin 4 → ℂ`, so that Dirac fermions cannot
+  be cast to or from the Weyl modules."
+
 end
 end Fermion


### PR DESCRIPTION
## Summary

Records a single `TODO` item in
`Physlib/Relativity/Tensors/ComplexTensor/Weyl/Modules.lean` requesting a
module for Dirac fermions, defined in the same style as the existing
`LeftHandedWeyl` and `RightHandedWeyl` Weyl-fermion modules.

## Why here

`Modules.lean` already defines the left-handed, right-handed, and dual Weyl
fermion modules as structures wrapping `Fin 2 → ℂ` (with `AddCommMonoid`,
`AddCommGroup`, `Module ℂ` instances and a linear equivalence), precisely the
pattern the requested Dirac-fermion definition should mirror. This is the most
specific existing home for the task.

## Changes

- Added one `TODO "..."` command in the file's `@[expose] public section`,
  next to the Weyl-fermion module definitions it concerns.

No declarations were changed. `Physlib.Meta.TODO.Basic` was already imported.
The project builds cleanly with no `sorry`, new axioms, errors, or warnings.

---

## Human review

- **Does the TODO item look correctly placed in the library and an accurate reflection of the input?**
  no
