### PR TITLE
feat(ClassicalMechanics): Hamiltonian formulation of the simple pendulum and the equivalence of formulations

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -20,6 +20,7 @@ public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMoti
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Equilibria
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Hamiltonian
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.LiftInvariance
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum
 public import Physlib.ClassicalMechanics.RigidBody.AngularMomentum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -12,10 +12,11 @@ Overview: |
     integral. This API records the configuration space with its manifold structure and its
     embedding into physical space, together with the lifted Lagrangian and equation of motion,
     the equivalence of that equation with the vanishing of the variational gradient of the
-    action, the conservation of energy, the equilibria with the separatrix energy and the
-    below/above-threshold energy bounds, and the invariance of the lifted dynamics under
-    shifting the angle by whole turns; the small-angle limit and the period follow in later
-    modules.
+    action, the conservation of energy, the Hamiltonian formulation with the equivalence of
+    the Newtonian, scalar, Hamiltonian and variational formulations, the equilibria with
+    the separatrix energy and the below/above-threshold energy bounds, and the invariance of
+    the lifted dynamics under shifting the angle by whole turns; the small-angle limit and
+    the period follow in later modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"
@@ -25,6 +26,7 @@ References:
   - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 1 (The Equations of motion), Section 5 (The Lagrangian for a system of particles).
   - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 3 (Integration of the equations of motion), Section 11 (Motion in one dimension).
   - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 5 (Small oscillations), Section 21 (Free oscillations in one dimension).
