### PR TITLE
The Jordan product on observables

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -336,7 +336,7 @@ public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
-public import Physlib.QuantumMechanics.OperatorAlgebra.Jordan
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Jordan
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -336,6 +336,7 @@ public import Physlib.QuantumMechanics.Hydrogen.Basic
 public import Physlib.QuantumMechanics.Hydrogen.LaplaceRungeLenzVector
 public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.Jordan
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
@@ -7,24 +7,21 @@ module
 
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
 public import Mathlib.Algebra.Jordan.Basic
+public import Mathlib.LinearAlgebra.Complex.Module
 
 /-!
 
 # Jordan structure on observables
 
-The observables of a complex C⋆-algebra carry the Jordan product
+The observables of a complex C⋆-algebra carry the symmetrized product
 
-    a ∘ b = 1/2 (ab + ba),
+    a ⊙ b = 1/2 (ab + ba),
 
 equivalently the real part of their algebra product.
 
-The product is commutative and satisfies the Jordan identity
-
-    (a ∘ b) ∘ (a ∘ a) = a ∘ (b ∘ (a ∘ a)).
-
-`JordanObservable A` is a thin wrapper around `Observable A` carrying this
-product as its multiplication. It is therefore a commutative Jordan algebra
-in Mathlib's sense.
+This product is commutative and satisfies the Jordan identity. The type
+`JordanObservable A` equips the real vector space of observables with this
+product as its multiplication, giving a commutative Jordan algebra.
 
 -/
 
@@ -36,43 +33,51 @@ variable {A : Type*} [CStarAlgebra A]
 
 namespace Observable
 
-/-- The Jordan product of observables is the real part of their algebra product. -/
+/-- The symmetrized product of two observables. -/
 noncomputable def jordan (a b : Observable A) : Observable A :=
   realPart ((a : A) * (b : A))
 
+scoped[OperatorAlgebra] infixl:70 " ⊙ " => Observable.jordan
+
 @[simp]
 lemma coe_jordan (a b : Observable A) :
