### PR TITLE
feat(ClassicalMechanics): the simple pendulum's configuration space

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -17,6 +17,7 @@ public import Physlib.ClassicalMechanics.Mass.MassUnit
 public import Physlib.ClassicalMechanics.OrbitalMechanics.VisViva
 public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum
 public import Physlib.ClassicalMechanics.RigidBody.AngularVelocity

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -9,14 +9,13 @@ Overview: |
     covers the pendulum problems of Landau and Lifshitz, Mechanics, 3rd ed.,
     Chapter 1, Section 5.
 
-    At present only the sliding pendulum has a defined configuration space, with
-    the horizontal support position and the string angle as its generalized
-    coordinates. The coplanar double pendulum's configuration space is declared but
-    not yet defined, and the miscellaneous pivot-motion problems have documentation
-    only. The remaining requirements, a manifold structure on the configuration
-    space, a map into real space, trajectories, and the lagrangian, are open and
-    recorded below with location N/A. The simple pendulum has its own API map in
-    Physlib/ClassicalMechanics/Pendulum/SimplePendulum.
+    The sliding pendulum has a defined configuration space in the generalized coordinates of the
+    support position and the string angle. The simple pendulum's configuration space, an angle
+    modulo a full turn, carries the manifold structure and the map into `Space`; it has its own API
+    map in `Physlib/ClassicalMechanics/Pendulum/SimplePendulum`. The coplanar double pendulum's
+    configuration space is declared but not yet defined, and the miscellaneous pivot-motion problems
+    have documentation only. Trajectories and the lagrangian remain open and are recorded below with
+    location N/A.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)
@@ -38,9 +37,7 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instIsManifold)
 
-  - description: >
-      The API contains a map from the configuration space to `Space`, giving the
-      position of the pendulum in real space.
+  - description: The API contains a map from the configuration space to `Space`, giving the position of the pendulum in real space (for the simple pendulum).
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace)
 

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -15,7 +15,8 @@ Overview: |
     not yet defined, and the miscellaneous pivot-motion problems have documentation
     only. The remaining requirements, a manifold structure on the configuration
     space, a map into real space, trajectories, and the lagrangian, are open and
-    recorded below with location N/A.
+    recorded below with location N/A. The simple pendulum has its own API map in
+    Physlib/ClassicalMechanics/Pendulum/SimplePendulum.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)
@@ -33,15 +34,15 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SlidingPendulum.lean (ConfigurationSpace)
 
-  - description: The API shall contain the structure of a manifold on the configuration space.
-    done: false
-    location: "N/A"
+  - description: The API contains the structure of a manifold on the configuration space (for the simple pendulum).
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instIsManifold)
 
   - description: >
-      The API shall contain a map from the configuration space to `Space`, giving the
+      The API contains a map from the configuration space to `Space`, giving the
       position of the pendulum in real space.
-    done: false
-    location: "N/A"
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace)
 
   - description: The API shall contain the definition of a trajectory based on the configuration space.
     done: false

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -7,10 +7,11 @@ Overview: |
     in a vertical plane under gravity g. Its configuration is the angle of the rod from the downward
     vertical, taken modulo a full turn, so the configuration space is a circle; the position of the
     bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
