### PR TITLE
auto-task(LorentzGroup): add API-map.yaml tracking the Lorentz Group API

### DIFF
--- a/Physlib/Relativity/LorentzGroup/API-map.yaml
+++ b/Physlib/Relativity/LorentzGroup/API-map.yaml
@@ -1,0 +1,61 @@
+version: v0.1
+
+Title: "Lorentz Group"
+
+Overview: |
+  The Lorentz group is the group of matrices preserving the Minkowski metric,
+  defined as matrices satisfying Λ * dual Λ = 1. It is the key symmetry group
+  of Minkowski spacetime, used throughout the library to define Lorentz tensors,
+  fermions, and the electromagnetic potential.
+
+ParentAPIs:
+  - Physlib/Relativity/MinkowskiMatrix.lean
+
+References:
+  - "Lorentz Transformations, Rotations, and Boosts, Jaffe. https://cdn.ku.edu.tr/cdn/files/amostafazadeh/phys517_518/phys517_2016f/Handouts/A_Jaffi_Lorentz_Group.pdf"
+
+Requirements:
+
+  - description: LorentzGroup is defined as the set of matrices satisfying Λ * dual Λ = 1
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Basic.lean (LorentzGroup)
+
+  - description: Instance as a group
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Basic.lean (lorentzGroupIsGroup)
+
+  - description: Instance as a Lie group
+    done: false
+    location: N/A
+
+  - description: Inclusion of boosts
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Boosts/Basic.lean (boost)
+
+  - description: Inclusion of rotations
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Rotations.lean (Rotations)
+
+  - description: Different membership conditions
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Basic.lean (mem_iff_self_mul_dual, mem_iff_dual_mul_self, mem_iff_transpose, mem_iff_neg_mem, mem_iff_transpose_mul_minkowskiMatrix_mul_self)
+
+  - description: Definition of proper Lorentz transforms
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Proper.lean (IsProper)
+
+  - description: Definition of orthochronous Lorentz transforms
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Orthochronous/Basic.lean (IsOrthochronous)
+
+  - description: Definition of the restricted Lorentz group
+    done: true
+    location: Physlib/Relativity/LorentzGroup/Restricted/Basic.lean (restricted)
+
+  - description: Prove topological properties of the Orthochronous Lorentz Group
+    done: false
+    location: N/A
+
+  - description: Prove that every member of the restricted Lorentz group is a combination of a boost and a rotation
+    done: false
+    location: N/A


### PR DESCRIPTION
## Summary

Adds `Physlib/Relativity/LorentzGroup/API-map.yaml` tracking the Lorentz Group API. Uses GitHub issue #885 as a reference for intended scope; every entry is generated from and verified against the directory's Lean files.

No Lean source is touched — this is a single new `.yaml` file.

## Verification

Links are pinned to the base commit (`3dddd61`) so line numbers stay accurate.

| Field / Requirement | YAML says | Source of truth |
|---|---|---|
| **Title / Overview** | "Lorentz Group" — group of matrices preserving the Minkowski metric (Λ \* dual Λ = 1) | module docstring + def: [Basic.lean#L14-L16](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L14-L16), [#L44-L48](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L44-L48); scope ("Lorentz tensors, fermions, EM potential") from issue #885 *Need* section |
| **ParentAPIs** | `Physlib/Relativity/MinkowskiMatrix.lean` | key import: [Basic.lean#L8](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L8) |
| **References** | Jaffe, *Lorentz Transformations, Rotations, and Boosts* | cited in docstring: [Basic.lean#L18-L21](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L18-L21) |

### Requirements (each checked against the code, not the issue's checkboxes)

| Requirement | done | Evidence |
|---|---|---|
| `LorentzGroup` defined as matrices with Λ \* dual Λ = 1 | ✅ | [Basic.lean#L44-L48](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L44-L48) (`LorentzGroup`) |
| Instance as a group | ✅ | [Basic.lean#L129-L138](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L129-L138) (`lorentzGroupIsGroup`) |
| Instance as a Lie group | ❌ | TODO: [Basic.lean#L26](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L26) |
| Inclusion of boosts | ✅ | [Boosts/Basic.lean#L50-L52](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Boosts/Basic.lean#L50-L52) (`boost`) |
| Inclusion of rotations | ✅ | [Rotations.lean#L23](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Rotations.lean#L23) (`Rotations`) |
| Different membership conditions | ✅ | [Basic.lean#L58-L119](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Basic.lean#L58-L119) (`mem_iff_self_mul_dual`, `mem_iff_dual_mul_self`, `mem_iff_transpose`, `mem_iff_neg_mem`, `mem_iff_transpose_mul_minkowskiMatrix_mul_self`) |
| Proper Lorentz transforms | ✅ | [Proper.lean#L176](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Proper.lean#L176) (`IsProper`) |
| Orthochronous Lorentz transforms | ✅ | [Orthochronous/Basic.lean#L35](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Orthochronous/Basic.lean#L35) (`IsOrthochronous`) |
| Restricted Lorentz group | ✅ | [Restricted/Basic.lean#L29](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean#L29) (`restricted`) |
| Topological properties of orthochronous group | ❌ | TODO: [Orthochronous/Basic.lean#L20](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Orthochronous/Basic.lean#L20) |
| Restricted = boost × rotation | ❌ | TODO: [Restricted/Basic.lean#L19-L20](https://github.com/leanprover-community/physlib/blob/3dddd61e231b2f8936dbaa1460dc60df71bc434d/Physlib/Relativity/LorentzGroup/Restricted/Basic.lean#L19-L20) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)