### PR TITLE
feat(ClassicalMechanics): add rigid-body angular momentum and prove L = Iω

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -81,6 +81,7 @@ public import Physlib.Mathematics.Calculus.ParametricIntegration
 public import Physlib.Mathematics.Calculus.Wirtinger.Basic
 public import Physlib.Mathematics.Calculus.Wirtinger.Coordinate
 public import Physlib.Mathematics.ConjModule
+public import Physlib.Mathematics.CrossProduct
 public import Physlib.Mathematics.CrossProductMatrix
 public import Physlib.Mathematics.DataStructures.FourTree.Basic
 public import Physlib.Mathematics.DataStructures.FourTree.UniqueMap

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -17,6 +17,7 @@ public import Physlib.ClassicalMechanics.OrbitalMechanics.VisViva
 public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
+public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum
 public import Physlib.ClassicalMechanics.RigidBody.AngularVelocity
 public import Physlib.ClassicalMechanics.RigidBody.Basic
 public import Physlib.ClassicalMechanics.RigidBody.Motion

--- a/Physlib/ClassicalMechanics/RigidBody/AngularMomentum.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularMomentum.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Physlib.ClassicalMechanics.RigidBody.Basic
+public import Physlib.Mathematics.CrossProductMatrix
+/-!
+
+# Angular momentum of a rigid body
+
+For a rigid body rotating with angular velocity `ω` about its reference point, each body point at
+position `r` moves with velocity `ω × r`, so the body's angular momentum about that point is
+`L = ∫ r × (ω × r) dm`. Expanding the double cross product,
+`r × (ω × r) = |r|² ω − (r · ω) r`, shows that `L` is linear in `ω` with matrix the inertia tensor:
+`L = I ω`.
+
+## References
+- Landau and Lifshitz, Mechanics, Section 32.
+-/
+
+@[expose] public section
+
+open Manifold Matrix
+
+namespace RigidBody
+
+/-- The angular momentum `L = ∫ r × (ω × r) dm` of a rigid body rotating with angular velocity `ω`
+about its reference point (each body point at `r` moving with velocity `ω × r`). Its `i`-th
+component is `ρ` applied to the scalar field `[r × (ω × r)]ᵢ`. -/
+noncomputable def angularMomentum (R : RigidBody 3) (ω : Fin 3 → ℝ) : Fin 3 → ℝ := fun i =>
+  R.ρ ⟨fun x => ((x : Fin 3 → ℝ) ⨯₃ (ω ⨯₃ (x : Fin 3 → ℝ))) i, ContDiff.contMDiff <| by
+    have h : (fun x : Space 3 => ((x : Fin 3 → ℝ) ⨯₃ (ω ⨯₃ (x : Fin 3 → ℝ))) i)
+        = fun x => (∑ k, (x k) ^ 2) * ω i - (∑ j, x j * ω j) * x i :=
+      funext fun x => cross_cross_self_apply (x : Fin 3 → ℝ) ω i
+    rw [h]; fun_prop⟩
+
+/-- The angular momentum of a rigid body equals its inertia tensor applied to the angular velocity:
+`L = I ω`. -/
+theorem angularMomentum_eq_inertiaTensor_mulVec (R : RigidBody 3) (ω : Fin 3 → ℝ) :
+    R.angularMomentum ω = R.inertiaTensor *ᵥ ω := by
+  funext i
+  simp only [angularMomentum, mulVec, dotProduct, inertiaTensor]
+  have hsmul : ∀ j : Fin 3,
+      R.ρ ⟨fun x => (if i = j then 1 else 0) * ∑ k, (x k) ^ 2 - x i * x j,
+        ContDiff.contMDiff <| by fun_prop⟩ * ω j
+      = R.ρ (ω j • ⟨fun x => (if i = j then 1 else 0) * ∑ k, (x k) ^ 2 - x i * x j,
+        ContDiff.contMDiff <| by fun_prop⟩) := by
+    intro j
+    rw [map_smul, smul_eq_mul, mul_comm]
+  rw [Finset.sum_congr rfl (fun j _ => hsmul j), ← map_sum]
+  congr 1
+  ext x
+  simp only [ContMDiffMap.coeFn_mk]
+  rw [cross_cross_self_apply, ← ContMDiffMap.coeFnAddMonoidHom_apply, map_sum,
+    Finset.sum_apply]
+  simp only [ContMDiffMap.coeFnAddMonoidHom_apply, ContMDiffMap.coe_smul, Pi.smul_apply,
+    ContMDiffMap.coeFn_mk, smul_eq_mul]
+  fin_cases i <;> simp [Fin.sum_univ_three] <;> ring
+
+end RigidBody

