### PR TITLE
docs(classical-mechanics): add TODO to split harmonic oscillator solution

### DIFF
--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -66,7 +66,18 @@ prove that they satisfy the equation of motion, and prove some properties of the
 References for the classical harmonic oscillator include:
 - Landau & Lifshitz, Mechanics, page 58, section 21.
 
+## v. TODOs
+
 -/
+
+TODO "Split this file into smaller modules, keeping `Solution.lean` as an umbrella import.
+The intended organization is:
+- `Solution.Basic` for trajectory construction and equation-of-motion facts;
+- `Solution.Energy` for energy-related lemmas;
+- `Solution.InitialData` for alternative initial-condition parametrizations;
+- `Solution.AmplitudePhase` for the amplitude-phase normal form;
+- `Solution.SpecialTimes` for velocity-zero times, turning points, and zero crossings;
+- `Solution.Periodicity` for period and recurrence facts."
 
 @[expose] public section
 

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Solution.lean
@@ -66,8 +66,6 @@ prove that they satisfy the equation of motion, and prove some properties of the
 References for the classical harmonic oscillator include:
 - Landau & Lifshitz, Mechanics, page 58, section 21.
 
-## v. TODOs
-
 -/
 
 TODO "Split this file into smaller modules, keeping `Solution.lean` as an umbrella import.


### PR DESCRIPTION
Adds a module-level TODO to `HarmonicOscillator/Solution.lean` recording the intended follow-up split discussed after #1308.

The TODO keeps `Solution.lean` as the umbrella import and records the proposed organization:

- `Solution.Basic` for trajectory construction and equation-of-motion facts;
- `Solution.Energy` for energy-related lemmas;
- `Solution.InitialData` for alternative initial-condition parametrizations;
- `Solution.AmplitudePhase` for the amplitude-phase normal form;
- `Solution.SpecialTimes` for velocity-zero times, turning points, and zero crossings;
- `Solution.Periodicity` for period and recurrence facts.

This is documentation only; no declarations or proofs are changed.
