### PR TITLE
feat(Mathematics): Real.completeEllipticK, Legendre's complete elliptic integral of the first kind

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -139,6 +139,7 @@ public import Physlib.Mathematics.RatComplexNum
 public import Physlib.Mathematics.Resolvent
 public import Physlib.Mathematics.SO3.Basic
 public import Physlib.Mathematics.SchurTriangulation
+public import Physlib.Mathematics.SpecialFunctions.EllipticIntegral
 public import Physlib.Mathematics.SpecialFunctions.PhysHermite
 public import Physlib.Mathematics.Trigonometry.Tanh
 public import Physlib.Mathematics.VariationalCalculus.Basic

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -141,6 +141,7 @@ public import Physlib.Mathematics.SO3.Basic
 public import Physlib.Mathematics.SchurTriangulation
 public import Physlib.Mathematics.SpecialFunctions.EllipticIntegral
 public import Physlib.Mathematics.SpecialFunctions.PhysHermite
+public import Physlib.Mathematics.Trigonometry.SinSq
 public import Physlib.Mathematics.Trigonometry.Tanh
 public import Physlib.Mathematics.VariationalCalculus.Basic
 public import Physlib.Mathematics.VariationalCalculus.HasVarAdjDeriv

--- a/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
+++ b/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
@@ -25,6 +25,14 @@ conventions are related by `m = k²`. Mathlib knows the Weierstrass elliptic fun
 complete integral of the first kind and develops its basic theory on the domain `m < 1`, where
 the radicand `1 - m sin² φ` is positive and the integrand continuous.
 
+The integral enters physics wherever a period or a potential is computed exactly rather than in a
+small-parameter expansion. Physlib's use of it so far is the simple pendulum: released from rest
+at amplitude `θ₀`, the pendulum has period `4 √(ℓ / g) K(sin² (θ₀ / 2))` (Landau & Lifshitz §11,
+Problem 1), the consumer being `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.PeriodFormula`.
+More broadly, the complete integrals of the first and second kind give the magnetic field of a
+circular current loop and the potential of a uniformly charged ring, and the second kind, `E`,
+gives the arc length of an ellipse. This file defines `K` so that such results can be stated.
+
 For `m ≥ 1` the definition still elaborates, but its value is not Legendre's. At `m = 1` the
 integrand is `1 / cos φ`, which is not interval integrable on `[0, π/2]`, so the integral is `0`
 by `intervalIntegral.integral_undef`, whereas `K(1) = ∞`. For `m > 1` the radicand is negative on

--- a/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
+++ b/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
@@ -6,7 +6,6 @@ Authors: Aadarsh Agarwal
 module
 
 public import Mathlib.MeasureTheory.Integral.DominatedConvergence
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 /-!
 
 # The complete elliptic integral of the first kind
@@ -27,43 +26,41 @@ complete integral of the first kind and develops its basic theory on the domain 
 the radicand `1 - m sin² φ` is positive and the integrand continuous.
 
 For `m ≥ 1` the definition still elaborates, but its value is not Legendre's. At `m = 1` the
-integrand agrees with `1 / cos φ` on `[0, π/2)`, which is not interval integrable, so the
-integral is `0` by `intervalIntegral.integral_undef`, whereas `K(1) = ∞`. For `m > 1` the
-radicand is negative on `(arcsin (1/√m), π/2]`, where the real power at exponent `-(1/2)` of a
-negative base vanishes (`Real.rpow_def_of_neg` supplies the factor `cos (-(1 / 2) * π) = 0`),
-so the Lean value is the finite positive integral over `[0, arcsin (1/√m)]`; by the
-reciprocal-modulus transformation this is `K(1/m) / √m`, the real part of the complex Legendre
-integral (DLMF §19.7(ii)) — not proved here. Every lemma of this file about a general
-parameter therefore carries its domain hypothesis `m < 1` explicitly.
+integrand is `1 / cos φ`, which is not interval integrable on `[0, π/2]`, so the integral is `0`
+by `intervalIntegral.integral_undef`, whereas `K(1) = ∞`. For `m > 1` the radicand is negative on
+`(arcsin (1/√m), π/2]`, where the real power at exponent `-(1/2)` of a negative base vanishes
+(`Real.rpow_def_of_neg` supplies the factor `cos (-(1 / 2) * π) = 0`), so the Lean value is the
+finite positive integral over `[0, arcsin (1/√m)]`; by the reciprocal-modulus transformation this
+is `K(1/m) / √m`, the real part of the complex Legendre integral (DLMF §19.7(ii)) — not proved
+here. Every lemma of this file about a general parameter therefore carries its domain hypothesis
+`m < 1` explicitly.
 
 ## ii. Key results
 
 - `completeEllipticK` : the complete elliptic integral of the first kind, as a function of
   the parameter `m`.
-- `completeEllipticK_radicand_pos` : for `m < 1` the radicand `1 - m sin² φ` is positive.
-- `completeEllipticK_integrand_continuous` : for `m < 1` the integrand is continuous.
-- `completeEllipticK_integrand_intervalIntegrable` : for `m < 1` the integrand is interval
-  integrable
-  on `[0, π/2]`.
 - `completeEllipticK_zero` : `K 0 = π / 2`.
 - `completeEllipticK_pos` : for `m < 1` the integral is positive.
 - `completeEllipticK_mono` : for `m₁ ≤ m₂ < 1`, `K m₁ ≤ K m₂`.
+- `completeEllipticK_strictMono` : for `m₁ < m₂ < 1`, `K m₁ < K m₂`.
 - `pi_div_two_le_completeEllipticK` : for `0 ≤ m < 1`, `π / 2 ≤ K m`.