-    small amplitudes it is harmonic with period 2π√(ℓ/g); in general the period grows with the
-    amplitude and is given by a complete elliptic integral. This API records the configuration
-    space with its manifold structure and its embedding into physical space; the dynamics, the
-    small-angle limit and the period follow in later modules.
+    small amplitudes it is harmonic with period 2π√(ℓ/g); for librations (amplitudes below the
+    inverted position) the period grows with the amplitude and is given by a complete elliptic
+    integral. This API records the configuration space with its manifold structure and its
+    embedding into physical space; the dynamics, the small-angle limit and the period follow in
+    later modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -1,0 +1,48 @@
+version: v0.1
+
+Title: Simple pendulum
+
+Overview: |
+    A simple pendulum is a bob on a rigid massless rod of length ℓ, pinned at a pivot and swinging
+    in a vertical plane under gravity g. Its configuration is the angle of the rod from the downward
+    vertical, taken modulo a full turn, so the configuration space is a circle; the position of the
+    bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
+    small amplitudes it is harmonic with period 2π√(ℓ/g); in general the period grows with the
+    amplitude and is given by a complete elliptic integral. This API records the configuration
+    space with its manifold structure and its embedding into physical space; the dynamics, the
+    small-angle limit and the period follow in later modules.
+
+ParentAPIs:
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Configuration space for pendulum (Physlib/ClassicalMechanics/Pendulum)"
+
+References:
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 1 (The Equations of motion), Section 5 (The Lagrangian for a system of particles).
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 3 (Integration of the equations of motion), Section 11 (Motion in one dimension).
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 5 (Small oscillations), Section 21 (Free oscillations in one dimension).
+
+Requirements:
+
+  - description: The key data structure, the configuration space of the simple pendulum, is defined as the angle of the rod from the downward vertical modulo a full turn.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace, SimplePendulum.ConfigurationSpace.circleHomeomorph)
+
+  - description: The API contains the structure of a manifold on the configuration space.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instChartedSpace, SimplePendulum.ConfigurationSpace.instIsManifold)
+
+  - description: The API contains the angular lift from the real line to the configuration space, periodic with period 2π.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.ofAngle, SimplePendulum.ConfigurationSpace.ofAngle_periodic, SimplePendulum.ConfigurationSpace.ofAngle_eq_iff)
+
+  - description: The API contains a map from the configuration space to `Space`, giving the position of the bob in real space, together with the rod-length constraint.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace, SimplePendulum.ConfigurationSpace.toSpace_ofAngle, SimplePendulum.ConfigurationSpace.toSpace_norm)
+
+  - description: The API shall contain the definition of a trajectory based on the configuration space.
+    done: false
+    location: N/A
+
+  - description: The API shall contain the Lagrangian of the simple pendulum and its equation of motion.
+    done: false
+    location: N/A

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.SpaceAndTime.Space.Basic
+public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+/-!
+
+# Configuration space of the simple pendulum
+
+## i. Overview
+
+A simple pendulum is a bob fixed to one end of a rigid massless rod of length `ℓ`, the other end
+of which is pinned at a pivot, swinging in a vertical plane under gravity. Its position is fixed by
+the angle of the rod from the downward vertical, and two angles that differ by a full turn describe
+the same position. The configuration space is therefore a circle.
+
+We record a configuration by its angle modulo `2π`, i.e. by an element of `Real.Angle`, as the
+sliding pendulum does (`Physlib.ClassicalMechanics.Pendulum.SlidingPendulum`). The circle carries
+the structure of a compact analytic one-dimensional manifold; we obtain it by identifying the
+configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The real-valued
+angle that is used to write down the dynamics is a lift of the configuration to the universal cover
+`ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
+motion. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends the
+configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
+points upwards.
+
+## ii. Key results
+
+- `ConfigurationSpace` : the configuration space of the planar simple pendulum.
+- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle.
+- `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
+  manifold structure, pulled back from `Circle`.
+- `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
+  `2π`, continuous and surjective.
+- `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
+  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
+
+## iii. Table of contents
+
+- A. The configuration space type
+- B. Topology and identification with the unit circle
+- C. Manifold structure
+- D. The angular lift
+- E. Map to physical space
+
+## iv. References
+
+- Landau & Lifshitz, Mechanics, 3rd ed., §5, Problems 1–3 (pendulum configurations).
+- Mathlib, `Mathlib.Geometry.Manifold.Instances.Sphere` (the manifold structure on `Circle`).
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open scoped Manifold ContDiff
+
+namespace ClassicalMechanics
+namespace SimplePendulum
+
+/-!
+
+## A. The configuration space type
+
+A configuration is the angle of the rod from the downward vertical, taken modulo a full turn.
+
+-/
+
+/-- The configuration space of the planar simple pendulum: the angle of the rod from the downward
+  vertical, modulo `2π`. -/
+structure ConfigurationSpace where
+  /-- The angle of the rod from the downward vertical, modulo `2π`. -/
+  angle : Real.Angle
+
+namespace ConfigurationSpace
+
+/-- Two configurations are equal precisely when their angles are equal. -/
+@[ext]
+lemma ext {p q : ConfigurationSpace} (h : p.angle = q.angle) : p = q := by
+  cases p; cases q; cases h; rfl
+
+/-!
+
+## B. Topology and identification with the unit circle
+
+The topology is that of `Real.Angle`; composing with Mathlib's identification of `Real.Angle`
+(the additive circle of period `2π`) with the unit circle `Circle ⊆ ℂ` gives a homeomorphism
+`ConfigurationSpace ≃ₜ Circle`, through which the circle's compactness and Hausdorff property
+transfer.
+
+-/
+
+/-- The identification of the configuration space with `Real.Angle`. -/
+def angleEquiv : ConfigurationSpace ≃ Real.Angle where
+  toFun := angle
+  invFun φ := ⟨φ⟩
+  left_inv q := by cases q; rfl
+  right_inv φ := rfl
+
+/-- The topology of the configuration space, induced from `Real.Angle`. -/
+instance instTopologicalSpace : TopologicalSpace ConfigurationSpace :=
+  TopologicalSpace.induced angle inferInstance
+
+/-- The identification with `Real.Angle` as a homeomorphism. -/
+def angleHomeomorph : ConfigurationSpace ≃ₜ Real.Angle where
+  toEquiv := angleEquiv
+  continuous_toFun := continuous_induced_dom
+  continuous_invFun := continuous_induced_rng.mpr continuous_id
+
+/-- The point of the unit circle `e^{iθ}` corresponding to a configuration at angle `θ`. -/
+def toCircle (q : ConfigurationSpace) : Circle := q.angle.toCircle
+
+/-- The identification of the configuration space with the unit circle. -/
+def circleHomeomorph : ConfigurationSpace ≃ₜ Circle :=
+  angleHomeomorph.trans AddCircle.homeomorphCircle'
+
+/-- The identification with the unit circle is given by `ConfigurationSpace.toCircle`. -/
+lemma circleHomeomorph_apply (q : ConfigurationSpace) : circleHomeomorph q = q.toCircle := rfl
+
+/-- The configuration space is Hausdorff, being homeomorphic to the unit circle. -/
+instance instT2Space : T2Space ConfigurationSpace := circleHomeomorph.symm.t2Space
+
+/-- The configuration space is compact, being homeomorphic to the unit circle. -/
+instance instCompactSpace : CompactSpace ConfigurationSpace := circleHomeomorph.symm.compactSpace
+
+/-- The configuration space is second countable, being homeomorphic to the unit circle. -/
+instance instSecondCountableTopology : SecondCountableTopology ConfigurationSpace :=
+  circleHomeomorph.secondCountableTopology
+
+end ConfigurationSpace
+end SimplePendulum
+end ClassicalMechanics
+
+end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -25,7 +25,7 @@ sliding pendulum does (`Physlib.ClassicalMechanics.Pendulum.SlidingPendulum`). T
 the structure of a compact analytic one-dimensional manifold; we obtain it by identifying the
 configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The smooth
 identification of the configuration space with `Circle` (the analogue of the harmonic oscillator's
-`valDiffeomorph`) is deferred to the module on trajectories. The real-valued angle that is used to
+`valDiffeomorph`) is deferred to a later module. The real-valued angle that is used to
 write down the dynamics is a lift of the configuration along the covering map
 `ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
 configuration. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -26,7 +26,7 @@ the structure of a compact analytic one-dimensional manifold; we obtain it by id
 configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The smooth
 identification of the configuration space with `Circle` (the analogue of the harmonic oscillator's
 `valDiffeomorph`) is deferred to the module on trajectories. The real-valued angle that is used to
-write down the dynamics is a lift of the configuration to the universal cover
+write down the dynamics is a lift of the configuration along the covering map
 `ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
 configuration. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends
 the configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