-    (jordan a b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
+    (a ⊙ b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
   change (↑(realPart ((a : A) * (b : A))) : A) =
     (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a)
   rw [realPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
 
-lemma jordan_comm (a b : Observable A) : jordan a b = jordan b a := by
+lemma jordan_comm (a b : Observable A) :
+    a ⊙ b = b ⊙ a := by
   apply Subtype.ext
   simp [coe_jordan, add_comm]
 
-lemma jordan_self (a : Observable A) : (jordan a a : A) = (a : A) * a := by
+@[simp]
+lemma jordan_self (a : Observable A) :
+    (a ⊙ a : A) = (a : A) * a := by
   rw [coe_jordan]
   module
 
-lemma add_jordan (a b c : Observable A) : jordan (a + b) c = jordan a c + jordan b c := by
+lemma add_jordan (a b c : Observable A) :
+    (a + b) ⊙ c = a ⊙ c + b ⊙ c := by
   change realPart (((a + b : Observable A) : A) * (c : A)) =
     realPart ((a : A) * (c : A)) + realPart ((b : A) * (c : A))
   rw [AddSubgroup.coe_add, add_mul, map_add]
 
-lemma jordan_add (a b c : Observable A) : jordan a (b + c) = jordan a b + jordan a c := by
+lemma jordan_add (a b c : Observable A) :
+    a ⊙ (b + c) = a ⊙ b + a ⊙ c := by
   change realPart ((a : A) * ((b + c : Observable A) : A)) =
     realPart ((a : A) * (b : A)) + realPart ((a : A) * (c : A))
   rw [AddSubgroup.coe_add, mul_add, map_add]
 
-lemma jordan_smul (t : ℝ) (a b : Observable A) : jordan a (t • b) = t • jordan a b := by
+lemma jordan_smul (t : ℝ) (a b : Observable A) :
+    a ⊙ (t • b) = t • (a ⊙ b) := by
   change realPart ((a : A) * ((t • b : Observable A) : A)) =
     t • realPart ((a : A) * (b : A))
   rw [selfAdjoint.val_smul, mul_smul_comm]
   exact map_smul (realPart : A →ₗ[ℝ] Observable A) t ((a : A) * (b : A))
 
 lemma jordan_identity (a b : Observable A) :
-    jordan (jordan a b) (jordan a a) = jordan a (jordan b (jordan a a)) := by
+    (a ⊙ b) ⊙ (a ⊙ a) = a ⊙ (b ⊙ (a ⊙ a)) := by
   apply Subtype.ext
   simp only [coe_jordan, smul_add]
   norm_num [← smul_add]
@@ -82,38 +87,41 @@ end Observable
 
 /-! ## Jordan observables
 
-`Observable A` itself cannot receive the Jordan product as a global `Mul`
-instance, since Mathlib can already provide multiplication on self-adjoint
-elements under stronger assumptions on `A`.
+`Observable A` itself cannot receive this product as a global `Mul` instance,
+since Mathlib can already provide multiplication on self-adjoint elements under
+stronger assumptions on `A`.
 
-`JordanObservable A` is therefore the same underlying real vector space,
-equipped with the Jordan product as multiplication.
+`JordanObservable A` is the same underlying real vector space equipped with the
+symmetrized product as multiplication.
 -/
 
 /-- Observables equipped with their Jordan multiplication. -/
-noncomputable abbrev JordanObservable (A : Type*) [CStarAlgebra A] := Observable A
+noncomputable abbrev JordanObservable (A : Type*) [CStarAlgebra A] :=
+  Observable A
 
 namespace JordanObservable
 
 variable {A : Type*} [CStarAlgebra A]
 
+open scoped Observable
+
 noncomputable instance instNonUnitalNonAssocCommRing :
     NonUnitalNonAssocCommRing (JordanObservable A) where
-  mul a b := Observable.jordan a b
+  mul a b := a ⊙ b
   mul_comm a b := Observable.jordan_comm a b
   left_distrib a b c := Observable.jordan_add a b c
   right_distrib a b c := Observable.add_jordan a b c
   zero_mul a := by
-    change Observable.jordan 0 a = 0
+    change (0 : Observable A) ⊙ a = 0
     simp [Observable.jordan]
   mul_zero a := by
-    change Observable.jordan a 0 = 0
+    change a ⊙ (0 : Observable A) = 0
     simp [Observable.jordan]
 
-noncomputable instance instIsCommJordan : IsCommJordan (JordanObservable A) where
+noncomputable instance instIsCommJordan :
+    IsCommJordan (JordanObservable A) where
   lmul_comm_rmul_rmul a b := by
-    change Observable.jordan (Observable.jordan a b) (Observable.jordan a a) =
-      Observable.jordan a (Observable.jordan b (Observable.jordan a a))
+    change (a ⊙ b) ⊙ (a ⊙ a) = a ⊙ (b ⊙ (a ⊙ a))
     exact Observable.jordan_identity a b
 
 end JordanObservable

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Mathlib.Algebra.Jordan.Basic
+
+/-!
+
+# Jordan structure on observables
+
+The observables of a complex C⋆-algebra carry the Jordan product
+
+    a ∘ b = 1/2 (ab + ba),
+
+equivalently the real part of their algebra product.
+
+The product is commutative and satisfies the Jordan identity
+
+    (a ∘ b) ∘ (a ∘ a) = a ∘ (b ∘ (a ∘ a)).
+
+`JordanObservable A` is a thin wrapper around `Observable A` carrying this
+product as its multiplication. It is therefore a commutative Jordan algebra
+in Mathlib's sense.
+
+-/
+
+@[expose] public section
+
+namespace OperatorAlgebra
+
+variable {A : Type*} [CStarAlgebra A]
+
+namespace Observable
+
+/-- The Jordan product of observables is the real part of their algebra product. -/
+noncomputable def jordan (a b : Observable A) : Observable A :=
+  realPart ((a : A) * (b : A))
+
+@[simp]
+lemma coe_jordan (a b : Observable A) :
+    (jordan a b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
+  change (↑(realPart ((a : A) * (b : A))) : A) =
+    (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a)
+  rw [realPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
+
+lemma jordan_comm (a b : Observable A) : jordan a b = jordan b a := by
+  apply Subtype.ext
+  simp [coe_jordan, add_comm]
+
+lemma jordan_self (a : Observable A) : (jordan a a : A) = (a : A) * a := by
+  rw [coe_jordan]
+  module
+
+lemma add_jordan (a b c : Observable A) : jordan (a + b) c = jordan a c + jordan b c := by
+  change realPart (((a + b : Observable A) : A) * (c : A)) =
+    realPart ((a : A) * (c : A)) + realPart ((b : A) * (c : A))
+  rw [AddSubgroup.coe_add, add_mul, map_add]
+
+lemma jordan_add (a b c : Observable A) : jordan a (b + c) = jordan a b + jordan a c := by
+  change realPart ((a : A) * ((b + c : Observable A) : A)) =
+    realPart ((a : A) * (b : A)) + realPart ((a : A) * (c : A))
+  rw [AddSubgroup.coe_add, mul_add, map_add]
+
+lemma jordan_smul (t : ℝ) (a b : Observable A) : jordan a (t • b) = t • jordan a b := by
+  change realPart ((a : A) * ((t • b : Observable A) : A)) =
+    t • realPart ((a : A) * (b : A))
+  rw [selfAdjoint.val_smul, mul_smul_comm]
+  exact map_smul (realPart : A →ₗ[ℝ] Observable A) t ((a : A) * (b : A))
+
+lemma jordan_identity (a b : Observable A) :
+    jordan (jordan a b) (jordan a a) = jordan a (jordan b (jordan a a)) := by
+  apply Subtype.ext
+  simp only [coe_jordan, smul_add]
+  norm_num [← smul_add]
+  noncomm_ring
+
+end Observable
+
+/-! ## Jordan observables
+
+`Observable A` itself cannot receive the Jordan product as a global `Mul`
+instance, since Mathlib can already provide multiplication on self-adjoint
+elements under stronger assumptions on `A`.
+
+`JordanObservable A` is therefore the same underlying real vector space,
+equipped with the Jordan product as multiplication.
+-/
+
+/-- Observables equipped with their Jordan multiplication. -/
+noncomputable abbrev JordanObservable (A : Type*) [CStarAlgebra A] := Observable A
+
+namespace JordanObservable
+
+variable {A : Type*} [CStarAlgebra A]
+
+noncomputable instance instNonUnitalNonAssocCommRing :
+    NonUnitalNonAssocCommRing (JordanObservable A) where
+  mul a b := Observable.jordan a b
+  mul_comm a b := Observable.jordan_comm a b
+  left_distrib a b c := Observable.jordan_add a b c
+  right_distrib a b c := Observable.add_jordan a b c
+  zero_mul a := by
+    change Observable.jordan 0 a = 0
+    simp [Observable.jordan]
+  mul_zero a := by
+    change Observable.jordan a 0 = 0
+    simp [Observable.jordan]
+
+noncomputable instance instIsCommJordan : IsCommJordan (JordanObservable A) where
+  lmul_comm_rmul_rmul a b := by
+    change Observable.jordan (Observable.jordan a b) (Observable.jordan a a) =
+      Observable.jordan a (Observable.jordan b (Observable.jordan a a))
+    exact Observable.jordan_identity a b
+
+end JordanObservable
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Jordan.lean
@@ -37,6 +37,7 @@ namespace Observable
 noncomputable def jordan (a b : Observable A) : Observable A :=
   realPart ((a : A) * (b : A))
 
+/-- The Jordan product on observables. -/
 scoped[OperatorAlgebra] infixl:70 " ⊙ " => Observable.jordan
 
 @[simp]
@@ -51,7 +52,6 @@ lemma jordan_comm (a b : Observable A) :
   apply Subtype.ext
   simp [coe_jordan, add_comm]
 
-@[simp]
 lemma jordan_self (a : Observable A) :
     (a ⊙ a : A) = (a : A) * a := by
   rw [coe_jordan]

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
@@ -44,7 +44,6 @@ noncomputable def jordan (a b : Observable A) : Observable A :=
 /-- The Jordan product on observables. -/
 scoped[OperatorAlgebra] infixl:70 " ⊙ " => Observable.jordan
 
-@[simp]
 lemma coe_jordan (a b : Observable A) :
     (a ⊙ b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
   change (↑(realPart ((a : A) * (b : A))) : A) =
@@ -95,13 +94,23 @@ end Observable
 symmetrized product as multiplication.
 -/
 
-/-- Observables equipped with their Jordan multiplication. -/
-noncomputable abbrev JordanObservable (A : Type*) [OperatorAlgebra A] :=
+/-- Observables equipped with their Jordan multiplication.
+
+This is a type synonym for `Observable A`, kept a `def` (rather than an `abbrev`) so that the
+`NonUnitalNonAssocCommRing` structure defined below on `JordanObservable A` is not silently
+inherited by `Observable A` itself, which has no canonical multiplication of its own. -/
+noncomputable def JordanObservable (A : Type*) [OperatorAlgebra A] :=
   Observable A
 
 namespace JordanObservable
 
 variable {A : Type*} [OperatorAlgebra A]
+
+noncomputable instance instAddCommGroup : AddCommGroup (JordanObservable A) :=
+  inferInstanceAs (AddCommGroup (Observable A))
+
+noncomputable instance instModule : Module ℝ (JordanObservable A) :=
+  inferInstanceAs (Module ℝ (Observable A))
 
 open scoped Observable
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
@@ -33,7 +33,7 @@ TODO "Investigate `https://github.com/Cobord/JordanAlgebra/` and determine
 
 namespace OperatorAlgebra
 
-variable {A : Type*} [CStarAlgebra A]
+variable {A : Type*} [OperatorAlgebra A]
 
 namespace Observable
 
@@ -91,21 +91,17 @@ end Observable
 
 /-! ## Jordan observables
 
-`Observable A` itself cannot receive this product as a global `Mul` instance,
-since Mathlib can already provide multiplication on self-adjoint elements under
-stronger assumptions on `A`.
-
 `JordanObservable A` is the same underlying real vector space equipped with the
 symmetrized product as multiplication.
 -/
 
 /-- Observables equipped with their Jordan multiplication. -/
-noncomputable abbrev JordanObservable (A : Type*) [CStarAlgebra A] :=
+noncomputable abbrev JordanObservable (A : Type*) [OperatorAlgebra A] :=
   Observable A
 
 namespace JordanObservable
 
-variable {A : Type*} [CStarAlgebra A]
+variable {A : Type*} [OperatorAlgebra A]
 
 open scoped Observable
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
@@ -6,6 +6,7 @@ Authors: Tom Ole Diem
 module
 
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.Meta.TODO.Basic
 public import Mathlib.Algebra.Jordan.Basic
 public import Mathlib.LinearAlgebra.Complex.Module
 
@@ -24,6 +25,9 @@ This product is commutative and satisfies the Jordan identity. The type
 product as its multiplication, giving a commutative Jordan algebra.
 
 -/
+
+TODO "Investigate `https://github.com/Cobord/JordanAlgebra/` and determine
+  which general Jordan-algebra results are relevant for quantum mechanics."
 
 @[expose] public section
 


### PR DESCRIPTION
Observables carry two product structures: the symmetric Jordan product and the antisymmetric Lie product.