-- `completeEllipticK_continuousOn` : `K` is continuous on `(-∞, 1)`.
-- `completeEllipticK_continuousAt_zero` : `K` is continuous at `m = 0`.
+- `completeEllipticK_le` : for `0 ≤ m < 1`, `K m ≤ π / 2 * (1 - m) ^ (-1/2)`.
+- `continuousOn_completeEllipticK` : `K` is continuous on `(-∞, 1)`.
+- `continuousAt_completeEllipticK` : `K` is continuous at every `m < 1`.
 
 ## iii. Table of contents
 
 - A. Definition and the integrand
 - B. Value at zero and positivity
-- C. Monotonicity in the parameter
+- C. Monotonicity and bounds in the parameter
 - D. Continuity on the domain
 
 ## iv. References
 
 - M. Abramowitz, I. A. Stegun, Handbook of Mathematical Functions, §17.3 (the parameter
   convention, 17.3.1).
-- Landau & Lifshitz, Mechanics, 3rd ed., §11 (the pendulum period as `K(k)`, in the modulus
+- NIST DLMF §19.7(ii) (the reciprocal-modulus transformation).
+- Landau & Lifshitz, Mechanics, 3rd ed., §11, Problem 1 (the pendulum period as `K(k)`, modulus
   convention).
 
 -/
@@ -89,8 +86,15 @@ with `m = k²`. The integrand is written as a real power rather than `1 / √(�
 continuity, positivity and monotonicity in `m` come from the `rpow` API (`Continuous.rpow_const`,
 `Real.rpow_pos_of_pos`, `Real.rpow_le_rpow_of_nonpos`); the two forms agree by
 `Real.sqrt_eq_rpow` and `Real.rpow_neg`. For `m ≥ 1` see the module docstring. -/
+@[pp_nodot]
 noncomputable def completeEllipticK (m : ℝ) : ℝ :=
   ∫ φ in (0 : ℝ)..π / 2, (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))
+
+/-- Unfolding lemma: `completeEllipticK m` is the interval integral of its integrand over
+`[0, π/2]`. -/
+lemma completeEllipticK_def (m : ℝ) :
+    completeEllipticK m = ∫ φ in (0 : ℝ)..π / 2, (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ)) :=
+  rfl
 
 /-- For `m < 1` the radicand `1 - m sin² φ` of the integrand of `completeEllipticK m` is
 positive at every angle `φ`. -/
@@ -101,15 +105,15 @@ lemma completeEllipticK_radicand_pos {m : ℝ} (hm : m < 1) (φ : ℝ) :
 
 /-- For `m < 1` the integrand of `completeEllipticK m` is continuous, the real power being
 taken at a positive base. -/
-lemma completeEllipticK_integrand_continuous {m : ℝ} (hm : m < 1) :
+lemma continuous_completeEllipticK_integrand {m : ℝ} (hm : m < 1) :
     Continuous fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ)) := by
   refine Continuous.rpow_const ?_ fun φ => Or.inl (completeEllipticK_radicand_pos hm φ).ne'
   fun_prop
 
 /-- For `m < 1` the integrand of `completeEllipticK m` is interval integrable on `[0, π/2]`. -/
-lemma completeEllipticK_integrand_intervalIntegrable {m : ℝ} (hm : m < 1) :
+lemma intervalIntegrable_completeEllipticK_integrand {m : ℝ} (hm : m < 1) :
     IntervalIntegrable (fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))) volume 0 (π / 2) :=
-  (completeEllipticK_integrand_continuous hm).intervalIntegrable 0 (π / 2)
+  (continuous_completeEllipticK_integrand hm).intervalIntegrable 0 (π / 2)
 
 /-!
 
@@ -128,32 +132,57 @@ lemma completeEllipticK_zero : completeEllipticK 0 = π / 2 := by
 /-- For `m < 1` the complete elliptic integral `completeEllipticK m` is positive. -/
 lemma completeEllipticK_pos {m : ℝ} (hm : m < 1) : 0 < completeEllipticK m := by
   refine intervalIntegral.intervalIntegral_pos_of_pos_on
-    (completeEllipticK_integrand_intervalIntegrable hm) (fun φ _ => ?_) pi_div_two_pos
+    (intervalIntegrable_completeEllipticK_integrand hm) (fun φ _ => ?_) pi_div_two_pos
   exact rpow_pos_of_pos (completeEllipticK_radicand_pos hm φ) _
 
 /-!
 
-## C. Monotonicity in the parameter
+## C. Monotonicity and bounds in the parameter
 
 For fixed `φ` the radicand `1 - m sin² φ` decreases in `m`, so the integrand, a negative power of
 the radicand, increases in `m` on the domain; integrating the pointwise inequality over
-`[0, π/2]` gives monotonicity of `K`. Together with `K 0 = π / 2` this bounds `K` below on
-`[0, 1)`.
+`[0, π/2]` gives monotonicity of `K`, and since the inequality is strict at `φ = π/2` the
+monotonicity is strict. Together with `K 0 = π / 2` this bounds `K` below on `[0, 1)`; bounding
+the radicand below by `1 - m` bounds `K` above by `π / 2 * (1 - m) ^ (-1/2)` there.
 
 -/
 
 /-- `completeEllipticK` is monotone on its domain: for `m₁ ≤ m₂ < 1`, `K m₁ ≤ K m₂`. The
 integrand is pointwise monotone in the parameter, the radicand being positive for both
 parameters. -/
+@[gcongr]
 lemma completeEllipticK_mono {m₁ m₂ : ℝ} (h12 : m₁ ≤ m₂) (h2 : m₂ < 1) :
     completeEllipticK m₁ ≤ completeEllipticK m₂ := by
   have h1 : m₁ < 1 := h12.trans_lt h2
   refine intervalIntegral.integral_mono_on pi_div_two_pos.le
-    (completeEllipticK_integrand_intervalIntegrable h1)
-    (completeEllipticK_integrand_intervalIntegrable h2)
+    (intervalIntegrable_completeEllipticK_integrand h1)
+    (intervalIntegrable_completeEllipticK_integrand h2)
     fun φ _ => ?_
   exact rpow_le_rpow_of_nonpos (completeEllipticK_radicand_pos h2 φ)
     (sub_le_sub_left (mul_le_mul_of_nonneg_right h12 (sq_nonneg _)) 1) (by norm_num)
+
+/-- `completeEllipticK` is monotone on its domain `(-∞, 1)`, as a `MonotoneOn` statement. -/
+lemma monotoneOn_completeEllipticK : MonotoneOn completeEllipticK (Set.Iio 1) :=
+  fun _ _ _ hm₂ h => completeEllipticK_mono h hm₂
+
+/-- `completeEllipticK` is strictly monotone on its domain: for `m₁ < m₂ < 1`, `K m₁ < K m₂`.
+The pointwise inequality between the integrands is strict at `φ = π / 2`, where `sin² φ = 1`. -/
+@[gcongr]
+lemma completeEllipticK_strictMono {m₁ m₂ : ℝ} (h12 : m₁ < m₂) (h2 : m₂ < 1) :
+    completeEllipticK m₁ < completeEllipticK m₂ := by
+  have h1 : m₁ < 1 := h12.trans h2
+  refine intervalIntegral.integral_lt_integral_of_continuousOn_of_le_of_exists_lt pi_div_two_pos
+    (continuous_completeEllipticK_integrand h1).continuousOn
+    (continuous_completeEllipticK_integrand h2).continuousOn
+    (fun φ _ => ?_) ⟨π / 2, Set.right_mem_Icc.2 pi_div_two_pos.le, ?_⟩
+  · exact rpow_le_rpow_of_nonpos (completeEllipticK_radicand_pos h2 φ)
+      (sub_le_sub_left (mul_le_mul_of_nonneg_right h12.le (sq_nonneg _)) 1) (by norm_num)
+  · simp only [sin_pi_div_two, one_pow, mul_one]
+    exact rpow_lt_rpow_of_neg (by linarith) (by linarith) (by norm_num)
+
+/-- `completeEllipticK` is strictly increasing on `(-∞, 1)`, as a bundled `StrictMonoOn`. -/
+lemma strictMonoOn_completeEllipticK : StrictMonoOn completeEllipticK (Set.Iio 1) :=
+  fun _ _ _ hm₂ h => completeEllipticK_strictMono h hm₂
 
 /-- For `0 ≤ m < 1` the complete elliptic integral `completeEllipticK m` is at least its value
 `π / 2` at `m = 0`. -/
@@ -161,6 +190,21 @@ lemma pi_div_two_le_completeEllipticK {m : ℝ} (hm0 : 0 ≤ m) (hm1 : m < 1) :
     π / 2 ≤ completeEllipticK m := by
   rw [← completeEllipticK_zero]
   exact completeEllipticK_mono hm0 hm1
+
+/-- For `0 ≤ m < 1` the complete elliptic integral `completeEllipticK m` is at most
+`π / 2 * (1 - m) ^ (-1/2)`: the radicand is at least `1 - m`, `sin² φ` being at most `1`, so the
+integrand is at most the constant `(1 - m) ^ (-1/2)`. With `pi_div_two_le_completeEllipticK` this
+sandwiches `K` on `[0, 1)`; for the pendulum, where `m = sin² (θ₀ / 2)`, it bounds the period by
+`T ≤ 2π √(ℓ / g) / cos (θ₀ / 2)`. -/
+lemma completeEllipticK_le {m : ℝ} (hm0 : 0 ≤ m) (hm1 : m < 1) :
+    completeEllipticK m ≤ π / 2 * (1 - m) ^ (-(1 / 2 : ℝ)) := by
+  have h : completeEllipticK m ≤ ∫ _ in (0 : ℝ)..π / 2, (1 - m) ^ (-(1 / 2 : ℝ)) := by
+    refine intervalIntegral.integral_mono_on pi_div_two_pos.le
+      (intervalIntegrable_completeEllipticK_integrand hm1) intervalIntegrable_const
+      fun φ _ => ?_
+    exact rpow_le_rpow_of_nonpos (by linarith)
+      (sub_le_sub_left (mul_le_of_le_one_right hm0 (sin_sq_le_one φ)) 1) (by norm_num)
+  rwa [intervalIntegral.integral_const, sub_zero, smul_eq_mul] at h
 
 /-!
 
@@ -170,24 +214,30 @@ The integrand is jointly continuous in `(m, φ)` on `(-∞, 1) × ℝ`, where th
 positive, but not on all of `ℝ × ℝ`. Restricting the parameter to the subtype `Set.Iio 1` makes
 the joint continuity global, so Mathlib's continuity of a parametric interval integral with
 fixed endpoints (`intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'`)
-applies and gives continuity of `K` on the domain. Continuity at `0` follows, `(-∞, 1)` being a
-neighbourhood of `0`.
+applies and gives continuity of `K` on the domain. Continuity at each point `m < 1` follows,
+`(-∞, 1)` being a neighbourhood of `m`.
 
 -/
 
 /-- `completeEllipticK` is continuous on its domain `(-∞, 1)`. -/
-lemma completeEllipticK_continuousOn : ContinuousOn completeEllipticK (Set.Iio 1) := by
+lemma continuousOn_completeEllipticK : ContinuousOn completeEllipticK (Set.Iio 1) := by
   rw [continuousOn_iff_continuous_domRestrict]
   have hf : Continuous fun p : Set.Iio (1 : ℝ) × ℝ =>
       (1 - p.1.1 * sin p.2 ^ 2) ^ (-(1 / 2 : ℝ)) := by
     refine Continuous.rpow_const ?_ fun p => Or.inl (completeEllipticK_radicand_pos p.1.2 p.2).ne'
     fun_prop
   exact intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+    -- `f` must be named: higher-order unification cannot recover it from `Continuous f.uncurry`.
     (f := fun (m : Set.Iio (1 : ℝ)) (φ : ℝ) => (1 - m.1 * sin φ ^ 2) ^ (-(1 / 2 : ℝ)))
     hf 0 (π / 2)
 
+/-- `completeEllipticK` is continuous at every point `m < 1` of its domain, `(-∞, 1)` being a
+neighbourhood of `m`. -/
+lemma continuousAt_completeEllipticK {m : ℝ} (hm : m < 1) : ContinuousAt completeEllipticK m :=
+  continuousOn_completeEllipticK.continuousAt (Iio_mem_nhds hm)
+
 /-- `completeEllipticK` is continuous at `m = 0`, an interior point of its domain `(-∞, 1)`. -/
-lemma completeEllipticK_continuousAt_zero : ContinuousAt completeEllipticK 0 :=
-  completeEllipticK_continuousOn.continuousAt (Iio_mem_nhds zero_lt_one)
+lemma continuousAt_completeEllipticK_zero : ContinuousAt completeEllipticK 0 :=
+  continuousAt_completeEllipticK zero_lt_one
 
 end Real

--- a/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
+++ b/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+/-!
+
+# The complete elliptic integral of the first kind
+
+This file may eventually be upstreamed to Mathlib.
+
+## i. Overview
+
+Legendre's complete elliptic integral of the first kind is, in the parameter convention,
+
+`K(m) = ∫ φ in 0..π/2, (1 - m sin² φ) ^ (-1/2)`
+
+(Abramowitz & Stegun 17.3.1). The physics literature more often uses the modulus convention and
+writes `K(k)`, as Landau & Lifshitz do, for what is here `completeEllipticK (k ^ 2)`; the two
+conventions are related by `m = k²`. Mathlib knows the Weierstrass elliptic function `℘`
+(`PeriodPair.weierstrassP`) but has no Legendre-form elliptic integrals; this file defines the
+complete integral of the first kind and develops its basic theory on the domain `m < 1`, where
+the radicand `1 - m sin² φ` is positive and the integrand continuous.
+
+For `m ≥ 1` the definition still elaborates, but its value is a junk value. At `m = 1` the
+integrand agrees with `1 / cos φ` on `[0, π/2)`, which is not interval integrable, so the
+integral is `0` by `intervalIntegral.integral_undef`. For `m > 1` the radicand becomes negative
+near `φ = π/2`, where the real power at exponent `-(1/2)` of a negative base vanishes
+(`Real.rpow_def_of_neg` supplies the factor `cos (-(π / 2)) = 0`), so the value is a finite
+number unrelated to Legendre's divergent integral. Every lemma of this file therefore carries
+its domain hypothesis `m < 1` explicitly.
+
+## ii. Key results
+
+- `completeEllipticK` : the complete elliptic integral of the first kind, as a function of
+  the parameter `m`.
+- `completeEllipticK_integrand_pos` : for `m < 1` the radicand `1 - m sin² φ` is positive.
+- `continuous_completeEllipticK_integrand` : for `m < 1` the integrand is continuous.
+- `completeEllipticK_intervalIntegrable` : for `m < 1` the integrand is interval integrable
+  on `[0, π/2]`.
+- `completeEllipticK_zero` : `K 0 = π / 2`.
+- `completeEllipticK_pos` : for `m < 1` the integral is positive.
+
+## iii. Table of contents
+
+- A. Definition and the integrand
+- B. Value at zero and positivity
+
+## iv. References
+
+- M. Abramowitz, I. A. Stegun, Handbook of Mathematical Functions, §17.3 (the parameter
+  convention, 17.3.1).
+- Landau & Lifshitz, Mechanics, 3rd ed., §11 (the pendulum period as `K(k)`, in the modulus
+  convention).
+
+-/
+
+@[expose] public section
+
+open MeasureTheory
+
+namespace Real
+
+/-!
+
+## A. Definition and the integrand
+
+The integral is defined for every real parameter `m`; on the domain `m < 1` the radicand is
+positive, so the integrand is continuous and interval integrable.
+
+-/
+
+/-- The complete elliptic integral of the first kind in the parameter convention,
+`K(m) = ∫ φ in 0..π/2, (1 - m sin² φ) ^ (-1/2)`. The physics literature often writes `K(k)`
+with `m = k²`. For `m ≥ 1` the value is a junk value: see the module docstring. -/
+noncomputable def completeEllipticK (m : ℝ) : ℝ :=
+  ∫ φ in (0 : ℝ)..π / 2, (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))
+
+/-- For `m < 1` the radicand `1 - m sin² φ` of the integrand of `completeEllipticK m` is
+positive at every angle `φ`. -/
+lemma completeEllipticK_integrand_pos {m : ℝ} (hm : m < 1) (φ : ℝ) :
+    0 < 1 - m * sin φ ^ 2 := by
+  have hs0 : (0 : ℝ) ≤ sin φ ^ 2 := sq_nonneg _
+  have hs1 : sin φ ^ 2 ≤ 1 := sin_sq_le_one φ
+  rcases le_or_gt m 0 with hm0 | hm0
+  · nlinarith
+  · nlinarith
+
+/-- For `m < 1` the integrand of `completeEllipticK m` is continuous, the real power being
+taken at a positive base. -/
+lemma continuous_completeEllipticK_integrand {m : ℝ} (hm : m < 1) :
+    Continuous fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ)) := by
+  refine Continuous.rpow_const ?_ fun φ => Or.inl (completeEllipticK_integrand_pos hm φ).ne'
+  fun_prop
+
+/-- For `m < 1` the integrand of `completeEllipticK m` is interval integrable on `[0, π/2]`. -/
+lemma completeEllipticK_intervalIntegrable {m : ℝ} (hm : m < 1) :
+    IntervalIntegrable (fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))) volume 0 (π / 2) :=
+  (continuous_completeEllipticK_integrand hm).intervalIntegrable 0 (π / 2)
+
+/-!
+
+## B. Value at zero and positivity
+
+At `m = 0` the integrand is the constant `1` and the integral is elementary; for `m < 1` the
+integral is positive, being the integral of a positive continuous function.
+
+-/
+
+/-- `K 0 = π / 2`: at parameter zero the integrand of `completeEllipticK` is the constant `1`. -/
+@[simp]
+lemma completeEllipticK_zero : completeEllipticK 0 = π / 2 := by
+  simp [completeEllipticK]
+
+/-- For `m < 1` the complete elliptic integral `completeEllipticK m` is positive. -/
+lemma completeEllipticK_pos {m : ℝ} (hm : m < 1) : 0 < completeEllipticK m := by
+  refine intervalIntegral.intervalIntegral_pos_of_pos_on
+    (completeEllipticK_intervalIntegrable hm) (fun φ _ => ?_) pi_div_two_pos
+  exact rpow_pos_of_pos (completeEllipticK_integrand_pos hm φ) _
+
+end Real

