### PR TITLE
The static theorem for reversible dynamics on Hilbert spaces

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -335,8 +335,8 @@ public import Physlib.QuantumMechanics.HilbertSpaces.TensorProducts.CompleteTens
 public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
-public import Physlib.QuantumMechanics.OperatorAlgebra.Automorphism
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.Dynamics.Automorphism
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -336,6 +336,7 @@ public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.HilbertSpace
 public import Physlib.QuantumMechanics.OperatorAlgebra.Dynamics.Automorphism
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -335,6 +335,7 @@ public import Physlib.QuantumMechanics.HilbertSpaces.TensorProducts.CompleteTens
 public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.Automorphism
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -336,8 +336,8 @@ public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
-public import Physlib.QuantumMechanics.OperatorAlgebra.HilbertSpace
 public import Physlib.QuantumMechanics.OperatorAlgebra.Dynamics.Automorphism
+public import Physlib.QuantumMechanics.OperatorAlgebra.HilbertSpace
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
+public import Mathlib.Analysis.Normed.Operator.ContinuousAlgEquiv
+public import Mathlib.Analysis.CStarAlgebra.Hom
+
+/-!
+# Automorphisms of the bounded operators
+
+Reversible transformations of a quantum system act on its observable algebra by
+⋆-automorphisms.
+
+For a complex Hilbert space `H`, every ⋆-automorphism of `B(H)` is implemented by
+unitary conjugation:
+  `A ↦ U A U⋆`.
+
+Two unitaries implement the same transformation exactly when they differ by a
+scalar phase. Consequently,
+  `Aut⋆(B(H)) ≅ U(H) / U(1) ≅ PU(H)`,
+the projective unitary group.
+
+For Hamiltonian dynamics, this projective ambiguity corresponds to
+the freedom to shift a Hamiltonian by a scalar multiple of the identity.
+-/
+
+@[expose] public section
+
+namespace OperatorAlgebra
+
+variable {H : Type*}
+    [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H]
+    [CompleteSpace H]
+
+/--
+Every ⋆-automorphism of `B(H)` is implemented by unitary conjugation.
+-/
+lemma conjStarAlgAut_surjective :
+    Function.Surjective
+      (Unitary.conjStarAlgAut ℂ (H →L[ℂ] H)) := by
+  intro φ
+  obtain ⟨U, hU⟩ :=
+    φ.eq_linearIsometryEquivConjStarAlgEquiv
+      (NonUnitalStarAlgHom.isometry φ φ.injective).continuous
+  refine ⟨Unitary.linearIsometryEquiv.symm U, ?_⟩
+  rw [Unitary.conjStarAlgAut_symm_unitaryLinearIsometryEquiv]
+  exact hU.symm
+
+
+/--
+Two unitaries implement the same ⋆-automorphism of `B(H)` exactly when
+they differ by a scalar phase.
+-/
+lemma conjStarAlgAut_eq_iff
+    (u v : unitary (H →L[ℂ] H)) :
+    Unitary.conjStarAlgAut ℂ (H →L[ℂ] H) u =
+        Unitary.conjStarAlgAut ℂ (H →L[ℂ] H) v ↔
+      ∃ c : unitary ℂ, u = c • v :=
+  Unitary.conjStarAlgAut_ext_iff' u v
+
+
+/--
+The projective unitary group of `H`.
+This is the unitary group modulo the scalar phases which act trivially
+by conjugation.
+-/
+noncomputable def ProjectiveUnitary (H : Type*)
+    [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H]
+    [CompleteSpace H] :=
+  unitary (H →L[ℂ] H) ⧸
+    MonoidHom.ker (Unitary.conjStarAlgAut ℂ (H →L[ℂ] H))
+
+noncomputable instance :
+    Group (ProjectiveUnitary H) :=
+  QuotientGroup.Quotient.group _
+
+/--
+Reversible transformations of `B(H)` are precisely projective unitaries.
+-/
+noncomputable def projectiveUnitaryEquivStarAlgAut :
+    ProjectiveUnitary H ≃*
+      ((H →L[ℂ] H) ≃⋆ₐ[ℂ] (H →L[ℂ] H)) :=
+  QuotientGroup.quotientKerEquivOfSurjective
+    _ conjStarAlgAut_surjective
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
@@ -5,6 +5,7 @@ Authors: Tom Ole Diem
 -/
 module
 
