### PR TITLE
ClassicalMechanics: total time derivative does not affect the Euler-Lagrange operator

### DIFF
--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -10,6 +10,8 @@ public import Mathlib.Analysis.InnerProductSpace.Dual
 public import Physlib.SpaceAndTime.Time.Derivatives
 public import Mathlib.Analysis.Calculus.ContDiff.CPolynomial
 public import Physlib.Mathematics.VariationalCalculus.HasVarGradient
+public import Physlib.ClassicalMechanics.EulerLagrange
+
 /-!
 
 # Equivalent Lagrangians under Total Derivatives
@@ -208,7 +210,7 @@ lemma isTotalTimeDerivative_neg {δL : Time → X → X → ℝ} (h :  IsTotalTi
     simp only [fderiv_fun_neg, _root_.neg_apply]
 
 /--
-If δL is a total time derivative (of a smooth function), then it is smooth 
+If δL is a total time derivative (of a smooth function), then it is smooth
 -/
 lemma totalTimeDerivative_contDiff {δL : Time → X → X → ℝ} (h : IsTotalTimeDerivative δL):
     ContDiff ℝ ∞ ↿δL := by
@@ -216,7 +218,7 @@ lemma totalTimeDerivative_contDiff {δL : Time → X → X → ℝ} (h : IsTotal
  let Fder_v := Prod.map (fderiv ℝ ↿(fun t q => F t q)) (fun (v : X) => v )
  let regroup := ↿(fun (t : Time) (q : X) (v : X) => ((t, q), v))
  let appv := fun (FV : ((Time × X →L[ℝ] ℝ) × X )) => FV.fst (1, FV.snd)
- have hδL : ↿δL = appv ∘ Fder_v ∘ regroup := by 
+ have hδL : ↿δL = appv ∘ Fder_v ∘ regroup := by
    funext tqv
    rcases tqv with ⟨t, q, v⟩
    simp
@@ -324,7 +326,7 @@ lemma totalTimeDerivative_varGradient_equivalenvce [CompleteSpace X] (L L' : Tim
       simp only [hL, hL', ↓reduceDIte]
 
 /--
-Corollary: If L and L' differ by a total time derivative, then the corresponding Euler-Lagrange 
+Corollary: If L and L' differ by a total time derivative, then the corresponding Euler-Lagrange
 operators coincide
 -/
 lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : Time → X → X → ℝ) 
@@ -336,7 +338,7 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
       | inl hL => 
         constructor 
         · exact hL
-        · have h_triv : ↿L' =  ↿L + ↿(L' - L) := by 
+        · have h_triv : ↿L' =  ↿L + ↿(L' - L) := by
             funext tqv
             rcases tqv with ⟨t, q', v⟩
             rw [Pi.add_apply]
@@ -346,10 +348,10 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
           rw [h_triv]
           apply ContDiff.add
           · exact hL
-          · exact h_δL_contDiff 
-      | inr hL' => 
+          · exact h_δL_contDiff
+      | inr hL' =>
         constructor
-        · have h_triv : ↿L =  ↿L' + ↿(-(L' - L)) := by 
+        · have h_triv : ↿L =  ↿L' + ↿(-(L' - L)) := by
             funext tqv
             rcases tqv with ⟨t, q', v⟩
             rw [Pi.add_apply]
@@ -361,8 +363,8 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
           · exact hL'
           · exact h_δL_contDiff
         · exact hL'