--- a/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
+++ b/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
@@ -5,7 +5,7 @@ Authors: Aadarsh Agarwal
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 /-!
 
@@ -26,21 +26,24 @@ conventions are related by `m = k²`. Mathlib knows the Weierstrass elliptic fun
 complete integral of the first kind and develops its basic theory on the domain `m < 1`, where
 the radicand `1 - m sin² φ` is positive and the integrand continuous.
 
-For `m ≥ 1` the definition still elaborates, but its value is a junk value. At `m = 1` the
+For `m ≥ 1` the definition still elaborates, but its value is not Legendre's. At `m = 1` the
 integrand agrees with `1 / cos φ` on `[0, π/2)`, which is not interval integrable, so the
-integral is `0` by `intervalIntegral.integral_undef`. For `m > 1` the radicand becomes negative
-near `φ = π/2`, where the real power at exponent `-(1/2)` of a negative base vanishes
-(`Real.rpow_def_of_neg` supplies the factor `cos (-(π / 2)) = 0`), so the value is a finite
-number unrelated to Legendre's divergent integral. Every lemma of this file therefore carries
-its domain hypothesis `m < 1` explicitly.
+integral is `0` by `intervalIntegral.integral_undef`, whereas `K(1) = ∞`. For `m > 1` the
+radicand is negative on `(arcsin (1/√m), π/2]`, where the real power at exponent `-(1/2)` of a
+negative base vanishes (`Real.rpow_def_of_neg` supplies the factor `cos (-(1 / 2) * π) = 0`),
+so the Lean value is the finite positive integral over `[0, arcsin (1/√m)]`; by the
+reciprocal-modulus transformation this is `K(1/m) / √m`, the real part of the complex Legendre
+integral (DLMF §19.7(ii)) — not proved here. Every lemma of this file about a general
+parameter therefore carries its domain hypothesis `m < 1` explicitly.
 
 ## ii. Key results
 
 - `completeEllipticK` : the complete elliptic integral of the first kind, as a function of
   the parameter `m`.