--- a/Physlib/ClassicalMechanics/RigidBody/AngularMomentum.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularMomentum.lean
@@ -6,7 +6,7 @@ Authors: Giuseppe Sorge
 module
 
 public import Physlib.ClassicalMechanics.RigidBody.Basic
-public import Physlib.Mathematics.CrossProductMatrix
+public import Physlib.Mathematics.CrossProduct
 /-!
 
 # Angular momentum of a rigid body

--- a/Physlib/Mathematics/CrossProduct.lean
+++ b/Physlib/Mathematics/CrossProduct.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Mathlib.Data.Matrix.Mul
+public import Mathlib.Data.Real.Basic
+public import Mathlib.LinearAlgebra.CrossProduct
+/-!
+
+# The cross product of three-dimensional vectors
+
+Identities for the cross product `⨯₃` on `Fin 3 → ℝ`, beyond those already in Mathlib, used in the
+formalisation of rigid-body dynamics.
+
+-/
+
+@[expose] public section
+
+namespace Matrix
+
+/-- The component form of the triple cross product `v ⨯₃ (w ⨯₃ v)`: by the `bac−cab` identity its
+`i`-th entry is `|v|² wᵢ − (v · w) vᵢ`, written with the explicit component sums `∑ k, (v k)²` and
+`∑ j, v j * w j`. -/
+lemma cross_cross_self_apply (v w : Fin 3 → ℝ) (i : Fin 3) :
+    (v ⨯₃ (w ⨯₃ v)) i = (∑ k, (v k) ^ 2) * w i - (∑ j, v j * w j) * v i := by
+  rw [cross_cross_eq_smul_sub_smul']
+  simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, dotProduct, Fin.sum_univ_three]
+  ring
+
+end Matrix

