### PR TITLE
feat(ClassicalMechanics): prove the velocity decomposition v = V + ω × r

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -119,8 +119,7 @@ lemma angularVelocityTensor_mul_orientation (M : RigidBodyMotion d) (t : Time) :
 /-- The velocity of a body point decomposes as `v = Ṙ (y − c) + V`: the rate of change of the
 orientation acting on the body-frame position, plus the centre-of-mass velocity. -/
 lemma velocity_eq_deriv_orientation (M : RigidBodyMotion d) (y : Space d) (t : Time) (i : Fin d)
-    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
-    (hX : Differentiable ℝ M.comTrajectory) :
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1)) (hX : Differentiable ℝ M.comTrajectory) :
     M.velocity y t i
       = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
         + M.centerOfMassVelocity t i := by
@@ -156,10 +155,8 @@ lemma velocity_eq_deriv_orientation (M : RigidBodyMotion d) (y : Space d) (t : T
 dimensions: the velocity of a body point is the centre-of-mass velocity plus the cross product of
 the angular velocity with the point's position relative to the centre of mass. -/
 theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : Time) (i : Fin 3)
-    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
-    (hX : Differentiable ℝ M.comTrajectory) :
-    M.velocity y t i
-      = M.centerOfMassVelocity t i
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1)) (hX : Differentiable ℝ M.comTrajectory) :
+    M.velocity y t i = M.centerOfMassVelocity t i
         + (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) i := by
   have hRw : (M.orientation t).1 *ᵥ (fun j => y j - M.centerOfMass j)
       = fun j => M.displacement t y j - M.comTrajectory t j := by

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -116,41 +116,6 @@ lemma angularVelocityTensor_mul_orientation (M : RigidBodyMotion d) (t : Time) :
   rw [angularVelocityTensor_eq, mul_assoc,
     mul_eq_one_comm.mp (M.orientation_mul_transpose t), mul_one]
 
