### PR TITLE
feat(ClassicalMechanics): the simple pendulum's dynamics, Lagrangian and equation of motion

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -17,6 +17,7 @@ public import Physlib.ClassicalMechanics.Mass.MassUnit
 public import Physlib.ClassicalMechanics.OrbitalMechanics.VisViva
 public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum
 public import Physlib.ClassicalMechanics.RigidBody.AngularVelocity

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -17,6 +17,7 @@ public import Physlib.ClassicalMechanics.Mass.MassUnit
 public import Physlib.ClassicalMechanics.OrbitalMechanics.VisViva
 public import Physlib.ClassicalMechanics.Pendulum.CoplanarDoublePendulum
 public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMotions
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -9,14 +9,13 @@ Overview: |
     covers the pendulum problems of Landau and Lifshitz, Mechanics, 3rd ed.,
     Chapter 1, Section 5.
 
-    At present only the sliding pendulum has a defined configuration space, with
-    the horizontal support position and the string angle as its generalized
-    coordinates. The coplanar double pendulum's configuration space is declared but
-    not yet defined, and the miscellaneous pivot-motion problems have documentation
-    only. The remaining requirements, a manifold structure on the configuration
-    space, a map into real space, trajectories, and the lagrangian, are open and
-    recorded below with location N/A. The simple pendulum has its own API map in
-    Physlib/ClassicalMechanics/Pendulum/SimplePendulum.
+    The sliding pendulum has a defined configuration space in the generalized coordinates of the
+    support position and the string angle. The simple pendulum's configuration space, an angle
+    modulo a full turn, carries the manifold structure and the map into `Space`; it has its own API
+    map in `Physlib/ClassicalMechanics/Pendulum/SimplePendulum`. The coplanar double pendulum's
+    configuration space is declared but not yet defined, and the miscellaneous pivot-motion problems
+    have documentation only. Trajectories and the lagrangian remain open and are recorded below with
+    location N/A.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)
@@ -38,9 +37,7 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instIsManifold)
 
-  - description: >
-      The API contains a map from the configuration space to `Space`, giving the
-      position of the pendulum in real space.
+  - description: The API contains a map from the configuration space to `Space`, giving the position of the pendulum in real space (for the simple pendulum).
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace)
 

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -15,7 +15,8 @@ Overview: |
     not yet defined, and the miscellaneous pivot-motion problems have documentation
     only. The remaining requirements, a manifold structure on the configuration
     space, a map into real space, trajectories, and the lagrangian, are open and
-    recorded below with location N/A.
+    recorded below with location N/A. The simple pendulum has its own API map in
+    Physlib/ClassicalMechanics/Pendulum/SimplePendulum.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)
@@ -33,15 +34,15 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SlidingPendulum.lean (ConfigurationSpace)
 
-  - description: The API shall contain the structure of a manifold on the configuration space.
-    done: false
-    location: "N/A"
+  - description: The API contains the structure of a manifold on the configuration space (for the simple pendulum).
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instIsManifold)
 
   - description: >
-      The API shall contain a map from the configuration space to `Space`, giving the
+      The API contains a map from the configuration space to `Space`, giving the
       position of the pendulum in real space.
-    done: false
-    location: "N/A"
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace)
 
   - description: The API shall contain the definition of a trajectory based on the configuration space.
     done: false

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -14,8 +14,10 @@ Overview: |
     modulo a full turn, carries the manifold structure and the map into `Space`; it has its own API
     map in `Physlib/ClassicalMechanics/Pendulum/SimplePendulum`. The coplanar double pendulum's
     configuration space is declared but not yet defined, and the miscellaneous pivot-motion problems
-    have documentation only. Trajectories and the lagrangian remain open and are recorded below with
-    location N/A.
+    have documentation only. The simple pendulum's Lagrangian and equation of motion on the
+    Euclidean lift are recorded in its own API map; the trajectory based on the configuration
+    space, and the Lagrangian derived from it, remain open and are recorded below with location
+    N/A.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -7,10 +7,11 @@ Overview: |
     in a vertical plane under gravity g. Its configuration is the angle of the rod from the downward
     vertical, taken modulo a full turn, so the configuration space is a circle; the position of the
     bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
-    small amplitudes it is harmonic with period 2π√(ℓ/g); in general the period grows with the
-    amplitude and is given by a complete elliptic integral. This API records the configuration
-    space with its manifold structure and its embedding into physical space; the dynamics, the
-    small-angle limit and the period follow in later modules.
+    small amplitudes it is harmonic with period 2π√(ℓ/g); for librations (amplitudes below the
+    inverted position) the period grows with the amplitude and is given by a complete elliptic
+    integral. This API records the configuration space with its manifold structure and its
+    embedding into physical space; the dynamics, the small-angle limit and the period follow in
+    later modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -9,9 +9,9 @@ Overview: |
     bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
     small amplitudes it is harmonic with period 2π√(ℓ/g); for librations (amplitudes below the
     inverted position) the period grows with the amplitude and is given by a complete elliptic
-    integral. This API records the configuration space with its manifold structure and its
-    embedding into physical space; the dynamics, the small-angle limit and the period follow in
-    later modules.
+    integral. This API records the configuration space and its embedding into physical space,
+    together with the lifted Lagrangian and equation of motion; the small-angle limit and the
+    period follow in later modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -9,9 +9,9 @@ Overview: |
     bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
     small amplitudes it is harmonic with period 2π√(ℓ/g); for librations (amplitudes below the
     inverted position) the period grows with the amplitude and is given by a complete elliptic
-    integral. This API records the configuration space and its embedding into physical space,
-    together with the lifted Lagrangian and equation of motion; the small-angle limit and the
-    period follow in later modules.
+    integral. This API records the configuration space with its manifold structure and its
+    embedding into physical space, together with the lifted Lagrangian and equation of motion;
+    the small-angle limit and the period follow in later modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -1,0 +1,48 @@
+version: v0.1
+
+Title: Simple pendulum
+
+Overview: |
+    A simple pendulum is a bob on a rigid massless rod of length ℓ, pinned at a pivot and swinging
+    in a vertical plane under gravity g. Its configuration is the angle of the rod from the downward
+    vertical, taken modulo a full turn, so the configuration space is a circle; the position of the
+    bob in the plane is (ℓ sin θ, −ℓ cos θ). The motion is governed by θ̈ + (g/ℓ) sin θ = 0. For
+    small amplitudes it is harmonic with period 2π√(ℓ/g); in general the period grows with the
+    amplitude and is given by a complete elliptic integral. This API records the configuration
+    space with its manifold structure and its embedding into physical space; the dynamics, the
+    small-angle limit and the period follow in later modules.
+
+ParentAPIs:
+  - "Space (Physlib/SpaceAndTime/Space)"
+  - "Configuration space for pendulum (Physlib/ClassicalMechanics/Pendulum)"
+
+References:
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 1 (The Equations of motion), Section 5 (The Lagrangian for a system of particles).
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 3 (Integration of the equations of motion), Section 11 (Motion in one dimension).
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 5 (Small oscillations), Section 21 (Free oscillations in one dimension).
+
+Requirements:
+
+  - description: The key data structure, the configuration space of the simple pendulum, is defined as the angle of the rod from the downward vertical modulo a full turn.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace, SimplePendulum.ConfigurationSpace.circleHomeomorph)
+
+  - description: The API contains the structure of a manifold on the configuration space.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.instChartedSpace, SimplePendulum.ConfigurationSpace.instIsManifold)
+
+  - description: The API contains the angular lift from the real line to the configuration space, periodic with period 2π.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.ofAngle, SimplePendulum.ConfigurationSpace.ofAngle_periodic, SimplePendulum.ConfigurationSpace.ofAngle_eq_iff)
+
+  - description: The API contains a map from the configuration space to `Space`, giving the position of the bob in real space, together with the rod-length constraint.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace, SimplePendulum.ConfigurationSpace.toSpace_ofAngle, SimplePendulum.ConfigurationSpace.toSpace_norm)
+
+  - description: The API shall contain the definition of a trajectory based on the configuration space.
+    done: false
+    location: N/A
+
+  - description: The API shall contain the Lagrangian of the simple pendulum and its equation of motion.
+    done: false
+    location: N/A

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -44,6 +44,10 @@ Requirements:
     done: false
     location: N/A
 