--- a/Physlib/Mathematics/CrossProductMatrix.lean
+++ b/Physlib/Mathematics/CrossProductMatrix.lean
@@ -17,9 +17,6 @@ The hat map sends a vector `ω : Fin 3 → ℝ` to the skew-symmetric matrix `[�
 `[ω]ₓ *ᵥ v = ω ⨯₃ v`. It realises the correspondence between `ℝ³` and the skew-symmetric `3 × 3`
 matrices (the Lie algebra `𝖘𝖔(3)`), and underlies the angular velocity of a rigid body.
 
-The file also records the component form of the triple (`bac−cab`) cross product `v ⨯₃ (w ⨯₃ v)`,
-used to express the angular momentum of a rigid body.
-
 -/
 
 @[expose] public section
@@ -69,14 +66,5 @@ lemma crossProductMatrix_crossProductVee {A : Matrix (Fin 3) (Fin 3) ℝ} (hA : 
     first
       | exact (h _ _).symm
       | exact (hdiag _).symm
-
-/-- The component form of the triple cross product `v ⨯₃ (w ⨯₃ v)`: by the `bac−cab` identity its
-`i`-th entry is `|v|² wᵢ − (v · w) vᵢ`, written with the explicit component sums `∑ k, (v k)²` and
-`∑ j, v j * w j`. -/
-lemma cross_cross_self_apply (v w : Fin 3 → ℝ) (i : Fin 3) :
-    (v ⨯₃ (w ⨯₃ v)) i = (∑ k, (v k) ^ 2) * w i - (∑ j, v j * w j) * v i := by
-  rw [cross_cross_eq_smul_sub_smul']
-  simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, dotProduct, Fin.sum_univ_three]
-  ring
 
 end Matrix

--- a/Physlib/Mathematics/CrossProductMatrix.lean
+++ b/Physlib/Mathematics/CrossProductMatrix.lean
@@ -17,6 +17,9 @@ The hat map sends a vector `ω : Fin 3 → ℝ` to the skew-symmetric matrix `[�
 `[ω]ₓ *ᵥ v = ω ⨯₃ v`. It realises the correspondence between `ℝ³` and the skew-symmetric `3 × 3`
 matrices (the Lie algebra `𝖘𝖔(3)`), and underlies the angular velocity of a rigid body.
 
+The file also records the component form of the triple (`bac−cab`) cross product `v ⨯₃ (w ⨯₃ v)`,
+used to express the angular momentum of a rigid body.
+
 -/
 
 @[expose] public section
@@ -66,5 +69,14 @@ lemma crossProductMatrix_crossProductVee {A : Matrix (Fin 3) (Fin 3) ℝ} (hA : 
     first
       | exact (h _ _).symm
       | exact (hdiag _).symm
+
+/-- The component form of the triple cross product `v ⨯₃ (w ⨯₃ v)`: by the `bac−cab` identity its
+`i`-th entry is `|v|² wᵢ − (v · w) vᵢ`, written with the explicit component sums `∑ k, (v k)²` and
+`∑ j, v j * w j`. -/
+lemma cross_cross_self_apply (v w : Fin 3 → ℝ) (i : Fin 3) :
+    (v ⨯₃ (w ⨯₃ v)) i = (∑ k, (v k) ^ 2) * w i - (∑ j, v j * w j) * v i := by
+  rw [cross_cross_eq_smul_sub_smul']
+  simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, dotProduct, Fin.sum_univ_three]
+  ring
 
 end Matrix


### PR DESCRIPTION
This PR adds the **angular momentum** of a rigid body and proves the fundamental identity `L = I ω`, the first step of the Landau–Lifshitz §32 rigid-body dynamics arc (#893).

For a body rotating with angular velocity `ω` about its reference point, each point at `r` moves with velocity `ω × r`, so the angular momentum is `L = ∫ r × (ω × r) dm`. Expanding the double cross product, `r × (ω × r) = |r|² ω − (r · ω) r`, shows that `L` is linear in `ω` with matrix the (already-formalized) inertia tensor.

### `Physlib/ClassicalMechanics/RigidBody/AngularMomentum.lean` (new)
- `RigidBody.angularMomentum ω` — the angular momentum, defined as `ρ` applied componentwise to the physical integrand `r × (ω × r)` (mathlib's `⨯₃` on the `Space 3` coordinates);
- `angularMomentum_eq_inertiaTensor_mulVec` — `L = inertiaTensor *ᵥ ω`.

### `Physlib/Mathematics/CrossProductMatrix.lean`
- `Matrix.cross_cross_self_apply` — the general `bac−cab` expansion `[v ⨯₃ (w ⨯₃ v)]ᵢ = |v|² wᵢ − (v · w) vᵢ` for `v w : Fin 3 → ℝ`, a thin componentwise corollary of mathlib's `cross_cross_eq_smul_sub_smul'`. It is the algebraic core of `L = Iω` and, being a general cross-product identity with no physics content, lives in the general cross-product file rather than the classical-mechanics one.

Builds only on merged master (`RigidBody.inertiaTensor` and the `ρ` mass-distribution API in `Basic.lean`, plus the cross-product file from #1324/#1363). All declarations reduce to `[propext, Classical.choice, Quot.sound]`.

This is the shared algebraic kernel of the next steps: König's kinetic-energy decomposition `T = ½M|V|² + ½ ω · Iω` is the same expansion dotted with `ω`, and Euler's equations consume `L = Iω`.

Toward #893.
