### PR TITLE
feat(ClassicalMechanics): add geometric kinetic energy for the harmonic oscillator

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -9,6 +9,7 @@ public import Physlib.ClassicalMechanics.FreeParticle.Basic
 public import Physlib.ClassicalMechanics.HamiltonsEquations
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.Basic
+public import Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.KineticEnergy
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.Trajectory
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Solution
 public import Physlib.ClassicalMechanics.Lagrangian.TotalDerivativeEquivalence

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Physlib.SpaceAndTime.Space.Basic
 public import Mathlib.Geometry.Manifold.Diffeomorph
+public import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+
 /-!
 # Configuration space of the harmonic oscillator
 
@@ -18,6 +20,10 @@ possible positions of the oscillator, formalised here as a one-dimensional smoot
 `Q` carries a single chosen global coordinate, modeled by `EuclideanSpace ℝ (Fin 1)`. This
 coordinate supplies the topology and the smooth-manifold structure through a single global
 chart.
+
+The global coordinate also identifies each tangent space with the same Euclidean model. The
+map `tangentCoord q` records the coordinate representative of a tangent vector at `q`; this
+tangent-coordinate infrastructure is used by later geometric constructions on the oscillator.
 
 ## ii. Key results
 
@@ -31,6 +37,12 @@ chart.
   diffeomorphism, upgrading `valHomeomorphism` to a smooth identification of `Q` with its model.
 - the `ChartedSpace` and `IsManifold` instances, exhibiting `Q` as a one-dimensional analytic
   manifold modeled on `EuclideanSpace ℝ (Fin 1)`.
+- `tangentCoord` : the chart-induced continuous linear equivalence from the tangent space at a
+  configuration to `EuclideanSpace ℝ (Fin 1)`.
+- `instNormedAddCommGroupTangent` and `instNormedSpaceTangent` : the normed real vector-space
+  structure on tangent spaces, supplied through the global coordinate model.
+- `instFiniteDimensionalTangent` : finite-dimensionality of each tangent space, transported
+  through `tangentCoord`.
 - `ConfigurationSpace.toSpace` : the point of physical `Space 1` determined by a
   configuration.
 
@@ -40,7 +52,8 @@ chart.
 - B. Topology and coordinate homeomorphism
 - C. Smooth manifold structure
 - D. The coordinate diffeomorphism
-- E. Map to physical space
+- E. Tangent-coordinate infrastructure
+- F. Map to physical space
 
 ## iv. References
 
@@ -53,6 +66,8 @@ chart.
 namespace ClassicalMechanics
 
 namespace HarmonicOscillator
+
+open scoped Manifold
 
 TODO "The API around the configuration space
     should be improved to allow further development of a proper
@@ -76,6 +91,7 @@ structure ConfigurationSpace where
 
 namespace ConfigurationSpace
 
+/-- Two configurations are equal when their chosen global coordinates are equal. -/
 @[ext]
 lemma ext {x y : ConfigurationSpace} (h : x.val = y.val) : x = y := by
   cases x