-  - description: The API shall contain the Lagrangian of the simple pendulum and its equation of motion.
+  - description: The API contains the Lagrangian of the simple pendulum and its equation of motion.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean (SimplePendulum.lagrangian, SimplePendulum.torque, SimplePendulum.EquationOfMotion, SimplePendulum.equationOfMotion_iff_scalar)
+
+  - description: The API shall contain the equivalence of the equation of motion with the vanishing of the variational gradient of the action, and energy conservation.
     done: false
     location: N/A

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -1,0 +1,446 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.ClassicalMechanics.EulerLagrange
+public import Physlib.ClassicalMechanics.HamiltonsEquations
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
+public import Physlib.Mathematics.Calculus.Gradient
+/-!
+
+# The simple gravity pendulum
+
+## i. Overview
+
+A simple gravity pendulum is a bob of mass `m` fixed to one end of a rigid massless rod of length
+`ℓ`, the other end of which is pinned at a pivot, swinging in a vertical plane under a uniform
+gravitational acceleration `g`. Its configuration is the angle `θ` of the rod from the downward
+vertical. The bob moves on the circle of radius `ℓ` about the pivot, so its moment of inertia
+about the pivot is `I = m ℓ²` and its kinetic energy is `T = ½ I θ̇²`. Swinging out to the angle
+`θ` raises the bob by `ℓ (1 - cos θ)` against gravity, so the potential energy is
+`V = m g ℓ (1 - cos θ)`, normalised to vanish at the bottom of the swing. Balancing the rate of
+change of the angular momentum about the pivot against the torque `-m g ℓ sin θ` of gravity gives
+the equation of motion `I θ̈ = -m g ℓ sin θ`, equivalently `θ̈ + (g/ℓ) sin θ = 0`. The mass drops
+out of the motion, which is governed by the single quantity `ω = √(g/ℓ)`, the angular frequency of
+the small oscillations about the bottom.
+
+The configuration of the pendulum is genuinely an angle modulo a full turn, an element of the
+circle `SimplePendulum.ConfigurationSpace`. As for the harmonic oscillator, the dynamics in this
+file are written instead on the Euclidean lift `Time → EuclideanSpace ℝ (Fin 1)`: the angle is
+carried by a real number, from which the configuration is recovered by
+`SimplePendulum.ConfigurationSpace.ofAngle`, and the one-dimensional Euclidean space stands in for
+both the configuration space and its tangent space, so that the Euler–Lagrange operator of Physlib
+applies verbatim. Two lifts differing by `2π n` describe the same motion; this, and the connection
+of the model here with the geometric configuration space, is proved in a later module.
+
+## ii. Key results
+
+- `SimplePendulum` contains the input data of the problem: the mass `m` of the bob, the length `ℓ`
+  of the rod and the gravitational acceleration `g`.
+- `SimplePendulum.ω` is the angular frequency `√(g/ℓ)` of the small oscillations, and
+  `SimplePendulum.inertia` is the moment of inertia `m ℓ²` of the bob about the pivot. They are
+  tied together by `SimplePendulum.ω_sq_mul_inertia`, the identity by which the mass cancels from
+  the equation of motion.
+- `SimplePendulum.kineticEnergy`, `SimplePendulum.potentialEnergy` and `SimplePendulum.energy` are
+  the energies, with the bounds `potentialEnergy_nonneg`, `potentialEnergy_le` and
+  `potentialEnergy_eq_zero_iff`, the gradient `gradient_potentialEnergy` of the potential and the
+  time derivatives `kineticEnergy_deriv`, `potentialEnergy_deriv` and `energy_deriv`.
+- `SimplePendulum.lagrangian` is the Lagrangian `T - V` of the pendulum, and
+  `SimplePendulum.torque` is the torque about the pivot, the quantity conjugate to the angle.
+- `SimplePendulum.EquationOfMotion` is the equation of motion `I θ̈ = τ(θ)`, with its scalar form
+  `equationOfMotion_iff_scalar` and its independence of the mass `equationOfMotion_iff_of_eq_ω`;
+  `SimplePendulum.IsSolution` is a classical, that is smooth, solution of it.
+- `SimplePendulum.gradLagrangian` is the variational derivative of the action, computed by
+  `gradLagrangian_eq_eulerLagrangeOp` and `gradLagrangian_eq_torque`.
+
+## iii. Table of contents
+
+- A. The input data
+  - A.1. The structure of the input data
+  - A.2. Simple inequalities for the input data
+- B. Frequency and moment of inertia
+  - B.1. The angular frequency
+  - B.2. The moment of inertia
+- C. The energies
+  - C.1. The definitions of the energies
+  - C.2. Simple equalities and bounds for the energies
+  - C.3. Smoothness of the energies and the gradient of the potential
+  - C.4. Time derivatives of the energies
+- D. The Lagrangian
+  - D.1. The definition of the Lagrangian and equalities for it
+  - D.2. Smoothness of the Lagrangian
+  - D.3. Gradients of the Lagrangian
+- E. The torque and the equation of motion
+  - E.1. The torque
+  - E.2. The equation of motion
+  - E.3. Classical solutions
+  - E.4. The scalar equation and independence of the mass
+- F. The variational derivative of the action
+  - F.1. The definition of the variational derivative
+  - F.2. Equality with the Euler–Lagrange operator
+  - F.3. The variational derivative in terms of the torque
+
+## iv. References
+
+References for the simple gravity pendulum include:
+- Landau & Lifshitz, Mechanics, 3rd ed., §5 and §21.
+- Arnold, Mathematical Methods of Classical Mechanics, 2nd ed., §4.
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+open Real InnerProductSpace
+
+/-!
+
+## A. The input data
+
+We start by defining a structure containing the input data of the simple pendulum, and proving
+basic properties thereof. The input data consists of the mass `m` of the bob, the length `ℓ` of
+the rod, and the gravitational acceleration `g`; everything else in this file is built from these
+three numbers.
+
+-/
+
+/-!
+
+### A.1. The structure of the input data
+
+The three numbers are carried by a structure, together with the positivity assumptions: a
+pendulum with a massless bob, a rod of zero length or no gravity is not a pendulum.
+
+-/
+
+/-- The simple gravity pendulum is specified by the mass `m` of its bob, the length `ℓ` of its
+  rod, and the gravitational acceleration `g`. All three are assumed to be positive. The
+  configuration of the pendulum is the angle of the rod from the downward vertical. -/
+structure SimplePendulum where
+  /-- The mass of the bob. -/
+  m : ℝ
+  /-- The length of the massless rod. -/
+  ℓ : ℝ
+  /-- The gravitational acceleration. -/
+  g : ℝ
+  m_pos : 0 < m
+  ℓ_pos : 0 < ℓ
+  g_pos : 0 < g
+
+namespace SimplePendulum
+
+variable (S : SimplePendulum)
+
+/-!
+
+### A.2. Simple inequalities for the input data
+
+The positivity of the input data is used most often through the corresponding non-vanishing
+statements, which is the form in which the field-clearing tactics consume it.
+
+-/
+
+/-- The mass of the bob is not equal to zero. -/
+@[simp]
+lemma m_ne_zero : S.m ≠ 0 := S.m_pos.ne'
+
+/-- The length of the rod is not equal to zero. -/
+@[simp]
+lemma ℓ_ne_zero : S.ℓ ≠ 0 := S.ℓ_pos.ne'
+
+/-- The gravitational acceleration is not equal to zero. -/
+@[simp]
+lemma g_ne_zero : S.g ≠ 0 := S.g_pos.ne'
+
+/-!
+
+## B. Frequency and moment of inertia
+
+Two derived quantities control the dynamics of the pendulum: the angular frequency `ω = √(g/ℓ)`
+of the small oscillations about the bottom of the swing, and the moment of inertia `I = m ℓ²` of
+the bob about the pivot.
+
+The mass enters the equation of motion only through `I`, where it cancels against the mass in the
+torque of gravity; what survives is `ω`. The identity performing that cancellation is
+`ω_sq_mul_inertia`.
+
+-/
+
+/-!
+
+### B.1. The angular frequency
+
+Linearising `sin θ ≈ θ` about the bottom of the swing turns the equation of motion into that of a
+harmonic oscillator of angular frequency `√(g/ℓ)`. The exact motion is not harmonic, but this
+frequency is the natural time scale of the pendulum and appears throughout its analysis.
+
+-/
+
+/-- The angular frequency of the simple pendulum, `ω`, is defined as `√(g/ℓ)`. It is the angular
+  frequency of the small oscillations of the pendulum about the bottom of its swing. -/
+noncomputable def ω : ℝ := √(S.g / S.ℓ)
+
+/-- The angular frequency of the simple pendulum is positive. -/
+@[simp]
+lemma ω_pos : 0 < S.ω := sqrt_pos.mpr (div_pos S.g_pos S.ℓ_pos)
+
+/-- The angular frequency of the simple pendulum is not equal to zero. -/
+lemma ω_ne_zero : S.ω ≠ 0 := S.ω_pos.ne'
+
+/-- The square of the angular frequency of the simple pendulum is equal to `g/ℓ`. -/
+lemma ω_sq : S.ω ^ 2 = S.g / S.ℓ := sq_sqrt (div_pos S.g_pos S.ℓ_pos).le
+
+/-- The inverse of the square of the angular frequency of the simple pendulum is `ℓ/g`. -/
+lemma inverse_ω_sq : (S.ω ^ 2)⁻¹ = S.ℓ / S.g := by rw [ω_sq, inv_div]
+
+/-!
+
+### B.2. The moment of inertia
+
+The bob is a point mass at the fixed distance `ℓ` from the pivot, so the moment of inertia of the
+pendulum about the pivot is `m ℓ²`. It is the coefficient relating the angular acceleration to
+the torque, and so plays for the angle the role that the mass plays for a position.
+
+-/
+
+/-- The moment of inertia of the simple pendulum about its pivot is `I = m ℓ²`, the moment of
+  inertia of a point mass `m` at distance `ℓ` from the axis. -/
+noncomputable def inertia : ℝ := S.m * S.ℓ ^ 2
+
+/-- The moment of inertia of the simple pendulum is positive. -/
+lemma inertia_pos : 0 < S.inertia := mul_pos S.m_pos (pow_pos S.ℓ_pos 2)
+
+/-- The moment of inertia of the simple pendulum is not equal to zero. -/
+@[simp]
+lemma inertia_ne_zero : S.inertia ≠ 0 := S.inertia_pos.ne'
+
+/-- The square of the angular frequency times the moment of inertia is `m g ℓ`, the coefficient
+  appearing in the potential energy and in the torque. This is the identity by which the mass
+  cancels from the equation of motion. -/
+lemma ω_sq_mul_inertia : S.ω ^ 2 * S.inertia = S.m * S.g * S.ℓ := by
+  rw [ω_sq, inertia]
+  field_simp
+
+open MeasureTheory Time
+open scoped ContDiff Gradient
+
+/-!
+
+## C. The energies
+
+The simple pendulum has a kinetic energy determined by the rate of change of its angle, and a
+potential energy determined by the height of the bob, hence by the angle itself. These combine to
+give the total energy of the pendulum.
+
+Here we state and prove a number of properties of these energies, including the gradient of the
+potential energy, which is the object entering the equation of motion.
+
+-/
+
+/-!
+
+### C.1. The definitions of the energies
+
+We define the three energies; it is these energies which control the dynamics of the pendulum,
+through the Lagrangian.
+
+-/
+
+/-- The kinetic energy of the simple pendulum along a lift `θ` of the angle is
+  $\frac{1}{2} I ‖\dot θ‖^2$, where `I` is the moment of inertia about the pivot. -/
+noncomputable def kineticEnergy (θ : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ := fun t =>
+  (1 / (2 : ℝ)) * S.inertia * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ
+
+/-- The potential energy of the simple pendulum at the angle `x` is `m g ℓ (1 - cos θ)`, the work
+  done against gravity in raising the bob from the bottom of the swing. It is normalised to
+  vanish at the bottom. -/
+noncomputable def potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) : ℝ :=
+  S.m * S.g * S.ℓ * (1 - Real.cos (x 0))
+
+/-- The energy of the simple pendulum is the kinetic energy plus the potential energy. -/
+noncomputable def energy (θ : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ := fun t =>
+  S.kineticEnergy θ t + S.potentialEnergy (θ t)
+
+/-!
+
+### C.2. Simple equalities and bounds for the energies
+
+Besides the definitional unfoldings, the potential energy of the pendulum satisfies two bounds
+that the harmonic oscillator has no analogue of: it is bounded, between `0` at the bottom of the
+swing and `2 m g ℓ` at the top, and it vanishes exactly at the bottom.
+
+-/
+
+/-- The kinetic energy of the simple pendulum, written out. -/
+lemma kineticEnergy_eq (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.kineticEnergy θ = fun t => (1 / (2 : ℝ)) * S.inertia * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ := rfl
+
+/-- The potential energy of the simple pendulum, written out. -/
+lemma potentialEnergy_eq (x : EuclideanSpace ℝ (Fin 1)) :
+    S.potentialEnergy x = S.m * S.g * S.ℓ * (1 - Real.cos (x 0)) := rfl
+
+/-- The energy of the simple pendulum, written out. -/
+lemma energy_eq (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.energy θ = fun t => S.kineticEnergy θ t + S.potentialEnergy (θ t) := rfl
+
+/-- The potential energy of the simple pendulum is non-negative, the bottom of the swing being
+  the lowest point of the circle on which the bob moves. -/
+lemma potentialEnergy_nonneg (x : EuclideanSpace ℝ (Fin 1)) : 0 ≤ S.potentialEnergy x := by
+  have hc : 0 < S.m * S.g * S.ℓ := mul_pos (mul_pos S.m_pos S.g_pos) S.ℓ_pos
+  have h : (0 : ℝ) ≤ 1 - Real.cos (x 0) := by
+    have := Real.cos_le_one (x 0)
+    linarith
+  rw [potentialEnergy_eq]
+  exact mul_nonneg hc.le h
+
+/-- The potential energy of the simple pendulum is at most `2 m g ℓ`, its value at the top of the
+  swing. -/
+lemma potentialEnergy_le (x : EuclideanSpace ℝ (Fin 1)) :
+    S.potentialEnergy x ≤ 2 * (S.m * S.g * S.ℓ) := by
+  have hc : 0 < S.m * S.g * S.ℓ := mul_pos (mul_pos S.m_pos S.g_pos) S.ℓ_pos
+  have h : 1 - Real.cos (x 0) ≤ 2 := by
+    have := Real.neg_one_le_cos (x 0)
+    linarith
+  calc S.potentialEnergy x = S.m * S.g * S.ℓ * (1 - Real.cos (x 0)) := S.potentialEnergy_eq x
+    _ ≤ S.m * S.g * S.ℓ * 2 := mul_le_mul_of_nonneg_left h hc.le
+    _ = 2 * (S.m * S.g * S.ℓ) := by ring
+
+/-- The potential energy of the simple pendulum vanishes exactly at the bottom of the swing, that
+  is exactly at the angles which are whole multiples of a full turn. -/
+lemma potentialEnergy_eq_zero_iff (x : EuclideanSpace ℝ (Fin 1)) :
+    S.potentialEnergy x = 0 ↔ Real.cos (x 0) = 1 := by
+  have hc : S.m * S.g * S.ℓ ≠ 0 := (mul_pos (mul_pos S.m_pos S.g_pos) S.ℓ_pos).ne'
+  rw [potentialEnergy_eq, mul_eq_zero, or_iff_right hc, sub_eq_zero, eq_comm]
+
+/-!
+
+### C.3. Smoothness of the energies and the gradient of the potential
+
+The potential energy is a smooth function of the angle, and its gradient on the one-dimensional
+Euclidean lift is `m g ℓ sin θ` times the unit vector of the angular coordinate. This gradient is
+what the equation of motion balances against the angular acceleration, so we record it here, once,
+together with the gradient of the cosine of the angular coordinate from which it comes.
+
+-/
+
+/-- The potential energy of the simple pendulum is a smooth function of the angle. -/
+@[fun_prop]
+lemma potentialEnergy_contDiff (n : WithTop ℕ∞) : ContDiff ℝ n S.potentialEnergy := by
+  unfold potentialEnergy
+  fun_prop
+
+/-- The potential energy of the simple pendulum is a differentiable function of the angle. -/
+@[fun_prop]
+lemma differentiable_potentialEnergy : Differentiable ℝ S.potentialEnergy :=
+  (S.potentialEnergy_contDiff 1).differentiable one_ne_zero
+
+/-- The gradient of the cosine of the angular coordinate on the one-dimensional Euclidean lift.
+  This is the chain rule applied to `Real.cos` and to the coordinate functional, whose gradient
+  is `gradient_coord`. It is specific to the cosine potential of the pendulum. -/
+lemma gradient_cos_coord (x : EuclideanSpace ℝ (Fin 1)) :
+    gradient (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0)) x =
+      -Real.sin (x 0) • EuclideanSpace.single 0 1 := by
+  have hdiff : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => y 0) x := by fun_prop
+  have hcoord : HasGradientAt (fun y : EuclideanSpace ℝ (Fin 1) => y 0)
+      (EuclideanSpace.single 0 1) x := by
+    simpa [gradient_coord] using hdiff.hasGradientAt
+  have hf : HasFDerivAt (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0))
+      (toDual ℝ (EuclideanSpace ℝ (Fin 1))
+        (-Real.sin (x 0) • EuclideanSpace.single 0 1)) x := by
+    refine ((Real.hasDerivAt_cos (x 0)).hasFDerivAt.comp x hcoord.hasFDerivAt).congr_fderiv ?_
+    ext y
+    simp [toDual_apply_apply, EuclideanSpace.inner_single_left, mul_comm]
+  simpa using hf.hasGradientAt.gradient
+
+/-- The gradient of the potential energy of the simple pendulum is `m g ℓ sin θ` times the unit
+  vector of the angular coordinate. -/
+lemma gradient_potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) :
+    gradient S.potentialEnergy x =
+      (S.m * S.g * S.ℓ * Real.sin (x 0)) • EuclideanSpace.single 0 1 := by
+  have hcos : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0)) x := by
+    fun_prop
+  have h : S.potentialEnergy = fun y : EuclideanSpace ℝ (Fin 1) =>
+      -(S.m * S.g * S.ℓ) * Real.cos (y 0) + S.m * S.g * S.ℓ := by
+    funext y
+    rw [potentialEnergy_eq]
+    ring
+  rw [h, gradient_add_const, gradient_const_mul _ hcos, gradient_cos_coord]
+  module
+
+/-- Along a smooth lift of the angle the kinetic energy is differentiable in time. -/
+@[fun_prop]
+lemma kineticEnergy_differentiable (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    Differentiable ℝ (S.kineticEnergy θ) := by
+  rw [kineticEnergy_eq]
+  fun_prop
+
+/-- Along a smooth lift of the angle the potential energy is differentiable in time. -/
+@[fun_prop]
+lemma potentialEnergy_differentiable (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    Differentiable ℝ (fun t => S.potentialEnergy (θ t)) := by
+  have hd : Differentiable ℝ θ := hθ.differentiable (by simp)
+  fun_prop
+
+/-- Along a smooth lift of the angle the energy is differentiable in time. -/
+@[fun_prop]
+lemma energy_differentiable (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    Differentiable ℝ (S.energy θ) := by
+  rw [energy_eq]
+  fun_prop
+
+/-!
+
+### C.4. Time derivatives of the energies
+
+For a general smooth lift of the angle, which need not satisfy the equation of motion, we can
+compute the time derivatives of the energies. Each is an inner product against the angular
+velocity: the equation of motion will be exactly the statement that the two contributions cancel.
+
+-/
+
+/-- The rate of change of the kinetic energy is the angular velocity paired with the angular
+  momentum's rate of change, `I θ̈`. -/
+lemma kineticEnergy_deriv (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    ∂ₜ (S.kineticEnergy θ) = fun t => ⟪∂ₜ θ t, S.inertia • ∂ₜ (∂ₜ θ) t⟫_ℝ := by
+  funext t
+  unfold kineticEnergy
+  have hd : DifferentiableAt ℝ (∂ₜ θ) t :=
+    (deriv_differentiable_of_contDiff θ hθ).differentiableAt
+  rw [Time.deriv_eq, fderiv_const_mul (by fun_prop), _root_.smul_apply,
+    fderiv_inner_apply (𝕜 := ℝ) hd hd, ← Time.deriv_eq]
+  simp [inner_smul_right, real_inner_comm]
+  ring
+
+/-- The rate of change of the potential energy is the angular velocity paired with the gradient
+  of the potential. -/
+lemma potentialEnergy_deriv (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    ∂ₜ (fun t => S.potentialEnergy (θ t)) =
+      fun t => ⟪∂ₜ θ t, gradient S.potentialEnergy (θ t)⟫_ℝ := by
+  funext t
+  have hd : DifferentiableAt ℝ θ t := (hθ.differentiable (by simp)).differentiableAt
+  have hV : DifferentiableAt ℝ S.potentialEnergy (θ t) :=
+    (S.potentialEnergy_contDiff ∞).differentiable (by simp) (θ t)
+  have hf : HasFDerivAt (fun t => S.potentialEnergy (θ t)) _ t :=
+    hV.hasFDerivAt.comp t hd.hasFDerivAt
+  rw [Time.deriv_eq, hf.fderiv]
+  simp [Time.deriv_eq]
+
+/-- The rate of change of the energy is the angular velocity paired with the sum of `I θ̈` and
+  the gradient of the potential; the equation of motion is exactly the vanishing of that sum. -/
+lemma energy_deriv (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    ∂ₜ (S.energy θ) =
+      fun t => ⟪∂ₜ θ t, S.inertia • ∂ₜ (∂ₜ θ) t + gradient S.potentialEnergy (θ t)⟫_ℝ := by
+  unfold energy
+  funext t
+  rw [Time.deriv_eq, fderiv_fun_add (by fun_prop) (S.potentialEnergy_differentiable θ hθ t)]
+  simp only [_root_.add_apply, ← Time.deriv_eq, S.kineticEnergy_deriv θ hθ,
+    S.potentialEnergy_deriv θ hθ, ← inner_add_right]
+
+end SimplePendulum
+
+end ClassicalMechanics
+
+end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -603,8 +603,8 @@ def EquationOfMotion (θ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
 /-- The equation of motion of the simple pendulum with all of its terms on one side: at every
   instant the rate of change `I θ̈` of the angular momentum plus the gradient of the potential
   energy vanishes. This is the rotational form of Newton's second law, in the shape in which
-  `DampedHarmonicOscillator` states its own; it is the form that the energy-conservation lemma
-  of a subsequent contribution consumes. -/
+  `DampedHarmonicOscillator` states its own; the sum on the left is exactly the combination that
+  `energy_deriv` pairs with the velocity `∂ₜ θ`. -/
 lemma equationOfMotion_iff_newtons_2nd_law (θ : Time → EuclideanSpace ℝ (Fin 1)) :
     S.EquationOfMotion θ ↔
       ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t + gradient S.potentialEnergy (θ t) = 0 := by
@@ -616,10 +616,11 @@ lemma equationOfMotion_iff_newtons_2nd_law (θ : Time → EuclideanSpace ℝ (Fi
 
 A solution of the pendulum is a smooth lift satisfying the equation of motion. Smoothness is part
 of the definition because the bare pointwise equation, being totalized, admits unphysical
-solutions: a lift jumping between the equilibrium angles `0` and `π` has `∂ₜ (∂ₜ θ) = 0` and zero
-torque everywhere, so it satisfies the equation while being nowhere continuous. Demanding
-smoothness excludes such junk, and is the regularity under which the variational description of
-the motion agrees with the pointwise one.
+solutions: a lift jumping between the equilibrium angles `0` and `π` has zero torque everywhere,
+and — being locally constant wherever it is differentiable at all — it has `∂ₜ θ`, and hence
+`∂ₜ (∂ₜ θ)`, identically zero, so it satisfies the equation even when it is nowhere continuous.
+Demanding smoothness excludes such junk, and is the regularity under which the variational
+description of the motion agrees with the pointwise one.
 
 -/
 

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -338,22 +338,11 @@ lemma differentiable_potentialEnergy : Differentiable ℝ S.potentialEnergy :=
   (S.potentialEnergy_contDiff 1).differentiable one_ne_zero
 
 /-- The gradient of the cosine of the angular coordinate on the one-dimensional Euclidean lift.
-  This is the chain rule applied to `Real.cos` and to the coordinate functional, whose gradient
-  is `gradient_coord`. It is specific to the cosine potential of the pendulum. -/
+  This is the specialization of `gradient_comp_coord` to the cosine. -/
 lemma gradient_cos_coord (x : EuclideanSpace ℝ (Fin 1)) :
     gradient (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0)) x =
-      -Real.sin (x 0) • EuclideanSpace.single 0 1 := by
-  have hdiff : DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => y 0) x := by fun_prop
-  have hcoord : HasGradientAt (fun y : EuclideanSpace ℝ (Fin 1) => y 0)
-      (EuclideanSpace.single 0 1) x := by
-    simpa [gradient_coord] using hdiff.hasGradientAt
-  have hf : HasFDerivAt (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0))
-      (toDual ℝ (EuclideanSpace ℝ (Fin 1))
-        (-Real.sin (x 0) • EuclideanSpace.single 0 1)) x := by
-    refine ((Real.hasDerivAt_cos (x 0)).hasFDerivAt.comp x hcoord.hasFDerivAt).congr_fderiv ?_
-    ext y
-    simp [toDual_apply_apply, EuclideanSpace.inner_single_left, mul_comm]
-  simpa using hf.hasGradientAt.gradient
+      -Real.sin (x 0) • EuclideanSpace.single 0 1 :=
+  gradient_comp_coord 0 x (Real.hasDerivAt_cos (x 0))
 
 /-- The gradient of the potential energy of the simple pendulum is `m g ℓ sin θ` times the unit
   vector of the angular coordinate. -/

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -548,9 +548,11 @@ We take that pointwise relation as the definition of the equation of motion, rat
 vanishing of the variational derivative of the action, which is how the harmonic oscillator defines
 its own. The reason is that the variational derivative is defined to be `0` whenever no variational
 gradient exists, so its vanishing holds vacuously for every lift of the angle too rough to admit
-one; it says what it is meant to say only under a smoothness assumption. The pointwise equation
-carries no such caveat, holds of any twice differentiable lift, and is the form in which the
-equation of motion is solved and used. The two agree for smooth lifts, by
+one; it says what it is meant to say only under a smoothness assumption. The pointwise equation is
+totalized too — `∂ₜ` is `fderiv`, which is `0` off differentiability — but its totalization cannot
+make the equation vacuously true: a lift too rough to differentiate is handed `θ̈ = 0` and then the
+equation is a genuine, and generally false, constraint. It is also the form in which the equation
+of motion is solved and used. The two agree for smooth lifts, by
 `equationOfMotion_iff_gradLagrangian_zero`, proved in a later module; the present module goes as
 far as `gradLagrangian_eq_torque`, from which that equivalence is one rearrangement away.
 

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -439,6 +439,307 @@ lemma energy_deriv (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff �
   simp only [_root_.add_apply, ← Time.deriv_eq, S.kineticEnergy_deriv θ hθ,
     S.potentialEnergy_deriv θ hθ, ← inner_add_right]
 
+/-!
+
+## D. The Lagrangian
+
+The pendulum is a conservative system, so its Lagrangian is the kinetic energy minus the potential
+energy, `L = ½ I θ̇² - m g ℓ (1 - cos θ)`. As for the harmonic oscillator, it is defined as a
+function on phase space, of the time, the angle and the angular velocity separately; that it is
+`T - V` along a lift of the angle is then a lemma rather than the definition.
+
+The Lagrangian carries no explicit time dependence, the pendulum being autonomous; the time
+argument is kept because it is the type the Euler–Lagrange operator of Physlib expects.
+
+-/
+
+/-!
+
+### D.1. The definition of the Lagrangian and equalities for it
+
+The Lagrangian is written directly in terms of the moment of inertia and the potential energy,
+so that the equalities below are the two ways of reading it: expanded in the input data, and as
+the kinetic energy minus the potential energy along a lift of the angle.
+
+-/
+
+set_option linter.unusedVariables false in
+/-- The Lagrangian of the simple pendulum, `L(t, θ, θ̇) = ½ I ‖θ̇‖² - V(θ)`, the kinetic energy
+  minus the potential energy as a function on phase space. It does not depend on the time. -/
+@[nolint unusedArguments]
+noncomputable def lagrangian (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) : ℝ :=
+  (1 / (2 : ℝ)) * S.inertia * ⟪v, v⟫_ℝ - S.potentialEnergy x
+
+/-- The Lagrangian of the simple pendulum, written out in the input data. -/
+lemma lagrangian_eq :
+    S.lagrangian = fun _ x v =>
+      (1 / (2 : ℝ)) * S.inertia * ⟪v, v⟫_ℝ - S.m * S.g * S.ℓ * (1 - Real.cos (x 0)) := by
+  funext t x v
+  rw [lagrangian, potentialEnergy_eq]
+
+/-- Along a lift of the angle the Lagrangian of the simple pendulum is the kinetic energy minus
+  the potential energy. -/
+lemma lagrangian_eq_kineticEnergy_sub_potentialEnergy (t : Time)
+    (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.lagrangian t (θ t) (∂ₜ θ t) = S.kineticEnergy θ t - S.potentialEnergy (θ t) := rfl
+
+/-!
+
+### D.2. Smoothness of the Lagrangian
+
+The Lagrangian is a smooth function of all of its arguments jointly. This is the hypothesis that
+the Euler–Lagrange theorem of Physlib places on a Lagrangian, so it is recorded on the uncurried
+form `↿S.lagrangian`.
+
+-/
+
+/-- The Lagrangian of the simple pendulum is a smooth function of the time, the angle and the
+  angular velocity jointly. -/
+@[fun_prop]
+lemma contDiff_lagrangian (n : WithTop ℕ∞) : ContDiff ℝ n ↿S.lagrangian := by
+  rw [lagrangian_eq]
+  fun_prop
+
+/-!
+
+### D.3. Gradients of the Lagrangian
+
+The Euler–Lagrange operator is built from the two partial gradients of the Lagrangian. The
+gradient in the angle is minus the gradient of the potential energy, that is the torque of
+section E; the gradient in the angular velocity is the angular momentum `I θ̇`.
+
+-/
+
+/-- The gradient of the Lagrangian of the simple pendulum in the angle is minus the gradient of
+  the potential energy, `-m g ℓ sin θ` times the unit vector of the angular coordinate. -/
+lemma gradient_lagrangian_position_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    gradient (fun x => S.lagrangian t x v) x =
+      -((S.m * S.g * S.ℓ * Real.sin (x 0)) • EuclideanSpace.single 0 1) := by
+  have h : (fun y : EuclideanSpace ℝ (Fin 1) => S.lagrangian t y v) =
+      fun y => (-1 : ℝ) * S.potentialEnergy y + (1 / (2 : ℝ)) * S.inertia * ⟪v, v⟫_ℝ := by
+    funext y
+    rw [lagrangian]
+    ring
+  rw [h, gradient_add_const, gradient_const_mul _ (S.differentiable_potentialEnergy x),
+    gradient_potentialEnergy]
+  module
+
+/-- The gradient of the Lagrangian of the simple pendulum in the angular velocity is the angular
+  momentum `I θ̇` about the pivot. -/
+lemma gradient_lagrangian_velocity_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    gradient (S.lagrangian t x) v = S.inertia • v := by
+  have h : S.lagrangian t x = fun y : EuclideanSpace ℝ (Fin 1) =>
+      ((1 / (2 : ℝ)) * S.inertia) * ⟪y, y⟫_ℝ + -S.potentialEnergy x := by
+    funext y
+    rw [lagrangian]
+    ring
+  rw [h, gradient_add_const, gradient_const_mul_inner_self]
+  module
+
+/-!
+
+## E. The torque and the equation of motion
+
+Gravity exerts on the bob a torque `-m g ℓ sin θ` about the pivot, the generalized force conjugate
+to the angle, and the equation of motion balances it against the rate of change `I θ̈` of the
+angular momentum.
+
+We take that pointwise relation as the definition of the equation of motion, rather than the
+vanishing of the variational derivative of the action, which is how the harmonic oscillator defines
+its own. The reason is that the variational derivative is defined to be `0` whenever no variational
+gradient exists, so its vanishing holds vacuously for every lift of the angle too rough to admit
+one; it says what it is meant to say only under a smoothness assumption. The pointwise equation
+carries no such caveat, holds of any twice differentiable lift, and is the form in which the
+equation of motion is solved and used. The two agree for smooth lifts, by
+`equationOfMotion_iff_gradLagrangian_zero`, proved in a later module; the present module goes as
+far as `gradLagrangian_eq_torque`, from which that equivalence is one rearrangement away.
+
+-/
+
+/-!
+
+### E.1. The torque
+
+The pendulum is conservative, so the generalized force conjugate to the angle is minus the
+gradient of the potential energy. It is a torque about the pivot rather than a force, the angle
+being the coordinate; this is why it is `m g ℓ sin θ` and not `m g sin θ`.
+
+-/
+
+/-- The generalized force of the simple pendulum conjugate to the angle, that is the torque about
+  the pivot, is minus the gradient of the potential energy, `τ = -∂V/∂θ`. -/
+noncomputable def torque (x : EuclideanSpace ℝ (Fin 1)) : EuclideanSpace ℝ (Fin 1) :=
+  -gradient S.potentialEnergy x
+
+/-- The torque of the simple pendulum is `-m g ℓ sin θ` times the unit vector of the angular
+  coordinate. It is restoring: it opposes the displacement from the bottom of the swing. -/
+lemma torque_eq (x : EuclideanSpace ℝ (Fin 1)) :
+    S.torque x = -((S.m * S.g * S.ℓ * Real.sin (x 0)) • EuclideanSpace.single 0 1) := by
+  rw [torque, gradient_potentialEnergy]
+
+/-- The single component of the torque of the simple pendulum is `-m g ℓ sin θ`. -/
+lemma torque_apply (x : EuclideanSpace ℝ (Fin 1)) :
+    S.torque x 0 = -(S.m * S.g * S.ℓ * Real.sin (x 0)) := by
+  rw [torque_eq]
+  simp
+
+/-!
+
+### E.2. The equation of motion
+
+The equation of motion of the simple pendulum equates the rate of change of the angular momentum
+about the pivot with the torque of gravity, at every instant.
+
+-/
+
+/-- The equation of motion of the simple pendulum: at every instant the rate of change `I θ̈` of
+  the angular momentum about the pivot equals the torque `τ(θ)` of gravity.
+
+  This pointwise relation, and not the vanishing of the variational derivative of the action, is
+  the definition of the equation of motion here; see the discussion in section E. For a smooth
+  lift of the angle the two agree, by `equationOfMotion_iff_gradLagrangian_zero` in a later
+  module. -/
+def EquationOfMotion (θ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
+  ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t)
+
+/-- The equation of motion of the simple pendulum is Newton's second law for rotation about the
+  pivot. This holds by `Iff.rfl`, the equation of motion being defined as that law; the lemma is
+  kept for parity with the corresponding names of the harmonic oscillator and of the damped
+  harmonic oscillator, where the two statements are genuinely different. -/
+lemma equationOfMotion_iff_newtons_2nd_law (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.EquationOfMotion θ ↔ ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t) := Iff.rfl
+
+/-!
+
+### E.3. Classical solutions
+
+A classical solution of the equation of motion is a smooth lift of the angle satisfying it. The
+smoothness is not needed to state the equation, but it is what the variational and Hamiltonian
+descriptions of the motion require, so solutions are asked for it once and for all.
+
+-/
+
+/-- A classical solution of the simple pendulum is a smooth lift of the angle satisfying the
+  equation of motion. -/
+def IsSolution (θ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
+  ContDiff ℝ ∞ θ ∧ S.EquationOfMotion θ
+
+/-- A classical solution of the simple pendulum is smooth. -/
+lemma IsSolution.contDiff {S : SimplePendulum} {θ : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution θ) : ContDiff ℝ ∞ θ := h.1
+
+/-- A classical solution of the simple pendulum satisfies the equation of motion. -/
+lemma IsSolution.equationOfMotion {S : SimplePendulum} {θ : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution θ) : S.EquationOfMotion θ := h.2
+
+/-!
+
+### E.4. The scalar equation and independence of the mass
+
+The angle is a single number, so the vector equation of motion is equivalent to the scalar
+equation obtained by reading off its one component. Dividing that component by the moment of
+inertia, using `ω_sq_mul_inertia`, cancels the mass and leaves `θ̈ + ω² sin θ = 0`: two pendulums
+with the same `ω = √(g/ℓ)` have exactly the same motions, whatever their masses.
+
+-/
+
+/-- The equation of motion of the simple pendulum in scalar form, `θ̈ + ω² sin θ = 0`. The mass
+  has cancelled: only the angular frequency `ω = √(g/ℓ)` survives. -/
+lemma equationOfMotion_iff_scalar (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.EquationOfMotion θ ↔ ∀ t, ∂ₜ (∂ₜ θ) t 0 + S.ω ^ 2 * Real.sin (θ t 0) = 0 := by
+  refine forall_congr' fun t => ?_
+  have hcomp : (S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t)) ↔
+      S.inertia * ∂ₜ (∂ₜ θ) t 0 = -(S.m * S.g * S.ℓ * Real.sin (θ t 0)) := by
+    rw [← S.torque_apply (θ t)]
+    constructor
+    · intro h
+      simpa using congrArg (fun y : EuclideanSpace ℝ (Fin 1) => y 0) h
+    · intro h
+      ext i
+      fin_cases i
+      simpa using h
+  rw [hcomp, ← S.ω_sq_mul_inertia]
+  constructor
+  · intro h
+    have h' : S.inertia * (∂ₜ (∂ₜ θ) t 0 + S.ω ^ 2 * Real.sin (θ t 0)) = 0 := by
+      linear_combination h
+    exact (mul_eq_zero.mp h').resolve_left S.inertia_ne_zero
+  · intro h
+    linear_combination S.inertia * h
+
+/-- Two simple pendulums with the same angular frequency have the same equation of motion, and
+  hence the same motions. In particular the motion of a pendulum does not depend on its mass. -/
+lemma equationOfMotion_iff_of_eq_ω (S' : SimplePendulum) (h : S'.ω = S.ω)
+    (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S'.EquationOfMotion θ ↔ S.EquationOfMotion θ := by
+  rw [S'.equationOfMotion_iff_scalar, S.equationOfMotion_iff_scalar, h]
+
+/-!
+
+## F. The variational derivative of the action
+
+The action of the simple pendulum is the time integral of the Lagrangian along a lift of the
+angle. Its variational derivative is computed here, in two steps: it is the Euler–Lagrange
+operator of the Lagrangian, and that operator is the torque minus the rate of change of the
+angular momentum.
+
+-/
+
+/-!
+
+### F.1. The definition of the variational derivative
+
+The variational derivative is that of Physlib's variational calculus, applied to the action of the
+pendulum. Recall that it is defined to be `0` when no variational gradient exists, so the lemmas
+below are stated for smooth lifts of the angle.
+
+-/
+
+/-- The variational derivative of the action of the simple pendulum, the action being the time
+  integral of the Lagrangian along a lift of the angle. -/
+noncomputable def gradLagrangian (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    Time → EuclideanSpace ℝ (Fin 1) :=
+  (δ (q':=θ), ∫ t, S.lagrangian t (q' t) (fderiv ℝ q' t 1))
+
+/-!
+
+### F.2. Equality with the Euler–Lagrange operator
+
+For a smooth lift of the angle the variational derivative of the action is the Euler–Lagrange
+operator of the Lagrangian, by the general theorem `euler_lagrange_varGradient`; the hypotheses
+of that theorem are the smoothness of the lift and `contDiff_lagrangian`.
+
+-/
+
+/-- For a smooth lift of the angle the variational derivative of the action of the simple
+  pendulum is the Euler–Lagrange operator of its Lagrangian. -/
+lemma gradLagrangian_eq_eulerLagrangeOp (θ : Time → EuclideanSpace ℝ (Fin 1))
+    (hθ : ContDiff ℝ ∞ θ) :
+    S.gradLagrangian θ = eulerLagrangeOp S.lagrangian θ := by
+  rw [gradLagrangian, euler_lagrange_varGradient _ _ hθ (S.contDiff_lagrangian _)]
+
+/-!
+
+### F.3. The variational derivative in terms of the torque
+
+Evaluating the Euler–Lagrange operator with the gradients of section D.3 gives the variational
+derivative as the torque minus the rate of change of the angular momentum. Its vanishing is
+therefore the equation of motion of section E; that equivalence,
+`equationOfMotion_iff_gradLagrangian_zero`, is proved in a later module, together with energy
+conservation, so that this module carries the model of the pendulum alone.
+
+-/
+
+/-- For a smooth lift of the angle the variational derivative of the action of the simple
+  pendulum is the torque minus the rate of change `I θ̈` of the angular momentum. -/
+lemma gradLagrangian_eq_torque (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    S.gradLagrangian θ = fun t => S.torque (θ t) - S.inertia • ∂ₜ (∂ₜ θ) t := by
+  funext t
+  rw [S.gradLagrangian_eq_eulerLagrangeOp θ hθ, eulerLagrangeOp]
+  simp [S.gradient_lagrangian_position_eq, S.gradient_lagrangian_velocity_eq, torque,
+    S.gradient_potentialEnergy,
+    Time.deriv_smul _ S.inertia (deriv_differentiable_of_contDiff θ hθ)]
+
 end SimplePendulum
 
 end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean
@@ -6,8 +6,6 @@ Authors: Aadarsh Agarwal
 module
 
 public import Physlib.ClassicalMechanics.EulerLagrange
-public import Physlib.ClassicalMechanics.HamiltonsEquations
-public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
 public import Physlib.Mathematics.Calculus.Gradient
 /-!
 
@@ -21,7 +19,7 @@ gravitational acceleration `g`. Its configuration is the angle `θ` of the rod f
 vertical. The bob moves on the circle of radius `ℓ` about the pivot, so its moment of inertia
 about the pivot is `I = m ℓ²` and its kinetic energy is `T = ½ I θ̇²`. Swinging out to the angle
 `θ` raises the bob by `ℓ (1 - cos θ)` against gravity, so the potential energy is
-`V = m g ℓ (1 - cos θ)`, normalised to vanish at the bottom of the swing. Balancing the rate of
+`V = m g ℓ (1 - cos θ)`, normalized to vanish at the bottom of the swing. Balancing the rate of
 change of the angular momentum about the pivot against the torque `-m g ℓ sin θ` of gravity gives
 the equation of motion `I θ̈ = -m g ℓ sin θ`, equivalently `θ̈ + (g/ℓ) sin θ = 0`. The mass drops
 out of the motion, which is governed by the single quantity `ω = √(g/ℓ)`, the angular frequency of
@@ -33,8 +31,9 @@ file are written instead on the Euclidean lift `Time → EuclideanSpace ℝ (Fin
 carried by a real number, from which the configuration is recovered by
 `SimplePendulum.ConfigurationSpace.ofAngle`, and the one-dimensional Euclidean space stands in for
 both the configuration space and its tangent space, so that the Euler–Lagrange operator of Physlib
-applies verbatim. Two lifts differing by `2π n` describe the same motion; this, and the connection
-of the model here with the geometric configuration space, is proved in a later module.
+applies verbatim. Two lifts differing by `2π n` describe the same motion, as a subsequent
+contribution proves; the connection of the model here with the geometric configuration space is
+made in a later module.
 
 ## ii. Key results
 
@@ -49,10 +48,11 @@ of the model here with the geometric configuration space, is proved in a later m
   `potentialEnergy_eq_zero_iff`, the gradient `gradient_potentialEnergy` of the potential and the
   time derivatives `kineticEnergy_deriv`, `potentialEnergy_deriv` and `energy_deriv`.
 - `SimplePendulum.lagrangian` is the Lagrangian `T - V` of the pendulum, and
-  `SimplePendulum.torque` is the torque about the pivot, the quantity conjugate to the angle.
+  `SimplePendulum.torque` is the torque about the pivot, the generalized force conjugate to
+  the angle.
 - `SimplePendulum.EquationOfMotion` is the equation of motion `I θ̈ = τ(θ)`, with its scalar form
   `equationOfMotion_iff_scalar` and its independence of the mass `equationOfMotion_iff_of_eq_ω`;
-  `SimplePendulum.IsSolution` is a classical, that is smooth, solution of it.
+  `SimplePendulum.IsSolution` is a smooth solution of it.
 - `SimplePendulum.gradLagrangian` is the variational derivative of the action, computed by
   `gradLagrangian_eq_eulerLagrangeOp` and `gradLagrangian_eq_torque`.
 
@@ -76,7 +76,7 @@ of the model here with the geometric configuration space, is proved in a later m
 - E. The torque and the equation of motion
   - E.1. The torque
   - E.2. The equation of motion
-  - E.3. Classical solutions
+  - E.3. Smooth solutions
   - E.4. The scalar equation and independence of the mass
 - F. The variational derivative of the action
   - F.1. The definition of the variational derivative
@@ -173,7 +173,7 @@ torque of gravity; what survives is `ω`. The identity performing that cancellat
 
 ### B.1. The angular frequency
 
-Linearising `sin θ ≈ θ` about the bottom of the swing turns the equation of motion into that of a
+Linearizing `sin θ ≈ θ` about the bottom of the swing turns the equation of motion into that of a
 harmonic oscillator of angular frequency `√(g/ℓ)`. The exact motion is not harmonic, but this
 frequency is the natural time scale of the pendulum and appears throughout its analysis.
 
@@ -208,7 +208,7 @@ the torque, and so plays for the angle the role that the mass plays for a positi
 
 /-- The moment of inertia of the simple pendulum about its pivot is `I = m ℓ²`, the moment of
   inertia of a point mass `m` at distance `ℓ` from the axis. -/
-noncomputable def inertia : ℝ := S.m * S.ℓ ^ 2
+def inertia : ℝ := S.m * S.ℓ ^ 2
 
 /-- The moment of inertia of the simple pendulum is positive. -/
 lemma inertia_pos : 0 < S.inertia := mul_pos S.m_pos (pow_pos S.ℓ_pos 2)
@@ -224,8 +224,8 @@ lemma ω_sq_mul_inertia : S.ω ^ 2 * S.inertia = S.m * S.g * S.ℓ := by
   rw [ω_sq, inertia]
   field_simp
 
-open MeasureTheory Time
-open scoped ContDiff Gradient
+open Time
+open scoped ContDiff
 
 /-!
 
@@ -254,8 +254,8 @@ through the Lagrangian.
 noncomputable def kineticEnergy (θ : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ := fun t =>
   (1 / (2 : ℝ)) * S.inertia * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ
 
-/-- The potential energy of the simple pendulum at the angle `x` is `m g ℓ (1 - cos θ)`, the work
-  done against gravity in raising the bob from the bottom of the swing. It is normalised to
+/-- The potential energy of the simple pendulum at the angle `x` is `m g ℓ (1 - cos (x 0))`, the
+  work done against gravity in raising the bob from the bottom of the swing. It is normalized to
   vanish at the bottom. -/
 noncomputable def potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) : ℝ :=
   S.m * S.g * S.ℓ * (1 - Real.cos (x 0))
@@ -268,9 +268,11 @@ noncomputable def energy (θ : Time → EuclideanSpace ℝ (Fin 1)) : Time → �
 
 ### C.2. Simple equalities and bounds for the energies
 
-Besides the definitional unfoldings, the potential energy of the pendulum satisfies two bounds
-that the harmonic oscillator has no analogue of: it is bounded, between `0` at the bottom of the
-swing and `2 m g ℓ` at the top, and it vanishes exactly at the bottom.
+Besides the definitional unfoldings, the potential energy of the pendulum is non-negative and
+vanishes exactly at the bottom of the swing, just as the potential energy of the harmonic
+oscillator is non-negative and vanishes exactly at the origin. What has no harmonic-oscillator
+analogue is the upper bound: the potential energy of the pendulum is at most `2 m g ℓ`, its
+value at the top of the swing.
 
 -/
 
@@ -308,8 +310,8 @@ lemma potentialEnergy_le (x : EuclideanSpace ℝ (Fin 1)) :
     _ ≤ S.m * S.g * S.ℓ * 2 := mul_le_mul_of_nonneg_left h hc.le
     _ = 2 * (S.m * S.g * S.ℓ) := by ring
 
-/-- The potential energy of the simple pendulum vanishes exactly at the bottom of the swing, that
-  is exactly at the angles which are whole multiples of a full turn. -/
+/-- The potential energy of the simple pendulum vanishes exactly when the cosine of the angle is
+  equal to `1`, that is exactly at the bottom of the swing. -/
 lemma potentialEnergy_eq_zero_iff (x : EuclideanSpace ℝ (Fin 1)) :
     S.potentialEnergy x = 0 ↔ Real.cos (x 0) = 1 := by
   have hc : S.m * S.g * S.ℓ ≠ 0 := (mul_pos (mul_pos S.m_pos S.g_pos) S.ℓ_pos).ne'
@@ -321,8 +323,11 @@ lemma potentialEnergy_eq_zero_iff (x : EuclideanSpace ℝ (Fin 1)) :
 
 The potential energy is a smooth function of the angle, and its gradient on the one-dimensional
 Euclidean lift is `m g ℓ sin θ` times the unit vector of the angular coordinate. This gradient is
-what the equation of motion balances against the angular acceleration, so we record it here, once,
-together with the gradient of the cosine of the angular coordinate from which it comes.
+what the equation of motion balances against the angular acceleration, so we record it here, once.
+The subsection also records that, along a smooth lift of the angle, each of the three energies is
+a differentiable function of the time — differentiability in time along the lift, as distinct
+from the differentiability in the angle of the potential energy — which is the differentiability
+that the time derivatives of section C.4 consume.
 
 -/
 
@@ -332,17 +337,12 @@ lemma potentialEnergy_contDiff (n : WithTop ℕ∞) : ContDiff ℝ n S.potential
   unfold potentialEnergy
   fun_prop
 
-/-- The potential energy of the simple pendulum is a differentiable function of the angle. -/
+/-- The potential energy of the simple pendulum is a differentiable function of the angle. This
+  is differentiability in the angle; for differentiability in time along a smooth lift of the
+  angle see `potentialEnergy_differentiable`. -/
 @[fun_prop]
 lemma differentiable_potentialEnergy : Differentiable ℝ S.potentialEnergy :=
   (S.potentialEnergy_contDiff 1).differentiable one_ne_zero
-
-/-- The gradient of the cosine of the angular coordinate on the one-dimensional Euclidean lift.
-  This is the specialization of `gradient_comp_coord` to the cosine. -/
-lemma gradient_cos_coord (x : EuclideanSpace ℝ (Fin 1)) :
-    gradient (fun y : EuclideanSpace ℝ (Fin 1) => Real.cos (y 0)) x =
-      -Real.sin (x 0) • EuclideanSpace.single 0 1 :=
-  gradient_comp_coord 0 x (Real.hasDerivAt_cos (x 0))
 
 /-- The gradient of the potential energy of the simple pendulum is `m g ℓ sin θ` times the unit
   vector of the angular coordinate. -/
@@ -356,7 +356,8 @@ lemma gradient_potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) :
     funext y
     rw [potentialEnergy_eq]
     ring
-  rw [h, gradient_add_const, gradient_const_mul _ hcos, gradient_cos_coord]
+  rw [h, gradient_add_const, gradient_const_mul _ hcos,
+    gradient_comp_coord 0 x (Real.hasDerivAt_cos (x 0))]
   module
 
 /-- Along a smooth lift of the angle the kinetic energy is differentiable in time. -/
@@ -366,7 +367,9 @@ lemma kineticEnergy_differentiable (θ : Time → EuclideanSpace ℝ (Fin 1)) (h
   rw [kineticEnergy_eq]
   fun_prop
 
-/-- Along a smooth lift of the angle the potential energy is differentiable in time. -/
+/-- Along a smooth lift of the angle the potential energy is a differentiable function of the
+  time. This is differentiability in time along the lift; for differentiability in the angle see
+  `differentiable_potentialEnergy`. -/
 @[fun_prop]
 lemma potentialEnergy_differentiable (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
     Differentiable ℝ (fun t => S.potentialEnergy (θ t)) := by
@@ -411,7 +414,7 @@ lemma potentialEnergy_deriv (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Co
   funext t
   have hd : DifferentiableAt ℝ θ t := (hθ.differentiable (by simp)).differentiableAt
   have hV : DifferentiableAt ℝ S.potentialEnergy (θ t) :=
-    (S.potentialEnergy_contDiff ∞).differentiable (by simp) (θ t)
+    (S.potentialEnergy_contDiff 1).differentiable one_ne_zero (θ t)
   have hf : HasFDerivAt (fun t => S.potentialEnergy (θ t)) _ t :=
     hV.hasFDerivAt.comp t hd.hasFDerivAt
   rw [Time.deriv_eq, hf.fderiv]
@@ -539,11 +542,14 @@ its own. The reason is that the variational derivative is defined to be `0` when
 gradient exists, so its vanishing holds vacuously for every lift of the angle too rough to admit
 one; it says what it is meant to say only under a smoothness assumption. The pointwise equation is
 totalized too — `∂ₜ` is `fderiv`, which is `0` off differentiability — but its totalization cannot
-make the equation vacuously true: a lift too rough to differentiate is handed `θ̈ = 0` and then the
-equation is a genuine, and generally false, constraint. It is also the form in which the equation
-of motion is solved and used. The two agree for smooth lifts, by
-`equationOfMotion_iff_gradLagrangian_zero`, proved in a later module; the present module goes as
-far as `gradLagrangian_eq_torque`, from which that equivalence is one rearrangement away.
+make the equation vacuously true: both sides remain genuine, and generally unequal, functions of
+time. A rough lift can still satisfy the equation accidentally — a discontinuous lift hopping
+between equilibrium angles solves it, as section E.3 explains — which is why the notion of a
+solution, `IsSolution`, demands smoothness as well. It is also the form in which the equation of
+motion is solved and used. The two agree for smooth lifts, by
+`equationOfMotion_iff_gradLagrangian_zero`, proved in a subsequent contribution; the present
+module goes as far as `gradLagrangian_eq_torque`, from which that equivalence is one rearrangement
+away.
 
 -/
 
@@ -563,7 +569,8 @@ noncomputable def torque (x : EuclideanSpace ℝ (Fin 1)) : EuclideanSpace ℝ (
   -gradient S.potentialEnergy x
 
 /-- The torque of the simple pendulum is `-m g ℓ sin θ` times the unit vector of the angular
-  coordinate. It is restoring: it opposes the displacement from the bottom of the swing. -/
+  coordinate. It is restoring near the bottom of the swing: for `|θ| < π` it opposes the
+  displacement, and it vanishes both at the bottom and at the inverted position. -/
 lemma torque_eq (x : EuclideanSpace ℝ (Fin 1)) :
     S.torque x = -((S.m * S.g * S.ℓ * Real.sin (x 0)) • EuclideanSpace.single 0 1) := by
   rw [torque, gradient_potentialEnergy]
@@ -588,38 +595,44 @@ about the pivot with the torque of gravity, at every instant.
 
   This pointwise relation, and not the vanishing of the variational derivative of the action, is
   the definition of the equation of motion here; see the discussion in section E. For a smooth
-  lift of the angle the two agree, by `equationOfMotion_iff_gradLagrangian_zero` in a later
-  module. -/
+  lift of the angle the two agree, by `equationOfMotion_iff_gradLagrangian_zero` in a subsequent
+  contribution. -/
 def EquationOfMotion (θ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
   ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t)
 
-/-- The equation of motion of the simple pendulum is Newton's second law for rotation about the
-  pivot. This holds by `Iff.rfl`, the equation of motion being defined as that law; the lemma is
-  kept for parity with the corresponding names of the harmonic oscillator and of the damped
-  harmonic oscillator, where the two statements are genuinely different. -/
+/-- The equation of motion of the simple pendulum with all of its terms on one side: at every
+  instant the rate of change `I θ̈` of the angular momentum plus the gradient of the potential
+  energy vanishes. This is the rotational form of Newton's second law, in the shape in which
+  `DampedHarmonicOscillator` states its own; it is the form that the energy-conservation lemma
+  of a subsequent contribution consumes. -/
 lemma equationOfMotion_iff_newtons_2nd_law (θ : Time → EuclideanSpace ℝ (Fin 1)) :
-    S.EquationOfMotion θ ↔ ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t) := Iff.rfl
+    S.EquationOfMotion θ ↔
+      ∀ t, S.inertia • ∂ₜ (∂ₜ θ) t + gradient S.potentialEnergy (θ t) = 0 := by
+  simp only [EquationOfMotion, torque, eq_neg_iff_add_eq_zero]
 
 /-!
 
-### E.3. Classical solutions
+### E.3. Smooth solutions
 
-A classical solution of the equation of motion is a smooth lift of the angle satisfying it. The
-smoothness is not needed to state the equation, but it is what the variational and Hamiltonian
-descriptions of the motion require, so solutions are asked for it once and for all.
+A solution of the pendulum is a smooth lift satisfying the equation of motion. Smoothness is part
+of the definition because the bare pointwise equation, being totalized, admits unphysical
+solutions: a lift jumping between the equilibrium angles `0` and `π` has `∂ₜ (∂ₜ θ) = 0` and zero
+torque everywhere, so it satisfies the equation while being nowhere continuous. Demanding
+smoothness excludes such junk, and is the regularity under which the variational description of
+the motion agrees with the pointwise one.
 
 -/
 
-/-- A classical solution of the simple pendulum is a smooth lift of the angle satisfying the
-  equation of motion. -/
+/-- A solution of the simple pendulum is a smooth lift of the angle satisfying the equation of
+  motion. -/
 def IsSolution (θ : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
   ContDiff ℝ ∞ θ ∧ S.EquationOfMotion θ
 
-/-- A classical solution of the simple pendulum is smooth. -/
+/-- A solution of the simple pendulum is smooth. -/
 lemma IsSolution.contDiff {S : SimplePendulum} {θ : Time → EuclideanSpace ℝ (Fin 1)}
     (h : S.IsSolution θ) : ContDiff ℝ ∞ θ := h.1
 
-/-- A classical solution of the simple pendulum satisfies the equation of motion. -/
+/-- A solution of the simple pendulum satisfies the equation of motion. -/
 lemma IsSolution.equationOfMotion {S : SimplePendulum} {θ : Time → EuclideanSpace ℝ (Fin 1)}
     (h : S.IsSolution θ) : S.EquationOfMotion θ := h.2
 
@@ -630,7 +643,7 @@ lemma IsSolution.equationOfMotion {S : SimplePendulum} {θ : Time → EuclideanS
 The angle is a single number, so the vector equation of motion is equivalent to the scalar
 equation obtained by reading off its one component. Dividing that component by the moment of
 inertia, using `ω_sq_mul_inertia`, cancels the mass and leaves `θ̈ + ω² sin θ = 0`: two pendulums
-with the same `ω = √(g/ℓ)` have exactly the same motions, whatever their masses.
+with the same `ω = √(g/ℓ)` have exactly the same angular motions, whatever their masses.
 
 -/
 
@@ -638,6 +651,7 @@ with the same `ω = √(g/ℓ)` have exactly the same motions, whatever their ma
   has cancelled: only the angular frequency `ω = √(g/ℓ)` survives. -/
 lemma equationOfMotion_iff_scalar (θ : Time → EuclideanSpace ℝ (Fin 1)) :
     S.EquationOfMotion θ ↔ ∀ t, ∂ₜ (∂ₜ θ) t 0 + S.ω ^ 2 * Real.sin (θ t 0) = 0 := by
+  simp only [EquationOfMotion]
   refine forall_congr' fun t => ?_
   have hcomp : (S.inertia • ∂ₜ (∂ₜ θ) t = S.torque (θ t)) ↔
       S.inertia * ∂ₜ (∂ₜ θ) t 0 = -(S.m * S.g * S.ℓ * Real.sin (θ t 0)) := by
@@ -658,8 +672,10 @@ lemma equationOfMotion_iff_scalar (θ : Time → EuclideanSpace ℝ (Fin 1)) :
   · intro h
     linear_combination S.inertia * h
 
-/-- Two simple pendulums with the same angular frequency have the same equation of motion, and
-  hence the same motions. In particular the motion of a pendulum does not depend on its mass. -/
+/-- Two simple pendulums with the same angular frequency have the same angular equation of
+  motion, and hence the same angular motions; in particular, changing only the mass does not
+  affect the angular motion. An equal `ω` still permits different lengths, and so different
+  trajectories of the bob in space. -/
 lemma equationOfMotion_iff_of_eq_ω (S' : SimplePendulum) (h : S'.ω = S.ω)
     (θ : Time → EuclideanSpace ℝ (Fin 1)) :
     S'.EquationOfMotion θ ↔ S.EquationOfMotion θ := by
@@ -716,8 +732,8 @@ lemma gradLagrangian_eq_eulerLagrangeOp (θ : Time → EuclideanSpace ℝ (Fin 1
 Evaluating the Euler–Lagrange operator with the gradients of section D.3 gives the variational
 derivative as the torque minus the rate of change of the angular momentum. Its vanishing is
 therefore the equation of motion of section E; that equivalence,
-`equationOfMotion_iff_gradLagrangian_zero`, is proved in a later module, together with energy
-conservation, so that this module carries the model of the pendulum alone.
+`equationOfMotion_iff_gradLagrangian_zero`, is proved in a subsequent contribution, together
+with energy conservation, so that this module carries the model of the pendulum alone.
 
 -/
 
@@ -727,8 +743,7 @@ lemma gradLagrangian_eq_torque (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ :
     S.gradLagrangian θ = fun t => S.torque (θ t) - S.inertia • ∂ₜ (∂ₜ θ) t := by
   funext t
   rw [S.gradLagrangian_eq_eulerLagrangeOp θ hθ, eulerLagrangeOp]
-  simp [S.gradient_lagrangian_position_eq, S.gradient_lagrangian_velocity_eq, torque,
-    S.gradient_potentialEnergy,
+  simp [S.gradient_lagrangian_position_eq, S.gradient_lagrangian_velocity_eq, S.torque_eq,
     Time.deriv_smul _ S.inertia (deriv_differentiable_of_contDiff θ hθ)]
 
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.SpaceAndTime.Space.Basic
+public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+/-!
+
+# Configuration space of the simple pendulum
+
+## i. Overview
+
+A simple pendulum is a bob fixed to one end of a rigid massless rod of length `ℓ`, the other end
+of which is pinned at a pivot, swinging in a vertical plane under gravity. Its position is fixed by
+the angle of the rod from the downward vertical, and two angles that differ by a full turn describe
+the same position. The configuration space is therefore a circle.
+
+We record a configuration by its angle modulo `2π`, i.e. by an element of `Real.Angle`, as the
+sliding pendulum does (`Physlib.ClassicalMechanics.Pendulum.SlidingPendulum`). The circle carries
+the structure of a compact analytic one-dimensional manifold; we obtain it by identifying the
+configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The real-valued
+angle that is used to write down the dynamics is a lift of the configuration to the universal cover
+`ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
+motion. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends the
+configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
+points upwards.
+
+## ii. Key results
+
+- `ConfigurationSpace` : the configuration space of the planar simple pendulum.
+- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle.
+- `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
+  manifold structure, pulled back from `Circle`.
+- `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
+  `2π`, continuous and surjective.
+- `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
+  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
+
+## iii. Table of contents
+
+- A. The configuration space type
+- B. Topology and identification with the unit circle
+- C. Manifold structure
+- D. The angular lift
+- E. Map to physical space
+
+## iv. References
+
+- Landau & Lifshitz, Mechanics, 3rd ed., §5, Problems 1–3 (pendulum configurations).
+- Mathlib, `Mathlib.Geometry.Manifold.Instances.Sphere` (the manifold structure on `Circle`).
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open scoped Manifold ContDiff
+
+namespace ClassicalMechanics
+namespace SimplePendulum
+
+/-!
+
+## A. The configuration space type
+
+A configuration is the angle of the rod from the downward vertical, taken modulo a full turn.
+
+-/
+
+/-- The configuration space of the planar simple pendulum: the angle of the rod from the downward
+  vertical, modulo `2π`. -/
+structure ConfigurationSpace where
+  /-- The angle of the rod from the downward vertical, modulo `2π`. -/
+  angle : Real.Angle
+
+namespace ConfigurationSpace
+
+/-- Two configurations are equal precisely when their angles are equal. -/
+@[ext]
+lemma ext {p q : ConfigurationSpace} (h : p.angle = q.angle) : p = q := by
+  cases p; cases q; cases h; rfl
+
+/-!
+
+## B. Topology and identification with the unit circle
+
+The topology is that of `Real.Angle`; composing with Mathlib's identification of `Real.Angle`
+(the additive circle of period `2π`) with the unit circle `Circle ⊆ ℂ` gives a homeomorphism
+`ConfigurationSpace ≃ₜ Circle`, through which the circle's compactness and Hausdorff property
+transfer.
+
+-/
+
+/-- The identification of the configuration space with `Real.Angle`. -/
+def angleEquiv : ConfigurationSpace ≃ Real.Angle where
+  toFun := angle
+  invFun φ := ⟨φ⟩
+  left_inv q := by cases q; rfl
+  right_inv φ := rfl
+
+/-- The topology of the configuration space, induced from `Real.Angle`. -/
+instance instTopologicalSpace : TopologicalSpace ConfigurationSpace :=
+  TopologicalSpace.induced angle inferInstance
+
+/-- The identification with `Real.Angle` as a homeomorphism. -/
+def angleHomeomorph : ConfigurationSpace ≃ₜ Real.Angle where
+  toEquiv := angleEquiv
+  continuous_toFun := continuous_induced_dom
+  continuous_invFun := continuous_induced_rng.mpr continuous_id
+
+/-- The point of the unit circle `e^{iθ}` corresponding to a configuration at angle `θ`. -/
+def toCircle (q : ConfigurationSpace) : Circle := q.angle.toCircle
+
+/-- The identification of the configuration space with the unit circle. -/
+def circleHomeomorph : ConfigurationSpace ≃ₜ Circle :=
+  angleHomeomorph.trans AddCircle.homeomorphCircle'
+
+/-- The identification with the unit circle is given by `ConfigurationSpace.toCircle`. -/
+lemma circleHomeomorph_apply (q : ConfigurationSpace) : circleHomeomorph q = q.toCircle := rfl
+
+/-- The configuration space is Hausdorff, being homeomorphic to the unit circle. -/
+instance instT2Space : T2Space ConfigurationSpace := circleHomeomorph.symm.t2Space
+
+/-- The configuration space is compact, being homeomorphic to the unit circle. -/
+instance instCompactSpace : CompactSpace ConfigurationSpace := circleHomeomorph.symm.compactSpace
+
+/-- The configuration space is second countable, being homeomorphic to the unit circle. -/
+instance instSecondCountableTopology : SecondCountableTopology ConfigurationSpace :=
+  circleHomeomorph.secondCountableTopology
+
+end ConfigurationSpace
+end SimplePendulum
+end ClassicalMechanics
+
+end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -26,7 +26,7 @@ the structure of a compact analytic one-dimensional manifold; we obtain it by id
 configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The smooth
 identification of the configuration space with `Circle` (the analogue of the harmonic oscillator's
 `valDiffeomorph`) is deferred to the module on trajectories. The real-valued angle that is used to
-write down the dynamics is a lift of the configuration to the universal cover
+write down the dynamics is a lift of the configuration along the covering map
 `ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
 configuration. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends
 the configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
@@ -35,13 +35,15 @@ points upwards.
 ## ii. Key results
 
 - `ConfigurationSpace` : the configuration space of the planar simple pendulum.
-- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle.
+- `ConfigurationSpace.circleHomeomorph` : its identification with the unit circle, with inverse
+  `ConfigurationSpace.ofCircle` (`toCircle_ofCircle`, `ofCircle_toCircle`).
 - `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
-  manifold structure, pulled back from `Circle`.
+  manifold structure, pulled back from `Circle` (`chartAt_source`, `chartAt_target`).
 - `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
-  `2π`, continuous, surjective and analytic.
+  `2π`, continuous, surjective, analytic, and a covering map (`isCoveringMap_ofAngle`).
 - `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
-  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
+  `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`; for `ℓ ≠ 0` it is a closed
+  embedding (`toSpace_isClosedEmbedding`).
 
 ## iii. Table of contents
 
@@ -227,7 +229,7 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
 `ℝ → ℝ / 2πℤ`, a covering map of the circle: it is continuous, surjective and `2π`-periodic, and
 two angles give the same configuration exactly when they differ by a whole number of turns. The
 dynamics of the pendulum are written for a real-valued lift of the angle; this section is what
-makes different lifts describe the same motion. In the charts pulled back from the circle the lift
+makes different lifts describe the same configuration. In the charts pulled back from the circle
 is `Circle.exp`, so it is analytic.
 
 -/
@@ -281,6 +283,11 @@ lemma isCoveringMap_ofAngle : IsCoveringMap ofAngle := by
 /-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
 @[simp]
 lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
+
+/-- The configuration of a point `e^{iθ}` of the unit circle is `ofAngle θ`. -/
+@[simp]
+lemma ofCircle_circleExp (θ : ℝ) : ofCircle (Circle.exp θ) = ofAngle θ := by
+  rw [← toCircle_ofAngle, ofCircle_toCircle]
 
 /-- The angular lift is analytic: read in the charts pulled back from the circle it is
   `Circle.exp`. -/

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -362,13 +362,10 @@ lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
     toSpace ℓ q 1 = -(ℓ * q.cos) := neg_mul ℓ q.cos
 
 /-- The position of the bob for the configuration at angle `θ`. -/
+@[simp]
 lemma toSpace_ofAngle (ℓ θ : ℝ) :
     toSpace ℓ (ofAngle θ) = ⟨![ℓ * Real.sin θ, -ℓ * Real.cos θ]⟩ := by
   simp [toSpace]
-
-/-- At `θ = 0` the bob hangs straight down, at `(0, -ℓ)`. -/
-lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]⟩ := by
-  simp [toSpace_ofAngle]
 
 /-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
 @[simp]

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Physlib.SpaceAndTime.Space.Module
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Topology.Covering.AddCircle
 /-!
 
 # Configuration space of the simple pendulum
@@ -22,11 +23,13 @@ the same position. The configuration space is therefore a circle.
 We record a configuration by its angle modulo `2π`, i.e. by an element of `Real.Angle`, as the
 sliding pendulum does (`Physlib.ClassicalMechanics.Pendulum.SlidingPendulum`). The circle carries
 the structure of a compact analytic one-dimensional manifold; we obtain it by identifying the
-configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The real-valued
-angle that is used to write down the dynamics is a lift of the configuration to the universal cover
+configuration space with Mathlib's unit circle `Circle` and pulling back its charts. The smooth
+identification of the configuration space with `Circle` (the analogue of the harmonic oscillator's
+`valDiffeomorph`) is deferred to the module on trajectories. The real-valued angle that is used to
+write down the dynamics is a lift of the configuration to the universal cover
 `ℝ → ConfigurationSpace`; it is not a chart, and two lifts differing by `2π n` describe the same
-motion. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends the
-configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
+configuration. Finally the position of the bob in the plane is recorded by `toSpace ℓ`, which sends
+the configuration at angle `θ` to `(ℓ sin θ, -ℓ cos θ)`: the pivot is the origin and the second axis
 points upwards.
 
 ## ii. Key results
@@ -120,8 +123,27 @@ def toCircle (q : ConfigurationSpace) : Circle := q.angle.toCircle
 def circleHomeomorph : ConfigurationSpace ≃ₜ Circle :=
   angleHomeomorph.trans AddCircle.homeomorphCircle'
 
+-- `rfl` proves this because `Real.Angle.toCircle` and `AddCircle.homeomorphCircle'` are the same
+-- lift of `Circle.exp`; should that stop holding definitionally, the fallback proof is
+-- `Real.Angle.induction_on` with `Real.Angle.toCircle_coe` and
+-- `AddCircle.homeomorphCircle'_apply_mk`.
 /-- The identification with the unit circle is given by `ConfigurationSpace.toCircle`. -/
 lemma circleHomeomorph_apply (q : ConfigurationSpace) : circleHomeomorph q = q.toCircle := rfl
+
+/-- The configuration corresponding to a point of the unit circle. -/
+def ofCircle : Circle → ConfigurationSpace := circleHomeomorph.symm
+
+/-- The point of the unit circle of the configuration attached to a point of the unit circle is
+  that point. -/
+@[simp]
+lemma toCircle_ofCircle (z : Circle) : (ofCircle z).toCircle = z :=
+  circleHomeomorph.apply_symm_apply z
+
+/-- The configuration attached to the point of the unit circle of a configuration is that
+  configuration. -/
+@[simp]
+lemma ofCircle_toCircle (q : ConfigurationSpace) : ofCircle q.toCircle = q :=
+  circleHomeomorph.symm_apply_apply q
 
 /-- The configuration space is Hausdorff, being homeomorphic to the unit circle. -/
 instance instT2Space : T2Space ConfigurationSpace := circleHomeomorph.symm.t2Space
@@ -162,6 +184,22 @@ lemma chartAt_eq (q : ConfigurationSpace) :
       circleHomeomorph.toOpenPartialHomeomorph.trans
         (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle) := rfl
 
+/-- The domain of the chart at a configuration is the preimage under the identification with the
+  unit circle of the domain of the chart of the circle at the corresponding point. -/
+lemma chartAt_source (q : ConfigurationSpace) :
+    (chartAt (EuclideanSpace ℝ (Fin 1)) q).source =
+      circleHomeomorph ⁻¹' (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle).source := by
+  rw [chartAt_eq, OpenPartialHomeomorph.trans_source]
+  simp
+
+/-- The codomain of the chart at a configuration is the codomain of the chart of the circle at the
+  corresponding point. -/
+lemma chartAt_target (q : ConfigurationSpace) :
+    (chartAt (EuclideanSpace ℝ (Fin 1)) q).target =
+      (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle).target := by
+  rw [chartAt_eq, OpenPartialHomeomorph.trans_target]
+  simp
+
 /-- The configuration space is an analytic manifold: every change of charts is a change of charts
   of the unit circle. -/
 instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
@@ -186,11 +224,11 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
 ## D. The angular lift
 
 `ofAngle θ` is the configuration at angle `θ` from the downward vertical. It is the quotient map
-`ℝ → ℝ / 2πℤ`, i.e. the universal covering of the circle: it is continuous, surjective and
-`2π`-periodic, and two angles give the same configuration exactly when they differ by a whole
-number of turns. The dynamics of the pendulum are written for a real-valued lift of the angle; this
-section is what makes different lifts describe the same motion. In the charts pulled back from the
-circle the lift is `Circle.exp`, so it is analytic.
+`ℝ → ℝ / 2πℤ`, a covering map of the circle: it is continuous, surjective and `2π`-periodic, and
+two angles give the same configuration exactly when they differ by a whole number of turns. The
+dynamics of the pendulum are written for a real-valued lift of the angle; this section is what
+makes different lifts describe the same motion. In the charts pulled back from the circle the lift
+is `Circle.exp`, so it is analytic.
 
 -/
 
@@ -225,14 +263,23 @@ lemma ofAngle_eq_iff (θ₁ θ₂ : ℝ) :
 /-- Every configuration is the configuration at some real angle: the lift is surjective. -/
 lemma ofAngle_surjective : Function.Surjective ofAngle := by
   rintro ⟨φ⟩
-  induction φ using Real.Angle.induction_on with
-  | h θ => exact ⟨θ, rfl⟩
+  induction φ using Real.Angle.induction_on
+  next θ => exact ⟨θ, rfl⟩
 
 /-- The angular lift is continuous. -/
+@[fun_prop]
 lemma continuous_ofAngle : Continuous ofAngle :=
   continuous_induced_rng.mpr Real.Angle.continuous_coe
 
+/-- The angular lift is a covering map. -/
+lemma isCoveringMap_ofAngle : IsCoveringMap ofAngle := by
+  have h : IsCoveringMap ((↑) : ℝ → Real.Angle) := AddCircle.isCoveringMap_coe (2 * Real.pi)
+  have he : ofAngle = ⇑angleHomeomorph.symm ∘ ((↑) : ℝ → Real.Angle) := rfl
+  rw [he]
+  exact h.homeomorph_comp angleHomeomorph.symm
+
 /-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
+@[simp]
 lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
 
 /-- The angular lift is analytic: read in the charts pulled back from the circle it is
@@ -241,6 +288,7 @@ lemma contMDiff_ofAngle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω ofAngle := by
   rw [contMDiff_iff]
   refine ⟨continuous_ofAngle, fun x y => ?_⟩
   have h := (contMDiff_iff.mp (contMDiff_circleExp (m := ω))).2 x y.toCircle
+  -- Two goals remain: the map read in the charts, and the domain on which it is read.
   convert h using 2
   · rfl
   · ext θ
@@ -251,6 +299,12 @@ def cos (q : ConfigurationSpace) : ℝ := Real.Angle.cos q.angle
 
 /-- The sine of the angle of a configuration. -/
 def sin (q : ConfigurationSpace) : ℝ := Real.Angle.sin q.angle
+
+/-- The cosine of a configuration is the cosine of its angle. -/
+lemma cos_angle (q : ConfigurationSpace) : q.cos = Real.Angle.cos q.angle := rfl
+
+/-- The sine of a configuration is the sine of its angle. -/
+lemma sin_angle (q : ConfigurationSpace) : q.sin = Real.Angle.sin q.angle := rfl
 
 /-- The cosine of the configuration at angle `θ` is `cos θ`. -/
 @[simp]
@@ -264,30 +318,41 @@ lemma sin_ofAngle (θ : ℝ) : (ofAngle θ).sin = Real.sin θ := Real.Angle.sin_
 lemma cos_sq_add_sin_sq (q : ConfigurationSpace) : q.cos ^ 2 + q.sin ^ 2 = 1 :=
   Real.Angle.cos_sq_add_sin_sq q.angle
 
+/-- The cosine of the angle depends continuously on the configuration. -/
+@[fun_prop]
+lemma continuous_cos : Continuous (cos : ConfigurationSpace → ℝ) :=
+  Real.Angle.continuous_cos.comp continuous_induced_dom
+
+/-- The sine of the angle depends continuously on the configuration. -/
+@[fun_prop]
+lemma continuous_sin : Continuous (sin : ConfigurationSpace → ℝ) :=
+  Real.Angle.continuous_sin.comp continuous_induced_dom
+
 /-!
 
 ## E. Map to physical space
 
 The pivot is the origin of the plane `Space 2`, the first coordinate is horizontal and the second
 points upwards. A rod of length `ℓ` at angle `θ` from the downward vertical places the bob at
-`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The image of the
-configuration space is the circle of radius `|ℓ|` about the pivot — the rod-length constraint —
-and for `ℓ ≠ 0` the map is injective, so the configuration is determined by the position.
+`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The bob lies on the
+circle of radius `|ℓ|` about the pivot — the rod-length constraint — and for `ℓ ≠ 0` the map is
+injective, so the configuration is determined by the position.
 
 -/
 
-/-- The position of the bob in the plane, for a rod of length `ℓ`. -/
+/-- The position of the bob in the plane, for a rod of length `ℓ`. `ℓ` is not assumed positive; the
+  bob is at distance `|ℓ|` from the pivot. -/
 def toSpace (ℓ : ℝ) (q : ConfigurationSpace) : Space 2 := ⟨![ℓ * q.sin, -ℓ * q.cos]⟩
 
-/-- The horizontal coordinate of the bob is `ℓ sin θ`. -/
+/-- The horizontal coordinate of the bob, `ℓ * q.sin`. -/
 @[simp]
 lemma toSpace_apply_zero (ℓ : ℝ) (q : ConfigurationSpace) :
     toSpace ℓ q 0 = ℓ * q.sin := rfl
 
-/-- The vertical coordinate of the bob is `-ℓ cos θ`. -/
+/-- The vertical coordinate of the bob, `-(ℓ * q.cos)`. -/
 @[simp]
 lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
-    toSpace ℓ q 1 = -ℓ * q.cos := rfl
+    toSpace ℓ q 1 = -(ℓ * q.cos) := neg_mul ℓ q.cos
 
 /-- The position of the bob for the configuration at angle `θ`. -/
 lemma toSpace_ofAngle (ℓ θ : ℝ) :
@@ -299,41 +364,36 @@ lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]
   simp [toSpace_ofAngle]
 
 /-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
+@[simp]
 lemma toSpace_norm (ℓ : ℝ) (q : ConfigurationSpace) : ‖toSpace ℓ q‖ = |ℓ| := by
-  have hq : (ℓ * q.sin) ^ 2 + (-ℓ * q.cos) ^ 2 = ℓ ^ 2 := by
+  have hq : (ℓ * q.sin) ^ 2 + (-(ℓ * q.cos)) ^ 2 = ℓ ^ 2 := by
     linear_combination ℓ ^ 2 * cos_sq_add_sin_sq q
   rw [Space.norm_eq, Fin.sum_univ_two, toSpace_apply_zero, toSpace_apply_one, hq,
     Real.sqrt_sq_eq_abs]
 
 /-- The position of the bob depends continuously on the configuration. -/
+@[fun_prop]
 lemma continuous_toSpace (ℓ : ℝ) : Continuous (toSpace ℓ) := by
-  have hcos : Continuous fun q : ConfigurationSpace => q.cos :=
-    Real.Angle.continuous_cos.comp continuous_induced_dom
-  have hsin : Continuous fun q : ConfigurationSpace => q.sin :=
-    Real.Angle.continuous_sin.comp continuous_induced_dom
-  have hv : Continuous fun q : ConfigurationSpace => (![ℓ * q.sin, -ℓ * q.cos] : Fin 2 → ℝ) := by
-    refine continuous_pi fun i => ?_
-    fin_cases i
-    · simpa using hsin.const_mul ℓ
-    · simpa using hcos.const_mul (-ℓ)
-  exact Space.mk_continuous.comp hv
+  refine Space.mk_continuous.comp (continuous_pi fun i => ?_)
+  fin_cases i <;> simp <;> fun_prop
 
 /-- For a rod of nonzero length the configuration is determined by the position of the bob. -/
 lemma toSpace_injective {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Function.Injective (toSpace ℓ) := by
   -- Equality of angles is detected by their cosine and sine.
   have key : ∀ θ ψ : Real.Angle, θ.cos = ψ.cos → θ.sin = ψ.sin → θ = ψ := by
-    intro θ ψ hc hs
-    rcases Real.Angle.cos_eq_iff_eq_or_eq_neg.mp hc with h | h
-    · exact h
-    rcases Real.Angle.sin_eq_iff_eq_or_add_eq_pi.mp hs with h' | h'
-    · exact h'
-    rw [h, neg_add_cancel] at h'
-    exact absurd h'.symm Real.Angle.pi_ne_zero
+    intro θ ψ
+    induction θ using Real.Angle.induction_on
+    induction ψ using Real.Angle.induction_on
+    simpa using Real.Angle.cos_sin_inj
   intro q₁ q₂ h
   have h0 : ℓ * q₁.sin = ℓ * q₂.sin := congrArg (fun p : Space 2 => p 0) h
   have h1 : -ℓ * q₁.cos = -ℓ * q₂.cos := congrArg (fun p : Space 2 => p 1) h
   exact ConfigurationSpace.ext
     (key _ _ (mul_left_cancel₀ (neg_ne_zero.mpr hℓ) h1) (mul_left_cancel₀ hℓ h0))
+
+/-- For `ℓ ≠ 0` the position map is a closed embedding of the configuration circle. -/
+lemma toSpace_isClosedEmbedding {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Topology.IsClosedEmbedding (toSpace ℓ) :=
+  (continuous_toSpace ℓ).isClosedEmbedding (toSpace_injective hℓ)
 
 end ConfigurationSpace
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -5,7 +5,7 @@ Authors: Aadarsh Agarwal
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Basic
+public import Physlib.SpaceAndTime.Space.Module
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.Geometry.Manifold.Instances.Sphere
 /-!
@@ -36,7 +36,7 @@ points upwards.
 - `ConfigurationSpace.instChartedSpace`, `ConfigurationSpace.instIsManifold` : the analytic
   manifold structure, pulled back from `Circle`.
 - `ConfigurationSpace.ofAngle` : the angular lift `ℝ → ConfigurationSpace`, periodic with period
-  `2π`, continuous and surjective.
+  `2π`, continuous, surjective and analytic.
 - `ConfigurationSpace.toSpace` : the position of the bob in `Space 2`, with
   `toSpace_ofAngle` and the rod-length constraint `toSpace_norm`.
 
@@ -180,6 +180,160 @@ instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
         hself, OpenPartialHomeomorph.refl_trans]
     rw [hcancel]
     exact HasGroupoid.compatible he₁ he₂
+
+/-!
+
+## D. The angular lift
+
+`ofAngle θ` is the configuration at angle `θ` from the downward vertical. It is the quotient map
+`ℝ → ℝ / 2πℤ`, i.e. the universal covering of the circle: it is continuous, surjective and
+`2π`-periodic, and two angles give the same configuration exactly when they differ by a whole
+number of turns. The dynamics of the pendulum are written for a real-valued lift of the angle; this
+section is what makes different lifts describe the same motion. In the charts pulled back from the
+circle the lift is `Circle.exp`, so it is analytic.
+
+-/
+
+/-- The configuration at angle `θ` (measured from the downward vertical). -/
+def ofAngle (θ : ℝ) : ConfigurationSpace := ⟨θ⟩
+
+/-- The angle of the configuration at angle `θ` is `θ` modulo `2π`. -/
+@[simp]
+lemma ofAngle_angle (θ : ℝ) : (ofAngle θ).angle = θ := rfl
+
+/-- Adding a full turn to the angle leaves the configuration unchanged. -/
+lemma ofAngle_add_two_pi (θ : ℝ) : ofAngle (θ + 2 * Real.pi) = ofAngle θ := by
+  ext
+  simp [Real.Angle.coe_add, Real.Angle.coe_two_pi]
+
+/-- The angular lift is periodic with period `2π`. -/
+lemma ofAngle_periodic : Function.Periodic ofAngle (2 * Real.pi) := ofAngle_add_two_pi
+
+/-- Two angles describe the same configuration exactly when they differ by a whole number of
+  turns. -/
+lemma ofAngle_eq_iff (θ₁ θ₂ : ℝ) :
+    ofAngle θ₁ = ofAngle θ₂ ↔ ∃ n : ℤ, θ₂ = θ₁ + n * (2 * Real.pi) := by
+  constructor
+  · intro h
+    obtain ⟨k, hk⟩ :=
+      Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp (congrArg ConfigurationSpace.angle h)
+    exact ⟨-k, by push_cast; linarith⟩
+  · rintro ⟨n, rfl⟩
+    exact ConfigurationSpace.ext
+      (Real.Angle.angle_eq_iff_two_pi_dvd_sub.mpr ⟨-n, by push_cast; ring⟩)
+
+/-- Every configuration is the configuration at some real angle: the lift is surjective. -/
+lemma ofAngle_surjective : Function.Surjective ofAngle := by
+  rintro ⟨φ⟩
+  induction φ using Real.Angle.induction_on with
+  | h θ => exact ⟨θ, rfl⟩
+
+/-- The angular lift is continuous. -/
+lemma continuous_ofAngle : Continuous ofAngle :=
+  continuous_induced_rng.mpr Real.Angle.continuous_coe
+
+/-- The configuration at angle `θ` corresponds to the point `e^{iθ}` of the unit circle. -/
+lemma toCircle_ofAngle (θ : ℝ) : (ofAngle θ).toCircle = Circle.exp θ := Real.Angle.toCircle_coe θ
+
+/-- The angular lift is analytic: read in the charts pulled back from the circle it is
+  `Circle.exp`. -/
+lemma contMDiff_ofAngle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ω ofAngle := by
+  rw [contMDiff_iff]
+  refine ⟨continuous_ofAngle, fun x y => ?_⟩
+  have h := (contMDiff_iff.mp (contMDiff_circleExp (m := ω))).2 x y.toCircle
+  convert h using 2
+  · rfl
+  · ext θ
+    simp [chartAt_eq, circleHomeomorph_apply, toCircle_ofAngle]
+
+/-- The cosine of the angle of a configuration. -/
+def cos (q : ConfigurationSpace) : ℝ := Real.Angle.cos q.angle
+
+/-- The sine of the angle of a configuration. -/
+def sin (q : ConfigurationSpace) : ℝ := Real.Angle.sin q.angle
+
+/-- The cosine of the configuration at angle `θ` is `cos θ`. -/
+@[simp]
+lemma cos_ofAngle (θ : ℝ) : (ofAngle θ).cos = Real.cos θ := Real.Angle.cos_coe θ
+
+/-- The sine of the configuration at angle `θ` is `sin θ`. -/
+@[simp]
+lemma sin_ofAngle (θ : ℝ) : (ofAngle θ).sin = Real.sin θ := Real.Angle.sin_coe θ
+
+/-- The Pythagorean identity for the angle of a configuration. -/
+lemma cos_sq_add_sin_sq (q : ConfigurationSpace) : q.cos ^ 2 + q.sin ^ 2 = 1 :=
+  Real.Angle.cos_sq_add_sin_sq q.angle
+
+/-!
+
+## E. Map to physical space
+
+The pivot is the origin of the plane `Space 2`, the first coordinate is horizontal and the second
+points upwards. A rod of length `ℓ` at angle `θ` from the downward vertical places the bob at
+`(ℓ sin θ, -ℓ cos θ)`; at `θ = 0` the bob hangs straight down at `(0, -ℓ)`. The image of the
+configuration space is the circle of radius `|ℓ|` about the pivot — the rod-length constraint —
+and for `ℓ ≠ 0` the map is injective, so the configuration is determined by the position.
+
+-/
+
+/-- The position of the bob in the plane, for a rod of length `ℓ`. -/
+def toSpace (ℓ : ℝ) (q : ConfigurationSpace) : Space 2 := ⟨![ℓ * q.sin, -ℓ * q.cos]⟩
+
+/-- The horizontal coordinate of the bob is `ℓ sin θ`. -/
+@[simp]
+lemma toSpace_apply_zero (ℓ : ℝ) (q : ConfigurationSpace) :
+    toSpace ℓ q 0 = ℓ * q.sin := rfl
+
+/-- The vertical coordinate of the bob is `-ℓ cos θ`. -/
+@[simp]
+lemma toSpace_apply_one (ℓ : ℝ) (q : ConfigurationSpace) :
+    toSpace ℓ q 1 = -ℓ * q.cos := rfl
+
+/-- The position of the bob for the configuration at angle `θ`. -/
+lemma toSpace_ofAngle (ℓ θ : ℝ) :
+    toSpace ℓ (ofAngle θ) = ⟨![ℓ * Real.sin θ, -ℓ * Real.cos θ]⟩ := by
+  simp [toSpace]
+
+/-- At `θ = 0` the bob hangs straight down, at `(0, -ℓ)`. -/
+lemma toSpace_ofAngle_zero (ℓ : ℝ) : toSpace ℓ (ofAngle 0) = ⟨![0, -ℓ]⟩ := by
+  simp [toSpace_ofAngle]
+
+/-- The rod-length constraint: the bob is at distance `|ℓ|` from the pivot. -/
+lemma toSpace_norm (ℓ : ℝ) (q : ConfigurationSpace) : ‖toSpace ℓ q‖ = |ℓ| := by
+  have hq : (ℓ * q.sin) ^ 2 + (-ℓ * q.cos) ^ 2 = ℓ ^ 2 := by
+    linear_combination ℓ ^ 2 * cos_sq_add_sin_sq q
+  rw [Space.norm_eq, Fin.sum_univ_two, toSpace_apply_zero, toSpace_apply_one, hq,
+    Real.sqrt_sq_eq_abs]
+
+/-- The position of the bob depends continuously on the configuration. -/
+lemma continuous_toSpace (ℓ : ℝ) : Continuous (toSpace ℓ) := by
+  have hcos : Continuous fun q : ConfigurationSpace => q.cos :=
+    Real.Angle.continuous_cos.comp continuous_induced_dom
+  have hsin : Continuous fun q : ConfigurationSpace => q.sin :=
+    Real.Angle.continuous_sin.comp continuous_induced_dom
+  have hv : Continuous fun q : ConfigurationSpace => (![ℓ * q.sin, -ℓ * q.cos] : Fin 2 → ℝ) := by
+    refine continuous_pi fun i => ?_
+    fin_cases i
+    · simpa using hsin.const_mul ℓ
+    · simpa using hcos.const_mul (-ℓ)
+  exact Space.mk_continuous.comp hv
+
+/-- For a rod of nonzero length the configuration is determined by the position of the bob. -/
+lemma toSpace_injective {ℓ : ℝ} (hℓ : ℓ ≠ 0) : Function.Injective (toSpace ℓ) := by
+  -- Equality of angles is detected by their cosine and sine.
+  have key : ∀ θ ψ : Real.Angle, θ.cos = ψ.cos → θ.sin = ψ.sin → θ = ψ := by
+    intro θ ψ hc hs
+    rcases Real.Angle.cos_eq_iff_eq_or_eq_neg.mp hc with h | h
+    · exact h
+    rcases Real.Angle.sin_eq_iff_eq_or_add_eq_pi.mp hs with h' | h'
+    · exact h'
+    rw [h, neg_add_cancel] at h'
+    exact absurd h'.symm Real.Angle.pi_ne_zero
+  intro q₁ q₂ h
+  have h0 : ℓ * q₁.sin = ℓ * q₂.sin := congrArg (fun p : Space 2 => p 0) h
+  have h1 : -ℓ * q₁.cos = -ℓ * q₂.cos := congrArg (fun p : Space 2 => p 1) h
+  exact ConfigurationSpace.ext
+    (key _ _ (mul_left_cancel₀ (neg_ne_zero.mpr hℓ) h1) (mul_left_cancel₀ hℓ h0))
 
 end ConfigurationSpace
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean
@@ -133,6 +133,54 @@ instance instCompactSpace : CompactSpace ConfigurationSpace := circleHomeomorph.
 instance instSecondCountableTopology : SecondCountableTopology ConfigurationSpace :=
   circleHomeomorph.secondCountableTopology
 
+/-!
+
+## C. Manifold structure
+
+The unit circle is an analytic one-dimensional manifold modelled on `EuclideanSpace ℝ (Fin 1)`
+(Mathlib, via stereographic projection). We pull its atlas back along `circleHomeomorph`: a chart
+of the configuration space is the identification with the circle followed by a chart of the circle.
+Since the identification cancels in every change of charts, the changes of charts are exactly those
+of the circle, hence analytic.
+
+-/
+
+/-- The charts of the configuration space: the identification with the unit circle followed by a
+  chart of the circle. -/
+instance instChartedSpace : ChartedSpace (EuclideanSpace ℝ (Fin 1)) ConfigurationSpace where
+  atlas := {circleHomeomorph.toOpenPartialHomeomorph.trans e |
+    e ∈ atlas (EuclideanSpace ℝ (Fin 1)) Circle}
+  chartAt q := circleHomeomorph.toOpenPartialHomeomorph.trans
+    (chartAt (EuclideanSpace ℝ (Fin 1)) (circleHomeomorph q))
+  mem_chart_source q := by simp
+  chart_mem_atlas q := ⟨_, chart_mem_atlas _ _, rfl⟩
+
+/-- The chart at a configuration is the identification with the unit circle followed by the chart
+  of the circle at the corresponding point. -/
+lemma chartAt_eq (q : ConfigurationSpace) :
+    chartAt (EuclideanSpace ℝ (Fin 1)) q =
+      circleHomeomorph.toOpenPartialHomeomorph.trans
+        (chartAt (EuclideanSpace ℝ (Fin 1)) q.toCircle) := rfl
+
+/-- The configuration space is an analytic manifold: every change of charts is a change of charts
+  of the unit circle. -/
+instance instIsManifold : IsManifold (𝓡 1) ω ConfigurationSpace where
+  compatible := by
+    rintro _ _ ⟨e₁, he₁, rfl⟩ ⟨e₂, he₂, rfl⟩
+    -- The identification `h` with the circle is global, so `h.symm ≫ₕ h` is the identity.
+    have hself : circleHomeomorph.toOpenPartialHomeomorph.symm.trans
+        circleHomeomorph.toOpenPartialHomeomorph = OpenPartialHomeomorph.refl Circle := by
+      rw [← Homeomorph.symm_toOpenPartialHomeomorph, ← Homeomorph.trans_toOpenPartialHomeomorph,
+        Homeomorph.symm_trans_self, Homeomorph.refl_toOpenPartialHomeomorph]
+    -- Hence it cancels in the change of charts, which is therefore that of the circle.
+    have hcancel : (circleHomeomorph.toOpenPartialHomeomorph.trans e₁).symm.trans
+        (circleHomeomorph.toOpenPartialHomeomorph.trans e₂) = e₁.symm.trans e₂ := by
+      rw [OpenPartialHomeomorph.trans_symm_eq_symm_trans_symm, OpenPartialHomeomorph.trans_assoc,
+        ← OpenPartialHomeomorph.trans_assoc circleHomeomorph.toOpenPartialHomeomorph.symm,
+        hself, OpenPartialHomeomorph.refl_trans]
+    rw [hcancel]
+    exact HasGroupoid.compatible he₁ he₂
+
 end ConfigurationSpace
 end SimplePendulum
 end ClassicalMechanics


### PR DESCRIPTION

Toward #883. Third of the series (after #1560 and #1561, both merged).

Follows #1560 and #1561 (both merged); this PR is now based directly on master.

**Size.** 754 added lines in `Basic.lean`, of which 434 are documentation (335 module-doc and section prose, 99 docstrings) and ~236 are non-blank Lean. For comparison, `HarmonicOscillator/Basic.lean` is 756 lines with the same section structure. The two feature commits are separable — `5114c9df` is sections A–C (data, frequency, inertia, energies) and `ccce411d` is D–F (Lagrangian, torque, equation of motion) — and I am happy to split this into two PRs at that boundary if you would prefer to review it that way.

**One design choice worth flagging.** The equation of motion is defined as the *pointwise* relation `∀ t, I • θ̈ t = τ(θ t)`, following `DampedHarmonicOscillator/Basic.lean`, rather than as the vanishing of the variational derivative as in `HarmonicOscillator/Basic.lean`. `varGradient` is defined to be `0` when no variational gradient exists, so its vanishing holds for every lift too rough to admit one; the pointwise form is totalized too, but its totalization hands a rough lift `θ̈ = 0` and leaves a genuine, generally false constraint rather than a vacuous truth. The two agree for smooth lifts; that equivalence, and energy conservation, come in the follow-up PR. `IsSolution θ := ContDiff ℝ ∞ θ ∧ EquationOfMotion θ` is the public notion of a solution, and excludes the piecewise-equilibrium functions that the bare pointwise equation admits.

### Reviewer reading order
1. The module doc (sections i–iv) — the physics, the choice of lift, and the table of contents.
2. Section E, and in particular the prose preceding E.1 — the rationale for the pointwise equation of motion. This is the only place where the pendulum departs from the harmonic oscillator's design, and it is the part most worth disagreeing with.
3. Sections A–C — the data, `ω`, `inertia`, and the energies. `ω_sq_mul_inertia` is the identity that cancels the mass; `gradient_potentialEnergy` is the only real calculus in the section.
4. Section D — the Lagrangian and its two partial gradients, both of which feed section F.
5. Sections E.4 and F — the scalar equation, mass independence, and the variational derivative.
6. `SimplePendulum/API-map.yaml` and the one-line addition to `Physlib.lean`.

### Declarations added

All in `Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean`, namespace `ClassicalMechanics.SimplePendulum`.

| Section | Declaration | What it is |
|---|---|---|
| A.1 | `SimplePendulum` | the input data: mass `m`, rod length `ℓ`, gravity `g`, all positive |
| A.2 | `m_ne_zero`, `ℓ_ne_zero`, `g_ne_zero` | `@[simp]` non-vanishing, the form the field-clearing tactics consume |
| B.1 | `ω` | the angular frequency `√(g/ℓ)` of the small oscillations |
| B.1 | `ω_pos`, `ω_ne_zero`, `ω_sq`, `inverse_ω_sq` | positivity, `ω² = g/ℓ`, `(ω²)⁻¹ = ℓ/g` |
| B.2 | `inertia` | the moment of inertia `m ℓ²` about the pivot |
| B.2 | `inertia_pos`, `inertia_ne_zero` | positivity and non-vanishing |
| B.2 | `ω_sq_mul_inertia` | `ω² I = m g ℓ` — the identity by which the mass cancels |
| C.1 | `kineticEnergy`, `potentialEnergy`, `energy` | `½ I θ̇²`, `m g ℓ (1 − cos θ)`, and their sum |
| C.2 | `kineticEnergy_eq`, `potentialEnergy_eq`, `energy_eq` | definitional unfoldings |
| C.2 | `potentialEnergy_nonneg`, `potentialEnergy_le`, `potentialEnergy_eq_zero_iff` | `0 ≤ V ≤ 2 m g ℓ`, and `V = 0 ↔ cos θ = 1` |
| C.3 | `potentialEnergy_contDiff`, `differentiable_potentialEnergy` | smoothness of `V` as a function of the angle |
| C.3 | `gradient_potentialEnergy` | `∇V = m g ℓ sin θ · e₀` |
| C.3 | `kineticEnergy_differentiable`, `potentialEnergy_differentiable`, `energy_differentiable` | differentiability in time along a smooth lift |
| C.4 | `kineticEnergy_deriv`, `potentialEnergy_deriv`, `energy_deriv` | each derivative as `⟪θ̇, ·⟫`; `energy_deriv` pairs `θ̇` with `I θ̈ + ∇V` |
| D.1 | `lagrangian`, `lagrangian_eq`, `lagrangian_eq_kineticEnergy_sub_potentialEnergy` | `L(t,θ,θ̇) = ½ I ‖θ̇‖² − V(θ)`, expanded, and as `T − V` along a lift |
| D.2 | `contDiff_lagrangian` | joint smoothness of `↿L`, the Euler–Lagrange hypothesis |
| D.3 | `gradient_lagrangian_position_eq`, `gradient_lagrangian_velocity_eq` | `∂L/∂θ = −∇V` and `∂L/∂θ̇ = I θ̇`, the angular momentum |
| E.1 | `torque`, `torque_eq`, `torque_apply` | `τ = −∇V`; the generalized force conjugate to the angle, `= −m g ℓ sin θ` |
| E.2 | `EquationOfMotion` | `∀ t, I • θ̈ t = τ(θ t)` |
| E.2 | `equationOfMotion_iff_newtons_2nd_law` | the equation with all terms on one side (`I θ̈ + ∇V = 0`), the damped oscillator's shape — the combination `energy_deriv` pairs with the velocity |
| E.3 | `IsSolution`, `IsSolution.contDiff`, `IsSolution.equationOfMotion` | a smooth lift satisfying the equation, and its two projections |
| E.4 | `equationOfMotion_iff_scalar` | `θ̈ + ω² sin θ = 0` — the mass has cancelled |
| E.4 | `equationOfMotion_iff_of_eq_ω` | two pendulums with the same `ω` have the same motions |
| F.1 | `gradLagrangian` | the variational derivative of the action |
| F.2 | `gradLagrangian_eq_eulerLagrangeOp` | it is the Euler–Lagrange operator, for smooth lifts |
| F.3 | `gradLagrangian_eq_torque` | it equals `τ(θ) − I θ̈` |

Also: one `public import` line in `Physlib.lean`, and two row updates in `SimplePendulum/API-map.yaml` (the Lagrangian/equation-of-motion requirement is now met; a new row records the variational equivalence and energy conservation as outstanding).

**Why `Pendulum/API-map.yaml` is in the diff:** this PR made the parent map's Overview stale, so it
is amended. I read the parent's "shall subsequently contain the definition of the lagrangian" row
as the Lagrangian built on the configuration-space trajectory — still open, coming with the
geometric bridge — so I left it `done: false` and recorded the Euclidean-lift Lagrangian in the
SimplePendulum map instead. Happy to flip it if you read that row differently.

### Verification
- [ ] `lake build Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic` — <fill from gate run>
- [ ] `lake build` — <fill>
- [ ] `lake exe runPhyslibLinters Physlib` — <fill>
- [ ] `lake exe check_file_imports` — <fill>
- [ ] `./scripts/lint-style.sh` (run on committed state) — <fill>
- [ ] `python scripts/api_map_linter.py --repo .` — <fill>
- [ ] `codespell` with the repo's `.codespellignore` — <fill>
- [ ] Each `public import` confirmed necessary by removing it and rebuilding — <fill>
- [ ] Landau & Lifshitz and Arnold references checked against the printed editions — <fill>

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.