-- `completeEllipticK_integrand_pos` : for `m < 1` the radicand `1 - m sin² φ` is positive.
-- `continuous_completeEllipticK_integrand` : for `m < 1` the integrand is continuous.
-- `completeEllipticK_intervalIntegrable` : for `m < 1` the integrand is interval integrable
+- `completeEllipticK_radicand_pos` : for `m < 1` the radicand `1 - m sin² φ` is positive.
+- `completeEllipticK_integrand_continuous` : for `m < 1` the integrand is continuous.
+- `completeEllipticK_integrand_intervalIntegrable` : for `m < 1` the integrand is interval
+  integrable
   on `[0, π/2]`.
 - `completeEllipticK_zero` : `K 0 = π / 2`.
 - `completeEllipticK_pos` : for `m < 1` the integral is positive.
@@ -82,31 +85,31 @@ positive, so the integrand is continuous and interval integrable.
 
 /-- The complete elliptic integral of the first kind in the parameter convention,
 `K(m) = ∫ φ in 0..π/2, (1 - m sin² φ) ^ (-1/2)`. The physics literature often writes `K(k)`
-with `m = k²`. For `m ≥ 1` the value is a junk value: see the module docstring. -/
+with `m = k²`. The integrand is written as a real power rather than `1 / √(…)` so that
+continuity, positivity and monotonicity in `m` come from the `rpow` API (`Continuous.rpow_const`,
+`Real.rpow_pos_of_pos`, `Real.rpow_le_rpow_of_nonpos`); the two forms agree by
+`Real.sqrt_eq_rpow` and `Real.rpow_neg`. For `m ≥ 1` see the module docstring. -/
 noncomputable def completeEllipticK (m : ℝ) : ℝ :=
   ∫ φ in (0 : ℝ)..π / 2, (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))
 
 /-- For `m < 1` the radicand `1 - m sin² φ` of the integrand of `completeEllipticK m` is
 positive at every angle `φ`. -/