-/-- The velocity of a body point decomposes as `v = Ṙ (y − c) + V`: the rate of change of the
-orientation acting on the body-frame position, plus the centre-of-mass velocity. -/
-lemma velocity_eq_deriv_orientation (M : RigidBodyMotion d) (y : Space d) (t : Time) (i : Fin d)
-    (hR : Differentiable ℝ (fun s => (M.orientation s).1)) (hX : Differentiable ℝ M.comTrajectory) :
-    M.velocity y t i
-      = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
-        + M.centerOfMassVelocity t i := by
-  have hentry : ∀ a b : Fin d, Differentiable ℝ (fun s => (M.orientation s).1 a b) := fun a b =>
-    ((Matrix.entryLinearMap ℝ ℝ a b).toContinuousLinearMap).differentiable.comp hR
-  have hXcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.comTrajectory s k) := fun k =>
-    (Space.eval_differentiable k).comp hX
-  have hd : Differentiable ℝ (fun s => M.displacement s y) := by
-    have hcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.displacement s y k) := by
-      intro k
-      simp only [displacement_apply]
-      exact (Differentiable.fun_sum
-        (fun j _ => (hentry k j).mul_const (y j - M.centerOfMass j))).add (hXcoord k)
-    exact Space.mk_differentiable.comp (differentiable_pi.mpr hcoord)
-  have hmv : (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
-      = ∑ j, (∂ₜ (fun s => (M.orientation s).1) t) i j * (y j - M.centerOfMass j) := rfl
-  rw [M.velocity_apply y t i hd]
-  simp only [displacement_apply]
-  rw [Time.deriv_add (fun s => ∑ j, (M.orientation s).1 i j * (y j - M.centerOfMass j))
-      (fun s => M.comTrajectory s i)
-      ((Differentiable.fun_sum
-        fun j _ => (hentry i j).mul_const (y j - M.centerOfMass j)) t) ((hXcoord i) t),
-    Time.deriv_fun_sum Finset.univ
-      (fun j s => (M.orientation s).1 i j * (y j - M.centerOfMass j))
-      (fun j _ => ((hentry i j).mul_const (y j - M.centerOfMass j)) t),
-    Finset.sum_congr rfl (fun j (_ : j ∈ Finset.univ) =>
-      Time.deriv_mul_const (fun s => (M.orientation s).1 i j)
-        (y j - M.centerOfMass j) ((hentry i j) t))]
-  simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
-  rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
-
 /-- The Landau–Lifshitz velocity decomposition `v = V + ω × r` for a rigid body in three
 dimensions: the velocity of a body point is the centre-of-mass velocity plus the cross product of
 the angular velocity with the point's position relative to the centre of mass. -/

--- a/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean
@@ -109,4 +109,68 @@ lemma angularVelocity_of_orientation_const (M : RigidBodyMotion 3)
   rw [angularVelocity_eq, congrFun (M.angularVelocityTensor_of_orientation_const R h) t]
   fin_cases i <;> simp [crossProductVee]
 
+/-- The time derivative of the orientation is `Ṙ = Ω R`, recovering the orientation path from its
+angular velocity tensor `Ω = Ṙ Rᵀ` via the orthogonality `Rᵀ R = 1`. -/
+lemma angularVelocityTensor_mul_orientation (M : RigidBodyMotion d) (t : Time) :
+    M.angularVelocityTensor t * (M.orientation t).1 = ∂ₜ (fun s => (M.orientation s).1) t := by
+  rw [angularVelocityTensor_eq, mul_assoc,
+    mul_eq_one_comm.mp (M.orientation_mul_transpose t), mul_one]
+
+/-- The velocity of a body point decomposes as `v = Ṙ (y − c) + V`: the rate of change of the
+orientation acting on the body-frame position, plus the centre-of-mass velocity. -/
+lemma velocity_eq_deriv_orientation (M : RigidBodyMotion d) (y : Space d) (t : Time) (i : Fin d)
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) :
+    M.velocity y t i
+      = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
+        + M.centerOfMassVelocity t i := by
+  have hentry : ∀ a b : Fin d, Differentiable ℝ (fun s => (M.orientation s).1 a b) := fun a b =>
+    ((Matrix.entryLinearMap ℝ ℝ a b).toContinuousLinearMap).differentiable.comp hR
+  have hXcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.comTrajectory s k) := fun k =>
+    (Space.eval_differentiable k).comp hX
+  have hd : Differentiable ℝ (fun s => M.displacement s y) := by
+    have hcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.displacement s y k) := by
+      intro k
+      simp only [displacement_apply]
+      exact (Differentiable.fun_sum
+        (fun j _ => (hentry k j).mul_const (y j - M.centerOfMass j))).add (hXcoord k)
+    exact Space.mk_differentiable.comp (differentiable_pi.mpr hcoord)
+  have hmv : (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
+      = ∑ j, (∂ₜ (fun s => (M.orientation s).1) t) i j * (y j - M.centerOfMass j) := rfl
+  rw [M.velocity_apply y t i hd]
+  simp only [displacement_apply]
+  rw [Time.deriv_add (fun s => ∑ j, (M.orientation s).1 i j * (y j - M.centerOfMass j))
+      (fun s => M.comTrajectory s i)
+      ((Differentiable.fun_sum
+        fun j _ => (hentry i j).mul_const (y j - M.centerOfMass j)) t) ((hXcoord i) t),
+    Time.deriv_fun_sum Finset.univ
+      (fun j s => (M.orientation s).1 i j * (y j - M.centerOfMass j))
+      (fun j _ => ((hentry i j).mul_const (y j - M.centerOfMass j)) t),
+    Finset.sum_congr rfl (fun j (_ : j ∈ Finset.univ) =>
+      Time.deriv_mul_const (fun s => (M.orientation s).1 i j)
+        (y j - M.centerOfMass j) ((hentry i j) t))]
+  simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
+  rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
+
+/-- The Landau–Lifshitz velocity decomposition `v = V + ω × r` for a rigid body in three
+dimensions: the velocity of a body point is the centre-of-mass velocity plus the cross product of
+the angular velocity with the point's position relative to the centre of mass. -/
+theorem velocity_eq_angularVelocity (M : RigidBodyMotion 3) (y : Space 3) (t : Time) (i : Fin 3)
+    (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) :
+    M.velocity y t i
+      = M.centerOfMassVelocity t i
+        + (M.angularVelocity t ⨯₃ fun j => M.displacement t y j - M.comTrajectory t j) i := by
+  have hRw : (M.orientation t).1 *ᵥ (fun j => y j - M.centerOfMass j)
+      = fun j => M.displacement t y j - M.comTrajectory t j := by
+    funext k
+    show ((M.orientation t).1 *ᵥ fun j => y j - M.centerOfMass j) k
+      = M.displacement t y k - M.comTrajectory t k
+    rw [eq_sub_iff_add_eq, displacement_apply]
+    rfl
+  rw [M.velocity_eq_deriv_orientation y t i hR hX, add_comm]
+  congr 1
+  rw [← M.angularVelocityTensor_mul_orientation t, ← Matrix.mulVec_mulVec, hRw,
+    ← M.crossProductMatrix_angularVelocity t (hR t), Matrix.crossProductMatrix_mulVec]
+
 end RigidBodyMotion

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.ClassicalMechanics.RigidBody.Basic
 public import Physlib.SpaceAndTime.Time.Derivatives
+public import Physlib.SpaceAndTime.Time.MatrixDerivatives
 public import Mathlib.LinearAlgebra.UnitaryGroup
 /-!
 
@@ -27,6 +28,9 @@ a rigid motion into a translation of the centre of mass plus a rotation about it
 @[expose] public section
 
 open Time Manifold Matrix
+
+attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
+  Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
 
 /-- A motion of a rigid body in `d`-dimensional space: the body together with the inertial-frame
 trajectory of its centre of mass and its time-dependent orientation (a rotation about the centre
@@ -219,5 +223,41 @@ lemma velocity_of_orientation_const {d : ℕ} (M : RigidBodyMotion d) (y : Space
   rw [hdisp]
   simp only [Time.deriv_eq]
   rw [fderiv_const_add]
+
+/-- The velocity of a body point decomposes as `v = Ṙ (y − c) + V`: the rate of change of the
+orientation acting on the body-frame position, plus the centre-of-mass velocity. -/
+lemma velocity_eq_deriv_orientation {d : ℕ} (M : RigidBodyMotion d) (y : Space d) (t : Time)
+    (i : Fin d) (hR : Differentiable ℝ (fun s => (M.orientation s).1))
+    (hX : Differentiable ℝ M.comTrajectory) :
+    M.velocity y t i
+      = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
+        + M.centerOfMassVelocity t i := by
+  have hentry : ∀ a b : Fin d, Differentiable ℝ (fun s => (M.orientation s).1 a b) := fun a b =>
+    ((Matrix.entryLinearMap ℝ ℝ a b).toContinuousLinearMap).differentiable.comp hR
+  have hXcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.comTrajectory s k) := fun k =>
+    (Space.eval_differentiable k).comp hX
+  have hd : Differentiable ℝ (fun s => M.displacement s y) := by
+    have hcoord : ∀ k : Fin d, Differentiable ℝ (fun s => M.displacement s y k) := by
+      intro k
+      simp only [displacement_apply]
+      exact (Differentiable.fun_sum
+        (fun j _ => (hentry k j).mul_const (y j - M.centerOfMass j))).add (hXcoord k)
+    exact Space.mk_differentiable.comp (differentiable_pi.mpr hcoord)
+  have hmv : (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
+      = ∑ j, (∂ₜ (fun s => (M.orientation s).1) t) i j * (y j - M.centerOfMass j) := rfl
+  rw [M.velocity_apply y t i hd]
+  simp only [displacement_apply]
+  rw [Time.deriv_add (fun s => ∑ j, (M.orientation s).1 i j * (y j - M.centerOfMass j))
+      (fun s => M.comTrajectory s i)
+      ((Differentiable.fun_sum
+        fun j _ => (hentry i j).mul_const (y j - M.centerOfMass j)) t) ((hXcoord i) t),
+    Time.deriv_fun_sum Finset.univ
+      (fun j s => (M.orientation s).1 i j * (y j - M.centerOfMass j))
+      (fun j _ => ((hentry i j).mul_const (y j - M.centerOfMass j)) t),
+    Finset.sum_congr rfl (fun j (_ : j ∈ Finset.univ) =>
+      Time.deriv_mul_const (fun s => (M.orientation s).1 i j)
+        (y j - M.centerOfMass j) ((hentry i j) t))]
+  simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
+  rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
 
 end RigidBodyMotion

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -129,6 +129,23 @@ lemma deriv_neg [NormedAddCommGroup M] [NormedSpace ℝ M] (f : Time → M) :
   rw [deriv, fderiv_neg]
   rfl
 
+lemma deriv_add [NormedAddCommGroup M] [NormedSpace ℝ M] (f g : Time → M)
+    (hf : DifferentiableAt ℝ f t) (hg : DifferentiableAt ℝ g t) :
+    ∂ₜ (fun s => f s + g s) t = ∂ₜ f t + ∂ₜ g t := by
+  simp only [Time.deriv_eq]
+  rw [fderiv_fun_add hf hg, _root_.add_apply]
+
+lemma deriv_fun_sum {ι : Type*} [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (s : Finset ι) (a : ι → Time → M) (ha : ∀ i ∈ s, DifferentiableAt ℝ (a i) t) :
+    ∂ₜ (fun x => ∑ i ∈ s, a i x) t = ∑ i ∈ s, ∂ₜ (a i) t := by
+  simp only [Time.deriv_eq]
+  rw [fderiv_fun_sum ha, _root_.sum_apply]
+
+lemma deriv_mul_const (f : Time → ℝ) (c : ℝ) (hf : DifferentiableAt ℝ f t) :
+    ∂ₜ (fun s => f s * c) t = ∂ₜ f t * c := by
+  simp only [Time.deriv_eq]
+  rw [fderiv_mul_const hf c, _root_.smul_apply, smul_eq_mul, mul_comm]
+
 /-- Quotient rule for `Time.deriv` on real-valued functions: if `c` and `g` are
   differentiable at `t` and `g t ≠ 0`, then
   `∂ₜ (c / g) t = (∂ₜ c t * g t - c t * ∂ₜ g t) / (g t)^2`. -/

--- a/Physlib/SpaceAndTime/Time/MatrixDerivatives.lean
+++ b/Physlib/SpaceAndTime/Time/MatrixDerivatives.lean
@@ -11,9 +11,9 @@ public import Mathlib.Analysis.Matrix.Normed
 
 # Time derivatives of matrix-valued functions
 
-General lemmas on the time derivative `∂ₜ` of square-matrix-valued functions of time: a product rule
-and the commutation of the derivative with transpose. These are the tools needed to differentiate a
-path of matrices.
+General lemmas on the time derivative `∂ₜ` of square-matrix-valued functions of time: a product
+rule, the commutation of the derivative with transpose, and the commutation of the derivative with
+taking a matrix entry. These are the tools needed to differentiate a path of matrices.
 
 They rely on the (opt-in) operator-norm structure on matrices — activated here as local instances —
 only to invoke the product rule and to view transpose (through `Matrix.transposeLinearEquiv`) as a
@@ -59,6 +59,17 @@ lemma deriv_matrix_transpose (A : Time → Matrix (Fin d) (Fin d) ℝ) (t : Time
     (transposeLinearEquiv (Fin d) (Fin d) ℝ ℝ).toLinearMap.toContinuousLinearMap
   have h : HasFDerivAt (fun s => (A s)ᵀ) (T.comp (fderiv ℝ A t)) t :=
     T.hasFDerivAt.comp t hA.hasFDerivAt
+  rw [Time.deriv_eq, h.fderiv, Time.deriv_eq]
+  rfl
+
+/-- The time derivative commutes with taking a matrix entry. -/
+lemma deriv_matrix_apply (A : Time → Matrix (Fin d) (Fin d) ℝ) (t : Time)
+    (hA : DifferentiableAt ℝ A t) (i j : Fin d) :
+    ∂ₜ (fun s => A s i j) t = (∂ₜ A t) i j := by
+  let E : Matrix (Fin d) (Fin d) ℝ →L[ℝ] ℝ :=
+    (Matrix.entryLinearMap ℝ ℝ i j).toContinuousLinearMap
+  have h : HasFDerivAt (fun s => A s i j) (E.comp (fderiv ℝ A t)) t :=
+    E.hasFDerivAt.comp t hA.hasFDerivAt
   rw [Time.deriv_eq, h.fderiv, Time.deriv_eq]
   rfl
 


### PR DESCRIPTION
This PR proves the **Landau–Lifshitz velocity decomposition** `v = V + ω × r` (§31) — the velocity of any material point of a rigid body in motion splits into the centre-of-mass velocity `V` and a rotational part. It is the kinematic input to König's kinetic-energy theorem (#893) and builds on the velocity field `velocity` and the angular velocity tensor `Ω`.

### `Physlib/ClassicalMechanics/RigidBody/AngularVelocity.lean`
- `angularVelocityTensor_mul_orientation` — `Ṙ = Ω R`, recovering the orientation's derivative from `Ω = Ṙ Rᵀ` via `Rᵀ R = 1`;
- `velocity_eq_deriv_orientation` — `v = Ṙ (y − c) + V`, the componentwise decomposition (rate of change of the orientation acting on the body-frame position, plus the centre-of-mass velocity);
- `velocity_eq_angularVelocity` — `v = V + ω × r` in three dimensions, with `r` the position relative to the centre of mass (`r = displacement − comTrajectory`), via `[ω]ₓ = Ω` and `[ω]ₓ *ᵥ r = ω × r`.

### `Physlib/SpaceAndTime/Time/MatrixDerivatives.lean`
- `Time.deriv_matrix_apply` — the time derivative commutes with taking a matrix entry, `∂ₜ (fun s => A s i j) t = (∂ₜ A t) i j`, via `Matrix.entryLinearMap` (mirrors the sibling `deriv_matrix_transpose`). The general lemma needed to read the derivative of the orientation path off entrywise.

All four declarations reduce to `[propext, Classical.choice, Quot.sound]`.

The next step is König's energy `T = ½M|V|² + ½ω·Iω`, obtained by integrating `½|v|²` over the body.

Toward #893.