+public import Physlib.Meta.TODO.Basic
 public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
 public import Mathlib.Analysis.Normed.Operator.ContinuousAlgEquiv
 public import Mathlib.Analysis.CStarAlgebra.Hom
@@ -27,6 +28,12 @@ the projective unitary group.
 For Hamiltonian dynamics, this projective ambiguity corresponds to
 the freedom to shift a Hamiltonian by a scalar multiple of the identity.
 -/
+
+TODO "Create a Hamiltonian file that quotients Hamiltonians by scalar multiples of the
+identity, and prove that commutators are invariant under this equivalence class. For example:
+  theorem commutator_add_smul_one
+      (H A : Observable 𝒜) (c : ℝ) :
+      ⁅H + c • 1, A⁆ = ⁅H, A⁆ := ..."
 
 @[expose] public section
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Automorphism.lean
@@ -5,7 +5,6 @@ Authors: Tom Ole Diem
 -/
 module
 
-public import Physlib.Meta.TODO.Basic
 public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
 public import Mathlib.Analysis.Normed.Operator.ContinuousAlgEquiv
 public import Mathlib.Analysis.CStarAlgebra.Hom
@@ -28,12 +27,6 @@ the projective unitary group.
 For Hamiltonian dynamics, this projective ambiguity corresponds to
 the freedom to shift a Hamiltonian by a scalar multiple of the identity.
 -/
-
-TODO "Create a Hamiltonian file that quotients Hamiltonians by scalar multiples of the
-identity, and prove that commutators are invariant under this equivalence class. For example:
-  theorem commutator_add_smul_one
-      (H A : Observable 𝒜) (c : ℝ) :
-      ⁅H + c • 1, A⁆ = ⁅H, A⁆ := ..."
 
 @[expose] public section
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
@@ -6,6 +6,7 @@ Authors: Tom Ole Diem
 module
 
 public import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
+public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
 public import Mathlib.Analysis.InnerProductSpace.StarOrder
 
 /-!
