### PR TITLE
refactor(Time): general lemmas for the time derivative under reparametrisation and reflection

### DIFF
--- a/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
+++ b/Physlib/ClassicalMechanics/DampedHarmonicOscillator/Solution.lean
@@ -496,21 +496,6 @@ private lemma phaseVectorField_apply (a b : EuclideanSpace ℝ (Fin 1)) :
     S.phaseVectorField (a, b) = (b, (-(S.m⁻¹ * S.k)) • a + (-(S.m⁻¹ * S.γ)) • b) := by
   simp [phaseVectorField]
 
-private lemma toRealCLE_symm_one : Time.toRealCLE.symm (1 : ℝ) = (1 : Time) := by
-  rw [ContinuousLinearEquiv.symm_apply_eq]
-  change (1 : ℝ) = (1 : Time).val
-  rw [Time.one_val]
-
-/-- Bridge from the time derivative to `HasDerivAt` for a curve reparametrised through the
-canonical `ℝ ≃L[ℝ] Time` equivalence. -/
-private lemma hasDerivAt_comp_toRealCLE_symm (w : Time → EuclideanSpace ℝ (Fin 1)) (τ : ℝ)
-    (hw : DifferentiableAt ℝ w (Time.toRealCLE.symm τ)) :
-    HasDerivAt (fun τ : ℝ => w (Time.toRealCLE.symm τ))
-      (∂ₜ w (Time.toRealCLE.symm τ)) τ := by
-  simpa [Function.comp_def, Time.deriv_eq, toRealCLE_symm_one] using
-    hw.hasFDerivAt.comp_hasDerivAt_of_eq τ
-      ((Time.toRealCLE.symm : ℝ →L[ℝ] Time).hasDerivAt) rfl
-
 /-- The phase curve `τ ↦ (z t, ẋ t)` (with `t = toRealCLE.symm τ`) of a smooth solution `z`
 solves the first-order phase-space ODE with vector field `phaseVectorField`. -/
 private lemma phaseCurve_hasDerivAt (z : Time → EuclideanSpace ℝ (Fin 1))
@@ -519,8 +504,8 @@ private lemma phaseCurve_hasDerivAt (z : Time → EuclideanSpace ℝ (Fin 1))
       (S.phaseVectorField (z (Time.toRealCLE.symm τ), ∂ₜ z (Time.toRealCLE.symm τ))) τ := by
   rw [S.phaseVectorField_apply,
     ← S.acceleration_eq_of_equationOfMotion z hEOM (Time.toRealCLE.symm τ)]
-  exact (hasDerivAt_comp_toRealCLE_symm z τ (hz.differentiable (by simp) _)).prodMk
-    (hasDerivAt_comp_toRealCLE_symm (∂ₜ z) τ (deriv_differentiable_of_contDiff z hz _))
+  exact (Time.hasDerivAt_comp_toRealCLE_symm z τ (hz.differentiable (by simp) _)).prodMk
+    (Time.hasDerivAt_comp_toRealCLE_symm (∂ₜ z) τ (deriv_differentiable_of_contDiff z hz _))
 
 /-- Any two smooth solutions of the damped equation of motion with the same initial position and
 velocity are equal. -/

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -88,9 +88,7 @@ curve pulled back to `Time` through `toRealCLE`.
 
 /-- The canonical equivalence `toRealCLE.symm : ℝ ≃L[ℝ] Time` sends `1 : ℝ` to `1 : Time`. -/
 lemma toRealCLE_symm_one : toRealCLE.symm (1 : ℝ) = (1 : Time) := by
-  rw [ContinuousLinearEquiv.symm_apply_eq]
-  change (1 : ℝ) = (1 : Time).val
-  rw [Time.one_val]
+  simp [toRealCLE]
 
 /-- Bridge from the time derivative to `HasDerivAt`: if `w : Time → M` is differentiable at
 `toRealCLE.symm τ`, then the curve `τ ↦ w (toRealCLE.symm τ)` on `ℝ` has derivative
@@ -98,9 +96,8 @@ lemma toRealCLE_symm_one : toRealCLE.symm (1 : ℝ) = (1 : Time) := by
 lemma hasDerivAt_comp_toRealCLE_symm [NormedAddCommGroup M] [NormedSpace ℝ M]
     (w : Time → M) (τ : ℝ) (hw : DifferentiableAt ℝ w (toRealCLE.symm τ)) :
     HasDerivAt (fun τ : ℝ => w (toRealCLE.symm τ)) (∂ₜ w (toRealCLE.symm τ)) τ := by
