### PR TITLE
feat(ClassicalMechanics): add the velocity field of a rigid body in motion

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -173,4 +173,51 @@ lemma massDistribution_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time)
     massDistribution_mass, key, smul_eq_mul, mul_comm, mul_one_div, mul_div_assoc, div_self h,
     mul_one]
 
+/-- The velocity of the material point `y` of a rigid body in motion: the inertial-frame time
+derivative of the trajectory `s ↦ displacement s y` of that point. -/
+noncomputable def velocity {d : ℕ} (M : RigidBodyMotion d) (y : Space d) : Time → Space d :=
+  fun t => ∂ₜ (fun s => M.displacement s y) t
+
+lemma velocity_eq {d : ℕ} (M : RigidBodyMotion d) (y : Space d) (t : Time) :
+    M.velocity y t = ∂ₜ (fun s => M.displacement s y) t := rfl
+
+/-- The `i`-th component of the velocity of a body point is the time derivative of the `i`-th
+coordinate of its inertial-frame trajectory. -/
+lemma velocity_apply {d : ℕ} (M : RigidBodyMotion d) (y : Space d) (t : Time) (i : Fin d)
+    (hd : Differentiable ℝ (fun s => M.displacement s y)) :
+    M.velocity y t i = ∂ₜ (fun s => M.displacement s y i) t := by
+  rw [velocity_eq]
+  exact (Time.deriv_space hd t i).symm
+
+/-- The material point at the centre of mass moves with the centre-of-mass velocity, for any
+motion: `v(centreOfMass) = V`. This is the velocity counterpart of `massDistribution_centerOfMass`.
+-/
+lemma velocity_centerOfMass {d : ℕ} (M : RigidBodyMotion d) :
+    M.velocity M.centerOfMass = M.centerOfMassVelocity := by
+  funext t
+  rw [velocity_eq, centerOfMassVelocity_eq]
+  congr 1
+  funext s
+  ext k
+  rw [displacement_apply]
+  simp
+
+/-- A rigid body in pure translation (constant orientation) has every point moving with the
+centre-of-mass velocity: `v = V`. -/
+lemma velocity_of_orientation_const {d : ℕ} (M : RigidBodyMotion d) (y : Space d)
+    (R : Matrix.specialOrthogonalGroup (Fin d) ℝ) (h : M.orientation = fun _ => R) :
+    M.velocity y = M.centerOfMassVelocity := by
+  funext t
+  rw [velocity_eq, centerOfMassVelocity_eq]
+  have hdisp : (fun s => M.displacement s y)
+      = fun s => (⟨fun k => ∑ j, R.1 k j * (y j - M.centerOfMass j)⟩ : Space d)
+          + M.comTrajectory s := by
+    funext s
+    ext k
+    rw [displacement_apply, h]
+    simp
+  rw [hdisp]
+  simp only [Time.deriv_eq]
+  rw [fderiv_const_add]
+
 end RigidBodyMotion

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -239,4 +239,9 @@ lemma deriv_lorentzVector {d : ℕ} {f : Time → Lorentz.Vector d}
   · fun_prop
   · fun_prop
 
+lemma deriv_space {d : ℕ} {f : Time → Space d}
+    (hf : Differentiable ℝ f) (t : Time) (i : Fin d) :
+    deriv (fun s => f s i) t = deriv f t i :=
+  (Space.fderiv_space_components i f hf t 1).symm
+
 end Time


### PR DESCRIPTION
This PR adds the **velocity field** of a rigid body in motion — the velocity of an arbitrary material point — the kinematic foundation for the Landau–Lifshitz velocity decomposition `v = V + Ω × r` and König's kinetic-energy theorem (§31–32, #893).

The material point `y` of a rigid body in motion follows the inertial-frame trajectory `s ↦ displacement s y`; its velocity is the time derivative of that trajectory.

### `Physlib/ClassicalMechanics/RigidBody/Motion.lean`
- `RigidBodyMotion.velocity y` — `∂ₜ (fun s => displacement s y)`, the velocity of the material point `y`;
- `velocity_apply` — the `i`-th velocity component equals `∂ₜ` of the `i`-th coordinate of the trajectory, for a differentiable trajectory;
- `velocity_centerOfMass` — the point at the centre of mass moves with the centre-of-mass velocity `V`, for any motion (the velocity counterpart of `massDistribution_centerOfMass`);
- `velocity_of_orientation_const` — a body in pure translation (constant orientation) has every point moving with `V`.

### `Physlib/SpaceAndTime/Time/Derivatives.lean`
- `Time.deriv_space` — the time derivative of a `Space d`-valued path commutes with taking a coordinate: `∂ₜ (fun s => f s i) t = (∂ₜ f t) i`, via `Space.coordCLM`. This mirrors the existing `deriv_euclid` / `deriv_lorentzVector` in the same section, and is the general lemma needed to read the velocity field off componentwise.

All five declarations reduce to `[propext, Classical.choice, Quot.sound]`.

The next steps build directly on this: the decomposition `v = Ṙ (y − c) + V = V + Ω × r`, then König's energy `T = ½M|V|² + ½ω·Iω`.

Toward #893.
