### PR TITLE
Fix position operator documentation

### DIFF
--- a/Physlib/QuantumMechanics/Operators/OneDimension/Position.lean
+++ b/Physlib/QuantumMechanics/Operators/OneDimension/Position.lean
@@ -80,7 +80,7 @@ def positionOperatorUnbounded : UnboundedOperator schwartzIncl schwartzIncl_inje
 
 /-!
 
-## Generalized eigenvectors of the momentum operator
+## Generalized eigenvectors of the position operator
 
 -/
 


### PR DESCRIPTION
## Summary

Fix an incorrect documentation heading in `Position.lean`.

The section describes generalized eigenvectors of `positionOperatorUnbounded`, but the heading incorrectly referred to the momentum operator. This changes the heading to correctly refer to the position operator.

## Verification

- `git diff --check`

Fixes #1540