### PR TITLE
auto-task(leftHandedRep): record TODO to rename Weyl fermion representations

### DIFF
--- a/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Weyl/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.Relativity.Tensors.ComplexTensor.Weyl.Modules
 public import Physlib.Relativity.SL2C.Basic
 public import Physlib.Meta.Informal.Basic
+public import Physlib.Meta.TODO.Basic
 /-!
 
 # Weyl fermions
@@ -26,6 +27,12 @@ open Module Matrix
 open MatrixGroups
 open Complex
 open TensorProduct
+
+TODO "Rename the Weyl fermion representations `leftHandedRep`, `dualLeftHandedRep`,
+  `rightHandedRep` and `dualRightHandedRep` to `LeftHandedWeyl.rep`,
+  `DualLeftHandedWeyl.rep`, `RightHandedWeyl.rep` and `DualRightHandedWeyl.rep`
+  respectively, so that each representation lives in the namespace of the module it
+  acts on, and update all references accordingly."
 
 /-- The vector space ℂ^2 carrying the fundamental representation of SL(2,C).
   In index notation corresponds to a Weyl fermion with indices ψ^a. -/


### PR DESCRIPTION
## Summary

Records a single `TODO` item in
`Physlib/Relativity/Tensors/ComplexTensor/Weyl/Basic.lean`, next to the
definition of `leftHandedRep`, proposing to rename the four Weyl fermion
representations into the namespaces of the modules they act on:

- `leftHandedRep` → `LeftHandedWeyl.rep`
- `dualLeftHandedRep` → `DualLeftHandedWeyl.rep`
- `rightHandedRep` → `RightHandedWeyl.rep`
- `dualRightHandedRep` → `DualRightHandedWeyl.rep`

## Changes

- Added `public import Physlib.Meta.TODO.Basic`.
- Added one `TODO "..."` command immediately before `leftHandedRep`.

No declarations were renamed or implemented; this only records the task. The
project still builds cleanly.

---

## Human review

- **Does the TODO item look correctly placed in the library and an accurate reflection of the input?** Yes
