### PR TITLE
feat(ClassicalMechanics): add RigidBodyMotion with centre-of-mass velocity

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -17,6 +17,7 @@ public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
 public import Physlib.ClassicalMechanics.RigidBody.Basic
+public import Physlib.ClassicalMechanics.RigidBody.Motion
 public import Physlib.ClassicalMechanics.RigidBody.SolidSphere
 public import Physlib.ClassicalMechanics.Scattering.RigidSphere
 public import Physlib.ClassicalMechanics.Vibrations.LinearTriatomic

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -63,12 +63,20 @@ noncomputable def linearMomentum {d : ℕ} (M : RigidBodyMotion d) : Time → Sp
 lemma linearMomentum_eq {d : ℕ} (M : RigidBodyMotion d) :
     M.linearMomentum = fun t => M.mass • M.centerOfMassVelocity t := rfl
 
+TODO "Define an action of the rotation and translation groups on `RigidBodyMotion`, and recover
+  `displacement` as the composite of those group actions."
+
 /-- The rigid displacement carrying the body frame into the inertial frame at time `t`: the
 rotation `orientation t` about the centre of mass, followed by the translation placing the centre
 of mass at `comTrajectory t`. -/
 noncomputable def displacement {d : ℕ} (M : RigidBodyMotion d) (t : Time) : Space d → Space d :=
   fun y => ⟨fun k => ∑ j, (M.orientation t).val k j * (y j - M.centerOfMass j) +
     M.comTrajectory t k⟩
