### PR TITLE
auto-task(BlochSphere): drop unused BargmannInvariant import

### DIFF
--- a/QuantumInfo/States/Pure/BlochSphere.lean
+++ b/QuantumInfo/States/Pure/BlochSphere.lean
@@ -5,7 +5,6 @@ Authors: Anand Nambakam
 -/
 module
 
-public import QuantumInfo.States.Pure.BargmannInvariant
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 


### PR DESCRIPTION
## Summary

Minimizes the imports of `QuantumInfo/States/Pure/BlochSphere.lean`.

## Change

Removed the unused import:

```
public import QuantumInfo.States.Pure.BargmannInvariant
```

The file's declarations (`BlochSphere`, `blochVecRaw`, `blochPoint`,
`blochPoint_val`, `solidAngle`, `dot_blochPoint`) reference nothing from
`BargmannInvariant` (nor its transitive `Braket` content). The only mention of
Pancharatnam/Berry is in the `## References` bibliography of the module
docstring, not in any code. The remaining two imports are both genuinely used:

- `Mathlib.LinearAlgebra.CrossProduct` — the `⨯₃` cross-product notation in `solidAngle`
- `Mathlib.Analysis.InnerProductSpace.PiL2` — `EuclideanSpace`, `WithLp.equiv`, `EuclideanSpace.norm_eq`/`dist_eq`

## Downstream

No file imports `QuantumInfo.States.Pure.BlochSphere`, so no downstream imports
needed to be added.

## Verification

`lake build QuantumInfo` completes successfully (8636 jobs), no `sorry`, no new
axioms, no new errors or warnings.
