### PR TITLE
feat(Mathematics): add the hat map realizing ℝ³ as skew-symmetric 3×3 matrices

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -77,6 +77,7 @@ public import Physlib.Mathematics.Calculus.ParametricIntegration
 public import Physlib.Mathematics.Calculus.Wirtinger.Basic
 public import Physlib.Mathematics.Calculus.Wirtinger.Coordinate
 public import Physlib.Mathematics.ConjModule
+public import Physlib.Mathematics.CrossProductMatrix
 public import Physlib.Mathematics.DataStructures.FourTree.Basic
 public import Physlib.Mathematics.DataStructures.FourTree.UniqueMap
 public import Physlib.Mathematics.DataStructures.Matrix.LieTrace

--- a/Physlib/Mathematics/CrossProductMatrix.lean
+++ b/Physlib/Mathematics/CrossProductMatrix.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Mathlib.Data.Matrix.Mul
+public import Mathlib.Data.Real.Basic
+public import Mathlib.LinearAlgebra.CrossProduct
+public import Mathlib.LinearAlgebra.Matrix.Notation
+/-!
+
+# The hat map on three-dimensional vectors
+
+The hat map sends a vector `ω : Fin 3 → ℝ` to the skew-symmetric matrix `[ω]ₓ` characterised by
+`[ω]ₓ *ᵥ v = ω ⨯₃ v`. It realises the correspondence between `ℝ³` and the skew-symmetric `3 × 3`
+matrices (the Lie algebra `𝖘𝖔(3)`), and underlies the angular velocity of a rigid body.
+
+-/
+
+@[expose] public section
+
+namespace Matrix
+
+/-- The hat map `[ω]ₓ`: the skew-symmetric `3 × 3` matrix acting as the cross product with `ω`,
+i.e. `[ω]ₓ *ᵥ v = ω ⨯₃ v`. -/
+def crossProductMatrix (ω : Fin 3 → ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![0, -ω 2, ω 1; ω 2, 0, -ω 0; -ω 1, ω 0, 0]
+
+/-- The hat matrix acts on a vector as the cross product. -/
+@[simp]
+lemma crossProductMatrix_mulVec (ω v : Fin 3 → ℝ) :
+    crossProductMatrix ω *ᵥ v = ω ⨯₃ v := by
+  funext i
+  fin_cases i <;>
+    simp [crossProductMatrix, mulVec, dotProduct, Fin.sum_univ_three, cross_apply] <;> ring
+
+/-- The hat map produces skew-symmetric matrices. -/
+@[simp]
+lemma crossProductMatrix_transpose (ω : Fin 3 → ℝ) :
+    (crossProductMatrix ω)ᵀ = - crossProductMatrix ω := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [crossProductMatrix]
+
+/-- The vee map: reads the vector off a `3 × 3` matrix. It is a left inverse of the hat map. -/
+def crossProductVee (A : Matrix (Fin 3) (Fin 3) ℝ) : Fin 3 → ℝ := ![A 2 1, A 0 2, A 1 0]
+
+/-- The vee map is a left inverse of the hat map. -/
+@[simp]
+lemma crossProductVee_crossProductMatrix (ω : Fin 3 → ℝ) :
+    crossProductVee (crossProductMatrix ω) = ω := by
+  funext i
+  fin_cases i <;> simp [crossProductVee, crossProductMatrix]
+
+end Matrix


### PR DESCRIPTION
## Summary

Toward #893 (API: Rigid body). Adds the **hat map** `[ω]ₓ` — the skew-symmetric `3 × 3` matrix realizing the cross product — the algebraic foundation for the rigid-body angular velocity (a later PR). This is general linear algebra, so it lives in `Physlib/Mathematics/`; it is independent of the other #893 PRs.

## Added — `Physlib/Mathematics/CrossProductMatrix.lean` (new file, `Matrix` namespace)

| Declaration | Meaning |
|---|---|
| `crossProductMatrix ω` | the hat matrix `[ω]ₓ = !![0,-ω 2,ω 1; ω 2,0,-ω 0; -ω 1,ω 0,0]` |
| `crossProductMatrix_mulVec` | `[ω]ₓ *ᵥ v = ω ⨯₃ v` (the defining property) |
| `crossProductMatrix_transpose` | `[ω]ₓᵀ = -[ω]ₓ` (skew-symmetry) |
| `crossProductVee A` | the vee map `![A 2 1, A 0 2, A 1 0]` |
| `crossProductVee_crossProductMatrix` | `vee (hat ω) = ω` (left inverse) |

One sorted `import` is added to `Physlib.lean`.

## Reviewer map

1. `crossProductMatrix` and `crossProductMatrix_mulVec` — the definition and its characterizing property.
2. `crossProductMatrix_transpose`.
3. `crossProductVee` and the round-trip lemma.

## Verification

- `lake build Physlib.Mathematics.CrossProductMatrix` — succeeds.
- `lake exe runLinter Physlib.Mathematics.CrossProductMatrix` — "Linting passed".
- `./scripts/lint-style.sh` — passes; no lines over 100 chars; `git diff --check` clean.
- `#print axioms` on the three lemmas — only `[propext, Classical.choice, Quot.sound]`.

Toward #893.