-lemma completeEllipticK_integrand_pos {m : ℝ} (hm : m < 1) (φ : ℝ) :
+lemma completeEllipticK_radicand_pos {m : ℝ} (hm : m < 1) (φ : ℝ) :
     0 < 1 - m * sin φ ^ 2 := by
-  have hs0 : (0 : ℝ) ≤ sin φ ^ 2 := sq_nonneg _
-  have hs1 : sin φ ^ 2 ≤ 1 := sin_sq_le_one φ
-  rcases le_or_gt m 0 with hm0 | hm0
-  · nlinarith
-  · nlinarith
+  nlinarith [sq_nonneg (sin φ), sin_sq_le_one φ,
+    mul_nonneg (sub_nonneg.2 hm.le) (sq_nonneg (sin φ))]
 
 /-- For `m < 1` the integrand of `completeEllipticK m` is continuous, the real power being
 taken at a positive base. -/
-lemma continuous_completeEllipticK_integrand {m : ℝ} (hm : m < 1) :
+lemma completeEllipticK_integrand_continuous {m : ℝ} (hm : m < 1) :
     Continuous fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ)) := by
-  refine Continuous.rpow_const ?_ fun φ => Or.inl (completeEllipticK_integrand_pos hm φ).ne'
+  refine Continuous.rpow_const ?_ fun φ => Or.inl (completeEllipticK_radicand_pos hm φ).ne'
   fun_prop
 
 /-- For `m < 1` the integrand of `completeEllipticK m` is interval integrable on `[0, π/2]`. -/