+  - Landau & Lifshitz, Mechanics, 3rd Edition, Chapter 7 (The canonical equations), Section 40 (Hamilton's equations).
 
 Requirements:
 
@@ -55,6 +57,10 @@ Requirements:
   - description: The API contains the equivalence of the equation of motion with the vanishing of the variational gradient of the action, and energy conservation.
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean (SimplePendulum.equationOfMotion_iff_gradLagrangian_zero, SimplePendulum.energy_conservation_of_equationOfMotion)
+
+  - description: The API contains the Hamiltonian formulation and the equivalence of the Newtonian, scalar, Hamiltonian and variational formulations.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean (SimplePendulum.hamiltonian, SimplePendulum.hamiltonEqOp, SimplePendulum.equationOfMotion_tfae)
 
   - description: The API contains the equilibria of the pendulum as solutions, together with the separatrix energy and the below/above-threshold energy bounds.
     done: true

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.ClassicalMechanics.HamiltonsEquations
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
+/-!
+
+# The Hamiltonian formulation of the simple pendulum
+
+## i. Overview
+
+This module gives the Hamiltonian formulation of the simple gravity pendulum, on the same
+one-dimensional Euclidean lift of the angle as `SimplePendulum.Basic`. The canonical momentum
+conjugate to the angle is the gradient of the Lagrangian in the angular velocity, the angular
+momentum `p = I θ̇` about the pivot; since the moment of inertia is positive, taking the
+canonical momentum is a linear equivalence between velocities and momenta. The Hamiltonian is
+the Legendre transform `H = ⟪p, θ̇⟫ - L` of the Lagrangian, which works out to the energy
+written on momentum-angle phase space, `H(t, p, θ) = ½ (1/I) ‖p‖² + V(θ)`; along any lift of
+the angle it is the energy of the lift. Hamilton's equations for the pendulum are packaged, as
+for the harmonic oscillator, into the vanishing of an operator on phase space, and for a smooth
+lift of the angle they are equivalent to the equation of motion of `SimplePendulum.Basic`.
+
+## ii. Key results
+
+- `SimplePendulum.toCanonicalMomentum` is the canonical momentum `p = ∂L/∂θ̇ = I θ̇`, as a
+  linear equivalence between velocities and momenta, with its value recorded by
+  `toCanonicalMomentum_eq`.
+- `SimplePendulum.hamiltonian` is the Legendre transform of the Lagrangian, computed by
+  `hamiltonian_eq` to be `½ (1/I) ‖p‖² + V(θ)`, smooth by `hamiltonian_contDiff`, with the
+  two partial gradients `gradient_hamiltonian_position_eq` and
+  `gradient_hamiltonian_momentum_eq`.
+- `SimplePendulum.hamiltonian_eq_energy` identifies the Hamiltonian, evaluated along any lift
+  of the angle on its canonical momentum, with the energy of the lift.
+- `SimplePendulum.hamiltonEqOp` is the operator on momentum-angle phase space whose vanishing
+  is Hamilton's equations, and `SimplePendulum.equationOfMotion_iff_hamiltonEqOp_eq_zero`
+  proves that, for a smooth lift of the angle, Hamilton's equations are equivalent to the
+  equation of motion.
+
+## iii. Table of contents
+
+- A. The canonical momentum and the Hamiltonian
+  - A.1. The canonical momentum
+    - A.1.1. Equality for the canonical momentum
+  - A.2. The Hamiltonian
+    - A.2.1. Equality for the Hamiltonian
+    - A.2.2. Smoothness of the Hamiltonian
+    - A.2.3. Gradients of the Hamiltonian
+  - A.3. Relation between Hamiltonian and energy
+  - A.4. Hamilton equation operator
+  - A.5. Equation of motion if and only if Hamilton's equations
+
+## iv. References
+
+References for the Hamiltonian formulation of the simple pendulum include:
+- Landau & Lifshitz, Mechanics, 3rd ed., §40, for the canonical momentum, the Hamiltonian as
+  the Legendre transform of the Lagrangian, and Hamilton's equations.
+- The module `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic`, whose Lagrangian,
+  energy and equation of motion this module reformulates.
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+
+open InnerProductSpace Time
+open scoped ContDiff
+
+namespace SimplePendulum
+
+variable (S : SimplePendulum)
+
+/-!
+
+## A. The canonical momentum and the Hamiltonian
+
+We now turn to the Hamiltonian formulation of the simple pendulum. We define the canonical
+momentum and the Hamiltonian, relate the Hamiltonian to the energy, and show that the equation
+of motion is equivalent to Hamilton's equations.
+
+-/
+
+/-!
+
+### A.1. The canonical momentum
+
+We define the canonical momentum as the gradient of the Lagrangian with respect to the angular
+velocity. By `gradient_lagrangian_velocity_eq` this is the angular momentum `I θ̇` about the
+pivot, and since the moment of inertia is positive it is a linear equivalence between
+velocities and momenta.
+
+-/
+
+/-- The canonical momentum of the simple pendulum, `p = ∂L/∂θ̇ = I θ̇`, as a linear
+  equivalence between velocities and momenta in the angular chart. -/
+noncomputable def toCanonicalMomentum (t : Time) (x : EuclideanSpace ℝ (Fin 1)) :
+    EuclideanSpace ℝ (Fin 1) ≃ₗ[ℝ] EuclideanSpace ℝ (Fin 1) where
+  toFun v := gradient (S.lagrangian t x ·) v
+  invFun p := (1 / S.inertia) • p
+  left_inv v := by
+    simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
+  right_inv p := by
+    simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
+  map_add' v1 v2 := by
+    simp [S.gradient_lagrangian_velocity_eq]
+  map_smul' c v := by
+    simp [S.gradient_lagrangian_velocity_eq]
+    module
+
+/-!
+
+#### A.1.1. Equality for the canonical momentum
+
+A simple equality for the canonical momentum.
+
+-/
+
+/-- The canonical momentum of the simple pendulum is the angular momentum `I θ̇` about the
+  pivot. -/
+lemma toCanonicalMomentum_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    S.toCanonicalMomentum t x v = S.inertia • v :=
+  S.gradient_lagrangian_velocity_eq t x v
+
+/-!
+
+### A.2. The Hamiltonian
+
+The Hamiltonian is defined as a function of time, canonical momentum and angle, as the
+Legendre transform
+```
+H = ⟪p, θ̇⟫ - L(t, θ, θ̇)
+```
+where the angular velocity `θ̇` is a function of `p` and `θ` through the inverse of the
+canonical momentum.
+
+-/
+
+/-- The Hamiltonian of the simple pendulum as a function of time, momentum and angle: the
+  Legendre transform `H(t, p, θ) = ⟪p, θ̇⟫ - L(t, θ, θ̇)` of the Lagrangian, the angular
+  velocity `θ̇` being recovered from the momentum by inverting the canonical momentum. -/
+noncomputable def hamiltonian (t : Time) (p x : EuclideanSpace ℝ (Fin 1)) : ℝ :=
+  ⟪p, (S.toCanonicalMomentum t x).symm p⟫_ℝ -
+    S.lagrangian t x ((S.toCanonicalMomentum t x).symm p)
+
+/-!
+
+#### A.2.1. Equality for the Hamiltonian
+
+We prove a simple equality for the Hamiltonian, to help in computations: it is the kinetic
+energy written in terms of the momentum, plus the potential energy.
+
+-/
+
+/-- The Hamiltonian of the simple pendulum is the kinetic energy written in terms of the
+  momentum, `½ (1/I) ‖p‖²`, plus the potential energy. -/
+lemma hamiltonian_eq :
+    S.hamiltonian = fun _ p x =>
+      (1 / (2 : ℝ)) * (1 / S.inertia) * ⟪p, p⟫_ℝ + S.potentialEnergy x := by
+  funext t p x
+  simp only [hamiltonian, toCanonicalMomentum, lagrangian, one_div, LinearEquiv.coe_symm_mk',
+    inner_smul_right, inner_smul_left, starRingEnd_apply, star_trivial]
+  field_simp [S.inertia_ne_zero]
+  ring
+
+/-!
+
+#### A.2.2. Smoothness of the Hamiltonian
+
+We show that the Hamiltonian is smooth in all its arguments jointly.
+
+-/
+
+/-- The Hamiltonian of the simple pendulum is a smooth function of the time, the momentum and
+  the angle jointly. -/
+@[fun_prop]
+lemma hamiltonian_contDiff (n : WithTop ℕ∞) : ContDiff ℝ n ↿S.hamiltonian := by
+  rw [hamiltonian_eq]
+  fun_prop
+
+/-!
+
+#### A.2.3. Gradients of the Hamiltonian
+
+We now write down the gradients of the Hamiltonian with respect to the angle and the momentum.
+These are the two sides of Hamilton's equations.
+
+-/
+
+/-- The gradient of the Hamiltonian of the simple pendulum in the angle is the gradient of the
+  potential energy, that is minus the torque. -/
+lemma gradient_hamiltonian_position_eq (t : Time) (x p : EuclideanSpace ℝ (Fin 1)) :
+    gradient (S.hamiltonian t p) x = gradient S.potentialEnergy x := by
+  have h : (fun y : EuclideanSpace ℝ (Fin 1) => S.hamiltonian t p y) =
+      fun y => S.potentialEnergy y + (1 / (2 : ℝ)) * (1 / S.inertia) * ⟪p, p⟫_ℝ := by
+    funext y
+    simp only [hamiltonian_eq]
+    ring
+  change gradient (fun y : EuclideanSpace ℝ (Fin 1) => S.hamiltonian t p y) x =
+    gradient S.potentialEnergy x
+  rw [h, gradient_add_const]
+
+/-- The gradient of the Hamiltonian of the simple pendulum in the momentum is the angular
+  velocity `(1/I) p` recovered from the momentum. -/
+lemma gradient_hamiltonian_momentum_eq (t : Time) (x p : EuclideanSpace ℝ (Fin 1)) :
+    gradient (S.hamiltonian t · x) p = (1 / S.inertia) • p := by
+  have h : (fun y : EuclideanSpace ℝ (Fin 1) => S.hamiltonian t y x) =
+      fun y => ((1 / (2 : ℝ)) * (1 / S.inertia)) * ⟪y, y⟫_ℝ + S.potentialEnergy x := by
+    funext y
+    simp only [hamiltonian_eq]
+  change gradient (fun y : EuclideanSpace ℝ (Fin 1) => S.hamiltonian t y x) p =
+    (1 / S.inertia) • p
+  rw [h, gradient_add_const, gradient_const_mul_inner_self]
+  module
+
+/-!
+
+### A.3. Relation between Hamiltonian and energy
+
+We show that the Hamiltonian, evaluated along any lift of the angle on the canonical momentum
+of the lift, is the energy. This is independent of whether the lift satisfies the equation of
+motion or not.
+
+-/
+
+/-- Along any lift of the angle, the Hamiltonian of the simple pendulum evaluated on the
+  canonical momentum of the lift is the energy of the lift. This holds whether or not the lift
+  satisfies the equation of motion. -/
+lemma hamiltonian_eq_energy (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    (fun t => S.hamiltonian t (S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) (θ t)) = S.energy θ := by
+  funext t
+  rw [hamiltonian_eq]
+  unfold energy kineticEnergy
+  simp only [toCanonicalMomentum_eq, inner_smul_left, inner_smul_right, starRingEnd_apply,
+    star_trivial]
+  field_simp [S.inertia_ne_zero]
+
+/-!
+
+### A.4. Hamilton equation operator
+
+We define the operator on momentum-angle phase space whose vanishing is equivalent to
+Hamilton's equations.
+
+-/
+
+/-- The Hamilton-equations operator of the Hamiltonian of the simple pendulum, on
+  momentum-angle phase space; its vanishing is equivalent to Hamilton's equations for the
+  momentum and the angle. -/
+noncomputable def hamiltonEqOp (p θ : Time → EuclideanSpace ℝ (Fin 1)) :=
+  ClassicalMechanics.hamiltonEqOp S.hamiltonian p θ
+
+/-!
+
+### A.5. Equation of motion if and only if Hamilton's equations
+
+We show that, for a smooth lift of the angle, the equation of motion is equivalent to
+Hamilton's equations for the lift and its canonical momentum, that is to the vanishing of the
+Hamilton equation operator on the pair. The equation for the angle recovers the angular
+velocity, and the equation for the momentum is the balance of the rate of change of the
+angular momentum against the torque.
+
+-/
+
+/-- For a smooth lift of the angle the equation of motion of the simple pendulum holds if and
+  only if Hamilton's equations hold for the lift and its canonical momentum, that is if and
+  only if the Hamilton-equations operator vanishes on the pair. -/
+lemma equationOfMotion_iff_hamiltonEqOp_eq_zero (θ : Time → EuclideanSpace ℝ (Fin 1))
+    (hθ : ContDiff ℝ ∞ θ) :
+    S.EquationOfMotion θ ↔
+      S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0 := by
+  rw [hamiltonEqOp, hamiltonEqOp_eq_zero_iff_hamiltons_equations,
+    S.equationOfMotion_iff_newtons_2nd_law θ]
+  simp only [toCanonicalMomentum_eq, gradient_hamiltonian_momentum_eq, one_div, smul_smul,
+    ne_eq, S.inertia_ne_zero, not_false_eq_true, inv_mul_cancel₀, one_smul, implies_true,
+    Time.deriv_smul _ S.inertia (deriv_differentiable_of_contDiff θ hθ),
+    gradient_hamiltonian_position_eq, true_and, eq_neg_iff_add_eq_zero]
+
+end SimplePendulum
+
+end ClassicalMechanics

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
@@ -26,9 +26,9 @@ lift of the angle they are equivalent to the equation of motion of `SimplePendul
 
 ## ii. Key results
 
-- `SimplePendulum.toCanonicalMomentum` is the canonical momentum `p = ∂L/∂θ̇ = I θ̇`, as a
+- `SimplePendulum.canonicalMomentum` is the canonical momentum `p = ∂L/∂θ̇ = I θ̇`, as a
   linear equivalence between velocities and momenta, with its value recorded by
-  `toCanonicalMomentum_eq`.
+  `canonicalMomentum_eq`.
 - `SimplePendulum.hamiltonian` is the Legendre transform of the Lagrangian, computed by
   `hamiltonian_eq` to be `½ (1/I) ‖p‖² + V(θ)`, smooth by `hamiltonian_contDiff`, with the
   two partial gradients `gradient_hamiltonian_position_eq` and
@@ -48,7 +48,6 @@ lift of the angle they are equivalent to the equation of motion of `SimplePendul
 
 - A. The canonical momentum and the Hamiltonian
   - A.1. The canonical momentum
-    - A.1.1. Equality for the canonical momentum
   - A.2. The Hamiltonian
     - A.2.1. Equality for the Hamiltonian
     - A.2.2. Smoothness of the Hamiltonian
@@ -102,32 +101,19 @@ velocities and momenta.
 
 /-- The canonical momentum of the simple pendulum, `p = ∂L/∂θ̇ = I θ̇`, as a linear
   equivalence between velocities and momenta in the angular chart. -/
-noncomputable def toCanonicalMomentum (t : Time) (x : EuclideanSpace ℝ (Fin 1)) :
+noncomputable def canonicalMomentum (t : Time) (x : EuclideanSpace ℝ (Fin 1)) :
     EuclideanSpace ℝ (Fin 1) ≃ₗ[ℝ] EuclideanSpace ℝ (Fin 1) where
   toFun v := gradient (S.lagrangian t x ·) v
   invFun p := (1 / S.inertia) • p
-  left_inv v := by
-    simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
-  right_inv p := by
-    simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
-  map_add' v1 v2 := by
-    simp [S.gradient_lagrangian_velocity_eq]
-  map_smul' c v := by
-    simp [S.gradient_lagrangian_velocity_eq]
-    module
-
-/-!
-
-#### A.1.1. Equality for the canonical momentum
-
-A simple equality for the canonical momentum.
-
--/
+  left_inv v := by simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
+  right_inv p := by simp [S.gradient_lagrangian_velocity_eq, smul_smul, S.inertia_ne_zero]
+  map_add' v1 v2 := by simp [S.gradient_lagrangian_velocity_eq]
+  map_smul' c v := by simp [S.gradient_lagrangian_velocity_eq]; module
 
 /-- The canonical momentum of the simple pendulum is the angular momentum `I θ̇` about the
   pivot. -/
-lemma toCanonicalMomentum_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
-    S.toCanonicalMomentum t x v = S.inertia • v :=
+lemma canonicalMomentum_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    S.canonicalMomentum t x v = S.inertia • v :=
   S.gradient_lagrangian_velocity_eq t x v
 
 /-!
@@ -148,8 +134,8 @@ canonical momentum.
   Legendre transform `H(t, p, θ) = ⟪p, θ̇⟫ - L(t, θ, θ̇)` of the Lagrangian, the angular
   velocity `θ̇` being recovered from the momentum by inverting the canonical momentum. -/
 noncomputable def hamiltonian (t : Time) (p x : EuclideanSpace ℝ (Fin 1)) : ℝ :=
-  ⟪p, (S.toCanonicalMomentum t x).symm p⟫_ℝ -
-    S.lagrangian t x ((S.toCanonicalMomentum t x).symm p)
+  ⟪p, (S.canonicalMomentum t x).symm p⟫_ℝ -
+    S.lagrangian t x ((S.canonicalMomentum t x).symm p)
 
 /-!
 
@@ -166,7 +152,7 @@ lemma hamiltonian_eq :
     S.hamiltonian = fun _ p x =>
       (1 / (2 : ℝ)) * (1 / S.inertia) * ⟪p, p⟫_ℝ + S.potentialEnergy x := by
   funext t p x
-  simp only [hamiltonian, toCanonicalMomentum, lagrangian, one_div, LinearEquiv.coe_symm_mk',
+  simp only [hamiltonian, canonicalMomentum, lagrangian, one_div, LinearEquiv.coe_symm_mk',
     inner_smul_right, inner_smul_left, starRingEnd_apply, star_trivial]
   field_simp [S.inertia_ne_zero]
   ring
@@ -235,11 +221,11 @@ motion or not.
   canonical momentum of the lift is the energy of the lift. This holds whether or not the lift
   satisfies the equation of motion. -/
 lemma hamiltonian_eq_energy (θ : Time → EuclideanSpace ℝ (Fin 1)) :
-    (fun t => S.hamiltonian t (S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) (θ t)) = S.energy θ := by
+    (fun t => S.hamiltonian t (S.canonicalMomentum t (θ t) (∂ₜ θ t)) (θ t)) = S.energy θ := by
   funext t
   rw [hamiltonian_eq]
   unfold energy kineticEnergy
-  simp only [toCanonicalMomentum_eq, inner_smul_left, inner_smul_right, starRingEnd_apply,
+  simp only [canonicalMomentum_eq, inner_smul_left, inner_smul_right, starRingEnd_apply,
     star_trivial]
   field_simp [S.inertia_ne_zero]
 
@@ -276,10 +262,10 @@ angular momentum against the torque.
 lemma equationOfMotion_iff_hamiltonEqOp_eq_zero (θ : Time → EuclideanSpace ℝ (Fin 1))
     (hθ : ContDiff ℝ ∞ θ) :
     S.EquationOfMotion θ ↔
-      S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0 := by
+      S.hamiltonEqOp (fun t => S.canonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0 := by
   rw [hamiltonEqOp, hamiltonEqOp_eq_zero_iff_hamiltons_equations,
     S.equationOfMotion_iff_newtons_2nd_law θ]
-  simp only [toCanonicalMomentum_eq, gradient_hamiltonian_momentum_eq, one_div, smul_smul,
+  simp only [canonicalMomentum_eq, gradient_hamiltonian_momentum_eq, one_div, smul_smul,
     ne_eq, S.inertia_ne_zero, not_false_eq_true, inv_mul_cancel₀, one_smul, implies_true,
     Time.deriv_smul _ S.inertia (deriv_differentiable_of_contDiff θ hθ),
     gradient_hamiltonian_position_eq, true_and, eq_neg_iff_add_eq_zero]
@@ -315,9 +301,9 @@ fourth entry states the same variational principle through the variational calcu
 lemma equationOfMotion_tfae (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
     List.TFAE [S.EquationOfMotion θ,
       ∀ t, ∂ₜ (∂ₜ θ) t 0 + S.ω ^ 2 * Real.sin (θ t 0) = 0,
-      S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0,
+      S.hamiltonEqOp (fun t => S.canonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0,
       (δ (q':=θ), ∫ t, S.lagrangian t (q' t) (fderiv ℝ q' t 1)) = 0,
-      (δ (pq':= fun t => (S.toCanonicalMomentum t (θ t) (∂ₜ θ t), θ t)),
+      (δ (pq':= fun t => (S.canonicalMomentum t (θ t) (∂ₜ θ t), θ t)),
         ∫ t, ⟪(pq' t).1, ∂ₜ (Prod.snd ∘ pq') t⟫_ℝ -
           S.hamiltonian t (pq' t).1 (pq' t).2) = 0] := by
   rw [← S.equationOfMotion_iff_hamiltonEqOp_eq_zero θ hθ,
@@ -328,12 +314,12 @@ lemma equationOfMotion_tfae (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Co
     ← S.equationOfMotion_iff_gradLagrangian_zero θ hθ]
   simp only [List.tfae_cons_self]
   show List.TFAE [S.EquationOfMotion θ,
-    S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0]
+    S.hamiltonEqOp (fun t => S.canonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0]
   rw [← S.equationOfMotion_iff_hamiltonEqOp_eq_zero θ hθ]
   simp only [List.tfae_cons_self, List.tfae_singleton]
   · exact hθ
   · exact S.contDiff_lagrangian _
-  · simp only [S.toCanonicalMomentum_eq]; fun_prop
+  · simp only [S.canonicalMomentum_eq]; fun_prop
   · exact S.hamiltonian_contDiff _
 
 end SimplePendulum

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean
@@ -39,6 +39,10 @@ lift of the angle they are equivalent to the equation of motion of `SimplePendul
   is Hamilton's equations, and `SimplePendulum.equationOfMotion_iff_hamiltonEqOp_eq_zero`
   proves that, for a smooth lift of the angle, Hamilton's equations are equivalent to the
   equation of motion.
+- `SimplePendulum.equationOfMotion_tfae` gathers the formulations into a single equivalence:
+  for a smooth lift of the angle the equation of motion, its scalar form `θ̈ + ω² sin θ = 0`,
+  Hamilton's equations, and the Lagrangian and Hamiltonian variational principles are all
+  equivalent.
 
 ## iii. Table of contents
 
@@ -52,6 +56,7 @@ lift of the angle they are equivalent to the equation of motion of `SimplePendul
   - A.3. Relation between Hamiltonian and energy
   - A.4. Hamilton equation operator
   - A.5. Equation of motion if and only if Hamilton's equations
+- B. Equivalences between the formulations
 
 ## iv. References
 
@@ -278,6 +283,58 @@ lemma equationOfMotion_iff_hamiltonEqOp_eq_zero (θ : Time → EuclideanSpace �
     ne_eq, S.inertia_ne_zero, not_false_eq_true, inv_mul_cancel₀, one_smul, implies_true,
     Time.deriv_smul _ S.inertia (deriv_differentiable_of_contDiff θ hθ),
     gradient_hamiltonian_position_eq, true_and, eq_neg_iff_add_eq_zero]
+
+/-!
+
+## B. Equivalences between the formulations
+
+We gather the formulations of the dynamics of the simple pendulum into a single equivalence.
+For a smooth lift of the angle the equation of motion, its scalar form, Hamilton's equations,
+the Lagrangian variational principle and the Hamiltonian variational principle are all
+equivalent. The equation of motion is itself the Newtonian formulation: the pointwise law is
+the rotational form of Newton's second law, so, unlike for the harmonic oscillator, no
+separate entry restates it. The equivalence of the equation of motion with the vanishing of
+the variational derivative of the action lives in section G.1 of the `Basic` module; the
+fourth entry states the same variational principle through the variational calculus directly.
+
+-/
+
+/-- For a smooth lift of the angle the following formulations of the dynamics of the simple
+  pendulum are equivalent:
+  1. the equation of motion, the pointwise rotational Newton law balancing the rate of change
+    of the angular momentum against the torque;
+  2. the scalar mass-independent form `θ̈ + ω² sin θ = 0` of the equation of motion;
+  3. Hamilton's equations for the lift and its canonical momentum, as the vanishing of the
+    Hamilton-equations operator;
+  4. the Lagrangian variational principle, the vanishing of the variational gradient of the
+    action integral of the Lagrangian, written through the variational calculus directly; the
+    same principle, through the variational derivative of the action, is recorded standalone
+    as `equationOfMotion_iff_gradLagrangian_zero` in the `Basic` module;
+  5. the Hamiltonian variational principle, the vanishing of the variational gradient of the
+    phase-space action on the pair of the canonical momentum and the lift. -/
+lemma equationOfMotion_tfae (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : ContDiff ℝ ∞ θ) :
+    List.TFAE [S.EquationOfMotion θ,
+      ∀ t, ∂ₜ (∂ₜ θ) t 0 + S.ω ^ 2 * Real.sin (θ t 0) = 0,
+      S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0,
+      (δ (q':=θ), ∫ t, S.lagrangian t (q' t) (fderiv ℝ q' t 1)) = 0,
+      (δ (pq':= fun t => (S.toCanonicalMomentum t (θ t) (∂ₜ θ t), θ t)),
+        ∫ t, ⟪(pq' t).1, ∂ₜ (Prod.snd ∘ pq') t⟫_ℝ -
+          S.hamiltonian t (pq' t).1 (pq' t).2) = 0] := by
+  rw [← S.equationOfMotion_iff_hamiltonEqOp_eq_zero θ hθ,
+    ← S.equationOfMotion_iff_scalar θ]
+  rw [hamiltons_equations_varGradient, euler_lagrange_varGradient]
+  simp only [List.tfae_cons_self]
+  rw [← S.gradLagrangian_eq_eulerLagrangeOp θ hθ,
+    ← S.equationOfMotion_iff_gradLagrangian_zero θ hθ]
+  simp only [List.tfae_cons_self]
+  show List.TFAE [S.EquationOfMotion θ,
+    S.hamiltonEqOp (fun t => S.toCanonicalMomentum t (θ t) (∂ₜ θ t)) θ = 0]
+  rw [← S.equationOfMotion_iff_hamiltonEqOp_eq_zero θ hθ]
+  simp only [List.tfae_cons_self, List.tfae_singleton]
+  · exact hθ
+  · exact S.contDiff_lagrangian _
+  · simp only [S.toCanonicalMomentum_eq]; fun_prop
+  · exact S.hamiltonian_contDiff _
 
 end SimplePendulum
 


### PR DESCRIPTION
Toward #883. Fifth of the series.

Follows #1560, #1561, #1564 and #1569 (all merged); this PR is now based directly on master
(`f6d7fe3d`) — its three commits (`7deac72b..bda52edb`) are the whole diff; the last one, `bda52edb`, is the review round (rename to `canonicalMomentum`, inlined proofs, one heading dropped).

One new module, `Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Hamiltonian.lean` (341 lines),
plus its `Physlib.lean` import and one API-map row. Kept separate from `Basic.lean` deliberately:
that file is already at ~1300 lines against the 1500-line style gate. Mirrors
`HarmonicOscillator/Basic.lean` §§G–H, adapted to the pendulum's pointwise equation of motion.

| Section | Contents |
|---|---|
| A | `toCanonicalMomentum` (`p = I θ̇`, a linear equivalence), `hamiltonian` as the **direct** Legendre transform with `hamiltonian_eq` deriving `½ p²/I + V`; joint smoothness (`@[fun_prop]`); both partial gradients; `hamiltonian_eq_energy` — along **any** lift, no equation-of-motion hypothesis; `equationOfMotion_iff_hamiltonEqOp_eq_zero` |
| B | `equationOfMotion_tfae` — five genuinely distinct formulations: the pointwise rotational Newton law; the scalar mass-independent ODE `θ̈ + ω² sin θ = 0`; Hamilton's equations for the canonical momentum; the Lagrangian variational principle; the Hamiltonian variational principle on the phase-space action |

The TFAE proof rewrites every entry to a single proposition and closes with `List.tfae_singleton`
— no `tfae_finish` chain that could silently be incomplete — and discharges all four smoothness
side goals explicitly rather than with a blanket `repeat fun_prop`.

**Reviewer reading order:** the module doc; A.1–A.2 (the Legendre transform is derived, not
asserted); A.3 (`hamiltonian_eq_energy`, hypothesis-free); A.5 (the bridge to `Basic.lean`'s
pointwise law); then B. Comparison point: `HarmonicOscillator/Basic.lean` §§G–H.

**Verification:** full `lake build` + complete linter battery pass; `#print axioms` on all 11
declarations → `propext`, `Classical.choice`, `Quot.sound` only; both imports verified load-bearing.

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.