-  simpa [Function.comp_def, Time.deriv_eq, Time.toRealCLE_symm_one] using
-    hw.hasFDerivAt.comp_hasDerivAt_of_eq τ
-      (toRealCLE.symm : ℝ →L[ℝ] Time).hasFDerivAt.hasDerivAt rfl
+  apply hw.hasFDerivAt.comp_hasDerivAt_of_eq τ _ rfl
+  exact Time.toRealCLE_symm_one ▸ toRealCLE.symm.hasFDerivAt.hasDerivAt
 
 /-- The converse of the bridge `hasDerivAt_comp_toRealCLE_symm`: if the curve `γ : ℝ → M` has
 derivative `v` at `toRealCLE t`, then the curve `t ↦ γ (toRealCLE t)` on `Time` has time
@@ -108,13 +105,10 @@ derivative `v` at `t`. -/
 lemma deriv_comp_toRealCLE_of_hasDerivAt [NormedAddCommGroup M] [NormedSpace ℝ M]
     (γ : ℝ → M) (t : Time) (v : M) (h : HasDerivAt γ v (toRealCLE t)) :
     ∂ₜ (fun s => γ (toRealCLE s)) t = v := by
-  have h' : HasFDerivAt (fun s => γ (toRealCLE s))
-      (((1 : ℝ →L[ℝ] ℝ).smulRight v).comp (toRealCLE : Time →L[ℝ] ℝ)) t :=
-    h.hasFDerivAt.comp t toRealCLE.hasFDerivAt
-  rw [Time.deriv_eq, h'.fderiv]
-  change toRealCLE 1 • v = v
-  change (1 : Time).val • v = v
-  rw [Time.one_val, one_smul]
+  rw [Time.deriv_eq, fderiv_fun_comp _ h.differentiableAt toRealCLE.differentiableAt,
+    toRealCLE.fderiv, ContinuousLinearMap.comp_apply, ContinuousLinearEquiv.coe_coe,
+    fderiv_eq_smul_deriv, h.deriv]
+  exact Eq.trans (by rfl) (Time.one_val ▸ one_smul _ v)
 
 /-!
 
@@ -267,12 +261,7 @@ lemma deriv_contDiff_of_space {n} {M : Type} [NormedAddCommGroup M] [NormedSpace
 lemma deriv_comp_neg {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (f : Time → M) (t : Time) (hf : DifferentiableAt ℝ f (-t)) :
     ∂ₜ (fun s => f (-s)) t = -∂ₜ f (-t) := by
-  have hneg : HasFDerivAt (fun s : Time => -s) (-ContinuousLinearMap.id ℝ Time) t :=
-    (hasFDerivAt_id t).neg
-  have h : HasFDerivAt (fun s => f (-s))
-      ((fderiv ℝ f (-t)).comp (-ContinuousLinearMap.id ℝ Time)) t :=
-    hf.hasFDerivAt.comp t hneg
-  rw [Time.deriv_eq, Time.deriv_eq, h.fderiv]
+  rw [Time.deriv_eq, Time.deriv_eq, fderiv_fun_comp _ hf (by fun_prop), fderiv_fun_neg]
   simp
 
 /-- The second derivative is unchanged by the reversal of time: for a smooth curve `f`, the second
@@ -281,12 +270,10 @@ cancelling. -/
 lemma deriv_deriv_comp_neg {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M]
     (f : Time → M) (hf : ContDiff ℝ ∞ f) (t : Time) :
     ∂ₜ (∂ₜ (fun s => f (-s))) t = ∂ₜ (∂ₜ f) (-t) := by
-  have h1 : ∂ₜ (fun s => f (-s)) = fun s => -∂ₜ f (-s) := by
-    funext s
-    exact deriv_comp_neg f s (hf.differentiable (by simp) _)
-  have h2 : ∂ₜ (fun s => -∂ₜ f (-s)) t = -∂ₜ (fun s => ∂ₜ f (-s)) t :=
-    Time.deriv_neg (fun s => ∂ₜ f (-s))
-  rw [h1, h2, deriv_comp_neg (∂ₜ f) t (deriv_differentiable_of_contDiff f hf _), neg_neg]
+  rw [← neg_neg (∂ₜ (∂ₜ f) (-t)), ← deriv_comp_neg _ _ (by fun_prop), ← Time.deriv_neg]
+  congr
+  ext
+  exact deriv_comp_neg f _ (hf.differentiable (by simp) _)
 
 /-!
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -22,15 +22,22 @@ In this module we define and prove basic lemmas about derivatives of functions o
 
 - `deriv` : The derivative of a function `Time → M` at a given time.
 - `manifoldDeriv` : The derivative of a function from `Time` to a manifold.
+- `hasDerivAt_comp_toRealCLE_symm` : The time derivative as a `HasDerivAt` on `ℝ`, for a curve
+  reparametrised through the canonical equivalence `toRealCLE.symm : ℝ ≃L[ℝ] Time`.
+- `deriv_comp_toRealCLE_of_hasDerivAt` : Its converse, a `HasDerivAt` on `ℝ` read as the time
+  derivative of the curve pulled back to `Time` through `toRealCLE`.
+- `deriv_comp_neg` and `deriv_deriv_comp_neg` : The first and second time derivatives under the
+  reversal of time `t ↦ -t`.
 
 ## iii. Table of contents
 
 - A. The definition of the derivative
   - A.1. Derivatives of functions into vector spaces
-  - A.2. Derivatives of functions into manifolds
+  - A.2. The derivative through the canonical equivalence with `ℝ`
+  - A.3. Derivatives of functions into manifolds
 - B. Linearlity properties of the derivative
 - C. Derivative of constant functions
-- D. Smoothness properties
+- D. Smoothness properties and the reversal of time
 - E. Derivatives of components
 
 ## iv. References
@@ -68,7 +75,50 @@ lemma deriv_eq [AddCommGroup M] [Module ℝ M] [TopologicalSpace M]
 
 /-!
 
-### A.2. Derivatives of functions into manifolds
+### A.2. The derivative through the canonical equivalence with `ℝ`
+
+`Time` is identified with `ℝ` by the continuous linear equivalence `toRealCLE`. Precomposing a
+curve `w : Time → M` with `toRealCLE.symm : ℝ ≃L[ℝ] Time` gives a curve on `ℝ`, whose Mathlib
+derivative (`HasDerivAt`) at `τ` is the time derivative `∂ₜ w` evaluated at `toRealCLE.symm τ`.
+This is the bridge through which Mathlib's calculus and ODE theory on `ℝ` applies to curves on
+`Time`. Conversely, a `HasDerivAt` on `ℝ` at `toRealCLE t` is the time derivative at `t` of the
+curve pulled back to `Time` through `toRealCLE`.
+
+-/
+
+/-- The canonical equivalence `toRealCLE.symm : ℝ ≃L[ℝ] Time` sends `1 : ℝ` to `1 : Time`. -/
+lemma toRealCLE_symm_one : toRealCLE.symm (1 : ℝ) = (1 : Time) := by
+  rw [ContinuousLinearEquiv.symm_apply_eq]
+  change (1 : ℝ) = (1 : Time).val
+  rw [Time.one_val]
+
+/-- Bridge from the time derivative to `HasDerivAt`: if `w : Time → M` is differentiable at
+`toRealCLE.symm τ`, then the curve `τ ↦ w (toRealCLE.symm τ)` on `ℝ` has derivative
+`∂ₜ w (toRealCLE.symm τ)` at `τ`. -/
+lemma hasDerivAt_comp_toRealCLE_symm [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (w : Time → M) (τ : ℝ) (hw : DifferentiableAt ℝ w (toRealCLE.symm τ)) :
+    HasDerivAt (fun τ : ℝ => w (toRealCLE.symm τ)) (∂ₜ w (toRealCLE.symm τ)) τ := by
+  simpa [Function.comp_def, Time.deriv_eq, Time.toRealCLE_symm_one] using
+    hw.hasFDerivAt.comp_hasDerivAt_of_eq τ
+      (toRealCLE.symm : ℝ →L[ℝ] Time).hasFDerivAt.hasDerivAt rfl
+
+/-- The converse of the bridge `hasDerivAt_comp_toRealCLE_symm`: if the curve `γ : ℝ → M` has
+derivative `v` at `toRealCLE t`, then the curve `t ↦ γ (toRealCLE t)` on `Time` has time
+derivative `v` at `t`. -/
+lemma deriv_comp_toRealCLE_of_hasDerivAt [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (γ : ℝ → M) (t : Time) (v : M) (h : HasDerivAt γ v (toRealCLE t)) :
+    ∂ₜ (fun s => γ (toRealCLE s)) t = v := by
+  have h' : HasFDerivAt (fun s => γ (toRealCLE s))
+      (((1 : ℝ →L[ℝ] ℝ).smulRight v).comp (toRealCLE : Time →L[ℝ] ℝ)) t :=
+    h.hasFDerivAt.comp t toRealCLE.hasFDerivAt
+  rw [Time.deriv_eq, h'.fderiv]
+  change toRealCLE 1 • v = v
+  change (1 : Time).val • v = v
+  rw [Time.one_val, one_smul]
+
+/-!
+
+### A.3. Derivatives of functions into manifolds
 
 -/
 
@@ -175,7 +225,7 @@ lemma deriv_const [NormedAddCommGroup M] [NormedSpace ℝ M] (m : M) :
 
 /-!
 
-## D. Smoothness properties
+## D. Smoothness properties and the reversal of time
 
 -/
 
@@ -211,6 +261,32 @@ lemma deriv_contDiff_of_space {n} {M : Type} [NormedAddCommGroup M] [NormedSpace
     ContDiff ℝ n fun (x : Space d) => (∂ₜ fun t => f t x) t := by
   unfold deriv
   fun_prop
+
+/-- The chain rule for the time derivative under the reversal of time: the derivative of
+`t ↦ f (-t)` at `t` is minus the derivative of `f` at `-t`. -/
+lemma deriv_comp_neg {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (f : Time → M) (t : Time) (hf : DifferentiableAt ℝ f (-t)) :
+    ∂ₜ (fun s => f (-s)) t = -∂ₜ f (-t) := by
+  have hneg : HasFDerivAt (fun s : Time => -s) (-ContinuousLinearMap.id ℝ Time) t :=
+    (hasFDerivAt_id t).neg
+  have h : HasFDerivAt (fun s => f (-s))
+      ((fderiv ℝ f (-t)).comp (-ContinuousLinearMap.id ℝ Time)) t :=
+    hf.hasFDerivAt.comp t hneg
+  rw [Time.deriv_eq, Time.deriv_eq, h.fderiv]
+  simp
+
+/-- The second derivative is unchanged by the reversal of time: for a smooth curve `f`, the second
+derivative of `t ↦ f (-t)` at `t` is the second derivative of `f` at `-t`, the two changes of sign
+cancelling. -/
+lemma deriv_deriv_comp_neg {M : Type} [NormedAddCommGroup M] [NormedSpace ℝ M]
+    (f : Time → M) (hf : ContDiff ℝ ∞ f) (t : Time) :
+    ∂ₜ (∂ₜ (fun s => f (-s))) t = ∂ₜ (∂ₜ f) (-t) := by
+  have h1 : ∂ₜ (fun s => f (-s)) = fun s => -∂ₜ f (-s) := by
+    funext s
+    exact deriv_comp_neg f s (hf.differentiable (by simp) _)
+  have h2 : ∂ₜ (fun s => -∂ₜ f (-s)) t = -∂ₜ (fun s => ∂ₜ f (-s)) t :=
+    Time.deriv_neg (fun s => ∂ₜ f (-s))
+  rw [h1, h2, deriv_comp_neg (∂ₜ f) t (deriv_differentiable_of_contDiff f hf _), neg_neg]
 
 /-!
 


### PR DESCRIPTION
Toward #883 (infrastructure for the pendulum's existence/uniqueness PR), but a self-contained
refactor: it de-duplicates the damped oscillator and adds general `Time` calculus in the place
AGENTS.md prescribes for it.

#1569 is merged, so this PR is now based directly on master (`33d99376`); its two commits (`7d55784b`, `1dc608c7`) are the whole diff; the second is the review golfing round. Independent of #1570–#1573.

`Physlib/SpaceAndTime/Time/Derivatives.lean` gains a documented subsection of general facts:

| Declaration | Statement |
|---|---|
| `Time.toRealCLE_symm_one` | `toRealCLE.symm (1 : ℝ) = (1 : Time)` |
| `Time.hasDerivAt_comp_toRealCLE_symm` | `τ ↦ w (toRealCLE.symm τ)` has derivative `∂ₜ w (toRealCLE.symm τ)` — generalized from `EuclideanSpace ℝ (Fin 1)` to any real normed space |
| `Time.deriv_comp_toRealCLE_of_hasDerivAt` | the converse bridge: `HasDerivAt γ v (toRealCLE t) → ∂ₜ (γ ∘ toRealCLE) t = v` |
| `Time.deriv_comp_neg` | chain rule under time reversal: `∂ₜ (fun s => f (-s)) t = -∂ₜ f (-t)` |
| `Time.deriv_deriv_comp_neg` | the second derivative is invariant under time reversal |

`DampedHarmonicOscillator/Solution.lean` loses its two private copies and calls the `Time` versions;
no other DHO proof changes. One proof-term change (`.hasFDerivAt.hasDerivAt`) avoids importing
`Deriv.Linear` into the hub file — no imports change anywhere.

**Reviewer reading order:** the new `Time/Derivatives.lean` subsection (five short lemmas), then the
DHO diff (deletions + two call-site renames).

**Verification:** full `lake build` and the complete linter battery pass; every importer of
`Time/Derivatives` rebuilt; `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`.

Developed with assistance from AI; all mathematics and proofs were reviewed and verified to compile.