-lemma completeEllipticK_intervalIntegrable {m : ℝ} (hm : m < 1) :
+lemma completeEllipticK_integrand_intervalIntegrable {m : ℝ} (hm : m < 1) :
     IntervalIntegrable (fun φ : ℝ => (1 - m * sin φ ^ 2) ^ (-(1 / 2 : ℝ))) volume 0 (π / 2) :=
-  (continuous_completeEllipticK_integrand hm).intervalIntegrable 0 (π / 2)
+  (completeEllipticK_integrand_continuous hm).intervalIntegrable 0 (π / 2)
 
 /-!
 
@@ -125,8 +128,8 @@ lemma completeEllipticK_zero : completeEllipticK 0 = π / 2 := by
 /-- For `m < 1` the complete elliptic integral `completeEllipticK m` is positive. -/
 lemma completeEllipticK_pos {m : ℝ} (hm : m < 1) : 0 < completeEllipticK m := by
   refine intervalIntegral.intervalIntegral_pos_of_pos_on
-    (completeEllipticK_intervalIntegrable hm) (fun φ _ => ?_) pi_div_two_pos
-  exact rpow_pos_of_pos (completeEllipticK_integrand_pos hm φ) _
+    (completeEllipticK_integrand_intervalIntegrable hm) (fun φ _ => ?_) pi_div_two_pos
+  exact rpow_pos_of_pos (completeEllipticK_radicand_pos hm φ) _
 
 /-!
 