@@ -89,6 +90,26 @@ abbrev Channel (A₁ A₂ : Type*) [OperatorAlgebra A₁] [OperatorAlgebra A₂]
   {φ : A₁ →CP A₂ // φ 1 = 1}
 
 end ObservableAlgebra
+
+/-!
+## Bounded operators on Hilbert space
+
+The bounded operators on any complex Hilbert space form a C⋆-algebra. Equip them with the
+canonical spectral order so they can be used as an `OperatorAlgebra`, independently of the
+finite-dimensional matrix layer.
+-/
+
+section HilbertSpaceOperatorAlgebra
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+noncomputable instance : PartialOrder (H →L[ℂ] H) := CStarAlgebra.spectralOrder _
+instance : StarOrderedRing (H →L[ℂ] H) := CStarAlgebra.spectralOrderedRing _
+
+/-- Bounded operators on a complex Hilbert space form an operator algebra via the spectral order. -/
+noncomputable instance instContinuousLinearMap : OperatorAlgebra (H →L[ℂ] H) where
+
+end HilbertSpaceOperatorAlgebra
 
 /-!
 ## Hilbert-space representations

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
@@ -49,18 +49,15 @@ variable {A : Type*} [OperatorAlgebra A]
 /-- An observable is a self-adjoint element of `A`: position, momentum, energy, spin, ... .
 Self-adjointness is exactly what makes an element a *measurable* quantity — it is what forces its
 spectrum, the possible measurement outcomes, to be real. -/
-noncomputable abbrev Observable (A : Type*) [CStarAlgebra A] :=
-  selfAdjoint A
+noncomputable abbrev Observable (A : Type*) [OperatorAlgebra A] := selfAdjoint A
 
 /-- A positive element of `A`: an observable whose measurement outcomes are all `≥ 0`.
 Positivity is what gives observables a meaningful order (`a ≤ b` meaning `b - a` is positive). -/
-abbrev PositiveElement (A : Type*) [OperatorAlgebra A] :=
-  {a : Observable A // 0 ≤ (a : A)}
+abbrev PositiveElement (A : Type*) [OperatorAlgebra A] := {a : Observable A // 0 ≤ (a : A)}
 
 /-- An effect is an observable between zero and the identity, representing a yes/no measurement
 outcome. -/
-abbrev Effect (A : Type*) [OperatorAlgebra A] :=
-  Set.Icc (0 : Observable A) 1
+abbrev Effect (A : Type*) [OperatorAlgebra A] := Set.Icc (0 : Observable A) 1
 
 /-- A finite POVM on `A`: the most general notion of a measurement with outcomes in `X`,
 generalizing a single yes/no `Effect` to several possible outcomes. -/
@@ -72,8 +69,7 @@ structure POVM (A : Type*) [OperatorAlgebra A] (X : Type*) [Fintype X] where
 
 /-- A unitary element of `A`: implements a reversible transformation of the system — a symmetry,
 or time evolution under a Hamiltonian — acting on observables by conjugation, `a ↦ U a U⋆`. -/
-noncomputable abbrev Unitary (A : Type*) [CStarAlgebra A] :=
-  unitary A
+noncomputable abbrev Unitary (A : Type*) [OperatorAlgebra A] := unitary A
 
 /-- A state on `A`: a positive complex-linear functional normalized by `ω 1 = 1`. `ω a` is the
 expected outcome of measuring observable `a` in this state — a state records everything that can
@@ -95,19 +91,25 @@ end ObservableAlgebra
 ## Bounded operators on Hilbert space
 
 The bounded operators on any complex Hilbert space form a C⋆-algebra. Equip them with the
-canonical spectral order so they can be used as an `OperatorAlgebra`, independently of the
-finite-dimensional matrix layer.
+canonical spectral order so they can be used as an `OperatorAlgebra`.
 -/
 
 section HilbertSpaceOperatorAlgebra
 
+/-- The bounded operators on a complex Hilbert space, written in the usual physics notation. -/
+notation "B(" H ")" => H →L[ℂ] H
+
 variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
 
-noncomputable instance : PartialOrder (H →L[ℂ] H) := CStarAlgebra.spectralOrder _
-instance : StarOrderedRing (H →L[ℂ] H) := CStarAlgebra.spectralOrderedRing _
+/-- The physical operator algebra of bounded operators on a complex Hilbert space. -/
+abbrev HilbertSpaceOperatorAlgebra (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] :=
+  OperatorAlgebra B(H)
+
+noncomputable instance : PartialOrder B(H) := CStarAlgebra.spectralOrder _
+instance : StarOrderedRing B(H) := CStarAlgebra.spectralOrderedRing _
 
 /-- Bounded operators on a complex Hilbert space form an operator algebra via the spectral order. -/
-noncomputable instance instContinuousLinearMap : OperatorAlgebra (H →L[ℂ] H) where
+noncomputable instance : HilbertSpaceOperatorAlgebra H := {}
 
 end HilbertSpaceOperatorAlgebra
 
@@ -125,14 +127,13 @@ This is also the target of the GNS construction associated with a state.
 
 section Representation
 
-variable {A : Type*} {H : Type*} [CStarAlgebra A] [NormedAddCommGroup H] [InnerProductSpace ℂ H]
-  [CompleteSpace H]
+variable {A : Type*} {H : Type*} [OperatorAlgebra A] [NormedAddCommGroup H]
+  [InnerProductSpace ℂ H] [CompleteSpace H]
 
 /-- A Hilbert-space representation of `A`: a unital ⋆-homomorphism from `A` into the algebra of
 bounded operators on the Hilbert space `H`. -/
-abbrev Representation (A : Type*) (H : Type*) [CStarAlgebra A] [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H] [CompleteSpace H] :=
-  A →⋆ₐ[ℂ] (H →L[ℂ] H)
+abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
 
 end Representation
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
@@ -6,8 +6,6 @@ Authors: Tom Ole Diem
 module
 
 public import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
-public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
-public import Mathlib.Analysis.InnerProductSpace.StarOrder
 
 /-!
 
@@ -86,55 +84,5 @@ abbrev Channel (A₁ A₂ : Type*) [OperatorAlgebra A₁] [OperatorAlgebra A₂]
   {φ : A₁ →CP A₂ // φ 1 = 1}
 
 end ObservableAlgebra
-
-/-!
-## Bounded operators on Hilbert space
-
-The bounded operators on any complex Hilbert space form a C⋆-algebra. Equip them with the
-canonical spectral order so they can be used as an `OperatorAlgebra`.
--/
-
-section HilbertSpaceOperatorAlgebra
-
-/-- The bounded operators on a complex Hilbert space, written in the usual physics notation. -/
-notation "B(" H ")" => H →L[ℂ] H
-
-variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
-
-/-- The physical operator algebra of bounded operators on a complex Hilbert space. -/
-abbrev HilbertSpaceOperatorAlgebra (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] :=
-  OperatorAlgebra B(H)
-
-noncomputable instance : PartialOrder B(H) := CStarAlgebra.spectralOrder _
-instance : StarOrderedRing B(H) := CStarAlgebra.spectralOrderedRing _
-
-/-- Bounded operators on a complex Hilbert space form an operator algebra via the spectral order. -/
-noncomputable instance : HilbertSpaceOperatorAlgebra H := {}
-
-end HilbertSpaceOperatorAlgebra
-
-/-!
-## Hilbert-space representations
-
-The abstract observable algebra need not initially be presented as operators on
-a Hilbert space.
-
-A concrete realization is a unital ⋆-representation into the C⋆-algebra of
-bounded operators on a complex Hilbert space.
-
-This is also the target of the GNS construction associated with a state.
--/
-
-section Representation
-
-variable {A : Type*} {H : Type*} [OperatorAlgebra A] [NormedAddCommGroup H]
-  [InnerProductSpace ℂ H] [CompleteSpace H]
-
-/-- A Hilbert-space representation of `A`: a unital ⋆-homomorphism from `A` into the algebra of
-bounded operators on the Hilbert space `H`. -/
-abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
-
-end Representation
 
 end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
@@ -32,7 +32,7 @@ the freedom to shift a Hamiltonian by a scalar multiple of the identity.
 
 namespace OperatorAlgebra
 
-variable {H : Type*} [HilbertSpace H]
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
 
 /-- Every ⋆-automorphism of `B(H)` is implemented by unitary conjugation. -/
 lemma conjStarAlgAut_surjective :
@@ -54,7 +54,8 @@ lemma conjStarAlgAut_eq_iff (u v : Unitary (B(H))) :
   Unitary.conjStarAlgAut_ext_iff' u v
 
 /-- The projective unitary group of `H`, obtained by quotienting out scalar phases. -/
-def ProjectiveUnitary (H : Type*) [HilbertSpace H] :=
+def ProjectiveUnitary (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+    [CompleteSpace H] :=
   Unitary (B(H)) ⧸ MonoidHom.ker (Unitary.conjStarAlgAut ℂ (B(H)))
 
 noncomputable instance : Group (ProjectiveUnitary H) := QuotientGroup.Quotient.group _

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
@@ -5,7 +5,7 @@ Authors: Tom Ole Diem
 -/
 module
 
-public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.HilbertSpace
 public import Mathlib.Analysis.Normed.Operator.ContinuousAlgEquiv
 public import Mathlib.Analysis.CStarAlgebra.Hom
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
@@ -32,10 +32,7 @@ the freedom to shift a Hamiltonian by a scalar multiple of the identity.
 
 namespace OperatorAlgebra
 
-variable {H : Type*}
-    [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H]
-    [CompleteSpace H]
+variable {H : Type*} [HilbertSpace H]
 
 /-- Every ⋆-automorphism of `B(H)` is implemented by unitary conjugation. -/
 lemma conjStarAlgAut_surjective :
@@ -50,18 +47,14 @@ lemma conjStarAlgAut_surjective :
 
 /-- Two unitaries implement the same ⋆-automorphism of `B(H)` exactly when they differ by a scalar
 phase. -/
-lemma conjStarAlgAut_eq_iff
-    (u v : Unitary (B(H))) :
+lemma conjStarAlgAut_eq_iff (u v : Unitary (B(H))) :
     Unitary.conjStarAlgAut ℂ (B(H)) u =
         Unitary.conjStarAlgAut ℂ (B(H)) v ↔
       ∃ c : unitary ℂ, u = c • v :=
   Unitary.conjStarAlgAut_ext_iff' u v
 
 /-- The projective unitary group of `H`, obtained by quotienting out scalar phases. -/
-def ProjectiveUnitary (H : Type*)
-    [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H]
-    [CompleteSpace H] :=
+def ProjectiveUnitary (H : Type*) [HilbertSpace H] :=
   Unitary (B(H)) ⧸ MonoidHom.ker (Unitary.conjStarAlgAut ℂ (B(H)))
 
 noncomputable instance : Group (ProjectiveUnitary H) := QuotientGroup.Quotient.group _

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Dynamics/Automorphism.lean
@@ -5,7 +5,7 @@ Authors: Tom Ole Diem
 -/
 module
 
-public import Mathlib.Analysis.CStarAlgebra.ContinuousLinearMap
+public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
 public import Mathlib.Analysis.Normed.Operator.ContinuousAlgEquiv
 public import Mathlib.Analysis.CStarAlgebra.Hom
 
@@ -37,12 +37,9 @@ variable {H : Type*}
     [InnerProductSpace ℂ H]
     [CompleteSpace H]
 
-/--
-Every ⋆-automorphism of `B(H)` is implemented by unitary conjugation.
--/
+/-- Every ⋆-automorphism of `B(H)` is implemented by unitary conjugation. -/
 lemma conjStarAlgAut_surjective :
-    Function.Surjective
-      (Unitary.conjStarAlgAut ℂ (H →L[ℂ] H)) := by
+    Function.Surjective (Unitary.conjStarAlgAut ℂ (B(H))) := by
   intro φ
   obtain ⟨U, hU⟩ :=
     φ.eq_linearIsometryEquivConjStarAlgEquiv
@@ -51,42 +48,27 @@ lemma conjStarAlgAut_surjective :
   rw [Unitary.conjStarAlgAut_symm_unitaryLinearIsometryEquiv]
   exact hU.symm
 
-
-/--
-Two unitaries implement the same ⋆-automorphism of `B(H)` exactly when
-they differ by a scalar phase.
--/
+/-- Two unitaries implement the same ⋆-automorphism of `B(H)` exactly when they differ by a scalar
+phase. -/
 lemma conjStarAlgAut_eq_iff
-    (u v : unitary (H →L[ℂ] H)) :
-    Unitary.conjStarAlgAut ℂ (H →L[ℂ] H) u =
-        Unitary.conjStarAlgAut ℂ (H →L[ℂ] H) v ↔
+    (u v : Unitary (B(H))) :
+    Unitary.conjStarAlgAut ℂ (B(H)) u =
+        Unitary.conjStarAlgAut ℂ (B(H)) v ↔
       ∃ c : unitary ℂ, u = c • v :=
   Unitary.conjStarAlgAut_ext_iff' u v
 
-
-/--
-The projective unitary group of `H`.
-This is the unitary group modulo the scalar phases which act trivially
-by conjugation.
--/
-noncomputable def ProjectiveUnitary (H : Type*)
+/-- The projective unitary group of `H`, obtained by quotienting out scalar phases. -/
+def ProjectiveUnitary (H : Type*)
     [NormedAddCommGroup H]
     [InnerProductSpace ℂ H]
     [CompleteSpace H] :=
-  unitary (H →L[ℂ] H) ⧸
-    MonoidHom.ker (Unitary.conjStarAlgAut ℂ (H →L[ℂ] H))
+  Unitary (B(H)) ⧸ MonoidHom.ker (Unitary.conjStarAlgAut ℂ (B(H)))
 
-noncomputable instance :
-    Group (ProjectiveUnitary H) :=
-  QuotientGroup.Quotient.group _
+noncomputable instance : Group (ProjectiveUnitary H) := QuotientGroup.Quotient.group _
 
-/--
-Reversible transformations of `B(H)` are precisely projective unitaries.
--/
+/-- Reversible transformations of `B(H)` are precisely projective unitaries. -/
 noncomputable def projectiveUnitaryEquivStarAlgAut :
-    ProjectiveUnitary H ≃*
-      ((H →L[ℂ] H) ≃⋆ₐ[ℂ] (H →L[ℂ] H)) :=
-  QuotientGroup.quotientKerEquivOfSurjective
-    _ conjStarAlgAut_surjective
+    ProjectiveUnitary H ≃* ((B(H)) ≃⋆ₐ[ℂ] (B(H))) :=
+  QuotientGroup.quotientKerEquivOfSurjective _ conjStarAlgAut_surjective
 
 end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
@@ -20,17 +20,10 @@ ordered-star-ring instances for bounded operators are supplied by Mathlib.
 
 namespace OperatorAlgebra
 
-/-- A complex Hilbert space: a complete complex inner-product space. -/
-class HilbertSpace (H : Type*) extends NormedAddCommGroup H, InnerProductSpace ℂ H, CompleteSpace H
-
-/-- Mathlib's separate Hilbert-space assumptions provide Physlib's bundled physics interface. -/
-noncomputable instance (priority := low) instHilbertSpace (H : Type*) [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H] [CompleteSpace H] : HilbertSpace H := {}
-
 /-- Bounded operators on a complex Hilbert space, written in the usual physics notation. -/
 notation "B(" H ")" => H →L[ℂ] H
 
-variable {H : Type*} [HilbertSpace H]
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
 
 /-- Bounded operators form an `OperatorAlgebra` using Mathlib's native Hilbert-space instances. -/
 noncomputable instance instOperatorAlgebraBoundedOperators : OperatorAlgebra B(H) := {}
@@ -38,7 +31,8 @@ noncomputable instance instOperatorAlgebraBoundedOperators : OperatorAlgebra B(H
 section Representation
 
 /-- A Hilbert-space representation of `A` as a unital ⋆-homomorphism into `B(H)`. -/
-abbrev Representation (A H : Type*) [OperatorAlgebra A] [HilbertSpace H] := A →⋆ₐ[ℂ] B(H)
+abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
 
 end Representation
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
@@ -20,30 +20,25 @@ ordered-star-ring instances for bounded operators are supplied by Mathlib.
 
 namespace OperatorAlgebra
 
+/-- A complex Hilbert space: a complete complex inner-product space. -/
+class HilbertSpace (H : Type*) extends NormedAddCommGroup H, InnerProductSpace ℂ H, CompleteSpace H
+
+/-- Mathlib's separate Hilbert-space assumptions provide Physlib's bundled physics interface. -/
+noncomputable instance (priority := low) instHilbertSpace (H : Type*) [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H] [CompleteSpace H] : HilbertSpace H := {}
+
 /-- Bounded operators on a complex Hilbert space, written in the usual physics notation. -/
 notation "B(" H ")" => H →L[ℂ] H
 
-section HilbertSpaceOperatorAlgebra
-
-variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
-
-/-- The operator algebra of bounded operators on a complex Hilbert space. -/
-abbrev HilbertSpaceOperatorAlgebra (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] :=
-  OperatorAlgebra B(H)
+variable {H : Type*} [HilbertSpace H]
 
 /-- Bounded operators form an `OperatorAlgebra` using Mathlib's native Hilbert-space instances. -/
-noncomputable instance : HilbertSpaceOperatorAlgebra H := {}
-
-end HilbertSpaceOperatorAlgebra
+noncomputable instance instOperatorAlgebraBoundedOperators : OperatorAlgebra B(H) := {}
 
 section Representation
 
-variable {A : Type*} {H : Type*} [OperatorAlgebra A] [NormedAddCommGroup H]
-  [InnerProductSpace ℂ H] [CompleteSpace H]
-
 /-- A Hilbert-space representation of `A` as a unital ⋆-homomorphism into `B(H)`. -/
-abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
-    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
+abbrev Representation (A H : Type*) [OperatorAlgebra A] [HilbertSpace H] := A →⋆ₐ[ℂ] B(H)
 
 end Representation
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/HilbertSpace.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Mathlib.Analysis.InnerProductSpace.StarOrder
+
+/-!
+# Bounded operators on Hilbert space
+
+This file connects the abstract operator-algebraic quantum-mechanics API with the concrete
+C⋆-algebra of bounded operators on a complex Hilbert space. The C⋆-algebra, Loewner order, and
+ordered-star-ring instances for bounded operators are supplied by Mathlib.
+-/
+
+@[expose] public section
+
+namespace OperatorAlgebra
+
+/-- Bounded operators on a complex Hilbert space, written in the usual physics notation. -/
+notation "B(" H ")" => H →L[ℂ] H
+
+section HilbertSpaceOperatorAlgebra
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- The operator algebra of bounded operators on a complex Hilbert space. -/
+abbrev HilbertSpaceOperatorAlgebra (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H] :=
+  OperatorAlgebra B(H)
+
+/-- Bounded operators form an `OperatorAlgebra` using Mathlib's native Hilbert-space instances. -/
+noncomputable instance : HilbertSpaceOperatorAlgebra H := {}
+
+end HilbertSpaceOperatorAlgebra
+
+section Representation
+
+variable {A : Type*} {H : Type*} [OperatorAlgebra A] [NormedAddCommGroup H]
+  [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- A Hilbert-space representation of `A` as a unital ⋆-homomorphism into `B(H)`. -/
+abbrev Representation (A H : Type*) [OperatorAlgebra A] [NormedAddCommGroup H]
+    [InnerProductSpace ℂ H] [CompleteSpace H] := A →⋆ₐ[ℂ] B(H)
+
+end Representation
+
+end OperatorAlgebra


### PR DESCRIPTION
## Summary

Adds the static classification of reversible dynamics on the bounded-operator algebra of a complex Hilbert space. Every star-automorphism is implemented by unitary conjugation, with the expected scalar-phase ambiguity.

## API structure

- `OperatorAlgebra.Basic` contains only the generic operator-algebraic vocabulary.
- `OperatorAlgebra.HilbertSpace` introduces the physics-facing class `OperatorAlgebra.HilbertSpace H`, bundling the standard complex Hilbert-space assumptions behind one uniform hypothesis.
- The same file defines `B(H)`, gives it a direct canonical `OperatorAlgebra` instance, and defines `Representation A H`. The redundant `HilbertSpaceOperatorAlgebra` alias has been removed.
- A low-priority compatibility instance lets existing Mathlib code with separate normed-group, inner-product, and completeness assumptions use the bundled interface.
- `OperatorAlgebra.Dynamics.Automorphism` contains the Hilbert-space automorphism results and now consistently assumes `[HilbertSpace H]`.