@@ -35,13 +35,15 @@ points upwards.
 ## ii. Key results
 
 - `ConfigurationSpace` : the configuration space of the planar simple pendulum.
-- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle.
+- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle, with inverse
+  `ConfigurationSpace.ofCircle` (`toCircle_ofCircle`, `ofCircle_toCircle`).
 - `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
-  manifold structure, pulled back from `Circle`.
+  manifold structure, pulled back from `Circle` (`chartAt_source`, `chartAt_target`).
 - `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
-  `2π`, continuous, surjective and analytic.
+  `2π`, continuous, surjective, analytic, and a covering map (`isCoveringMap_ofAngle`).
 - `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
-  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
+  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`; for `ℓ ≠ 0` it is a closed
+  embedding (`toSpace_isClosedEmbedding`).
 
 ## iii. Table of contents
 
@@ -227,7 +229,7 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
 `ℝ → ℝ / 2πℤ`, a covering map of the circle: it is continuous, surjective and `2π`-periodic, and
 two angles give the same configuration exactly when they differ by a whole number of turns. The
 dynamics of the pendulum are written for a real-valued lift of the angle; this section is what
-makes different lifts describe the same motion. In the charts pulled back from the circle the lift
+makes different lifts describe the same configuration. In the charts pulled back from the circle
 is `Circle.exp`, so it is analytic.
 
 -/
@@ -281,6 +283,11 @@ lemma isCoveringMap_ofAngle : IsCoveringMap ofAngle := by
 /-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
 @[simp]
 lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
+
+/-- The configuration of a point `e^{iθ}` of the unit circle is `ofAngle θ`. -/
+@[simp]
+lemma ofCircle_circleExp (θ : ℝ) : ofCircle (Circle.exp θ) = ofAngle θ := by
+  rw [← toCircle_ofAngle, ofCircle_toCircle]
 
 /-- The angular lift is analytic: read in the charts pulled back from the circle it is
   `Circle.exp`. -/

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -362,13 +362,10 @@ lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
     toSpace ℓ q 1 = -(ℓ * q.cos) := neg_mul ℓ q.cos
 
 /-- The position of the bob for the configuration at angle `θ`. -/
+@[simp]
 lemma toSpace_ofAngle (ℓ θ : ℝ) :
     toSpace ℓ (ofAngle θ) = ⟨![ℓ * Real.sin θ, -ℓ * Real.cos θ]⟩ := by
   simp [toSpace]
-
-/-- At `θ = 0` the bob hangs straight down, at `(0, -ℓ)`. -/
-lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]⟩ := by
-  simp [toSpace_ofAngle]
 
 /-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
 @[simp]

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.SpaceAndTime.Space.Module
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Topology.Covering.AddCircle
 /-!
 
 # Configuration space of the simple pendulum
@@ -22,11 +23,13 @@ the same position. The configuration space is therefore a circle.
 We record a configuration by its angle modulo `2π`, i.e. by an element of `Real.Angle`, as the
 sliding pendulum does (`Physlib.ClassicalMechanics.Pendulum.SlidingPendulum`). The circle carries
 the structure of a compact analytic one-dimensional manifold; we obtain it by identifying the
-configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The real-valued
-angle that is used to write down the dynamics is a lift of the configuration to the universal cover
+configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The smooth
+identification of the configuration space with `Circle` (the analogue of the harmonic oscillator's
+`valDiffeomorph`) is deferred to the module on trajectories. The real-valued angle that is used to
+write down the dynamics is a lift of the configuration to the universal cover
 `ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
-motion. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends the
-configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
+configuration. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends
+the configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
 points upwards.
 
 ## ii. Key results
@@ -120,8 +123,27 @@ def toCircle (q : ConfigurationSpace) : Circle := q.angle.toCircle
 def circleHomeomorph : ConfigurationSpace ≃ₜ Circle :=
   angleHomeomorph.trans AddCircle.homeomorphCircle'
 
+-- `rfl` proves this because `Real.Angle.toCircle` and `AddCircle.homeomorphCircle'` are the same
+-- lift of `Circle.exp`; should that stop holding definitionally, the fallback proof is
+-- `Real.Angle.induction_on` with `Real.Angle.toCircle_coe` and
+-- `AddCircle.homeomorphCircle'_apply_mk`.
 /-- The identification with the unit circle is given by `ConfigurationSpace.toCircle`. -/
 lemma circleHomeomorph_apply (q : ConfigurationSpace) : circleHomeomorph q = q.toCircle := rfl
