### PR TITLE
feat(ClassicalMechanics): pendulum trajectories on the configuration circle and the bridge to physical space

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -20,6 +20,7 @@ public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMoti
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Equilibria
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Trajectory
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Hamiltonian
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.LiftInvariance
 public import Physlib.ClassicalMechanics.Pendulum.SlidingPendulum

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -20,6 +20,7 @@ public import Physlib.ClassicalMechanics.Pendulum.MiscellaneousPendulumPivotMoti
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Equilibria
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.PhysicalSpace
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Trajectory
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Hamiltonian
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.LiftInvariance

--- a/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/API-map.yaml
@@ -16,8 +16,8 @@ Overview: |
     configuration space is declared but not yet defined, and the miscellaneous pivot-motion problems
     have documentation only. The simple pendulum's Lagrangian and equation of motion on the
     Euclidean lift are recorded in its own API map; the trajectory based on the configuration
-    space, and the Lagrangian derived from it, remain open and are recorded below with location
-    N/A.
+    space, and the identification of the lifted Lagrangian with that of the bob in physical
+    space, are recorded below.
 
 ParentAPIs:
   - Classical mechanics Lagrangian (Physlib/ClassicalMechanics/Lagrangian)
@@ -43,10 +43,10 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace)
 
-  - description: The API shall contain the definition of a trajectory based on the configuration space.
-    done: false
-    location: "N/A"
+  - description: The API contains the definition of a trajectory based on the configuration space.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean (SimplePendulum.Trajectory, SimplePendulum.Trajectory.ofLift)
 
-  - description: The API shall subsequently contain the definition of the lagrangian.
-    done: false
-    location: "N/A"
+  - description: The API subsequently contains the definition of the lagrangian.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Basic.lean (SimplePendulum.lagrangian); Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean (SimplePendulum.lagrangian_eq_space)

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/API-map.yaml
@@ -14,9 +14,11 @@ Overview: |
     the equivalence of that equation with the vanishing of the variational gradient of the
     action, the conservation of energy, the Hamiltonian formulation with the equivalence of
     the Newtonian, scalar, Hamiltonian and variational formulations, the equilibria with
-    the separatrix energy and the below/above-threshold energy bounds, and the invariance of
-    the lifted dynamics under shifting the angle by whole turns; the small-angle limit and
-    the period follow in later modules.
+    the separatrix energy and the below/above-threshold energy bounds, the invariance of
+    the lifted dynamics under shifting the angle by whole turns, the trajectories on the
+    configuration circle, and the identification of the lifted energies and Lagrangian with
+    those of the bob in physical space; the small-angle limit and the period follow in later
+    modules.
 
 ParentAPIs:
   - "Space (Physlib/SpaceAndTime/Space)"
@@ -46,9 +48,9 @@ Requirements:
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Basic.lean (SimplePendulum.ConfigurationSpace.toSpace, SimplePendulum.ConfigurationSpace.toSpace_ofAngle, SimplePendulum.ConfigurationSpace.toSpace_norm)
 
-  - description: The API shall contain the definition of a trajectory based on the configuration space.
-    done: false
-    location: N/A
+  - description: The API contains the definition of a trajectory based on the configuration space.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean (SimplePendulum.Trajectory, SimplePendulum.Trajectory.ofLift, SimplePendulum.Trajectory.contMDiff_ofLift)
 
   - description: The API contains the Lagrangian of the simple pendulum and its equation of motion.
     done: true
@@ -69,3 +71,7 @@ Requirements:
   - description: The API contains the invariance of the lifted dynamics under shifting the angle by whole turns.
     done: true
     location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/LiftInvariance.lean (SimplePendulum.equationOfMotion_add_int_mul_two_pi, SimplePendulum.energy_add_int_mul_two_pi, SimplePendulum.isSolution_add_int_mul_two_pi)
+
+  - description: The API contains the identification of the lifted energies and Lagrangian with those of the bob in physical space.
+    done: true
+    location: Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean (SimplePendulum.kineticEnergy_eq_space, SimplePendulum.potentialEnergy_eq_height, SimplePendulum.lagrangian_eq_space, SimplePendulum.energy_eq_space)

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean
@@ -57,8 +57,7 @@ the trajectory module.
 
 open Real InnerProductSpace Time
 
-namespace ClassicalMechanics
-namespace SimplePendulum
+namespace ClassicalMechanics.SimplePendulum
 
 variable (S : SimplePendulum)
 
