### PR TITLE
auto-task(StandardModel.Representations): record TODO for Standard Model fermion content as left-handed Weyl fermions

### DIFF
--- a/Physlib/Particles/StandardModel/Representations.lean
+++ b/Physlib/Particles/StandardModel/Representations.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.LinearAlgebra.UnitaryGroup
+public import Physlib.Meta.TODO.Basic
 /-!
 # Representations appearing in the Standard Model
 
@@ -54,5 +55,11 @@ lemma repU1_fundamentalSU2_commute (u1 : unitary ℂ) (g : specialUnitaryGroup (
     repU1 u1 * fundamentalSU2 g = fundamentalSU2 g * repU1 u1 := by
   apply Subtype.ext
   simp
+
+TODO "Define a structure capturing the fermionic content of the Standard Model, with all fermions
+  expressed as left-handed Weyl fermions (`Fermion.LeftHandedWeyl`) and including all three
+  families. The structure should carry a `Module ℂ` instance together with a representation of the
+  Lorentz group and a representation of the global gauge group `GaugeGroupI` (built from `repU1`
+  and `fundamentalSU2`)."
 
 end StandardModel


### PR DESCRIPTION
## Summary

Records a single `TODO` in the Standard Model representations file for the structure
holding the Standard Model's fermionic content, expressed entirely as left-handed
Weyl fermions.

The TODO was **written by a human** (the task author); Claude placed it in the
correct file and section of the library and verified the build and linters.

## Original request

> - **What TODO item would you like to add to the Physlib repository?**
>   The structure containing the fermionic content of the Standard Model, all as
>   left-handed Weyl fermions. The structure should contain an instance of a module,
>   the Lorentz group action, the action of the global Gauge group of the Standard
>   model. It should contain all three families.
> - **Name (for copyright header), if needed:** Joseph Tooby-Smith

## What changed

In `Physlib/Particles/StandardModel/Representations.lean`, added:

```lean
TODO "Define a structure capturing the fermionic content of the Standard Model, with all fermions
  expressed as left-handed Weyl fermions (`Fermion.LeftHandedWeyl`) and including all three
  families. The structure should carry a `Module ℂ` instance together with a representation of the
  Lorentz group and a representation of the global gauge group `GaugeGroupI` (built from `repU1`
  and `fundamentalSU2`)."
```

The required `public import Physlib.Meta.TODO.Basic` was added, since this file only
imported pure Mathlib and the `TODO` command did not otherwise elaborate.

## Why this location

`Representations.lean` defines the representations appearing in the Standard Model
(`repU1`, `fundamentalSU2`) and lives alongside `Basic.lean` which defines the global
gauge group `GaugeGroupI`. The fermion-content structure is exactly the matter that
transforms in these representations, so this is the most specific existing home. The
TODO text refers to the relevant existing definitions (`Fermion.LeftHandedWeyl`,
`GaugeGroupI`, `repU1`, `fundamentalSU2`) so a future contributor has the building
blocks to hand. No equivalent TODO already existed.

## Verification

- `lake build` succeeds with no new errors, warnings, `sorry`s, or axioms.
- `lake exe runPhyslibLinters` — clean.
- `./scripts/lint-style.sh` — clean.

No declarations were implemented or proved; this PR only records the TODO.

---

## Human review

- **Does the TODO item look correctly placed in the library and an accurate reflection of the input?** Yes