@@ -88,6 +104,8 @@ underlying coordinate. This mirrors the function-like use of `EuclideanSpace ℝ
 instance : CoeFun ConfigurationSpace (fun _ => Fin 1 → ℝ) where
   coe x := fun i => x.val i
 
+/-- Applying a configuration as a function reads the corresponding component of its global
+coordinate. -/
 lemma coe_apply (x : ConfigurationSpace) (i : Fin 1) : x i = x.val i := rfl
 
 /-!
@@ -195,8 +213,52 @@ def valDiffeomorph :
         from rfl, contMDiffOn_univ] at h
     exact h
 
+end ConfigurationSpace
+
 /-!
-## E. Map to physical space
+## E. Tangent-coordinate infrastructure
+
+The global coordinate on `ConfigurationSpace` also gives a coordinate representative for tangent
+vectors. The tangent spaces inherit their normed real vector-space structure from the Euclidean
+coordinate model, and `tangentCoord q` records the resulting continuous linear equivalence.
+-/
+
+noncomputable section
+
+-- Let Lean use the definitional tangent/model identification used by `tangentCoord`.
+set_option backward.isDefEq.respectTransparency false
+
+/-- The model-space normed additive group structure on tangent spaces. -/
+instance instNormedAddCommGroupTangent (q : ConfigurationSpace) :
+    NormedAddCommGroup (TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :=
+  inferInstanceAs (NormedAddCommGroup (EuclideanSpace ℝ (Fin 1)))
+
+/-- The model-space real normed vector space structure on tangent spaces. -/
+instance instNormedSpaceTangent (q : ConfigurationSpace) :
+    NormedSpace ℝ (TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :=
+  inferInstanceAs (NormedSpace ℝ (EuclideanSpace ℝ (Fin 1)))
+
+/-- The chart-induced continuous linear equivalence from the tangent space at `q` to the
+Euclidean coordinate model `EuclideanSpace ℝ (Fin 1)`. -/
+def tangentCoord (q : ConfigurationSpace) :
+    TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q ≃L[ℝ] EuclideanSpace ℝ (Fin 1) where
+  toFun v := v
+  invFun v := v
+  map_add' := by simp
+  map_smul' := by simp
+
+/-- Each tangent space is finite-dimensional because it is linearly equivalent to
+`EuclideanSpace ℝ (Fin 1)` through `tangentCoord`. -/
+instance instFiniteDimensionalTangent (q : ConfigurationSpace) :
+    FiniteDimensional ℝ (TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :=
+  LinearEquiv.finiteDimensional (tangentCoord q).symm.toLinearEquiv
+
+end
+
+namespace ConfigurationSpace
+
+/-!
+## F. Map to physical space
 
 The point of one-dimensional physical `Space 1` determined by a configuration, obtained by
 reading off the underlying coordinate. This links the abstract configuration manifold to the
@@ -206,6 +268,8 @@ concrete coordinate model.
 /-- The position in one-dimensional space associated to the configuration. -/
 def toSpace (q : ConfigurationSpace) : Space 1 := ⟨fun i => q.val i⟩
 
+/-- The physical-space coordinate associated to a configuration is its chosen global
+coordinate. -/
 lemma toSpace_apply (q : ConfigurationSpace) (i : Fin 1) : q.toSpace i = q.val i := rfl
 
 end ConfigurationSpace

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/KineticEnergy.lean
@@ -7,64 +7,44 @@ module
 
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
 public import Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.Basic
-public import Physlib.Mathematics.Geometry.Metric.PseudoRiemannian.Defs
-public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+public import Mathlib.Geometry.Manifold.VectorBundle.Riemannian
 
 /-!
 # Geometric kinetic energy of the harmonic oscillator
 
 ## i. Overview
 
-The configuration space `Q` of the geometric harmonic oscillator is `ConfigurationSpace`.
-Velocities lie in the tangent bundle `TQ`; at a configuration `q`, a velocity is a tangent
-vector in `TangentSpace I q`.
+The configuration space of the geometric harmonic oscillator is `ConfigurationSpace`.
+At a configuration `q`, velocities are tangent vectors in
+`TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q`.
 
-Given a pseudo-Riemannian metric `g` on `Q`, the definition of the kinetic-energy function
-on `TQ` is given by `geometricKineticEnergy g q v = 1 / 2 * g.inner q v v`. This is the
-metric-induced kinetic term used for natural mechanical systems.
+The oscillator mass determines a Riemannian metric on `ConfigurationSpace`. At each
+configuration `q`, the metric is the mass-scaled Euclidean inner product on tangent
+vectors, recorded by `massMetricVal S q`.
 
-For the oscillator mass metric, tangent vectors are first read in the chosen global
-Euclidean coordinate. The map `tangentCoord q : TangentSpace I q ≃L[ℝ] Model` is the
-chart-induced continuous linear equivalence from the tangent space at `q` to the Euclidean
-coordinate model `Model := EuclideanSpace ℝ (Fin 1)`. We use it to form the pullback of
-the Euclidean inner product to `TangentSpace I q`.
-
-The mass metric `massPseudoRiemannianMetric S` is the mass-scaled pullback of the Euclidean
-inner product along `tangentCoord q`: `S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ`.
-Positivity of `S.m`, together with positive-definiteness of the Euclidean inner product on
-`Model`, gives nondegeneracy and negative index `0`.
-
-Evaluating `geometricKineticEnergy` on `massPseudoRiemannianMetric` gives the usual coordinate
-kinetic-energy expression
+The kinetic energy associated with this mass metric is
+`geometricKineticEnergy S q v = (1 / 2 : ℝ) * S.massRiemannianMetric.inner q v v`.
+In coordinates this gives the standard expression
 `(1 / 2 : ℝ) * S.m * ⟪tangentCoord q v, tangentCoord q v⟫_ℝ`.
 
 ## ii. Key results
 
-- `Model` : the Euclidean coordinate model for the oscillator configuration space.
-- `I` : the model-with-corners structure used for the global chart on `ConfigurationSpace`.
-- `tangentCoord` : the chart-induced continuous linear equivalence from `TangentSpace I q`
-  to `Model`.
-- `instFiniteDimensionalTangent` : finite-dimensionality of each tangent space, transported
-  from `Model` through `tangentCoord`.
-- `geometricKineticEnergy` : for a metric `g` on `Q`, the function
-  `K_g(q, v) = 1 / 2 * g_q(v, v)` on `TQ`.
-- `geometricKineticEnergy_eq` : the formula
-  `geometricKineticEnergy g q v = 1 / 2 * g.inner q v v`.
-- `massPseudoRiemannianMetric` : the mass-scaled pullback of the Euclidean inner product,
-  as a pseudo-Riemannian metric on `ConfigurationSpace`.
-- `massPseudoRiemannianMetric_inner_apply` : evaluation of the mass metric in the global
-  coordinate.
-- `massPseudoRiemannianMetric_pos` : positivity of the oscillator mass metric.
+- `massRiemannianMetric` : the mass-scaled Euclidean inner product as a Riemannian metric
+  on `ConfigurationSpace`.
+- `geometricKineticEnergy` : the geometric kinetic-energy function associated to the
+  oscillator mass metric.
+- `massRiemannianMetric_inner_apply` : evaluation of the mass metric in global tangent
+  coordinates.
+- `massRiemannianMetric_pos` : positive definiteness of the mass Riemannian metric.
 - `geometricKineticEnergy_massMetric_eq` : the metric-induced kinetic energy for
-  `massPseudoRiemannianMetric` is the mass-scaled coordinate kinetic energy.
+  the oscillator mass metric is the mass-scaled coordinate kinetic energy.
 
 ## iii. Table of contents
 
-- A. Coordinate identification of the tangent space
-- B. Metric-induced kinetic energy
-- C. The mass pseudo-Riemannian metric
-- D. Positivity
-- E. Coordinate form of kinetic energy
+- A. Pointwise mass metric
+- B. Riemannian mass metric
+- C. Geometric kinetic energy
+- D. Coordinate formula
 
 ## iv. References
 
@@ -78,221 +58,169 @@ namespace ClassicalMechanics
 namespace HarmonicOscillator
 
 open scoped Manifold
+open Bundle Bornology
 open Manifold ContDiff
 open InnerProductSpace
 
 noncomputable section
 
-/-!
-## A. Coordinate identification of the tangent space
-
-The oscillator configuration space has a single chosen global coordinate modeled on
-`EuclideanSpace ℝ (Fin 1)`. In this one-chart model, each tangent space is represented by
-the same Euclidean coordinate model. The continuous linear equivalence `tangentCoord q`
-gives the coordinate representative of a tangent vector at `q`; it does not install an
-intrinsic inner-product structure on tangent spaces.
--/
-
--- Let Lean use the definitional tangent/model identification used by `tangentCoord`
+-- Let Lean use the definitional tangent-coordinate identification in the metric proofs.
 set_option backward.isDefEq.respectTransparency false
 
-/-- The Euclidean coordinate model for the harmonic oscillator configuration space. -/
-abbrev Model := EuclideanSpace ℝ (Fin 1)
-
-/-- The model-with-corners structure for the global chart on `ConfigurationSpace`. -/
-abbrev I := 𝓘(ℝ, Model)
-
-/-- The chart-induced continuous linear equivalence from the tangent space at `q` to the
-Euclidean coordinate model. It sends a tangent vector to its coordinate representative in
-`Model`. -/
-def tangentCoord (q : ConfigurationSpace) :
-    TangentSpace I q ≃L[ℝ] Model where
-  toFun v := v
-  invFun v := v
-  map_add' := by simp
-  map_smul' := by simp
-
-/-- Each tangent space is finite-dimensional because it is linearly equivalent to the
-finite-dimensional coordinate model through `tangentCoord`. -/
-instance instFiniteDimensionalTangent (q : ConfigurationSpace) :
-    FiniteDimensional ℝ (TangentSpace I q) :=
-  LinearEquiv.finiteDimensional (tangentCoord q).symm.toLinearEquiv
-
-/-- In the single global chart, differentiating the chart inverse in the model direction `v`
-and then reading the resulting tangent vector through `tangentCoord` returns `v`. This is the
-coordinate identity used to show that the mass metric is constant in charts. -/
-private lemma tangentCoord_mfderiv_extChartAt_symm
-    (x₀ : ConfigurationSpace) (y v : Model) :
-    tangentCoord ((extChartAt I x₀).symm y) (mfderiv I I (extChartAt I x₀).symm y v) = v := by
-  change mfderiv I I (extChartAt I x₀).symm y v = v
-  let q : ConfigurationSpace := (extChartAt I x₀).symm y
-  have hpoint : (extChartAt I q) q = y := by
-    simp [q, extChartAt, ConfigurationSpace.valHomeomorphism, ConfigurationSpace.valEquiv]
-  have hderiv := congrArg (fun L => L v)
-    (mfderivWithin_range_extChartAt_symm (I := I) (x := q))
-  rw [hpoint] at hderiv
-  have hid :
-      ((ContinuousLinearMap.id ℝ (TangentSpace 𝓘(ℝ, Model) y)) v : TangentSpace I q) = v := rfl
-  have hderiv' :
-      mfderivWithin 𝓘(ℝ, Model) I (extChartAt I q).symm (Set.range I) y v = v :=
-    hderiv.trans hid
-  simpa [q, extChartAt, mfderivWithin_univ, ConfigurationSpace.valHomeomorphism,
-    ConfigurationSpace.valEquiv] using hderiv'
-
 /-!
-## B. Metric-induced kinetic energy
+## A. Pointwise mass metric
 
-A pseudo-Riemannian metric `g` on `Q` assigns a bilinear form `g_q` to each tangent space
-`TangentSpace I q`. The kinetic-energy function associated to `g` is
-`K_g(q, v) = 1 / 2 * g_q(v, v)`.
--/
-
-/-- For a pseudo-Riemannian metric `g` on `Q`, the kinetic-energy function
-`K_g(q, v) = 1 / 2 * g.inner q v v` on the tangent bundle `TQ`. -/
-noncomputable def geometricKineticEnergy
-    (g : PseudoRiemannianMetric
-      Model
-      Model
-      ConfigurationSpace
-      ω
-      I)
-    (q : ConfigurationSpace)
-    (v : TangentSpace I q) : ℝ :=
-  (1 / 2 : ℝ) * g.inner q v v
-
-/-- The defining formula for `geometricKineticEnergy`. -/
-lemma geometricKineticEnergy_eq
-    (g : PseudoRiemannianMetric
-      Model
-      Model
-      ConfigurationSpace
-      ω
-      I)
-    (q : ConfigurationSpace)
-    (v : TangentSpace I q) :
-    geometricKineticEnergy g q v = (1 / 2 : ℝ) * g.inner q v v := by
-  rfl
-
-/-!
-## C. The mass pseudo-Riemannian metric
-
-The oscillator mass determines the inertial metric. At each configuration `q`, this metric is
-the mass-scaled pullback of the Euclidean inner product on `Model` along the continuous linear
-equivalence `tangentCoord q`.
+The pointwise mass metric is the mass-scaled Euclidean inner product in global tangent
+coordinates. Its positivity, boundedness, and smoothness properties are established here
+before assembling the Riemannian metric.
 -/
 
 /-- The value of the oscillator mass metric at `q`. It is the mass-scaled pullback of the
 Euclidean inner product along `tangentCoord q`, so
 `massMetricVal S q v w = S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ`. -/
 noncomputable def massMetricVal (S : HarmonicOscillator) (q : ConfigurationSpace) :
-    TangentSpace I q →L[ℝ] TangentSpace I q →L[ℝ] ℝ :=
-  S.m • (innerSL ℝ : Model →L[ℝ] Model →L[ℝ] ℝ)
+    TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q →L[ℝ]
+      TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q →L[ℝ] ℝ :=
+  S.m • (innerSL ℝ :
+    EuclideanSpace ℝ (Fin 1) →L[ℝ] EuclideanSpace ℝ (Fin 1) →L[ℝ] ℝ)
 
 /-- Applying the mass metric value to two tangent vectors gives the mass-scaled Euclidean
 inner product of their coordinate representatives. -/
-private lemma massMetricVal_apply
+lemma massMetricVal_apply
     (S : HarmonicOscillator) (q : ConfigurationSpace)
-    (v w : TangentSpace I q) :
+    (v w : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :
     massMetricVal S q v w = S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ := by
   rfl
 
 /-- A nonzero tangent vector has nonzero coordinate representative under `tangentCoord`. -/
-private lemma tangentCoord_ne_zero {q : ConfigurationSpace} {v : TangentSpace I q}
+lemma tangentCoord_ne_zero {q : ConfigurationSpace}
+    {v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q}
     (hv : v ≠ 0) : tangentCoord q v ≠ 0 := by
   intro h
   apply hv
   exact (tangentCoord q).injective (by simpa using h)
 
-/-- The quadratic form associated to the oscillator mass metric has negative index zero at
-every configuration, because `S.m > 0` and the Euclidean inner product is positive definite
-on coordinate representatives. -/
-private lemma massMetricVal_negDim_eq_zero
-    (S : HarmonicOscillator) (q : ConfigurationSpace) :
-    (pseudoRiemannianMetricValToQuadraticForm (massMetricVal S)
-      (by
-        intro q v w
-        rw [massMetricVal_apply, massMetricVal_apply, real_inner_comm]) q).negDim = 0 := by
-  apply QuadraticForm.rankNeg_eq_zero
-  intro v hv
-  change 0 < massMetricVal S q v v
+/-- The oscillator mass metric is positive on nonzero tangent vectors. -/
+lemma massMetricVal_pos
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) (hv : v ≠ 0) :
+    0 < massMetricVal S q v v := by
   rw [massMetricVal_apply]
   exact mul_pos S.m_pos (real_inner_self_pos.mpr (tangentCoord_ne_zero hv))
 
-/-- The mass-scaled pullback of the Euclidean inner product, as a pseudo-Riemannian metric on
-the oscillator configuration space. -/
-noncomputable def massPseudoRiemannianMetric (S : HarmonicOscillator) :
-    PseudoRiemannianMetric
-      Model
-      Model
-      ConfigurationSpace
-      ω
-      I where
-  val := massMetricVal S
-  symm := by
-    intro q v w
+/-- The mass metric unit ball is bounded in the model norm. -/
+lemma massMetricVal_isVonNBounded
+    (S : HarmonicOscillator) (q : ConfigurationSpace) :
+    IsVonNBounded ℝ
+      {v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q | massMetricVal S q v v < 1} := by
+  change IsVonNBounded ℝ
+    {v : EuclideanSpace ℝ (Fin 1) | S.m * ⟪v, v⟫_ℝ < 1}
+  rw [NormedSpace.isVonNBounded_iff']
+  refine ⟨Real.sqrt (1 / S.m), ?_⟩
+  intro v hv
+  have hv' : S.m * ⟪v, v⟫_ℝ < 1 := by simpa using hv
+  rw [real_inner_self_eq_norm_sq] at hv'
+  have hmul : S.m * ‖v‖ ^ 2 < 1 := hv'
+  have hsq_le : ‖v‖ ^ 2 ≤ 1 / S.m := by
+    have hsq_lt : ‖v‖ ^ 2 < 1 / S.m := by
+      rw [lt_div_iff₀ S.m_pos]
+      nlinarith [hmul]
+    exact hsq_lt.le
+  exact Real.le_sqrt_of_sq_le hsq_le
+
+/-- The oscillator mass metric is constant in the global tangent-bundle chart. -/
+lemma massMetricVal_contMDiff (S : HarmonicOscillator) :
+    ContMDiff 𝓘(ℝ, EuclideanSpace ℝ (Fin 1))
+      (𝓘(ℝ, EuclideanSpace ℝ (Fin 1)).prod
+        𝓘(ℝ, EuclideanSpace ℝ (Fin 1) →L[ℝ]
+          EuclideanSpace ℝ (Fin 1) →L[ℝ] ℝ)) ω
+      (fun q : ConfigurationSpace =>
+        TotalSpace.mk'
+          (EuclideanSpace ℝ (Fin 1) →L[ℝ] EuclideanSpace ℝ (Fin 1) →L[ℝ] ℝ)
+          (E := fun q : ConfigurationSpace =>
+            TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q →L[ℝ]
+              TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q →L[ℝ] ℝ)
+          q (massMetricVal S q)) := by
+  intro x
+  rw [contMDiffAt_section]
+  convert! contMDiffAt_const (c := S.m • (innerSL ℝ :
+    EuclideanSpace ℝ (Fin 1) →L[ℝ] EuclideanSpace ℝ (Fin 1) →L[ℝ] ℝ))
+  ext v w
+  simp [hom_trivializationAt_apply, ContinuousLinearMap.inCoordinates, massMetricVal, TangentSpace]
+
+/-!
+## B. Riemannian mass metric
+
+The pointwise bilinear forms assemble into a `ContMDiffRiemannianMetric` on the oscillator
+configuration space.
+-/
+
+/-- The mass-scaled Euclidean inner product as a Riemannian metric on the oscillator
+configuration space. -/
+noncomputable def massRiemannianMetric (S : HarmonicOscillator) :
+    ContMDiffRiemannianMetric 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) ω
+      (EuclideanSpace ℝ (Fin 1))
+      (TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) : ConfigurationSpace → Type _) where
+  inner q := massMetricVal S q
+  symm q v w := by
     rw [massMetricVal_apply, massMetricVal_apply, real_inner_comm]
-  nondegenerate := by
-    intro q v h
-    have hv := h v
-    rw [massMetricVal_apply] at hv
-    have h_inner : ⟪tangentCoord q v, tangentCoord q v⟫_ℝ = 0 := by
-      exact (mul_eq_zero.mp hv).resolve_left S.m_ne_zero
-    apply (tangentCoord q).injective
-    simpa using (inner_self_eq_zero.mp h_inner)
-  smooth_in_charts' := by
-    intro x₀ v w
-    refine (contDiffWithinAt_const (c := S.m * ⟪v, w⟫_ℝ)).congr (fun y _hy => ?_) ?_
-    · rw [massMetricVal_apply, tangentCoord_mfderiv_extChartAt_symm,
-        tangentCoord_mfderiv_extChartAt_symm]
-    · rw [massMetricVal_apply, tangentCoord_mfderiv_extChartAt_symm,
-        tangentCoord_mfderiv_extChartAt_symm]
-  negDim_isLocallyConstant := by
-    apply IsLocallyConstant.of_constant
-    intro x y
-    rw [massMetricVal_negDim_eq_zero S x, massMetricVal_negDim_eq_zero S y]
+  pos q v hv := massMetricVal_pos S q v hv
+  isVonNBounded q := massMetricVal_isVonNBounded S q
+  contMDiff := massMetricVal_contMDiff S
 
 /-!
-## D. Positivity
+## C. Geometric kinetic energy
 
-The mass metric is positive definite because `S.m` is positive and every nonzero tangent
-vector has a nonzero coordinate representative in the Euclidean model.
+The geometric kinetic energy is defined directly from the oscillator's mass Riemannian
+metric.
 -/
 
-/-- The oscillator mass pseudo-Riemannian metric is positive definite. -/
-lemma massPseudoRiemannianMetric_pos
+/-- The defining formula for the oscillator geometric kinetic energy. -/
+noncomputable def geometricKineticEnergy
     (S : HarmonicOscillator) (q : ConfigurationSpace)
-    (v : TangentSpace I q)
-    (hv : v ≠ 0) :
-    0 < S.massPseudoRiemannianMetric.inner q v v := by
-  rw [PseudoRiemannianMetric.inner_apply, massPseudoRiemannianMetric, massMetricVal_apply]
-  exact mul_pos S.m_pos (real_inner_self_pos.mpr (tangentCoord_ne_zero hv))
+    (v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) : ℝ :=
+  (1 / 2 : ℝ) * S.massRiemannianMetric.inner q v v
+
+/-- The geometric kinetic energy is one half the mass Riemannian metric applied to `v`
+twice. -/
+lemma geometricKineticEnergy_eq
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :
+    geometricKineticEnergy S q v =
+      (1 / 2 : ℝ) * S.massRiemannianMetric.inner q v v := by
+  rfl
 
 /-!
-## E. Coordinate form of kinetic energy
+## D. Coordinate formula
 
-The continuous linear equivalence `tangentCoord q` represents tangent vectors at `q` as
-vectors in `Model`. Under these coordinate representatives, the mass metric and the induced
-kinetic energy have the standard coordinate formulas.
+The coordinate identities below recover the usual mass-scaled formula for kinetic energy.
 -/
+
+/-- The oscillator mass Riemannian metric is positive definite. -/
+lemma massRiemannianMetric_pos
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q)
+    (hv : v ≠ 0) :
+    0 < S.massRiemannianMetric.inner q v v :=
+  massMetricVal_pos S q v hv
 
 /-- In the global coordinate, the oscillator mass metric is the mass-scaled Euclidean inner
 product of coordinate representatives. -/
-lemma massPseudoRiemannianMetric_inner_apply
+lemma massRiemannianMetric_inner_apply
     (S : HarmonicOscillator) (q : ConfigurationSpace)
-    (v w : TangentSpace I q) :
-    S.massPseudoRiemannianMetric.inner q v w =
+    (v w : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :
+    S.massRiemannianMetric.inner q v w =
       S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ := by
-  rw [PseudoRiemannianMetric.inner_apply, massPseudoRiemannianMetric]
   exact massMetricVal_apply S q v w
 
 /-- The metric-induced kinetic energy for the mass metric has the standard
 harmonic-oscillator coordinate form. -/
 lemma geometricKineticEnergy_massMetric_eq
     (S : HarmonicOscillator) (q : ConfigurationSpace)
-    (v : TangentSpace I q) :
-    geometricKineticEnergy S.massPseudoRiemannianMetric q v =
+    (v : TangentSpace 𝓘(ℝ, EuclideanSpace ℝ (Fin 1)) q) :
+    geometricKineticEnergy S q v =
       (1 / 2 : ℝ) * S.m * ⟪tangentCoord q v, tangentCoord q v⟫_ℝ := by
-  rw [geometricKineticEnergy_eq, massPseudoRiemannianMetric_inner_apply]
+  rw [geometricKineticEnergy_eq, massRiemannianMetric_inner_apply]
   ring
 
 end

--- a/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/HarmonicOscillator/Geometric/KineticEnergy.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 Nathaneal Sajan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nathaneal Sajan
+-/
+module
+
+public import Physlib.ClassicalMechanics.HarmonicOscillator.Basic
+public import Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.Basic
+public import Physlib.Mathematics.Geometry.Metric.PseudoRiemannian.Defs
+public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+
+/-!
+# Geometric kinetic energy of the harmonic oscillator
+
+## i. Overview
+
+The configuration space `Q` of the geometric harmonic oscillator is `ConfigurationSpace`.
+Velocities lie in the tangent bundle `TQ`; at a configuration `q`, a velocity is a tangent
+vector in `TangentSpace I q`.
+
+Given a pseudo-Riemannian metric `g` on `Q`, the definition of the kinetic-energy function
+on `TQ` is given by `geometricKineticEnergy g q v = 1 / 2 * g.inner q v v`. This is the
+metric-induced kinetic term used for natural mechanical systems.
+
+For the oscillator mass metric, tangent vectors are first read in the chosen global
+Euclidean coordinate. The map `tangentCoord q : TangentSpace I q ≃L[ℝ] Model` is the
+chart-induced continuous linear equivalence from the tangent space at `q` to the Euclidean
+coordinate model `Model := EuclideanSpace ℝ (Fin 1)`. We use it to form the pullback of
+the Euclidean inner product to `TangentSpace I q`.
+
+The mass metric `massPseudoRiemannianMetric S` is the mass-scaled pullback of the Euclidean
+inner product along `tangentCoord q`: `S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ`.
+Positivity of `S.m`, together with positive-definiteness of the Euclidean inner product on
+`Model`, gives nondegeneracy and negative index `0`.
+
+Evaluating `geometricKineticEnergy` on `massPseudoRiemannianMetric` gives the usual coordinate
+kinetic-energy expression
+`(1 / 2 : ℝ) * S.m * ⟪tangentCoord q v, tangentCoord q v⟫_ℝ`.
+
+## ii. Key results
+
+- `Model` : the Euclidean coordinate model for the oscillator configuration space.
+- `I` : the model-with-corners structure used for the global chart on `ConfigurationSpace`.
+- `tangentCoord` : the chart-induced continuous linear equivalence from `TangentSpace I q`
+  to `Model`.
+- `instFiniteDimensionalTangent` : finite-dimensionality of each tangent space, transported
+  from `Model` through `tangentCoord`.
+- `geometricKineticEnergy` : for a metric `g` on `Q`, the function
+  `K_g(q, v) = 1 / 2 * g_q(v, v)` on `TQ`.
+- `geometricKineticEnergy_eq` : the formula
+  `geometricKineticEnergy g q v = 1 / 2 * g.inner q v v`.
+- `massPseudoRiemannianMetric` : the mass-scaled pullback of the Euclidean inner product,
+  as a pseudo-Riemannian metric on `ConfigurationSpace`.
+- `massPseudoRiemannianMetric_inner_apply` : evaluation of the mass metric in the global
+  coordinate.
+- `massPseudoRiemannianMetric_pos` : positivity of the oscillator mass metric.
+- `geometricKineticEnergy_massMetric_eq` : the metric-induced kinetic energy for
+  `massPseudoRiemannianMetric` is the mass-scaled coordinate kinetic energy.
+
+## iii. Table of contents
+
+- A. Coordinate identification of the tangent space
+- B. Metric-induced kinetic energy
+- C. The mass pseudo-Riemannian metric
+- D. Positivity
+- E. Coordinate form of kinetic energy
+
+## iv. References
+
+- Ivo Terek, Introductory Variational Calculus on Manifolds, pages 1-2.
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+
+namespace HarmonicOscillator
+
+open scoped Manifold
+open Manifold ContDiff
+open InnerProductSpace
+
+noncomputable section
+
+/-!
+## A. Coordinate identification of the tangent space
+
+The oscillator configuration space has a single chosen global coordinate modeled on
+`EuclideanSpace ℝ (Fin 1)`. In this one-chart model, each tangent space is represented by
+the same Euclidean coordinate model. The continuous linear equivalence `tangentCoord q`
+gives the coordinate representative of a tangent vector at `q`; it does not install an
+intrinsic inner-product structure on tangent spaces.
+-/
+
+-- Let Lean use the definitional tangent/model identification used by `tangentCoord`
+set_option backward.isDefEq.respectTransparency false
+
+/-- The Euclidean coordinate model for the harmonic oscillator configuration space. -/
+abbrev Model := EuclideanSpace ℝ (Fin 1)
+
+/-- The model-with-corners structure for the global chart on `ConfigurationSpace`. -/
+abbrev I := 𝓘(ℝ, Model)
+
+/-- The chart-induced continuous linear equivalence from the tangent space at `q` to the
+Euclidean coordinate model. It sends a tangent vector to its coordinate representative in
+`Model`. -/
+def tangentCoord (q : ConfigurationSpace) :
+    TangentSpace I q ≃L[ℝ] Model where
+  toFun v := v
+  invFun v := v
+  map_add' := by simp
+  map_smul' := by simp
+
+/-- Each tangent space is finite-dimensional because it is linearly equivalent to the
+finite-dimensional coordinate model through `tangentCoord`. -/
+instance instFiniteDimensionalTangent (q : ConfigurationSpace) :
+    FiniteDimensional ℝ (TangentSpace I q) :=
+  LinearEquiv.finiteDimensional (tangentCoord q).symm.toLinearEquiv
+
+/-- In the single global chart, differentiating the chart inverse in the model direction `v`
+and then reading the resulting tangent vector through `tangentCoord` returns `v`. This is the
+coordinate identity used to show that the mass metric is constant in charts. -/
+private lemma tangentCoord_mfderiv_extChartAt_symm
+    (x₀ : ConfigurationSpace) (y v : Model) :
+    tangentCoord ((extChartAt I x₀).symm y) (mfderiv I I (extChartAt I x₀).symm y v) = v := by
+  change mfderiv I I (extChartAt I x₀).symm y v = v
+  let q : ConfigurationSpace := (extChartAt I x₀).symm y
+  have hpoint : (extChartAt I q) q = y := by
+    simp [q, extChartAt, ConfigurationSpace.valHomeomorphism, ConfigurationSpace.valEquiv]
+  have hderiv := congrArg (fun L => L v)
+    (mfderivWithin_range_extChartAt_symm (I := I) (x := q))
+  rw [hpoint] at hderiv
+  have hid :
+      ((ContinuousLinearMap.id ℝ (TangentSpace 𝓘(ℝ, Model) y)) v : TangentSpace I q) = v := rfl
+  have hderiv' :
+      mfderivWithin 𝓘(ℝ, Model) I (extChartAt I q).symm (Set.range I) y v = v :=
+    hderiv.trans hid
+  simpa [q, extChartAt, mfderivWithin_univ, ConfigurationSpace.valHomeomorphism,
+    ConfigurationSpace.valEquiv] using hderiv'
+
+/-!
+## B. Metric-induced kinetic energy
+
+A pseudo-Riemannian metric `g` on `Q` assigns a bilinear form `g_q` to each tangent space
+`TangentSpace I q`. The kinetic-energy function associated to `g` is
+`K_g(q, v) = 1 / 2 * g_q(v, v)`.
+-/
+
+/-- For a pseudo-Riemannian metric `g` on `Q`, the kinetic-energy function
+`K_g(q, v) = 1 / 2 * g.inner q v v` on the tangent bundle `TQ`. -/
+noncomputable def geometricKineticEnergy
+    (g : PseudoRiemannianMetric
+      Model
+      Model
+      ConfigurationSpace
+      ω
+      I)
+    (q : ConfigurationSpace)
+    (v : TangentSpace I q) : ℝ :=
+  (1 / 2 : ℝ) * g.inner q v v
+
+/-- The defining formula for `geometricKineticEnergy`. -/
+lemma geometricKineticEnergy_eq
+    (g : PseudoRiemannianMetric
+      Model
+      Model
+      ConfigurationSpace
+      ω
+      I)
+    (q : ConfigurationSpace)
+    (v : TangentSpace I q) :
+    geometricKineticEnergy g q v = (1 / 2 : ℝ) * g.inner q v v := by
+  rfl
+
+/-!
+## C. The mass pseudo-Riemannian metric
+
+The oscillator mass determines the inertial metric. At each configuration `q`, this metric is
+the mass-scaled pullback of the Euclidean inner product on `Model` along the continuous linear
+equivalence `tangentCoord q`.
+-/
+
+/-- The value of the oscillator mass metric at `q`. It is the mass-scaled pullback of the
+Euclidean inner product along `tangentCoord q`, so
+`massMetricVal S q v w = S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ`. -/
+noncomputable def massMetricVal (S : HarmonicOscillator) (q : ConfigurationSpace) :
+    TangentSpace I q →L[ℝ] TangentSpace I q →L[ℝ] ℝ :=
+  S.m • (innerSL ℝ : Model →L[ℝ] Model →L[ℝ] ℝ)
+
+/-- Applying the mass metric value to two tangent vectors gives the mass-scaled Euclidean
+inner product of their coordinate representatives. -/
+private lemma massMetricVal_apply
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v w : TangentSpace I q) :
+    massMetricVal S q v w = S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ := by
+  rfl
+
+/-- A nonzero tangent vector has nonzero coordinate representative under `tangentCoord`. -/
+private lemma tangentCoord_ne_zero {q : ConfigurationSpace} {v : TangentSpace I q}
+    (hv : v ≠ 0) : tangentCoord q v ≠ 0 := by
+  intro h
+  apply hv
+  exact (tangentCoord q).injective (by simpa using h)
+
+/-- The quadratic form associated to the oscillator mass metric has negative index zero at
+every configuration, because `S.m > 0` and the Euclidean inner product is positive definite
+on coordinate representatives. -/
+private lemma massMetricVal_negDim_eq_zero
+    (S : HarmonicOscillator) (q : ConfigurationSpace) :
+    (pseudoRiemannianMetricValToQuadraticForm (massMetricVal S)
+      (by
+        intro q v w
+        rw [massMetricVal_apply, massMetricVal_apply, real_inner_comm]) q).negDim = 0 := by
+  apply QuadraticForm.rankNeg_eq_zero
+  intro v hv
+  change 0 < massMetricVal S q v v
+  rw [massMetricVal_apply]
+  exact mul_pos S.m_pos (real_inner_self_pos.mpr (tangentCoord_ne_zero hv))
+
+/-- The mass-scaled pullback of the Euclidean inner product, as a pseudo-Riemannian metric on
+the oscillator configuration space. -/
+noncomputable def massPseudoRiemannianMetric (S : HarmonicOscillator) :
+    PseudoRiemannianMetric
+      Model
+      Model
+      ConfigurationSpace
+      ω
+      I where
+  val := massMetricVal S
+  symm := by
+    intro q v w
+    rw [massMetricVal_apply, massMetricVal_apply, real_inner_comm]
+  nondegenerate := by
+    intro q v h
+    have hv := h v
+    rw [massMetricVal_apply] at hv
+    have h_inner : ⟪tangentCoord q v, tangentCoord q v⟫_ℝ = 0 := by
+      exact (mul_eq_zero.mp hv).resolve_left S.m_ne_zero
+    apply (tangentCoord q).injective
+    simpa using (inner_self_eq_zero.mp h_inner)
+  smooth_in_charts' := by
+    intro x₀ v w
+    refine (contDiffWithinAt_const (c := S.m * ⟪v, w⟫_ℝ)).congr (fun y _hy => ?_) ?_
+    · rw [massMetricVal_apply, tangentCoord_mfderiv_extChartAt_symm,
+        tangentCoord_mfderiv_extChartAt_symm]
+    · rw [massMetricVal_apply, tangentCoord_mfderiv_extChartAt_symm,
+        tangentCoord_mfderiv_extChartAt_symm]
+  negDim_isLocallyConstant := by
+    apply IsLocallyConstant.of_constant
+    intro x y
+    rw [massMetricVal_negDim_eq_zero S x, massMetricVal_negDim_eq_zero S y]
+
+/-!
+## D. Positivity
+
+The mass metric is positive definite because `S.m` is positive and every nonzero tangent
+vector has a nonzero coordinate representative in the Euclidean model.
+-/
+
+/-- The oscillator mass pseudo-Riemannian metric is positive definite. -/
+lemma massPseudoRiemannianMetric_pos
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v : TangentSpace I q)
+    (hv : v ≠ 0) :
+    0 < S.massPseudoRiemannianMetric.inner q v v := by
+  rw [PseudoRiemannianMetric.inner_apply, massPseudoRiemannianMetric, massMetricVal_apply]
+  exact mul_pos S.m_pos (real_inner_self_pos.mpr (tangentCoord_ne_zero hv))
+
+/-!
+## E. Coordinate form of kinetic energy
+
+The continuous linear equivalence `tangentCoord q` represents tangent vectors at `q` as
+vectors in `Model`. Under these coordinate representatives, the mass metric and the induced
+kinetic energy have the standard coordinate formulas.
+-/
+
+/-- In the global coordinate, the oscillator mass metric is the mass-scaled Euclidean inner
+product of coordinate representatives. -/
+lemma massPseudoRiemannianMetric_inner_apply
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v w : TangentSpace I q) :
+    S.massPseudoRiemannianMetric.inner q v w =
+      S.m * ⟪tangentCoord q v, tangentCoord q w⟫_ℝ := by
+  rw [PseudoRiemannianMetric.inner_apply, massPseudoRiemannianMetric]
+  exact massMetricVal_apply S q v w
+
+/-- The metric-induced kinetic energy for the mass metric has the standard
+harmonic-oscillator coordinate form. -/
+lemma geometricKineticEnergy_massMetric_eq
+    (S : HarmonicOscillator) (q : ConfigurationSpace)
+    (v : TangentSpace I q) :
+    geometricKineticEnergy S.massPseudoRiemannianMetric q v =
+      (1 / 2 : ℝ) * S.m * ⟪tangentCoord q v, tangentCoord q v⟫_ℝ := by
+  rw [geometricKineticEnergy_eq, massPseudoRiemannianMetric_inner_apply]
+  ring
+
+end
+
+end HarmonicOscillator
+
+end ClassicalMechanics


### PR DESCRIPTION
I add a geometric notion of kinetic energy for the harmonic oscillator in a new file, building on the geometric `ConfigurationSpace`. The metric-induced kinetic energy is defined coordinate-free and parametric in any pseudo-Riemannian metric, and I then construct the oscillator's own mass metric and show it reproduces the standard KE formula.

Some challenges I ran into:

- **No inner product on tangent spaces.** My first version wrote `⟪v, w⟫` directly on velocities, which doesn't compile, as Mathlib deliberately withholds inner-product/normed instances from `TangentSpace`. I resolved this with an explicit coordinate identification `tangentCoord`. I tried installing instances but the instance route creates diamonds.
- **Smoothness of the metric.** `fun_prop` couldn't discharge this, because it can't see that the global chart inverse has identity derivative. I added a dedicated lemma establishing exactly that, which collapses the metric to a constant in the chart, after which smoothness is immediate.
- **Declaration ordering / defeq.** The tangent identification and its finite-dimensional instance had to precede `geometricKineticEnergy` (whose type already demands them), and I needed a file-scoped `set_option backward.isDefEq.respectTransparency false` for the tangent≡model identification.

---
*Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.*