@@ -87,13 +86,13 @@ lemma spaceTrajectory_eq (θ : Time → EuclideanSpace ℝ (Fin 1)) :
 /-- The horizontal position of the bob along a lifted trajectory is `ℓ sin (θ t 0)`. -/
 lemma spaceTrajectory_apply_zero (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
     S.spaceTrajectory θ t 0 = S.ℓ * Real.sin (θ t 0) := by
-  rw [S.spaceTrajectory_eq θ]; rfl
+  simp [S.spaceTrajectory_eq θ]
 
 /-- The vertical position of the bob along a lifted trajectory is `-ℓ cos (θ t 0)`, the pivot
   being the origin and the second axis pointing upwards. -/
 lemma spaceTrajectory_apply_one (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
     S.spaceTrajectory θ t 1 = -S.ℓ * Real.cos (θ t 0) := by
-  rw [S.spaceTrajectory_eq θ]; rfl
+  simp [S.spaceTrajectory_eq θ]
 
 /-- The rod-length constraint along a lifted trajectory: the bob of the pendulum `S` stays at
   distance `ℓ` from the pivot, the length of the rod being positive. -/
@@ -119,42 +118,26 @@ stand-alone lemmas.
   times the angular velocity. -/
 lemma deriv_sin_coord (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
     (t : Time) : ∂ₜ (fun s => Real.sin (θ s 0)) t = Real.cos (θ t 0) * (∂ₜ θ t) 0 := by
-  have hc : Differentiable ℝ fun s => θ s 0 :=
-    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
-  have h : HasFDerivAt (fun s => Real.sin (θ s 0))
-      (Real.cos (θ t 0) • fderiv ℝ (fun s => θ s 0) t) t :=
-    HasDerivAt.comp_hasFDerivAt (h₂ := Real.sin) t (Real.hasDerivAt_sin (θ t 0))
-      (hc t).hasFDerivAt
-  rw [Time.deriv_eq, h.fderiv, _root_.smul_apply, smul_eq_mul, ← Time.deriv_eq,
-    Time.deriv_euclid hθ t]
+  rw [Time.deriv_eq, fderiv_sin, smul_apply, smul_eq_mul, ← Time.deriv_eq, Time.deriv_euclid hθ t]
+  fun_prop
 
 /-- The time derivative of the cosine of the angle read from a lift is minus the sine of the
   angle times the angular velocity. -/
 lemma deriv_cos_coord (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
     (t : Time) : ∂ₜ (fun s => Real.cos (θ s 0)) t = -Real.sin (θ t 0) * (∂ₜ θ t) 0 := by
-  have hc : Differentiable ℝ fun s => θ s 0 :=
-    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
-  have h : HasFDerivAt (fun s => Real.cos (θ s 0))
-      (-Real.sin (θ t 0) • fderiv ℝ (fun s => θ s 0) t) t :=
-    HasDerivAt.comp_hasFDerivAt (h₂ := Real.cos) t (Real.hasDerivAt_cos (θ t 0))
-      (hc t).hasFDerivAt
-  rw [Time.deriv_eq, h.fderiv, _root_.smul_apply, smul_eq_mul, ← Time.deriv_eq,
-    Time.deriv_euclid hθ t]
+  rw [Time.deriv_eq, fderiv_cos, smul_apply, smul_eq_mul, ← Time.deriv_eq, Time.deriv_euclid hθ t]
+  fun_prop
 
 /-- Along a differentiable lift of the angle the position of the bob is differentiable in
   time. -/
+@[fun_prop]
 lemma differentiable_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1))
     (hθ : Differentiable ℝ θ) : Differentiable ℝ (S.spaceTrajectory θ) := by
   rw [S.spaceTrajectory_eq θ]
-  have h : Differentiable ℝ fun t => θ t 0 :=
-    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
-  have hpi : Differentiable ℝ
-      fun t => (![S.ℓ * Real.sin (θ t 0), -S.ℓ * Real.cos (θ t 0)] : Fin 2 → ℝ) :=
-    differentiable_pi.mpr fun i => by
-      fin_cases i
-      · simpa using (Real.differentiable_sin.comp h).const_mul S.ℓ
-      · simpa using (Real.differentiable_cos.comp h).const_mul (-S.ℓ)
-  exact Space.mk_differentiable.comp hpi
+  apply Space.mk_differentiable.comp
+  rw [differentiable_pi]
+  intro i
+  fin_cases i <;> (simp; fun_prop)
 
 /-- The velocity of the bob along a differentiable lift `θ` of the angle is
   `(ℓ cos (θ t 0), ℓ sin (θ t 0))` times the angular velocity: the vector tangent to the circle
@@ -163,28 +146,16 @@ lemma deriv_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Di
     (t : Time) :
     ∂ₜ (S.spaceTrajectory θ) t =
       ⟨![S.ℓ * Real.cos (θ t 0) * (∂ₜ θ t) 0, S.ℓ * Real.sin (θ t 0) * (∂ₜ θ t) 0]⟩ := by
-  have hF : Differentiable ℝ (S.spaceTrajectory θ) := S.differentiable_spaceTrajectory θ hθ
-  have h0 : ∂ₜ (fun s => S.spaceTrajectory θ s 0) t
-      = S.ℓ * Real.cos (θ t 0) * (∂ₜ θ t) 0 := by
-    simp only [S.spaceTrajectory_apply_zero θ]
-    have hsin : Differentiable ℝ fun s => Real.sin (θ s 0) :=
-      Real.differentiable_sin.comp
-        ((EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ)
-    rw [Time.deriv_eq, fderiv_const_mul (hsin t) S.ℓ, _root_.smul_apply, smul_eq_mul,
-      ← Time.deriv_eq, deriv_sin_coord θ hθ t, mul_assoc]
-  have h1 : ∂ₜ (fun s => S.spaceTrajectory θ s 1) t
-      = S.ℓ * Real.sin (θ t 0) * (∂ₜ θ t) 0 := by
-    simp only [S.spaceTrajectory_apply_one θ]
-    have hcos : Differentiable ℝ fun s => Real.cos (θ s 0) :=
-      Real.differentiable_cos.comp
-        ((EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ)
-    rw [Time.deriv_eq, fderiv_const_mul (hcos t) (-S.ℓ), _root_.smul_apply, smul_eq_mul,
-      ← Time.deriv_eq, deriv_cos_coord θ hθ t]
+  refine Space.eq_of_apply fun i ↦ ?_
+  fin_cases i <;> apply (Time.deriv_space (by fun_prop) t _).symm.trans
+  · simp only [S.spaceTrajectory_apply_zero, Fin.zero_eta, Matrix.cons_val_zero]
+    rw [Time.deriv_eq, fderiv_const_mul, smul_apply, smul_eq_mul, ← Time.deriv, deriv_sin_coord,
+      mul_assoc]
+    all_goals fun_prop
+  · simp only [Fin.mk_one, S.spaceTrajectory_apply_one, Matrix.cons_val_one, Matrix.cons_val_zero]
+    rw [Time.deriv_eq, fderiv_const_mul, smul_apply, smul_eq_mul, ← Time.deriv, deriv_cos_coord]
     ring
-  refine Space.eq_of_apply fun i => ?_
-  fin_cases i
-  · exact (Time.deriv_space hF t 0).symm.trans h0
-  · exact (Time.deriv_space hF t 1).symm.trans h1
+    all_goals fun_prop
 
 /-- The square of the speed of the bob along a differentiable lift of the angle is `ℓ² θ̇²`. -/
 lemma norm_sq_deriv_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1))
@@ -216,9 +187,8 @@ lemma kineticEnergy_eq_space (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : D
     (t : Time) :
     S.kineticEnergy θ t = (1 / (2 : ℝ)) * S.m * ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2 := by
   rw [S.norm_sq_deriv_spaceTrajectory θ hθ t]
-  show (1 / (2 : ℝ)) * S.inertia * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ = _
-  rw [inertia]
-  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, Fin.sum_univ_one]
+  show (1 / (2 : ℝ)) * (S.m * S.ℓ ^ 2) * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ = _
+  rw [PiLp.inner_apply, Fin.sum_univ_one, RCLike.inner_apply, conj_trivial]
   ring
 
 /-- The chart potential energy of the pendulum is the gravitational potential of the bob in
@@ -248,10 +218,9 @@ lemma energy_eq_space (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differen
     S.energy θ t =
       (1 / (2 : ℝ)) * S.m * ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2
         + S.m * S.g * (S.spaceTrajectory θ t 1 + S.ℓ) := by
-  have hE : S.energy θ t = S.kineticEnergy θ t + S.potentialEnergy (θ t) := rfl
-  rw [hE, S.kineticEnergy_eq_space θ hθ t, S.potentialEnergy_eq_height θ t]
+  rw [← S.kineticEnergy_eq_space θ hθ t, ← S.potentialEnergy_eq_height θ t]
+  rfl
 
-end SimplePendulum
-end ClassicalMechanics
+end ClassicalMechanics.SimplePendulum
 
 end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/PhysicalSpace.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Trajectory
+/-!
+
+# The simple pendulum in physical space
+
+## i. Overview
+
+The trajectory module places the bob in the plane along a lifted trajectory; this module fixes a
+simple pendulum `S` and identifies the dynamics of `SimplePendulum.Basic`, written on the
+Euclidean lift of the angle, with the dynamics of the bob moving in physical space. Along a lift
+`θ` the bob is at `S.spaceTrajectory θ`, at the fixed distance `ℓ` from the pivot; its velocity
+is obtained by differentiating the position componentwise, and the square of its speed is
+`ℓ² θ̇²`. The chart kinetic energy `½ I θ̇²` is then exactly the kinetic energy `½ m ‖v‖²` of
+the bob, the chart potential energy `m g ℓ (1 - cos θ)` is exactly the gravitational potential
+`m g h` of the bob with the height `h` measured from the bottom of the swing, and the chart
+Lagrangian is the constrained Lagrangian `T - V` of a point mass moving on the circle of radius
+`ℓ` about the pivot. Velocities in this module are physical-space time derivatives; the
+geometric velocity as a tangent vector to the configuration circle is deferred, as discussed in
+the trajectory module.
+
+## ii. Key results
+
+- `SimplePendulum.spaceTrajectory` : the bob's position in the plane along a lifted trajectory,
+  with the rod-length constraint `SimplePendulum.norm_spaceTrajectory`.
+- `SimplePendulum.deriv_spaceTrajectory` : the bob's velocity along a lifted trajectory, with
+  the square of its speed `SimplePendulum.norm_sq_deriv_spaceTrajectory`.
+- `SimplePendulum.kineticEnergy_eq_space`, `SimplePendulum.potentialEnergy_eq_height` and
+  `SimplePendulum.lagrangian_eq_space` : the chart kinetic energy, potential energy and
+  Lagrangian are those of the bob in physical space; `SimplePendulum.energy_eq_space` is the
+  corresponding statement for the total energy.
+
+## iii. Table of contents
+
+- A. The bob's position along a lifted trajectory
+- B. The bob's velocity and speed
+- C. The energies and the Lagrangian in physical space
+
+## iv. References
+
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Basic` (the lifted dynamics: the
+  energies and the Lagrangian on the Euclidean lift of the angle).
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Trajectory` (trajectories on
+  the configuration circle and the position of the bob along them).
+- Landau & Lifshitz, Mechanics, 3rd ed., §5, Problems 1–3 (pendulum configurations).
+
+-/
+
+@[expose] public section
+
+open Real InnerProductSpace Time
+
+namespace ClassicalMechanics
+namespace SimplePendulum
+
+variable (S : SimplePendulum)
+
+/-!
+
+## A. The bob's position along a lifted trajectory
+
+Fixing a pendulum `S`, the position of the bob in the plane along the trajectory described by a
+lift `θ` of the angle is obtained by composing the lifted trajectory with the map to physical
+space for a rod of length `S.ℓ`. Along it the bob is at `(ℓ sin θ, -ℓ cos θ)`, and since the
+length of the rod is positive the bob stays at distance `ℓ` from the pivot at all times.
+
+-/
+
+/-- The position of the bob in the plane along the trajectory described by a lift `θ` of the
+  angle, for the pendulum `S`. -/
+noncomputable def spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1)) : Time → Space 2 :=
+  Trajectory.toSpace S.ℓ (Trajectory.ofLift θ)
+
+/-- Along the trajectory described by a lift `θ` of the angle the bob of the pendulum `S` is at
+  `(ℓ sin (θ t 0), -ℓ cos (θ t 0))`. -/
+lemma spaceTrajectory_eq (θ : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.spaceTrajectory θ = fun t => ⟨![S.ℓ * Real.sin (θ t 0), -S.ℓ * Real.cos (θ t 0)]⟩ :=
+  funext fun t => Trajectory.toSpace_ofLift S.ℓ θ t
+
+/-- The horizontal position of the bob along a lifted trajectory is `ℓ sin (θ t 0)`. -/
+lemma spaceTrajectory_apply_zero (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.spaceTrajectory θ t 0 = S.ℓ * Real.sin (θ t 0) := by
+  rw [S.spaceTrajectory_eq θ]; rfl
+
+/-- The vertical position of the bob along a lifted trajectory is `-ℓ cos (θ t 0)`, the pivot
+  being the origin and the second axis pointing upwards. -/
+lemma spaceTrajectory_apply_one (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.spaceTrajectory θ t 1 = -S.ℓ * Real.cos (θ t 0) := by
+  rw [S.spaceTrajectory_eq θ]; rfl
+
+/-- The rod-length constraint along a lifted trajectory: the bob of the pendulum `S` stays at
+  distance `ℓ` from the pivot, the length of the rod being positive. -/
+lemma norm_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    ‖S.spaceTrajectory θ t‖ = S.ℓ :=
+  (Trajectory.norm_toSpace S.ℓ (Trajectory.ofLift θ) t).trans (abs_of_pos S.ℓ_pos)
+
+/-!
+
+## B. The bob's velocity and speed
+
+Differentiating the position of the bob componentwise gives its velocity in the plane: along a
+differentiable lift the bob's position is differentiable in time, and its velocity is
+`(ℓ cos θ, ℓ sin θ)` times the angular velocity — the vector tangent to the circle of radius
+`ℓ`, of length `ℓ |θ̇|`. The square of the speed is therefore `ℓ² θ̇²`, which is the identity
+behind the identification of the kinetic energies in the next section. The two chain-rule
+computations for the sine and the cosine of the angle read from a lift are recorded as
+stand-alone lemmas.
+
+-/
+
+/-- The time derivative of the sine of the angle read from a lift is the cosine of the angle
+  times the angular velocity. -/
+lemma deriv_sin_coord (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) : ∂ₜ (fun s => Real.sin (θ s 0)) t = Real.cos (θ t 0) * (∂ₜ θ t) 0 := by
+  have hc : Differentiable ℝ fun s => θ s 0 :=
+    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
+  have h : HasFDerivAt (fun s => Real.sin (θ s 0))
+      (Real.cos (θ t 0) • fderiv ℝ (fun s => θ s 0) t) t :=
+    HasDerivAt.comp_hasFDerivAt (h₂ := Real.sin) t (Real.hasDerivAt_sin (θ t 0))
+      (hc t).hasFDerivAt
+  rw [Time.deriv_eq, h.fderiv, _root_.smul_apply, smul_eq_mul, ← Time.deriv_eq,
+    Time.deriv_euclid hθ t]
+
+/-- The time derivative of the cosine of the angle read from a lift is minus the sine of the
+  angle times the angular velocity. -/
+lemma deriv_cos_coord (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) : ∂ₜ (fun s => Real.cos (θ s 0)) t = -Real.sin (θ t 0) * (∂ₜ θ t) 0 := by
+  have hc : Differentiable ℝ fun s => θ s 0 :=
+    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
+  have h : HasFDerivAt (fun s => Real.cos (θ s 0))
+      (-Real.sin (θ t 0) • fderiv ℝ (fun s => θ s 0) t) t :=
+    HasDerivAt.comp_hasFDerivAt (h₂ := Real.cos) t (Real.hasDerivAt_cos (θ t 0))
+      (hc t).hasFDerivAt
+  rw [Time.deriv_eq, h.fderiv, _root_.smul_apply, smul_eq_mul, ← Time.deriv_eq,
+    Time.deriv_euclid hθ t]
+
+/-- Along a differentiable lift of the angle the position of the bob is differentiable in
+  time. -/
+lemma differentiable_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1))
+    (hθ : Differentiable ℝ θ) : Differentiable ℝ (S.spaceTrajectory θ) := by
+  rw [S.spaceTrajectory_eq θ]
+  have h : Differentiable ℝ fun t => θ t 0 :=
+    (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ
+  have hpi : Differentiable ℝ
+      fun t => (![S.ℓ * Real.sin (θ t 0), -S.ℓ * Real.cos (θ t 0)] : Fin 2 → ℝ) :=
+    differentiable_pi.mpr fun i => by
+      fin_cases i
+      · simpa using (Real.differentiable_sin.comp h).const_mul S.ℓ
+      · simpa using (Real.differentiable_cos.comp h).const_mul (-S.ℓ)
+  exact Space.mk_differentiable.comp hpi
+
+/-- The velocity of the bob along a differentiable lift `θ` of the angle is
+  `(ℓ cos (θ t 0), ℓ sin (θ t 0))` times the angular velocity: the vector tangent to the circle
+  of radius `ℓ` at the position of the bob. -/
+lemma deriv_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) :
+    ∂ₜ (S.spaceTrajectory θ) t =
+      ⟨![S.ℓ * Real.cos (θ t 0) * (∂ₜ θ t) 0, S.ℓ * Real.sin (θ t 0) * (∂ₜ θ t) 0]⟩ := by
+  have hF : Differentiable ℝ (S.spaceTrajectory θ) := S.differentiable_spaceTrajectory θ hθ
+  have h0 : ∂ₜ (fun s => S.spaceTrajectory θ s 0) t
+      = S.ℓ * Real.cos (θ t 0) * (∂ₜ θ t) 0 := by
+    simp only [S.spaceTrajectory_apply_zero θ]
+    have hsin : Differentiable ℝ fun s => Real.sin (θ s 0) :=
+      Real.differentiable_sin.comp
+        ((EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ)
+    rw [Time.deriv_eq, fderiv_const_mul (hsin t) S.ℓ, _root_.smul_apply, smul_eq_mul,
+      ← Time.deriv_eq, deriv_sin_coord θ hθ t, mul_assoc]
+  have h1 : ∂ₜ (fun s => S.spaceTrajectory θ s 1) t
+      = S.ℓ * Real.sin (θ t 0) * (∂ₜ θ t) 0 := by
+    simp only [S.spaceTrajectory_apply_one θ]
+    have hcos : Differentiable ℝ fun s => Real.cos (θ s 0) :=
+      Real.differentiable_cos.comp
+        ((EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).differentiable.comp hθ)
+    rw [Time.deriv_eq, fderiv_const_mul (hcos t) (-S.ℓ), _root_.smul_apply, smul_eq_mul,
+      ← Time.deriv_eq, deriv_cos_coord θ hθ t]
+    ring
+  refine Space.eq_of_apply fun i => ?_
+  fin_cases i
+  · exact (Time.deriv_space hF t 0).symm.trans h0
+  · exact (Time.deriv_space hF t 1).symm.trans h1
+
+/-- The square of the speed of the bob along a differentiable lift of the angle is `ℓ² θ̇²`. -/
+lemma norm_sq_deriv_spaceTrajectory (θ : Time → EuclideanSpace ℝ (Fin 1))
+    (hθ : Differentiable ℝ θ) (t : Time) :
+    ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2 = S.ℓ ^ 2 * ((∂ₜ θ t) 0) ^ 2 := by
+  rw [S.deriv_spaceTrajectory θ hθ t, Space.norm_sq_eq, Fin.sum_univ_two]
+  show (S.ℓ * Real.cos (θ t 0) * (∂ₜ θ t) 0) ^ 2
+      + (S.ℓ * Real.sin (θ t 0) * (∂ₜ θ t) 0) ^ 2 = _
+  linear_combination S.ℓ ^ 2 * ((∂ₜ θ t) 0) ^ 2 * Real.sin_sq_add_cos_sq (θ t 0)
+
+/-!
+
+## C. The energies and the Lagrangian in physical space
+
+The identities of the previous section identify the energies of `SimplePendulum.Basic`, written
+on the lift of the angle, with the energies of the bob in the plane. The chart kinetic energy
+`½ I θ̇²` is the kinetic energy `½ m ‖v‖²` of the bob, since `I = m ℓ²` and the square of the
+speed is `ℓ² θ̇²`; the chart potential energy `m g ℓ (1 - cos θ)` is the gravitational
+potential `m g h` of the bob, the height `h` above the bottom of the swing being the vertical
+position of the bob plus `ℓ`. Consequently the chart Lagrangian is the constrained Lagrangian
+`T - V` of a point mass moving on the circle of radius `ℓ`, and the chart energy is its total
+energy `T + V`.
+
+-/
+
+/-- The chart kinetic energy of the pendulum along a differentiable lift of the angle is the
+  kinetic energy of the bob in physical space. -/
+lemma kineticEnergy_eq_space (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) :
+    S.kineticEnergy θ t = (1 / (2 : ℝ)) * S.m * ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2 := by
+  rw [S.norm_sq_deriv_spaceTrajectory θ hθ t]
+  show (1 / (2 : ℝ)) * S.inertia * ⟪∂ₜ θ t, ∂ₜ θ t⟫_ℝ = _
+  rw [inertia]
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, Fin.sum_univ_one]
+  ring
+
+/-- The chart potential energy of the pendulum is the gravitational potential of the bob in
+  physical space, normalized to vanish at the bottom of the swing: the height of the bob above
+  the bottom is its vertical position plus `ℓ`. -/
+lemma potentialEnergy_eq_height (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.potentialEnergy (θ t) = S.m * S.g * (S.spaceTrajectory θ t 1 + S.ℓ) := by
+  rw [S.potentialEnergy_eq (θ t), S.spaceTrajectory_apply_one θ t]
+  ring
+
+/-- The chart Lagrangian of the pendulum along a differentiable lift of the angle is the
+  constrained Lagrangian of the bob in physical space: the kinetic energy of the point mass
+  minus its gravitational potential. -/
+lemma lagrangian_eq_space (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) :
+    S.lagrangian t (θ t) (∂ₜ θ t) =
+      (1 / (2 : ℝ)) * S.m * ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2
+        - S.m * S.g * (S.spaceTrajectory θ t 1 + S.ℓ) := by
+  rw [S.lagrangian_eq_kineticEnergy_sub_potentialEnergy t θ, S.kineticEnergy_eq_space θ hθ t,
+    S.potentialEnergy_eq_height θ t]
+
+/-- The chart energy of the pendulum along a differentiable lift of the angle is the total
+  energy of the bob in physical space: the kinetic energy of the point mass plus its
+  gravitational potential. -/
+lemma energy_eq_space (θ : Time → EuclideanSpace ℝ (Fin 1)) (hθ : Differentiable ℝ θ)
+    (t : Time) :
+    S.energy θ t =
+      (1 / (2 : ℝ)) * S.m * ‖∂ₜ (S.spaceTrajectory θ) t‖ ^ 2
+        + S.m * S.g * (S.spaceTrajectory θ t 1 + S.ℓ) := by
+  have hE : S.energy θ t = S.kineticEnergy θ t + S.potentialEnergy (θ t) := rfl
+  rw [hE, S.kineticEnergy_eq_space θ hθ t, S.potentialEnergy_eq_height θ t]
+
+end SimplePendulum
+end ClassicalMechanics
+
+end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
@@ -59,8 +59,7 @@ noncomputable section
 
 open scoped Manifold
 
-namespace ClassicalMechanics
-namespace SimplePendulum
+namespace ClassicalMechanics.SimplePendulum
 
 /-!
 
@@ -89,23 +88,19 @@ def ofLift (θ : Time → EuclideanSpace ℝ (Fin 1)) : Trajectory := fun t =>
 lemma ofLift_apply (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
     ofLift θ t = ConfigurationSpace.ofAngle (θ t 0) := rfl
 
-/-- Shifting a lift of the angle by a whole number of turns leaves the described trajectory
-  unchanged. -/
-lemma ofLift_add_int_mul_two_pi (θ : Time → EuclideanSpace ℝ (Fin 1)) (n : ℤ) :
-    ofLift (fun t => θ t + (n * (2 * Real.pi)) • EuclideanSpace.single 0 1) = ofLift θ := by
-  funext t
-  simp only [ofLift_apply]
-  have h0 : (θ t + (n * (2 * Real.pi)) • EuclideanSpace.single 0 1 : EuclideanSpace ℝ (Fin 1)) 0
-      = θ t 0 + n * (2 * Real.pi) := by
-    simp
-  rw [h0]
-  exact ConfigurationSpace.ofAngle_periodic.int_mul n (θ t 0)
-
 /-- Two lifts of the angle describe the same trajectory exactly when at each time they differ by
   a whole number of turns. -/
 lemma ofLift_eq_iff (θ₁ θ₂ : Time → EuclideanSpace ℝ (Fin 1)) :
     ofLift θ₁ = ofLift θ₂ ↔ ∀ t, ∃ n : ℤ, θ₂ t 0 = θ₁ t 0 + n * (2 * Real.pi) := by
   simp only [funext_iff, ofLift_apply, ConfigurationSpace.ofAngle_eq_iff]
+
+/-- Shifting a lift of the angle by a whole number of turns leaves the described trajectory
+  unchanged. -/
+lemma ofLift_add_int_mul_two_pi (θ : Time → EuclideanSpace ℝ (Fin 1)) (n : ℤ) :
+    ofLift (fun t => θ t + (n * (2 * Real.pi)) • EuclideanSpace.single 0 1) = ofLift θ := by
+  rw [ofLift_eq_iff]
+  intro
+  exact ⟨-n, by simp⟩
 
 /-!
 
@@ -129,9 +124,8 @@ lemma continuous_ofLift {θ : Time → EuclideanSpace ℝ (Fin 1)} (hθ : Contin
   circle. -/
 lemma contMDiff_ofLift {n : WithTop ℕ∞} {θ : Time → EuclideanSpace ℝ (Fin 1)}
     (hθ : ContDiff ℝ n θ) : ContMDiff 𝓘(ℝ, Time) (𝓡 1) n (ofLift θ) := by
-  have h : ContDiff ℝ n fun t => θ t 0 :=
-    (ContinuousLinearMap.contDiff (𝕜 := ℝ) (EuclideanSpace.proj (0 : Fin 1))).comp hθ
-  exact (ConfigurationSpace.contMDiff_ofAngle.of_le le_top).comp (contMDiff_iff_contDiff.mpr h)
+  apply (ConfigurationSpace.contMDiff_ofAngle.of_le le_top).comp (contMDiff_iff_contDiff.mpr _)
+  exact (ContinuousLinearMap.contDiff (𝕜 := ℝ) (EuclideanSpace.proj (0 : Fin 1))).comp hθ
 
 /-!
 
@@ -144,7 +138,7 @@ constraint holds at all times: the bob stays on the circle of radius `|ℓ|` abo
 -/
 
 /-- The physical position of the bob along a trajectory, over time, for a rod of length `ℓ`. -/
-def toSpace (ℓ : ℝ) (γ : Trajectory) : Time → Space 2 := fun t => (γ t).toSpace ℓ
+def toSpace (ℓ : ℝ) (γ : Trajectory) (t : Time) : Space 2 := (γ t).toSpace ℓ
 
 /-- Along the trajectory described by a lift `θ` of the angle the bob is at
   `(ℓ sin (θ t 0), -ℓ cos (θ t 0))`. -/
@@ -163,9 +157,6 @@ lemma continuous_toSpace (ℓ : ℝ) {γ : Trajectory} (hγ : Continuous γ) :
     Continuous (toSpace ℓ γ) :=
   (ConfigurationSpace.continuous_toSpace ℓ).comp hγ
 
-end Trajectory
-
-end SimplePendulum
-end ClassicalMechanics
+end ClassicalMechanics.SimplePendulum.Trajectory
 
 end

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
+public import Physlib.SpaceAndTime.Time.Basic
+public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
+/-!
+
+# Geometric trajectories of the simple pendulum
+
+## i. Overview
+
+A trajectory of the simple pendulum is a time-parametrized curve in the configuration circle.
+The dynamics of the pendulum is written for a real-valued lift of the angle;
+`Trajectory.ofLift` sends such a lift to the trajectory it describes on the circle, by applying
+the angular lift `ConfigurationSpace.ofAngle` at each time. Two lifts describe the same
+trajectory exactly when at each time they differ by a whole number of turns, a smooth lift
+describes a smooth curve in the circle, and composing with `ConfigurationSpace.toSpace` places
+the bob in the plane along the trajectory, at distance `|ℓ|` from the pivot at all times.
+
+The geometric velocity — the `mfderiv` of a trajectory as a tangent vector to the circle, read
+in its stereographic charts — is left for a later module, as is the smooth identification of
+the configuration space with `Circle`; in this module and the next, velocities are computed in
+physical space, on the position of the bob in the plane.
+
+## ii. Key results
+
+- `Trajectory` : a trajectory of the pendulum, a curve in the configuration circle.
+- `Trajectory.ofLift` : the trajectory described by a lift of the angle, with
+  `Trajectory.ofLift_add_int_mul_two_pi` and `Trajectory.ofLift_eq_iff` making precise that two
+  lifts describe the same trajectory exactly when they differ by whole turns at each time.
+- `Trajectory.contMDiff_ofLift` : the trajectory described by a `C^n` lift is a `C^n` curve in
+  the configuration circle; `Trajectory.continuous_ofLift` is the topological counterpart.
+- `Trajectory.toSpace` : the physical position of the bob along a trajectory, with the
+  rod-length constraint `Trajectory.norm_toSpace`.
+
+## iii. Table of contents
+
+- A. The trajectory type and the lift
+- B. Smoothness of lifted trajectories
+- C. Physical position along a trajectory
+
+## iv. References
+
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic` (the configuration
+  circle, the angular lift `ofAngle` and the map to physical space).
+- `Physlib.ClassicalMechanics.HarmonicOscillator.Geometric.Trajectory` (the corresponding
+  trajectory module of the harmonic oscillator, whose structure this module follows).
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open scoped Manifold
+
+namespace ClassicalMechanics
+namespace SimplePendulum
+
+/-!
+
+## A. The trajectory type and the lift
+
+A trajectory is a curve in the configuration circle, parametrized by `Time`. The dynamics is
+written for the Euclidean lift `Time → EuclideanSpace ℝ (Fin 1)` of the angle; `ofLift` sends a
+lift to the trajectory it describes, and the lift is faithful up to a whole number of turns at
+each time: shifting a lift by `2π n` gives the same trajectory, and two lifts give the same
+trajectory exactly when at each time they differ by some whole number of turns (possibly a
+different number at different times).
+
+-/
+
+/-- A trajectory of the pendulum: a curve in the configuration space. -/
+abbrev Trajectory := Time → ConfigurationSpace
+
+namespace Trajectory
+
+/-- The trajectory on the circle described by a lift `θ` of the angle. -/
+def ofLift (θ : Time → EuclideanSpace ℝ (Fin 1)) : Trajectory := fun t =>
+  ConfigurationSpace.ofAngle (θ t 0)
+
+/-- At time `t` the trajectory described by a lift `θ` of the angle is the configuration at
+  angle `θ t 0`. -/
+lemma ofLift_apply (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    ofLift θ t = ConfigurationSpace.ofAngle (θ t 0) := rfl
+
+/-- Shifting a lift of the angle by a whole number of turns leaves the described trajectory
+  unchanged. -/
+lemma ofLift_add_int_mul_two_pi (θ : Time → EuclideanSpace ℝ (Fin 1)) (n : ℤ) :
+    ofLift (fun t => θ t + (n * (2 * Real.pi)) • EuclideanSpace.single 0 1) = ofLift θ := by
+  funext t
+  simp only [ofLift_apply]
+  have h0 : (θ t + (n * (2 * Real.pi)) • EuclideanSpace.single 0 1 : EuclideanSpace ℝ (Fin 1)) 0
+      = θ t 0 + n * (2 * Real.pi) := by
+    simp
+  rw [h0]
+  exact ConfigurationSpace.ofAngle_periodic.int_mul n (θ t 0)
+
+/-- Two lifts of the angle describe the same trajectory exactly when at each time they differ by
+  a whole number of turns. -/
+lemma ofLift_eq_iff (θ₁ θ₂ : Time → EuclideanSpace ℝ (Fin 1)) :
+    ofLift θ₁ = ofLift θ₂ ↔ ∀ t, ∃ n : ℤ, θ₂ t 0 = θ₁ t 0 + n * (2 * Real.pi) := by
+  simp only [funext_iff, ofLift_apply, ConfigurationSpace.ofAngle_eq_iff]
+
+/-!
+
+## B. Smoothness of lifted trajectories
+
+The angular lift `ConfigurationSpace.ofAngle` is analytic, so the trajectory described by a lift
+inherits the regularity of the lift: a continuous lift describes a continuous trajectory, and a
+`C^n` lift describes a `C^n` curve in the configuration circle. Since `Time` is a normed space,
+smoothness of the lift is ordinary `ContDiff` smoothness, while smoothness of the trajectory is
+manifold smoothness into the circle.
+
+-/
+
+/-- The trajectory described by a continuous lift of the angle is continuous. -/
+lemma continuous_ofLift {θ : Time → EuclideanSpace ℝ (Fin 1)} (hθ : Continuous θ) :
+    Continuous (ofLift θ) :=
+  ConfigurationSpace.continuous_ofAngle.comp
+    ((EuclideanSpace.proj (0 : Fin 1)).continuous.comp hθ)
+
+/-- The trajectory described by a `C^n` lift of the angle is a `C^n` curve in the configuration
+  circle. -/
+lemma contMDiff_ofLift {n : WithTop ℕ∞} {θ : Time → EuclideanSpace ℝ (Fin 1)}
+    (hθ : ContDiff ℝ n θ) : ContMDiff 𝓘(ℝ, Time) (𝓡 1) n (ofLift θ) := by
+  have h : ContDiff ℝ n fun t => θ t 0 :=
+    (ContinuousLinearMap.contDiff (𝕜 := ℝ) (EuclideanSpace.proj (0 : Fin 1))).comp hθ
+  exact (ConfigurationSpace.contMDiff_ofAngle.of_le le_top).comp (contMDiff_iff_contDiff.mpr h)
+
+/-!
+
+## C. Physical position along a trajectory
+
+Composing a trajectory with the map to physical space places the bob in the plane at each time.
+Along the trajectory described by a lift the bob is at `(ℓ sin θ, -ℓ cos θ)`, and the rod-length
+constraint holds at all times: the bob stays on the circle of radius `|ℓ|` about the pivot.
+
+-/
+
+/-- The physical position of the bob along a trajectory, over time, for a rod of length `ℓ`. -/
+def toSpace (ℓ : ℝ) (γ : Trajectory) : Time → Space 2 := fun t => (γ t).toSpace ℓ
+
+/-- Along the trajectory described by a lift `θ` of the angle the bob is at
+  `(ℓ sin (θ t 0), -ℓ cos (θ t 0))`. -/
+lemma toSpace_ofLift (ℓ : ℝ) (θ : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    toSpace ℓ (ofLift θ) t = ⟨![ℓ * Real.sin (θ t 0), -ℓ * Real.cos (θ t 0)]⟩ :=
+  ConfigurationSpace.toSpace_ofAngle ℓ (θ t 0)
+
+/-- The rod-length constraint along a trajectory: the bob stays at distance `|ℓ|` from the
+  pivot. -/
+lemma norm_toSpace (ℓ : ℝ) (γ : Trajectory) (t : Time) : ‖toSpace ℓ γ t‖ = |ℓ| :=
+  ConfigurationSpace.toSpace_norm ℓ (γ t)
+
+/-- The physical position of the bob along a continuous trajectory depends continuously on the
+  time. -/
+lemma continuous_toSpace (ℓ : ℝ) {γ : Trajectory} (hγ : Continuous γ) :
+    Continuous (toSpace ℓ γ) :=
+  (ConfigurationSpace.continuous_toSpace ℓ).comp hγ
+
+end Trajectory
+
+end SimplePendulum
+end ClassicalMechanics
+
+end


### PR DESCRIPTION
Toward #883 — closes the tracker's trajectory and Lagrangian requirements: with this PR the parent
pendulum API map has no `N/A` rows left.

Follows #1560–#1564, #1569 and #1570 (all merged); this PR is now based directly on master
(`33d99376`) — its three commits (`b30a3922..d86c888b`) are the whole diff; the last one, `d86c888b`, is the review golfing round.

Two new modules under `SimplePendulum/Geometric/`:

**`Trajectory.lean`** — `Trajectory := Time → ConfigurationSpace`; `Trajectory.ofLift` (the
trajectory described by a lift of the angle) with: invariance under whole-turn shifts
(`ofLift_add_int_mul_two_pi`), `ofLift_eq_iff` (two lifts give the same trajectory iff **at each
time** they differ by whole turns — the quantifiers are `∀ t, ∃ n`; the uniform-`n` version is
false), continuity, and `contMDiff_ofLift` (a `C^n` lift describes a `C^n` curve in the circle —
forward direction only; the converse needs the covering-map lift and is deferred honestly); the
bob's position along a trajectory with the rod-length constraint.

**`PhysicalSpace.lean`** — `spaceTrajectory` (the bob's position for a fixed pendulum), its
velocity `(ℓ cos θ, ℓ sin θ)·θ̇` and speed `ℓ²θ̇²`, and the payoff identities under
`Differentiable ℝ θ`: `kineticEnergy_eq_space` (`½ I θ̇² = ½ m ‖v‖²`), `potentialEnergy_eq_height`
(`V = m g h`, `h` from the bottom of the swing), `lagrangian_eq_space` — **the chart Lagrangian of
#1564 is the constrained Lagrangian of a point mass on the circle of radius ℓ** — and
`energy_eq_space`.

`deriv_sin_coord`/`deriv_cos_coord` are general chain-rule facts kept local to keep this PR to one
file pair; happy to promote them to `Time/Derivatives.lean` in a follow-up if preferred.

**Reviewer reading order:** `Trajectory.lean` §A (check `ofLift_eq_iff`'s quantifiers), §B, §C;
then `PhysicalSpace.lean` §A–B (the global-`Differentiable` hypothesis comes from the `Time.deriv`
API), §C (the four identities); the API maps last — the parent's trajectory and Lagrangian rows
flip to done, the Lagrangian row citing both the definition (`SimplePendulum.lagrangian`,
`Basic.lean`) and the identification proved here.

**Verification:** full `lake build` + complete linter battery pass; axiom audit clean; the two new
modules' imports verified minimal.

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.