@@ -146,9 +149,10 @@ lemma completeEllipticK_mono {m₁ m₂ : ℝ} (h12 : m₁ ≤ m₂) (h2 : m₂ 
     completeEllipticK m₁ ≤ completeEllipticK m₂ := by
   have h1 : m₁ < 1 := h12.trans_lt h2
   refine intervalIntegral.integral_mono_on pi_div_two_pos.le
-    (completeEllipticK_intervalIntegrable h1) (completeEllipticK_intervalIntegrable h2)
+    (completeEllipticK_integrand_intervalIntegrable h1)
+    (completeEllipticK_integrand_intervalIntegrable h2)
     fun φ _ => ?_
-  exact rpow_le_rpow_of_nonpos (completeEllipticK_integrand_pos h2 φ)
+  exact rpow_le_rpow_of_nonpos (completeEllipticK_radicand_pos h2 φ)
     (sub_le_sub_left (mul_le_mul_of_nonneg_right h12 (sq_nonneg _)) 1) (by norm_num)
 
 /-- For `0 ≤ m < 1` the complete elliptic integral `completeEllipticK m` is at least its value
@@ -176,7 +180,7 @@ lemma completeEllipticK_continuousOn : ContinuousOn completeEllipticK (Set.Iio 1
   rw [continuousOn_iff_continuous_domRestrict]
   have hf : Continuous fun p : Set.Iio (1 : ℝ) × ℝ =>
       (1 - p.1.1 * sin p.2 ^ 2) ^ (-(1 / 2 : ℝ)) := by
-    refine Continuous.rpow_const ?_ fun p => Or.inl (completeEllipticK_integrand_pos p.1.2 p.2).ne'
+    refine Continuous.rpow_const ?_ fun p => Or.inl (completeEllipticK_radicand_pos p.1.2 p.2).ne'
     fun_prop
   exact intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
     (f := fun (m : Set.Iio (1 : ℝ)) (φ : ℝ) => (1 - m.1 * sin φ ^ 2) ^ (-(1 / 2 : ℝ)))

--- a/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
+++ b/Physlib/Mathematics/SpecialFunctions/EllipticIntegral.lean
@@ -44,11 +44,17 @@ its domain hypothesis `m < 1` explicitly.
   on `[0, π/2]`.
 - `completeEllipticK_zero` : `K 0 = π / 2`.
 - `completeEllipticK_pos` : for `m < 1` the integral is positive.
+- `completeEllipticK_mono` : for `m₁ ≤ m₂ < 1`, `K m₁ ≤ K m₂`.
+- `pi_div_two_le_completeEllipticK` : for `0 ≤ m < 1`, `π / 2 ≤ K m`.
+- `completeEllipticK_continuousOn` : `K` is continuous on `(-∞, 1)`.
+- `completeEllipticK_continuousAt_zero` : `K` is continuous at `m = 0`.
 
 ## iii. Table of contents
 
 - A. Definition and the integrand
 - B. Value at zero and positivity
+- C. Monotonicity in the parameter
+- D. Continuity on the domain
 
 ## iv. References
 
@@ -121,5 +127,63 @@ lemma completeEllipticK_pos {m : ℝ} (hm : m < 1) : 0 < completeEllipticK m := 
   refine intervalIntegral.intervalIntegral_pos_of_pos_on
     (completeEllipticK_intervalIntegrable hm) (fun φ _ => ?_) pi_div_two_pos
   exact rpow_pos_of_pos (completeEllipticK_integrand_pos hm φ) _
+
+/-!
+
+## C. Monotonicity in the parameter
+
+For fixed `φ` the radicand `1 - m sin² φ` decreases in `m`, so the integrand, a negative power of
+the radicand, increases in `m` on the domain; integrating the pointwise inequality over
+`[0, π/2]` gives monotonicity of `K`. Together with `K 0 = π / 2` this bounds `K` below on
+`[0, 1)`.
+
+-/
+
+/-- `completeEllipticK` is monotone on its domain: for `m₁ ≤ m₂ < 1`, `K m₁ ≤ K m₂`. The
+integrand is pointwise monotone in the parameter, the radicand being positive for both
+parameters. -/
+lemma completeEllipticK_mono {m₁ m₂ : ℝ} (h12 : m₁ ≤ m₂) (h2 : m₂ < 1) :
+    completeEllipticK m₁ ≤ completeEllipticK m₂ := by
+  have h1 : m₁ < 1 := h12.trans_lt h2
+  refine intervalIntegral.integral_mono_on pi_div_two_pos.le
+    (completeEllipticK_intervalIntegrable h1) (completeEllipticK_intervalIntegrable h2)
+    fun φ _ => ?_
+  exact rpow_le_rpow_of_nonpos (completeEllipticK_integrand_pos h2 φ)
+    (sub_le_sub_left (mul_le_mul_of_nonneg_right h12 (sq_nonneg _)) 1) (by norm_num)
+
+/-- For `0 ≤ m < 1` the complete elliptic integral `completeEllipticK m` is at least its value
+`π / 2` at `m = 0`. -/
+lemma pi_div_two_le_completeEllipticK {m : ℝ} (hm0 : 0 ≤ m) (hm1 : m < 1) :
+    π / 2 ≤ completeEllipticK m := by
+  rw [← completeEllipticK_zero]
+  exact completeEllipticK_mono hm0 hm1
+
+/-!
+
+## D. Continuity on the domain
+
+The integrand is jointly continuous in `(m, φ)` on `(-∞, 1) × ℝ`, where the radicand is
+positive, but not on all of `ℝ × ℝ`. Restricting the parameter to the subtype `Set.Iio 1` makes
+the joint continuity global, so Mathlib's continuity of a parametric interval integral with
+fixed endpoints (`intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'`)
+applies and gives continuity of `K` on the domain. Continuity at `0` follows, `(-∞, 1)` being a
+neighbourhood of `0`.
+
+-/
+
+/-- `completeEllipticK` is continuous on its domain `(-∞, 1)`. -/
+lemma completeEllipticK_continuousOn : ContinuousOn completeEllipticK (Set.Iio 1) := by
+  rw [continuousOn_iff_continuous_domRestrict]
+  have hf : Continuous fun p : Set.Iio (1 : ℝ) × ℝ =>
+      (1 - p.1.1 * sin p.2 ^ 2) ^ (-(1 / 2 : ℝ)) := by
+    refine Continuous.rpow_const ?_ fun p => Or.inl (completeEllipticK_integrand_pos p.1.2 p.2).ne'
+    fun_prop
+  exact intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+    (f := fun (m : Set.Iio (1 : ℝ)) (φ : ℝ) => (1 - m.1 * sin φ ^ 2) ^ (-(1 / 2 : ℝ)))
+    hf 0 (π / 2)
+
+/-- `completeEllipticK` is continuous at `m = 0`, an interior point of its domain `(-∞, 1)`. -/
+lemma completeEllipticK_continuousAt_zero : ContinuousAt completeEllipticK 0 :=
+  completeEllipticK_continuousOn.continuousAt (Iio_mem_nhds zero_lt_one)
 
 end Real

--- a/Physlib/Mathematics/Trigonometry/SinSq.lean
+++ b/Physlib/Mathematics/Trigonometry/SinSq.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 Aadarsh Agarwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aadarsh Agarwal
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+/-!
+
+# Strict bounds on the square of the sine
+
+This file may eventually be upstreamed to Mathlib.
+
+## i. Overview
+
+Mathlib bounds the square of the sine by `sin x ^ 2 ≤ 1` for every real `x` (`Real.sin_sq_le_one`),
+with equality exactly at the odd multiples of `π / 2`. This file records the strict form of that
+bound, `sin x ^ 2 < 1` on the open interval `|x| < π / 2`, where the cosine is positive and
+`1 - sin² x = cos² x`, together with its half-angle form `sin (θ / 2) ^ 2 < 1` for `|θ| < π`.
+
+Physlib uses the half-angle form for the simple pendulum: the parameter `sin² (θ₀ / 2)` of the
+period formula lies in the domain `m < 1` of the complete elliptic integral `Real.completeEllipticK`
+for every libration amplitude `|θ₀| < π`.
+
+## ii. Key results
+
+- `Real.sin_sq_lt_one` : `sin x ^ 2 < 1` for `|x| < π / 2`.
+- `Real.sin_half_sq_lt_one` : `sin (θ / 2) ^ 2 < 1` for `|θ| < π`.
+
+## iii. Table of contents
+
+- A. Strict bounds on the square of the sine
+
+## iv. References
+
+- Landau & Lifshitz, Mechanics, 3rd ed., §11, Problem 1 (the pendulum period, whose parameter is
+  `sin² (θ₀ / 2)`).
+
+-/
+
+@[expose] public section
+
+namespace Real
+
+/-!
+
+## A. Strict bounds on the square of the sine
+
+On `|x| < π / 2` the cosine is positive, so `1 - sin² x = cos² x` is positive; the half-angle form
+follows by applying this at `x = θ / 2`.
+
+-/
+
+/-- `sin x ^ 2 < 1` for `|x| < π / 2`: the cosine is positive there, and `1 - sin² x = cos² x`. -/
+lemma sin_sq_lt_one {x : ℝ} (h : |x| < π / 2) : sin x ^ 2 < 1 := by
+  obtain ⟨h₁, h₂⟩ := abs_lt.1 h
+  rw [← sub_pos, ← cos_sq']
+  exact pow_pos (cos_pos_of_mem_Ioo ⟨by linarith, h₂⟩) 2
+
+/-- The half-angle form of `sin_sq_lt_one`: `sin (θ / 2) ^ 2 < 1` for `|θ| < π`. For the pendulum
+this says that the parameter `sin² (θ₀ / 2)` of the period formula lies in the domain of
+`completeEllipticK` for every libration amplitude `|θ₀| < π`. -/
+lemma sin_half_sq_lt_one {θ : ℝ} (h : |θ| < π) : sin (θ / 2) ^ 2 < 1 := by
+  refine sin_sq_lt_one ?_
+  rw [abs_div, abs_two]
+  linarith [abs_nonneg θ]
+
+end Real


### PR DESCRIPTION
Toward #883, but **standalone**: this PR is based on `master`, depends on nothing in the pendulum
stack, and nothing in the stack is needed to review it. It is pure mathematics written to Mathlib
standards — the file header says "This file may eventually be upstreamed to Mathlib", following
`Physlib/Mathematics/SpecialFunctions/PhysHermite.lean`.

**Why here.** Mathlib has the Weierstrass `℘` (`PeriodPair.weierstrassP`) but no Legendre-form
elliptic integrals. The exact period of a simple pendulum is `4√(ℓ/g)·K(sin²(θ₀/2))`, so Physlib
needs `K` before it can state that; `Physlib/Mathematics/` is where such prerequisites live.

**Convention.** The *parameter* convention `K(m) = ∫₀^{π/2} (1 − m sin²φ)^(−1/2) dφ`
(Abramowitz & Stegun 17.3.1), not the modulus convention `K(k)` of Landau & Lifshitz; `m = k²`, and
the module doc says so.

**Domain.** Everything is stated on `m < 1`, where the radicand is positive. The module doc is
explicit that `m ≥ 1` gives a junk value and says exactly which: at `m = 1` the integrand is
`1/cos φ`, not interval integrable, so `intervalIntegral.integral_undef` returns `0` (whereas
`K(1) = ∞`); for `m > 1` the radicand goes negative past `arcsin(1/√m)`, where
`Real.rpow_def_of_neg` contributes the factor `cos(−(1/2)·π) = 0`, leaving the finite integral over
`[0, arcsin(1/√m)]` — which is `K(1/m)/√m`, the real part of the continued Legendre integral
(DLMF §19.7(ii)). Every lemma about a general parameter therefore carries `m < 1` explicitly.

| Declaration | Statement |
|---|---|
| `Real.completeEllipticK` | `def : ℝ → ℝ` (`@[pp_nodot]`), `∫ φ in 0..π/2, (1 − m sin² φ)^(−1/2)` |
| `completeEllipticK_def` | the unfolding lemma (`rfl`) |
| `completeEllipticK_radicand_pos` | `m < 1 → ∀ φ, 0 < 1 − m sin² φ` |
| `continuous_completeEllipticK_integrand`, `intervalIntegrable_completeEllipticK_integrand` | `m < 1 →` the integrand is continuous / interval integrable on `[0, π/2]` |
| `completeEllipticK_zero` | `@[simp] K 0 = π/2` |
| `completeEllipticK_pos` | `m < 1 → 0 < K m` |
| `completeEllipticK_mono`, `completeEllipticK_strictMono` (both `@[gcongr]`) | `m₁ ≤ m₂ → m₂ < 1 → K m₁ ≤ K m₂`; strict for `m₁ < m₂` |
| `monotoneOn_completeEllipticK`, `strictMonoOn_completeEllipticK` | `MonotoneOn` / `StrictMonoOn K (Set.Iio 1)` |
| `pi_div_two_le_completeEllipticK`, `completeEllipticK_le` | `0 ≤ m < 1 → π/2 ≤ K m ≤ (π/2)(1 − m)^(−1/2)` |
| `continuousOn_completeEllipticK`, `continuousAt_completeEllipticK`, `_zero` | `ContinuousOn K (Set.Iio 1)`; `m < 1 → ContinuousAt K m`; at `0` |

**Reading order.** Module doc §i (the junk-value paragraph is where the design decision lives) →
§A definition and integrand → §B `K 0 = π/2`, positivity → §C monotonicity and bounds → §D
continuity. §D is the only non-obvious proof: the integrand is not jointly continuous in `(m, φ)`
on `ℝ × ℝ`, so the parameter is restricted to the subtype `Set.Iio 1`, where joint continuity is
global; `intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'` then applies and
`continuousOn_iff_continuous_domRestrict` converts back.

**Verification.** Module builds zero-warning against Mathlib v4.33.0; no `sorry`, no `set_option`,
no linter exemptions; full `lake build` + Physlib linter battery pass; `lint-style` clean, TOC 1:1;
single import (`Mathlib.MeasureTheory.Integral.DominatedConvergence`) — shake-clean; `K` is *strictly*
increasing on `(-∞, 1)` and sandwiched there by `π/2 ≤ K m ≤ (π/2)(1 − m)^(−1/2)` for `0 ≤ m < 1`; no deprecated
names; `Set.Iio 1` is the maximal honest domain (`K` is genuinely discontinuous at `1`).

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.