-  rw [←euler_lagrange_varGradient L q hq hContDiff_both.left]
-  rw [←euler_lagrange_varGradient L' q hq hContDiff_both.right]
+  rw [← euler_lagrange_varGradient L q hq hContDiff_both.left]
+  rw [← euler_lagrange_varGradient L' q hq hContDiff_both.right]
   apply Eq.symm
   apply totalTimeDerivative_varGradient_equivalenvce
   · exact htot

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -331,7 +331,7 @@ operators coincide
 -/
 lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : Time → X → X → ℝ)
     (htot : IsTotalTimeDerivative (L' - L)) (hContDiff : (ContDiff ℝ ∞ ↿L) ∨ (ContDiff ℝ ∞ ↿L'))
-    (q : Time → X)    (hq : ContDiff ℝ ∞ q) : eulerLagrangeOp L q = eulerLagrangeOp L' q := by
+    (q : Time → X) (hq : ContDiff ℝ ∞ q) : eulerLagrangeOp L q = eulerLagrangeOp L' q := by
   rcases (isTotalTimeDerivative_explicit.mp htot) with ⟨F, hFContDiff, hEq⟩
   have hContDiff_both :  (ContDiff ℝ ∞ ↿L) ∧ (ContDiff ℝ ∞ ↿L') := by
     cases hContDiff with

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -346,9 +346,7 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
             simp
           have h_δL_contDiff := totalTimeDerivative_contDiff htot
           rw [h_triv]
-          apply ContDiff.add
-          · exact hL
-          · exact h_δL_contDiff
+          exact hL.add h_δL_contDiff
       | inr hL' =>
         constructor
         · have h_triv : ↿L =  ↿L' + ↿(-(L' - L)) := by

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -357,9 +357,7 @@ lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : T
             simp
           have h_δL_contDiff := totalTimeDerivative_contDiff (isTotalTimeDerivative_neg htot)
           rw [h_triv]