+
+/-- The configuration corresponding to a point of the unit circle. -/
+def ofCircle : Circle → ConfigurationSpace := circleHomeomorph.symm
+
+/-- The point of the unit circle of the configuration attached to a point of the unit circle is
+  that point. -/
+@[simp]
+lemma toCircle_ofCircle (z : Circle) : (ofCircle z).toCircle = z :=
+  circleHomeomorph.apply_symm_apply z
+
+/-- The configuration attached to the point of the unit circle of a configuration is that
+  configuration. -/
+@[simp]
+lemma ofCircle_toCircle (q : ConfigurationSpace) : ofCircle q.toCircle = q :=
+  circleHomeomorph.symm_apply_apply q
 
 /-- The configuration space is Hausdorff, being homeomorphic to the unit circle. -/
 instance instT2Space : T2Space ConfigurationSpace := circleHomeomorph.symm.t2Space
@@ -162,6 +184,22 @@ lemma chartAt_eq (q : ConfigurationSpace) :
       circleHomeomorph.toOpenPartialHomeomorph.trans
         (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle) := rfl
 
+/-- The domain of the chart at a configuration is the preimage under the identification with the
+  unit circle of the domain of the chart of the circle at the corresponding point. -/
+lemma chartAt_source (q : ConfigurationSpace) :
+    (chartAt (EuclideanSpace ℝ (Fin 1)) q).source =
+      circleHomeomorph ⁻¹' (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle).source := by
+  rw [chartAt_eq, OpenPartialHomeomorph.trans_source]
+  simp
+
+/-- The codomain of the chart at a configuration is the codomain of the chart of the circle at the
+  corresponding point. -/
+lemma chartAt_target (q : ConfigurationSpace) :
+    (chartAt (EuclideanSpace ℝ (Fin 1)) q).target =
+      (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle).target := by
+  rw [chartAt_eq, OpenPartialHomeomorph.trans_target]
+  simp
+
 /-- The configuration space is an analytic manifold: every change of charts is a change of charts
   of the unit circle. -/
 instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
@@ -186,11 +224,11 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
 ## D. The angular lift
 
 `ofAngle θ` is the configuration at angle `θ` from the downward vertical. It is the quotient map
-`ℝ → ℝ / 2πℤ`, i.e. the universal covering of the circle: it is continuous, surjective and
-`2π`-periodic, and two angles give the same configuration exactly when they differ by a whole
-number of turns. The dynamics of the pendulum are written for a real-valued lift of the angle; this
-section is what makes different lifts describe the same motion. In the charts pulled back from the
-circle the lift is `Circle.exp`, so it is analytic.
+`ℝ → ℝ / 2πℤ`, a covering map of the circle: it is continuous, surjective and `2π`-periodic, and
+two angles give the same configuration exactly when they differ by a whole number of turns. The
+dynamics of the pendulum are written for a real-valued lift of the angle; this section is what
+makes different lifts describe the same motion. In the charts pulled back from the circle the lift
+is `Circle.exp`, so it is analytic.
 
 -/
 
@@ -225,14 +263,23 @@ lemma ofAngle_eq_iff (θ₁ θ₂ : ℝ) :
 /-- Every configuration is the configuration at some real angle: the lift is surjective. -/
 lemma ofAngle_surjective : Function.Surjective ofAngle := by
   rintro ⟨φ⟩
-  induction φ using Real.Angle.induction_on with
-  | h θ => exact ⟨θ, rfl⟩
+  induction φ using Real.Angle.induction_on
+  next θ => exact ⟨θ, rfl⟩
 
 /-- The angular lift is continuous. -/
+@[fun_prop]
 lemma continuous_ofAngle : Continuous ofAngle :=
   continuous_induced_rng.mpr Real.Angle.continuous_coe
 
+/-- The angular lift is a covering map. -/
+lemma isCoveringMap_ofAngle : IsCoveringMap ofAngle := by
+  have h : IsCoveringMap ((↑) : ℝ → Real.Angle) := AddCircle.isCoveringMap_coe (2 * Real.pi)
+  have he : ofAngle = ⇑angleHomeomorph.symm ∘ ((↑) : ℝ → Real.Angle) := rfl
+  rw [he]
+  exact h.homeomorph_comp angleHomeomorph.symm
+
 /-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
+@[simp]
 lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
 
 /-- The angular lift is analytic: read in the charts pulled back from the circle it is
@@ -241,6 +288,7 @@ lemma contMDiff_ofAngle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω ofAngle := by
   rw [contMDiff_iff]
   refine ⟨continuous_ofAngle, fun x y => ?_⟩
   have h := (contMDiff_iff.mp (contMDiff_circleExp (m := ω))).2 x y.toCircle
+  -- Two goals remain: the map read in the charts, and the domain on which it is read.
   convert h using 2
   · rfl
   · ext θ
@@ -251,6 +299,12 @@ def cos (q : ConfigurationSpace) : ℝ := Real.Angle.cos q.angle
 
 /-- The sine of the angle of a configuration. -/
 def sin (q : ConfigurationSpace) : ℝ := Real.Angle.sin q.angle
+
+/-- The cosine of a configuration is the cosine of its angle. -/
+lemma cos_angle (q : ConfigurationSpace) : q.cos = Real.Angle.cos q.angle := rfl
+
+/-- The sine of a configuration is the sine of its angle. -/
+lemma sin_angle (q : ConfigurationSpace) : q.sin = Real.Angle.sin q.angle := rfl
 
 /-- The cosine of the configuration at angle `θ` is `cos θ`. -/
 @[simp]
