### PR TITLE
Add Euler-Lagrange equation API to PhyslibAlpha

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -4,6 +4,7 @@ public import PhyslibAlpha.Basic
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
 public import PhyslibAlpha.ClassicalFieldTheory.Local.Action
 public import PhyslibAlpha.ClassicalFieldTheory.Local.EulerLagrange
+public import PhyslibAlpha.ClassicalFieldTheory.Local.EulerLagrangeEquation
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstOrder
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Basic
 public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation.Criterion

--- a/PhyslibAlpha/ClassicalFieldTheory/Local/EulerLagrangeEquation.lean
+++ b/PhyslibAlpha/ClassicalFieldTheory/Local/EulerLagrangeEquation.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Juan Jose Fernandez Morales. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Jose Fernandez Morales
+-/
+module
+
+public import PhyslibAlpha.ClassicalFieldTheory.Local.FirstVariation
+/-!
+# Local Euler-Lagrange equations
+
+## i. Overview
+
+This module gives a named predicate for fields satisfying the local Euler-Lagrange equations.
+
+The equation itself is still the existing local coordinate equation
+
+`eulerLagrangeOp L f = 0`.
+
+The purpose of this file is only to expose that condition as a reusable API point and to restate
+the already-proved criticality criteria using this named predicate. It does not introduce a new
+Euler-Lagrange operator or any new analytic hypotheses.
+
+## ii. Key results
+
+- `ClassicalFieldTheory.Local.SatisfiesEulerLagrange`
+- `ClassicalFieldTheory.Local.
+  isCritical_iff_satisfiesEulerLagrange_of_contDiff_and_smoothInCoordinates`
+- `ClassicalFieldTheory.Local.
+  isCritical_iff_satisfiesEulerLagrange_of_admissibleForAction_and_smoothInCoordinates`
+
+## iii. Table of contents
+
+- A. Euler-Lagrange equation predicate
+- B. Criticality criteria
+
+## iv. References
+
+- J. Cortés and A. Haupt, *Lecture Notes on Mathematical Methods of Classical Physics*,
+  arXiv:1612.03100v2, Chapter 5, Theorem 5.2.
+
+-/
+
+@[expose] public section
+
+open scoped ContDiff
+
+namespace ClassicalFieldTheory
+namespace Local
+
+/-!
+## A. Euler-Lagrange equation predicate
+
+-/
+
+/-- A field satisfies the local Euler-Lagrange equations for a local lagrangian when the
+Euler-Lagrange operator vanishes along that field. -/
+def SatisfiesEulerLagrange (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) : Prop :=
+  eulerLagrangeOp L f = 0
+
+@[simp]
+lemma satisfiesEulerLagrange_iff (L : Lagrangian d m k)
+    (f : Space d → EuclideanSpace ℝ (Fin m)) :
+    SatisfiesEulerLagrange L f ↔ eulerLagrangeOp L f = 0 :=
+  Iff.rfl
+
+lemma SatisfiesEulerLagrange.eulerLagrangeOp_eq_zero
+    {L : Lagrangian d m k} {f : Space d → EuclideanSpace ℝ (Fin m)}
+    (h : SatisfiesEulerLagrange L f) :
+    eulerLagrangeOp L f = 0 :=
+  h
+
+lemma SatisfiesEulerLagrange.of_eulerLagrangeOp_eq_zero
+    {L : Lagrangian d m k} {f : Space d → EuclideanSpace ℝ (Fin m)}
+    (h : eulerLagrangeOp L f = 0) :
+    SatisfiesEulerLagrange L f :=
+  h
+
+/-!
+## B. Criticality criteria
+
+-/
+
+theorem isCritical_iff_satisfiesEulerLagrange_of_contDiff_and_smoothInCoordinates
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m)) (hf : ContDiff ℝ ∞ f)
+    (hL : Lagrangian.SmoothInCoordinates L)
+    (hbase : HasFiniteAction L f) :
+    IsCritical L f ↔ SatisfiesEulerLagrange L f := by
+  exact isCritical_iff_eulerLagrange_zero_of_contDiff_and_smoothInCoordinates L f hf hL hbase
+
+theorem isCritical_iff_satisfiesEulerLagrange_of_admissibleForAction_and_smoothInCoordinates
+    (L : Lagrangian d m k) (f : Space d → EuclideanSpace ℝ (Fin m))
+    (hLf : IsAdmissibleForAction L f)
+    (hL : Lagrangian.SmoothInCoordinates L) :
+    IsCritical L f ↔ SatisfiesEulerLagrange L f := by
+  exact isCritical_iff_eulerLagrange_zero_of_admissibleForAction_and_smoothInCoordinates L f hLf hL
+
+end Local
+end ClassicalFieldTheory


### PR DESCRIPTION
This PR adds a small named API layer for the local Euler--Lagrange equations in `PhyslibAlpha`.

It introduces:

- `SatisfiesEulerLagrange L f`, a transparent predicate for the existing condition `eulerLagrangeOp L f = 0`;
- basic conversion lemmas between `SatisfiesEulerLagrange L f` and `eulerLagrangeOp L f = 0`;
- restatements of the existing criticality criteria using the named predicate.

This PR does not introduce a new Euler--Lagrange operator or new analytic hypotheses. It only names the equation solved by a field and exposes the already-proved criticality equivalences in that vocabulary.

Validation:

- `lake build PhyslibAlpha.ClassicalFieldTheory.Local.EulerLagrangeEquation`
- `lake build PhyslibAlpha`
- `lake exe runPhyslibAlphaLinters`
- `./scripts/PhyslibAlpha/alphaPythonLinters.sh`
- `python3 ./scripts/PhyslibAlpha/alphaFileImports.py`
- `python3 ./scripts/PhyslibAlpha/noAlphaImports.py`