-          apply ContDiff.add
-          · exact hL'
-          · exact h_δL_contDiff
+          exact hL'.add h_δL_contDiff
         · exact hL'
   rw [← euler_lagrange_varGradient L q hq hContDiff_both.left]
   rw [← euler_lagrange_varGradient L' q hq hContDiff_both.right]

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -221,7 +221,7 @@ lemma totalTimeDerivative_contDiff {δL : Time → X → X → ℝ} (h : IsTotal
  have hδL : ↿δL = appv ∘ Fder_v ∘ regroup := by
    funext tqv
    rcases tqv with ⟨t, q, v⟩
-   simp
+   simp only [Function.comp_apply]
    change δL t q v = appv (Fder_v (regroup (t, q, v)))
    rw [heq t q v]
    rfl
@@ -329,14 +329,14 @@ lemma totalTimeDerivative_varGradient_equivalenvce [CompleteSpace X] (L L' : Tim
 Corollary: If L and L' differ by a total time derivative, then the corresponding Euler-Lagrange
 operators coincide
 -/
-lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : Time → X → X → ℝ) 
-    (htot : IsTotalTimeDerivative (L' - L)) (hContDiff : (ContDiff ℝ ∞ ↿L) ∨ (ContDiff ℝ ∞ ↿L') )
+lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : Time → X → X → ℝ)
+    (htot : IsTotalTimeDerivative (L' - L)) (hContDiff : (ContDiff ℝ ∞ ↿L) ∨ (ContDiff ℝ ∞ ↿L'))
     (q : Time → X)    (hq : ContDiff ℝ ∞ q) : eulerLagrangeOp L q = eulerLagrangeOp L' q := by
   rcases (isTotalTimeDerivative_explicit.mp htot) with ⟨F, hFContDiff, hEq⟩
   have hContDiff_both :  (ContDiff ℝ ∞ ↿L) ∧ (ContDiff ℝ ∞ ↿L') := by
     cases hContDiff with
-      | inl hL => 
-        constructor 
+      | inl hL =>
+        constructor
         · exact hL
         · have h_triv : ↿L' =  ↿L + ↿(L' - L) := by
             funext tqv

--- a/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
+++ b/Physlib/ClassicalMechanics/Lagrangian/TotalDerivativeEquivalence.lean
@@ -207,6 +207,28 @@ lemma isTotalTimeDerivative_neg {δL : Time → X → X → ℝ} (h :  IsTotalTi
     unfold Time.deriv
     simp only [fderiv_fun_neg, _root_.neg_apply]
 
+/--
+If δL is a total time derivative (of a smooth function), then it is smooth 
+-/
+lemma totalTimeDerivative_contDiff {δL : Time → X → X → ℝ} (h : IsTotalTimeDerivative δL):
+    ContDiff ℝ ∞ ↿δL := by
+ rcases isTotalTimeDerivative_explicit.mp h with ⟨F, hContDiff, heq⟩
+ let Fder_v := Prod.map (fderiv ℝ ↿(fun t q => F t q)) (fun (v : X) => v )
+ let regroup := ↿(fun (t : Time) (q : X) (v : X) => ((t, q), v))
+ let appv := fun (FV : ((Time × X →L[ℝ] ℝ) × X )) => FV.fst (1, FV.snd)
+ have hδL : ↿δL = appv ∘ Fder_v ∘ regroup := by 
+   funext tqv
+   rcases tqv with ⟨t, q, v⟩
+   simp
+   change δL t q v = appv (Fder_v (regroup (t, q, v)))
+   rw [heq t q v]
+   rfl
+ rw [hδL]
+ unfold appv
+ unfold Fder_v
+ unfold regroup
+ fun_prop
+
 /-!
 ## B. Total time derivative do not affect the physical content
   The total time derivative does not affect the Euler-Lagrange equations, because its variational
@@ -300,6 +322,51 @@ lemma totalTimeDerivative_varGradient_equivalenvce [CompleteSpace X] (L L' : Tim
         exact hgrad
     · unfold varGradient
       simp only [hL, hL', ↓reduceDIte]
+
+/--
+Corollary: If L and L' differ by a total time derivative, then the corresponding Euler-Lagrange 
+operators coincide
+-/
+lemma totalTimeDerivative_eulerLagrange_equivalenvce [CompleteSpace X] (L L' : Time → X → X → ℝ) 
+    (htot : IsTotalTimeDerivative (L' - L)) (hContDiff : (ContDiff ℝ ∞ ↿L) ∨ (ContDiff ℝ ∞ ↿L') )
+    (q : Time → X)    (hq : ContDiff ℝ ∞ q) : eulerLagrangeOp L q = eulerLagrangeOp L' q := by
+  rcases (isTotalTimeDerivative_explicit.mp htot) with ⟨F, hFContDiff, hEq⟩
+  have hContDiff_both :  (ContDiff ℝ ∞ ↿L) ∧ (ContDiff ℝ ∞ ↿L') := by
+    cases hContDiff with
+      | inl hL => 
+        constructor 
+        · exact hL
+        · have h_triv : ↿L' =  ↿L + ↿(L' - L) := by 
+            funext tqv
+            rcases tqv with ⟨t, q', v⟩
+            rw [Pi.add_apply]
+            change L' t q' v = L t q' v + (L' - L) t q' v
+            simp
+          have h_δL_contDiff := totalTimeDerivative_contDiff htot
+          rw [h_triv]
+          apply ContDiff.add
+          · exact hL
+          · exact h_δL_contDiff 
+      | inr hL' => 
+        constructor
+        · have h_triv : ↿L =  ↿L' + ↿(-(L' - L)) := by 
+            funext tqv
+            rcases tqv with ⟨t, q', v⟩
+            rw [Pi.add_apply]
+            change L t q' v = L' t q' v + (- (L' - L)) t q' v
+            simp
+          have h_δL_contDiff := totalTimeDerivative_contDiff (isTotalTimeDerivative_neg htot)
+          rw [h_triv]
+          apply ContDiff.add
+          · exact hL'
+          · exact h_δL_contDiff
+        · exact hL'
+  rw [←euler_lagrange_varGradient L q hq hContDiff_both.left]
+  rw [←euler_lagrange_varGradient L' q hq hContDiff_both.right]
+  apply Eq.symm
+  apply totalTimeDerivative_varGradient_equivalenvce
+  · exact htot
+  · exact hq
 
 /-!
 


### PR DESCRIPTION
This is a small follow-up of my [previous commit](https://github.com/leanprover-community/physlib/commit/9c588d88d972b039bc1a38035a070010eedc4615);
adding a total time derivative does not affect the Euler-Lagrange operator.

This required prooving a technical lemma: total time derivative of a smooth function is smooth.