@@ -264,30 +318,41 @@ lemma sin_ofAngle (θ : ℝ) : (ofAngle θ).sin = Real.sin θ := Real.Angle.sin_
 lemma cos_sq_add_sin_sq (q : ConfigurationSpace) : q.cos ^ 2 + q.sin ^ 2 = 1 :=
   Real.Angle.cos_sq_add_sin_sq q.angle
 
+/-- The cosine of the angle depends continuously on the configuration. -/
+@[fun_prop]
+lemma continuous_cos : Continuous (cos : ConfigurationSpace → ℝ) :=
+  Real.Angle.continuous_cos.comp continuous_induced_dom
+
+/-- The sine of the angle depends continuously on the configuration. -/
+@[fun_prop]
+lemma continuous_sin : Continuous (sin : ConfigurationSpace → ℝ) :=
+  Real.Angle.continuous_sin.comp continuous_induced_dom
+
 /-!
 
 ## E. Map to physical space
 
 The pivot is the origin of the plane `Space 2`, the first coordinate is horizontal and the second
 points upwards. A rod of length `ℓ` at angle `θ` from the downward vertical places the bob at
-`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The image of the
-configuration space is the circle of radius `|ℓ|` about the pivot — the rod-length constraint —
-and for `ℓ ≠ 0` the map is injective, so the configuration is determined by the position.
+`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The bob lies on the
+circle of radius `|ℓ|` about the pivot — the rod-length constraint — and for `ℓ ≠ 0` the map is
+injective, so the configuration is determined by the position.
 
 -/
 
-/-- The position of the bob in the plane, for a rod of length `ℓ`. -/
+/-- The position of the bob in the plane, for a rod of length `ℓ`. `ℓ` is not assumed positive; the
+  bob is at distance `|ℓ|` from the pivot. -/
 def toSpace (ℓ : ℝ) (q : ConfigurationSpace) : Space 2 := ⟨![ℓ * q.sin, -ℓ * q.cos]⟩
 
-/-- The horizontal coordinate of the bob is `ℓ sin θ`. -/
+/-- The horizontal coordinate of the bob, `ℓ * q.sin`. -/
 @[simp]
 lemma toSpace_apply_zero (ℓ : ℝ) (q : ConfigurationSpace) :
     toSpace ℓ q 0 = ℓ * q.sin := rfl
 
-/-- The vertical coordinate of the bob is `-ℓ cos θ`. -/
+/-- The vertical coordinate of the bob, `-(ℓ * q.cos)`. -/
 @[simp]
 lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
-    toSpace ℓ q 1 = -ℓ * q.cos := rfl
+    toSpace ℓ q 1 = -(ℓ * q.cos) := neg_mul ℓ q.cos
 
 /-- The position of the bob for the configuration at angle `θ`. -/
 lemma toSpace_ofAngle (ℓ θ : ℝ) :
@@ -299,41 +364,36 @@ lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]
   simp [toSpace_ofAngle]
 
 /-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
+@[simp]
 lemma toSpace_norm (ℓ : ℝ) (q : ConfigurationSpace) : ‖toSpace ℓ q‖ = |ℓ| := by
-  have hq : (ℓ * q.sin) ^ 2 + (-ℓ * q.cos) ^ 2 = ℓ ^ 2 := by
+  have hq : (ℓ * q.sin) ^ 2 + (-(ℓ * q.cos)) ^ 2 = ℓ ^ 2 := by
     linear_combination ℓ ^ 2 * cos_sq_add_sin_sq q
   rw [Space.norm_eq, Fin.sum_univ_two, toSpace_apply_zero, toSpace_apply_one, hq,
     Real.sqrt_sq_eq_abs]
 
 /-- The position of the bob depends continuously on the configuration. -/
+@[fun_prop]
 lemma continuous_toSpace (ℓ : ℝ) : Continuous (toSpace ℓ) := by