+
+/-- The `k`-th coordinate of the rigid displacement applied to `y`. -/
+lemma displacement_apply {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) (k : Fin d) :
+    M.displacement t y k =
+      (∑ j, (M.orientation t).val k j * (y j - M.centerOfMass j)) + M.comTrajectory t k := rfl
 
 lemma displacement_contDiff {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
     ContDiff ℝ ⊤ (M.displacement t) := by
@@ -111,12 +119,6 @@ private lemma contMDiffMap_sum_apply {d : ℕ} {ι : Type*} (s : Finset ι)
   | empty => simp
   | insert a s ha ih =>
     simp only [Finset.sum_insert ha, ContMDiffMap.coe_add, Pi.add_apply, ih]
-
-/-- The `k`-th coordinate of the rigid displacement applied to `y`. -/
-private lemma displacement_apply {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d)
-    (k : Fin d) :
-    M.displacement t y k =
-      (∑ j, (M.orientation t).val k j * (y j - M.centerOfMass j)) + M.comTrajectory t k := rfl
 
 /-- The first moment of the body-fixed distribution about its own centre of mass vanishes:
 for nonzero mass, `ρ` of the centred `j`-th coordinate function is zero. -/

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Physlib.ClassicalMechanics.RigidBody.Basic
+public import Physlib.SpaceAndTime.Time.Derivatives
+public import Mathlib.LinearAlgebra.UnitaryGroup
+/-!
+
+# Rigid body motion
+
+The static `RigidBody` records a body-fixed mass distribution. To describe a rigid body *in
+motion* we record, in addition, the trajectory of its centre of mass in the inertial frame and the
+body's time-dependent orientation (a rotation about the centre of mass).
+
+From this configuration we define the velocity of the centre of mass and the body's linear
+momentum. The reference point is taken to be the centre of mass, following the decomposition of
+a rigid motion into a translation of the centre of mass plus a rotation about it.
+
+## References
+- Landau and Lifshitz, Mechanics, Section 32.
+-/
+
+@[expose] public section
+
+open Time
+
+/-- A motion of a rigid body in `d`-dimensional space: the body together with the inertial-frame
+trajectory of its centre of mass and its time-dependent orientation (a rotation about the centre
+of mass). -/
+structure RigidBodyMotion (d : ℕ) extends RigidBody d where
+  /-- The position of the centre of mass in the inertial frame as a function of time. -/
+  comTrajectory : Time → Space d
+  /-- The orientation of the body, a rotation about the centre of mass, as a function of time. -/
+  orientation : Time → Matrix.specialOrthogonalGroup (Fin d) ℝ
+
+namespace RigidBodyMotion
+
+/-- The velocity of the centre of mass of a rigid body in motion, defined as the time-derivative
+of its centre-of-mass trajectory. This is the velocity `V` in the Landau–Lifshitz decomposition
+`v = V + Ω × r` of the velocity of a point of the body. -/
+noncomputable def centerOfMassVelocity {d : ℕ} (M : RigidBodyMotion d) : Time → Space d :=
+  ∂ₜ M.comTrajectory
+
+lemma centerOfMassVelocity_eq {d : ℕ} (M : RigidBodyMotion d) :
+    M.centerOfMassVelocity = ∂ₜ M.comTrajectory := rfl
+
+/-- A rigid body whose centre of mass is stationary has zero centre-of-mass velocity. -/
+lemma centerOfMassVelocity_of_comTrajectory_const {d : ℕ} (M : RigidBodyMotion d) (c : Space d)
+    (h : M.comTrajectory = fun _ => c) : M.centerOfMassVelocity = 0 := by
+  rw [centerOfMassVelocity_eq, h]
+  funext t
+  exact Time.deriv_const c
+
+/-- The linear momentum of a rigid body in motion: the total mass times the velocity of the
+centre of mass. -/
+noncomputable def linearMomentum {d : ℕ} (M : RigidBodyMotion d) : Time → Space d :=
+  fun t => M.mass • M.centerOfMassVelocity t
+
+lemma linearMomentum_eq {d : ℕ} (M : RigidBodyMotion d) :
+    M.linearMomentum = fun t => M.mass • M.centerOfMassVelocity t := rfl
+
+end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -81,20 +81,8 @@ body-fixed mass distribution along the rigid displacement, acting on a test func
 noncomputable def massDistribution {d : ℕ} (M : RigidBodyMotion d) (t : Time) : RigidBody d where
   ρ :=
     { toFun := fun f => M.ρ (f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩)
-      map_add' := by
-        intro f g
-        have h : (f + g).comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ =
-            f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ +
-            g.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ := by
-          ext y; simp
-        rw [h, map_add]
-      map_smul' := by
-        intro r f
-        have h : (r • f).comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ =
-            r • f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ := by
-          ext y; simp
-        rw [h]
-        exact map_smul M.ρ r _ }
+      map_add' := fun f g => by rw [ContMDiffMap.add_comp, map_add]
+      map_smul' := fun r f => by rw [ContMDiffMap.smul_comp, map_smul, RingHom.id_apply] }
 
 /-- The motion preserves the total mass: the mass distribution at any time `t` has the same total
 mass as the body. -/
@@ -103,5 +91,78 @@ lemma massDistribution_mass {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
     (M.massDistribution t).mass = M.mass := by
   simp only [RigidBody.mass, massDistribution, LinearMap.coe_mk, AddHom.coe_mk]
   congr 1
+
+/-- Bundle a smooth real-valued function on `Space d` as an element of the space of test
+functions. Keeping this as a named constructor ensures the resulting type head stays
+`ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/
+private def cmap {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) :
+    C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯ := ⟨f, hf.contMDiff⟩
+
+@[simp]
+private lemma cmap_apply {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) (y : Space d) :
+    cmap f hf y = f y := rfl
+
+/-- Evaluation commutes with finite sums of smooth functions. -/
+private lemma contMDiffMap_sum_apply {d : ℕ} {ι : Type*} (s : Finset ι)
+    (f : ι → C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) (y : Space d) :
+    (∑ j ∈ s, f j) y = ∑ j ∈ s, f j y := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+    simp only [Finset.sum_insert ha, ContMDiffMap.coe_add, Pi.add_apply, ih]
+
+/-- The `k`-th coordinate of the rigid displacement applied to `y`. -/
+private lemma displacement_apply {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d)
+    (k : Fin d) :
+    M.displacement t y k =
+      (∑ j, (M.orientation t).val k j * (y j - M.centerOfMass j)) + M.comTrajectory t k := rfl
+
+/-- The first moment of the body-fixed distribution about its own centre of mass vanishes:
+for nonzero mass, `ρ` of the centred `j`-th coordinate function is zero. -/
+private lemma rho_coord_sub_centerOfMass {d : ℕ} (R : RigidBody d) (h : R.mass ≠ 0) (j : Fin d) :
+    R.ρ (cmap (fun y => y j - R.centerOfMass j) (by fun_prop)) = 0 := by
+  have hsplit : cmap (fun y => y j - R.centerOfMass j) (by fun_prop)
+        = cmap (fun y => y j) (by fun_prop)
+          - R.centerOfMass j • (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
+    ext y
+    simp only [cmap_apply, ContMDiffMap.coe_sub, ContMDiffMap.coe_smul,
+      ContMDiffMap.coe_one, Pi.sub_apply, Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+  have hmass : R.ρ (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) = R.mass := rfl
+  have hcoord : R.ρ (cmap (fun y => y j) (by fun_prop)) = R.mass * R.centerOfMass j := by
+    have hc : R.centerOfMass j = (1 / R.mass) • R.ρ (cmap (fun y => y j) (by fun_prop)) := rfl
+    rw [hc, smul_eq_mul, one_div, ← mul_assoc, mul_inv_cancel₀ h, one_mul]
+  rw [hsplit, map_sub, map_smul, hmass, hcoord, smul_eq_mul]
+  ring
+
+/-- The centre of mass of the moving mass distribution tracks the prescribed trajectory: for a
+body of nonzero mass, the centre of mass of `massDistribution M t` is exactly `comTrajectory t`.
+This is the decisive check that `comTrajectory` and `orientation` are wired correctly in
+`RigidBodyMotion`. -/
+lemma massDistribution_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time) (h : M.mass ≠ 0) :
+    (M.massDistribution t).centerOfMass = M.comTrajectory t := by
+  ext i
+  have hone : M.ρ (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) = M.mass := rfl
+  have hdecomp :
+      ContMDiffMap.comp (cmap (fun x => x i) (by fun_prop))
+          ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩
+        = (∑ j, (M.orientation t).val i j •
+              cmap (fun y => y j - M.centerOfMass j) (by fun_prop))
+            + M.comTrajectory t i • (1 : C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯) := by
+    ext y
+    simp only [ContMDiffMap.comp_apply, cmap_apply, ContMDiffMap.coeFn_mk, displacement_apply,
+      ContMDiffMap.coe_add, ContMDiffMap.coe_smul, ContMDiffMap.coe_one, Pi.add_apply,
+      Pi.smul_apply, Pi.one_apply, smul_eq_mul, mul_one, contMDiffMap_sum_apply]
+  have key : (M.massDistribution t).ρ (cmap (fun x => x i) (by fun_prop))
+      = M.comTrajectory t i * M.mass := by
+    simp only [massDistribution, LinearMap.coe_mk, AddHom.coe_mk]
+    rw [hdecomp, map_add, map_sum, map_smul, hone]
+    simp only [map_smul, rho_coord_sub_centerOfMass M.toRigidBody h, smul_eq_mul, mul_zero,
+      Finset.sum_const_zero, zero_add]
+  rw [show (M.massDistribution t).centerOfMass i
+      = (1 / (M.massDistribution t).mass) •
+          (M.massDistribution t).ρ (cmap (fun x => x i) (by fun_prop)) from rfl,
+    massDistribution_mass, key, smul_eq_mul, mul_comm, mul_one_div, mul_div_assoc, div_self h,
+    mul_one]
 
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -26,7 +26,7 @@ a rigid motion into a translation of the centre of mass plus a rotation about it
 
 @[expose] public section
 
-open Time
+open Time Manifold
 
 /-- A motion of a rigid body in `d`-dimensional space: the body together with the inertial-frame
 trajectory of its centre of mass and its time-dependent orientation (a rotation about the centre
@@ -62,5 +62,46 @@ noncomputable def linearMomentum {d : ℕ} (M : RigidBodyMotion d) : Time → Sp
 
 lemma linearMomentum_eq {d : ℕ} (M : RigidBodyMotion d) :
     M.linearMomentum = fun t => M.mass • M.centerOfMassVelocity t := rfl
+
+/-- The rigid displacement carrying the body frame into the inertial frame at time `t`: the
+rotation `orientation t` about the centre of mass, followed by the translation placing the centre
+of mass at `comTrajectory t`. -/
+noncomputable def displacement {d : ℕ} (M : RigidBodyMotion d) (t : Time) : Space d → Space d :=
+  fun y => ⟨fun k => ∑ j, (M.orientation t).val k j * (y j - M.centerOfMass j) +
+    M.comTrajectory t k⟩
+
+lemma displacement_contDiff {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
+    ContDiff ℝ ⊤ (M.displacement t) := by
+  unfold displacement
+  fun_prop
+
+/-- The mass distribution of the rigid body in motion at time `t`: the pushforward of the
+body-fixed mass distribution along the rigid displacement, acting on a test function `f` by
+`f ↦ ρ (f ∘ displacement t)`. -/
+noncomputable def massDistribution {d : ℕ} (M : RigidBodyMotion d) (t : Time) : RigidBody d where
+  ρ :=
+    { toFun := fun f => M.ρ (f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩)
+      map_add' := by
+        intro f g
+        have h : (f + g).comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ =
+            f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ +
+            g.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ := by
+          ext y; simp
+        rw [h, map_add]
+      map_smul' := by
+        intro r f
+        have h : (r • f).comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ =
+            r • f.comp ⟨M.displacement t, (M.displacement_contDiff t).contMDiff⟩ := by
+          ext y; simp
+        rw [h]
+        exact map_smul M.ρ r _ }
+
+/-- The motion preserves the total mass: the mass distribution at any time `t` has the same total
+mass as the body. -/
+@[simp]
+lemma massDistribution_mass {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
+    (M.massDistribution t).mass = M.mass := by
+  simp only [RigidBody.mass, massDistribution, LinearMap.coe_mk, AddHom.coe_mk]
+  congr 1
 
 end RigidBodyMotion


### PR DESCRIPTION
## Summary

Toward #893 (API: Rigid body). Adds the time-dependent configuration of a rigid body and the kinematics of its centre of mass — the first of the four open Landau–Lifshitz §32 items. This PR covers the **centre-of-mass velocity**; angular velocity, kinetic energy and Euler angles will follow in separate PRs.

## Added — `Physlib/ClassicalMechanics/RigidBody/Motion.lean` (new file)

| Declaration | Kind | Meaning |
|---|---|---|
| `RigidBodyMotion d` | structure, extends `RigidBody d` | a moving rigid body: the body plus the inertial-frame centre-of-mass trajectory `comTrajectory : Time → Space d` and orientation `orientation : Time → SO(d)` |
| `centerOfMassVelocity` | def | `∂ₜ comTrajectory` — the velocity `V` of the centre of mass (§32, `v = V + Ω × r`) |
| `centerOfMassVelocity_eq` | lemma | definitional unfolding |
| `centerOfMassVelocity_of_comTrajectory_const` | lemma | a stationary centre of mass has zero velocity |
| `linearMomentum` | def | `mass • centerOfMassVelocity` — total linear momentum `P = M V` |
| `linearMomentum_eq` | lemma | definitional unfolding |

One sorted `import` line is added to `Physlib.lean`.

## Reviewer map

1. `RigidBodyMotion` — the configuration data type (the core contribution).
2. `centerOfMassVelocity` and its two lemmas.
3. `linearMomentum` and its lemma.

`orientation` is intentionally included now even though it is unused in this PR: it is the body's time-dependent rotation about the centre of mass, and is the foundation for the angular-velocity and kinetic-energy follow-up PRs toward #893.

## Scope — what is not changed

No existing declaration is modified; this only adds one new file plus one import. The corresponding `informal_*` stubs in `RigidBody/Basic.lean` are left in place.

## Verification

- `lake build Physlib.ClassicalMechanics.RigidBody.Motion` — succeeds.
- `lake exe runLinter Physlib.ClassicalMechanics.RigidBody.Motion` — zero errors originating from the new file.
- `./scripts/lint-style.sh` — passes; no trailing whitespace, no lines over 100 chars; `git diff --check` clean.
- `#print axioms` on all four new declarations — only `[propext, Classical.choice, Quot.sound]`.

Toward #893.