-  have hcos : Continuous fun q : ConfigurationSpace => q.cos :=
-    Real.Angle.continuous_cos.comp continuous_induced_dom
-  have hsin : Continuous fun q : ConfigurationSpace => q.sin :=
-    Real.Angle.continuous_sin.comp continuous_induced_dom
-  have hv : Continuous fun q : ConfigurationSpace => (![ℓ * q.sin, -ℓ * q.cos] : Fin 2 → ℝ) := by
-    refine continuous_pi fun i => ?_
-    fin_cases i
-    · simpa using hsin.const_mul ℓ
-    · simpa using hcos.const_mul (-ℓ)
-  exact Space.mk_continuous.comp hv
+  refine Space.mk_continuous.comp (continuous_pi fun i => ?_)
+  fin_cases i <;> simp <;> fun_prop
 
 /-- For a rod of nonzero length the configuration is determined by the position of the bob. -/
 lemma toSpace_injective {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Function.Injective (toSpace ℓ) := by
   -- Equality of angles is detected by their cosine and sine.
   have key : ∀ θ ψ : Real.Angle, θ.cos = ψ.cos → θ.sin = ψ.sin → θ = ψ := by
-    intro θ ψ hc hs
-    rcases Real.Angle.cos_eq_iff_eq_or_eq_neg.mp hc with h | h
-    · exact h
-    rcases Real.Angle.sin_eq_iff_eq_or_add_eq_pi.mp hs with h' | h'
-    · exact h'
-    rw [h, neg_add_cancel] at h'
-    exact absurd h'.symm Real.Angle.pi_ne_zero
+    intro θ ψ
+    induction θ using Real.Angle.induction_on
+    induction ψ using Real.Angle.induction_on
+    simpa using Real.Angle.cos_sin_inj
   intro q₁ q₂ h
   have h0 : ℓ * q₁.sin = ℓ * q₂.sin := congrArg (fun p : Space 2 => p 0) h
   have h1 : -ℓ * q₁.cos = -ℓ * q₂.cos := congrArg (fun p : Space 2 => p 1) h
   exact ConfigurationSpace.ext
     (key _ _ (mul_left_cancel₀ (neg_ne_zero.mpr hℓ) h1) (mul_left_cancel₀ hℓ h0))
+
+/-- For `ℓ ≠ 0` the position map is a closed embedding of the configuration circle. -/
+lemma toSpace_isClosedEmbedding {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Topology.IsClosedEmbedding (toSpace ℓ) :=
+  (continuous_toSpace ℓ).isClosedEmbedding (toSpace_injective hℓ)
 
 end ConfigurationSpace
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -5,7 +5,7 @@ Authors: Aadarsh Agarwal
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Basic
+public import Physlib.SpaceAndTime.Space.Module
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.Geometry.Manifold.Instances.Sphere
 /-!
@@ -36,7 +36,7 @@ points upwards.
 - `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
   manifold structure, pulled back from `Circle`.
 - `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
-  `2π`, continuous and surjective.
+  `2π`, continuous, surjective and analytic.
 - `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
   `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
 
@@ -180,6 +180,160 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
         hself, OpenPartialHomeomorph.refl_trans]
     rw [hcancel]
     exact HasGroupoid.compatible he₁ he₂
+
+/-!
+
+## D. The angular lift
+
+`ofAngle θ` is the configuration at angle `θ` from the downward vertical. It is the quotient map
+`ℝ → ℝ / 2πℤ`, i.e. the universal covering of the circle: it is continuous, surjective and
+`2π`-periodic, and two angles give the same configuration exactly when they differ by a whole
+number of turns. The dynamics of the pendulum are written for a real-valued lift of the angle; this
+section is what makes different lifts describe the same motion. In the charts pulled back from the
+circle the lift is `Circle.exp`, so it is analytic.
+
+-/
+
+/-- The configuration at angle `θ` (measured from the downward vertical). -/
+def ofAngle (θ : ℝ) : ConfigurationSpace := ⟨θ⟩
+
+/-- The angle of the configuration at angle `θ` is `θ` modulo `2π`. -/
+@[simp]
+lemma ofAngle_angle (θ : ℝ) : (ofAngle θ).angle = θ := rfl
+
+/-- Adding a full turn to the angle leaves the configuration unchanged. -/
+lemma ofAngle_add_two_pi (θ : ℝ) : ofAngle (θ + 2 * Real.pi) = ofAngle θ := by
+  ext
+  simp [Real.Angle.coe_add, Real.Angle.coe_two_pi]
+
+/-- The angular lift is periodic with period `2π`. -/
+lemma ofAngle_periodic : Function.Periodic ofAngle (2 * Real.pi) := ofAngle_add_two_pi
+
+/-- Two angles describe the same configuration exactly when they differ by a whole number of
+  turns. -/
+lemma ofAngle_eq_iff (θ₁ θ₂ : ℝ) :
+    ofAngle θ₁ = ofAngle θ₂ ↔ ∃ n : ℤ, θ₂ = θ₁ + n * (2 * Real.pi) := by
+  constructor
+  · intro h
+    obtain ⟨k, hk⟩ :=
+      Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp (congrArg ConfigurationSpace.angle h)
+    exact ⟨-k, by push_cast; linarith⟩
+  · rintro ⟨n, rfl⟩
+    exact ConfigurationSpace.ext
+      (Real.Angle.angle_eq_iff_two_pi_dvd_sub.mpr ⟨-n, by push_cast; ring⟩)
+
+/-- Every configuration is the configuration at some real angle: the lift is surjective. -/
+lemma ofAngle_surjective : Function.Surjective ofAngle := by
+  rintro ⟨φ⟩
+  induction φ using Real.Angle.induction_on with
+  | h θ => exact ⟨θ, rfl⟩
+
+/-- The angular lift is continuous. -/
+lemma continuous_ofAngle : Continuous ofAngle :=
+  continuous_induced_rng.mpr Real.Angle.continuous_coe
+
+/-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
+lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
+
+/-- The angular lift is analytic: read in the charts pulled back from the circle it is
+  `Circle.exp`. -/
+lemma contMDiff_ofAngle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω ofAngle := by
+  rw [contMDiff_iff]
+  refine ⟨continuous_ofAngle, fun x y => ?_⟩
+  have h := (contMDiff_iff.mp (contMDiff_circleExp (m := ω))).2 x y.toCircle
+  convert h using 2
+  · rfl
+  · ext θ
+    simp [chartAt_eq, circleHomeomorph_apply, toCircle_ofAngle]
+
+/-- The cosine of the angle of a configuration. -/
+def cos (q : ConfigurationSpace) : ℝ := Real.Angle.cos q.angle
+
+/-- The sine of the angle of a configuration. -/
+def sin (q : ConfigurationSpace) : ℝ := Real.Angle.sin q.angle
+
+/-- The cosine of the configuration at angle `θ` is `cos θ`. -/
+@[simp]
+lemma cos_ofAngle (θ : ℝ) : (ofAngle θ).cos = Real.cos θ := Real.Angle.cos_coe θ
+
+/-- The sine of the configuration at angle `θ` is `sin θ`. -/
+@[simp]
+lemma sin_ofAngle (θ : ℝ) : (ofAngle θ).sin = Real.sin θ := Real.Angle.sin_coe θ
+
+/-- The Pythagorean identity for the angle of a configuration. -/
+lemma cos_sq_add_sin_sq (q : ConfigurationSpace) : q.cos ^ 2 + q.sin ^ 2 = 1 :=
+  Real.Angle.cos_sq_add_sin_sq q.angle
+
+/-!
+
+## E. Map to physical space
+
+The pivot is the origin of the plane `Space 2`, the first coordinate is horizontal and the second
+points upwards. A rod of length `ℓ` at angle `θ` from the downward vertical places the bob at
+`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The image of the
+configuration space is the circle of radius `|ℓ|` about the pivot — the rod-length constraint —
+and for `ℓ ≠ 0` the map is injective, so the configuration is determined by the position.
+
+-/
+
+/-- The position of the bob in the plane, for a rod of length `ℓ`. -/
+def toSpace (ℓ : ℝ) (q : ConfigurationSpace) : Space 2 := ⟨![ℓ * q.sin, -ℓ * q.cos]⟩
+
+/-- The horizontal coordinate of the bob is `ℓ sin θ`. -/
+@[simp]
+lemma toSpace_apply_zero (ℓ : ℝ) (q : ConfigurationSpace) :
+    toSpace ℓ q 0 = ℓ * q.sin := rfl
+
+/-- The vertical coordinate of the bob is `-ℓ cos θ`. -/
+@[simp]
+lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
+    toSpace ℓ q 1 = -ℓ * q.cos := rfl
+
+/-- The position of the bob for the configuration at angle `θ`. -/
+lemma toSpace_ofAngle (ℓ θ : ℝ) :
+    toSpace ℓ (ofAngle θ) = ⟨![ℓ * Real.sin θ, -ℓ * Real.cos θ]⟩ := by
+  simp [toSpace]
+
+/-- At `θ = 0` the bob hangs straight down, at `(0, -ℓ)`. -/
+lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]⟩ := by
+  simp [toSpace_ofAngle]
+
+/-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
+lemma toSpace_norm (ℓ : ℝ) (q : ConfigurationSpace) : ‖toSpace ℓ q‖ = |ℓ| := by
+  have hq : (ℓ * q.sin) ^ 2 + (-ℓ * q.cos) ^ 2 = ℓ ^ 2 := by
+    linear_combination ℓ ^ 2 * cos_sq_add_sin_sq q
+  rw [Space.norm_eq, Fin.sum_univ_two, toSpace_apply_zero, toSpace_apply_one, hq,
+    Real.sqrt_sq_eq_abs]
+
+/-- The position of the bob depends continuously on the configuration. -/
+lemma continuous_toSpace (ℓ : ℝ) : Continuous (toSpace ℓ) := by
+  have hcos : Continuous fun q : ConfigurationSpace => q.cos :=
+    Real.Angle.continuous_cos.comp continuous_induced_dom
+  have hsin : Continuous fun q : ConfigurationSpace => q.sin :=
+    Real.Angle.continuous_sin.comp continuous_induced_dom
+  have hv : Continuous fun q : ConfigurationSpace => (![ℓ * q.sin, -ℓ * q.cos] : Fin 2 → ℝ) := by
+    refine continuous_pi fun i => ?_
+    fin_cases i
+    · simpa using hsin.const_mul ℓ
+    · simpa using hcos.const_mul (-ℓ)
+  exact Space.mk_continuous.comp hv
+
+/-- For a rod of nonzero length the configuration is determined by the position of the bob. -/
+lemma toSpace_injective {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Function.Injective (toSpace ℓ) := by
+  -- Equality of angles is detected by their cosine and sine.
+  have key : ∀ θ ψ : Real.Angle, θ.cos = ψ.cos → θ.sin = ψ.sin → θ = ψ := by
+    intro θ ψ hc hs
+    rcases Real.Angle.cos_eq_iff_eq_or_eq_neg.mp hc with h | h
+    · exact h
+    rcases Real.Angle.sin_eq_iff_eq_or_add_eq_pi.mp hs with h' | h'
+    · exact h'
+    rw [h, neg_add_cancel] at h'
+    exact absurd h'.symm Real.Angle.pi_ne_zero
+  intro q₁ q₂ h
+  have h0 : ℓ * q₁.sin = ℓ * q₂.sin := congrArg (fun p : Space 2 => p 0) h
+  have h1 : -ℓ * q₁.cos = -ℓ * q₂.cos := congrArg (fun p : Space 2 => p 1) h
+  exact ConfigurationSpace.ext
+    (key _ _ (mul_left_cancel₀ (neg_ne_zero.mpr hℓ) h1) (mul_left_cancel₀ hℓ h0))
 
 end ConfigurationSpace
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -133,6 +133,54 @@ instance instCompactSpace : CompactSpace ConfigurationSpace := circleHomeomorph.
 instance instSecondCountableTopology : SecondCountableTopology ConfigurationSpace :=
   circleHomeomorph.secondCountableTopology
 
+/-!
+
+## C. Manifold structure
+
+The unit circle is an analytic one-dimensional manifold modelled on `EuclideanSpace ℝ (Fin 1)`
+(Mathlib, via stereographic projection). We pull its atlas back along `circleHomeomorph`: a chart
+of the configuration space is the identification with the circle followed by a chart of the circle.
+Since the identification cancels in every change of charts, the changes of charts are exactly those
+of the circle, hence analytic.
+
+-/
+
+/-- The charts of the configuration space: the identification with the unit circle followed by a
+  chart of the circle. -/
+instance instChartedSpace : ChartedSpace (EuclideanSpace ℝ (Fin 1)) ConfigurationSpace where
+  atlas := {circleHomeomorph.toOpenPartialHomeomorph.trans e |
+    e ∈ atlas (EuclideanSpace ℝ (Fin 1)) Circle}
+  chartAt q := circleHomeomorph.toOpenPartialHomeomorph.trans
+    (chartAt (EuclideanSpace ℝ (Fin 1)) (circleHomeomorph q))
+  mem_chart_source q := by simp
+  chart_mem_atlas q := ⟨_, chart_mem_atlas _ _, rfl⟩
+
+/-- The chart at a configuration is the identification with the unit circle followed by the chart
+  of the circle at the corresponding point. -/
+lemma chartAt_eq (q : ConfigurationSpace) :
+    chartAt (EuclideanSpace ℝ (Fin 1)) q =
+      circleHomeomorph.toOpenPartialHomeomorph.trans
+        (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle) := rfl
+
+/-- The configuration space is an analytic manifold: every change of charts is a change of charts
+  of the unit circle. -/
+instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
+  compatible := by
+    rintro _ _ ⟨e₁, he₁, rfl⟩ ⟨e₂, he₂, rfl⟩
+    -- The identification `h` with the circle is global, so `h.symm ≫ₕ h` is the identity.
+    have hself : circleHomeomorph.toOpenPartialHomeomorph.symm.trans
+        circleHomeomorph.toOpenPartialHomeomorph = OpenPartialHomeomorph.refl Circle := by
+      rw [← Homeomorph.symm_toOpenPartialHomeomorph, ← Homeomorph.trans_toOpenPartialHomeomorph,
+        Homeomorph.symm_trans_self, Homeomorph.refl_toOpenPartialHomeomorph]
+    -- Hence it cancels in the change of charts, which is therefore that of the circle.
+    have hcancel : (circleHomeomorph.toOpenPartialHomeomorph.trans e₁).symm.trans
+        (circleHomeomorph.toOpenPartialHomeomorph.trans e₂) = e₁.symm.trans e₂ := by
+      rw [OpenPartialHomeomorph.trans_symm_eq_symm_trans_symm, OpenPartialHomeomorph.trans_assoc,
+        ← OpenPartialHomeomorph.trans_assoc circleHomeomorph.toOpenPartialHomeomorph.symm,
+        hself, OpenPartialHomeomorph.refl_trans]
+    rw [hcancel]
+    exact HasGroupoid.compatible he₁ he₂
+
 end ConfigurationSpace
 end SimplePendulum
 end ClassicalMechanics


### PR DESCRIPTION

Toward #883. First of a series of small PRs formalizing the classical mechanics of the simple
pendulum (per the project-ideas list).

Adds `Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean` (409 lines: 166
documentation, 182 non-blank Lean): the pendulum's configuration space as the circle of angles,
with its manifold structure and its embedding into physical space. Design follows the approach
suggested on Zulip (the coplanar-double-pendulum thread): a structure wrapping `Real.Angle`,

```lean
structure ConfigurationSpace where
  angle : Real.Angle
```

with API built around it so the wrapper is never in the way.

### What it contains
- **Topology** transported along `angleEquiv : ConfigurationSpace ≃ Real.Angle` (induced), with
  `circleHomeomorph : ConfigurationSpace ≃ₜ Circle`; T2, compact, second countable.
- **Manifold structure**: `instChartedSpace` by an explicit atlas — every chart is
  `circleHomeomorph.toOpenPartialHomeomorph.trans e` for `e` in `Circle`'s atlas — and
  `instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace`. Mathlib has no transport of a manifold
  structure across a homeomorphism (mathlib#40202, in progress, would provide it); the explicit
  atlas keeps every chart definitionally transparent (`chartAt_eq` is `rfl`) and uses no choice.
  When #40202 lands I am happy to replace the atlas with the generic transport. This answers the
  `Circle`-vs-`Real.Angle` question from the Zulip thread: the `Real.Angle` ergonomics and the
  manifold instance are compatible.
- **The angular lift** `ofAngle : ℝ → ConfigurationSpace`: 2π-periodic, surjective, continuous, a
  covering map (`isCoveringMap_ofAngle`), and analytic (`contMDiff_ofAngle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω`).
- **Coordinates** `cos`/`sin` with `cos_sq_add_sin_sq` and continuity.
- **The embedding** `toSpace ℓ q = (ℓ sin θ, −ℓ cos θ) : Space 2`, with `toSpace_norm = |ℓ|`,
  injectivity and `IsClosedEmbedding` for `ℓ ≠ 0`.
- `SimplePendulum/API-map.yaml` (new) and the two matching requirement rows of
  `Pendulum/API-map.yaml` flipped to done (manifold structure; the map to `Space`).

### Reviewer reading order
1. Module doc (i–iv) — the design choices, and why the atlas is explicit.
2. Section B (charted space + `IsManifold`) — the mathematical heart.
3. Section C (`ofAngle`, the covering map) and D–E (`cos`/`sin`, `toSpace`).
4. The two API-map files.

### Verification
- `lake build` — clean.
- `lake exe runPhyslibLinters Physlib`, `lake exe check_file_imports`, `lake exe check_dup_tags`,
  `lake exe sorry_lint` — all pass.
- `./scripts/lint-style.sh`, `python scripts/api_map_linter.py --repo .`, codespell — all pass.
- `#synth IsManifold (𝓡 1) ω ConfigurationSpace` — succeeds.

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.
