### PR TITLE
feat(Units): reducible rational arithmetic via Exponent

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -540,8 +540,8 @@ public import Physlib.Thermodynamics.Temperature.Basic
 public import Physlib.Thermodynamics.Temperature.TemperatureUnits
 public import Physlib.Units.Basic
 public import Physlib.Units.Dimension
-public import Physlib.Units.Exponent
 public import Physlib.Units.Examples
+public import Physlib.Units.Exponent
 public import Physlib.Units.FDeriv
 public import Physlib.Units.ISQBridge
 public import Physlib.Units.ISQDimensionBase

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -540,6 +540,7 @@ public import Physlib.Thermodynamics.Temperature.Basic
 public import Physlib.Thermodynamics.Temperature.TemperatureUnits
 public import Physlib.Units.Basic
 public import Physlib.Units.Dimension
+public import Physlib.Units.Exponent
 public import Physlib.Units.Examples
 public import Physlib.Units.FDeriv
 public import Physlib.Units.ISQBridge

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -108,11 +108,10 @@ noncomputable def dimScale (u1 u2 : LTMCTUnitChoices) :Dimension LTMCTDimensionB
   map_one' := by
     simp
   map_mul' d1 d2 := by
-    simp only [Dimension.length_mul, map_add, Rat.cast_add, Dimension.time_mul,
+    simp only [Dimension.length_mul, Dimension.Exponent.coe_add, Rat.cast_add, Dimension.time_mul,
       Dimension.mass_mul, Dimension.charge_mul, Dimension.temperature_mul]
-    repeat rw [@NNReal.rpow_add]
+    repeat rw [NNReal.rpow_add (by simp)]
     ring
-    all_goals simp
 
 lemma dimScale_apply (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d =

--- a/Physlib/Units/Basic.lean
+++ b/Physlib/Units/Basic.lean
@@ -108,12 +108,11 @@ noncomputable def dimScale (u1 u2 : LTMCTUnitChoices) :Dimension LTMCTDimensionB
   map_one' := by
     simp
   map_mul' d1 d2 := by
-    simp only [Dimension.length_mul, Rat.cast_add, Dimension.time_mul, Dimension.mass_mul,
-      Dimension.charge_mul, Dimension.temperature_mul]
-    repeat rw [rpow_add]
+    simp only [Dimension.length_mul, map_add, Rat.cast_add, Dimension.time_mul,
+      Dimension.mass_mul, Dimension.charge_mul, Dimension.temperature_mul]
+    repeat rw [@NNReal.rpow_add]
     ring
-    all_goals
-      simp
+    all_goals simp
 
 lemma dimScale_apply (u1 u2 : LTMCTUnitChoices) (d : Dimension LTMCTDimensionBase) :
     dimScale u1 u2 d =

--- a/Physlib/Units/Dimension.lean
+++ b/Physlib/Units/Dimension.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Normed.Field.Lemmas
 public import Mathlib.Tactic.DeriveFintype
+public import Physlib.Units.Exponent
 /-!
 
 # Dimension
@@ -14,8 +15,8 @@ public import Mathlib.Tactic.DeriveFintype
 In this module we define the type `Dimension` which carries the dimension
 of a physical quantity.
 
-A `Dimension B` is parameterised by a *basis* `B` of base dimensions: it assigns a
-rational `exponent` to each base dimension `b : B`. The parameterisation is purely in
+A `Dimension B` is parameterised by a *basis* `B` of base dimensions: it assigns an
+`Exponent` to each base dimension `b : B`. The parameterisation is purely in
 the dimensional *algebra*: `Dimension B` is a `CommGroup` for every `B`
 (multiplication adds exponents, inversion negates them), so quantities can be typed by
 dimensions over any basis. The commutative-group and `ℚ`-power structure, decidable
@@ -41,11 +42,11 @@ open NNReal
 
 -/
 
-/-- A dimension over a basis `B` of base dimensions: a rational `exponent` for each
+/-- A dimension over a basis `B` of base dimensions: an `Exponent` for each
   base dimension `b : B`. PhysLib's default basis is `LTMCTDimensionBase`. -/
 structure Dimension (B : Type) where
   /-- The exponent of each base dimension. -/
-  exponent : B → ℚ
+  exponent : B → Dimension.Exponent
 
 namespace Dimension
 
@@ -106,11 +107,11 @@ lemma npow_exponent (d : Dimension B) (n : ℕ) (b : B) :
   | succ n ih => rw [pow_succ, mul_exponent, ih, succ_nsmul]
 
 instance : Pow (Dimension B) ℚ where
-  pow d q := ⟨fun b => d.exponent b * q⟩
+  pow d q := ⟨fun b => d.exponent b * Exponent.ofRat q⟩
 
 @[simp]
 lemma qpow_exponent (d : Dimension B) (q : ℚ) (b : B) :
-    (d ^ q).exponent b = d.exponent b * q := rfl
+    (d ^ q).exponent b = d.exponent b * Exponent.ofRat q := rfl
 
 /-- Decidable equality of dimensions over a finite basis `B`. -/
 instance [Fintype B] : DecidableEq (Dimension B) := fun d1 d2 =>

--- a/Physlib/Units/Dimension.lean
+++ b/Physlib/Units/Dimension.lean
@@ -15,9 +15,10 @@ public import Physlib.Units.Exponent
 In this module we define the type `Dimension` which carries the dimension
 of a physical quantity.
 
-A `Dimension B` is parameterised by a *basis* `B` of base dimensions: it assigns an
-`Exponent` to each base dimension `b : B`. The parameterisation is purely in
-the dimensional *algebra*: `Dimension B` is a `CommGroup` for every `B`
+A `Dimension B` is parameterised by a *basis* `B` of base dimensions equipped with a
+`DimensionBasis` representation. Each representation is additively equivalent to assigning an
+`Exponent` to every base dimension `b : B`. The parameterisation is purely in
+the dimensional *algebra*: `Dimension B` is a `CommGroup` for every represented basis `B`
 (multiplication adds exponents, inversion negates them), so quantities can be typed by
 dimensions over any basis. The commutative-group and `ℚ`-power structure, decidable
 equality (`DecidableEq`), the base vectors `single b`, and the change-of-basis map
@@ -42,36 +43,73 @@ open NNReal
 
 -/
 
-/-- A dimension over a basis `B` of base dimensions: an `Exponent` for each
-  base dimension `b : B`. PhysLib's default basis is `LTMCTDimensionBase`. -/
-structure Dimension (B : Type) where
-  /-- The exponent of each base dimension. -/
-  exponent : B → Dimension.Exponent
+/-- A choice of exponent-tuple representation for a basis `B`. Native addition on `Exponents`
+is used for dimension multiplication, while `exponentEquiv` provides the basis-generic API. -/
+class DimensionBasis (B : Type) where
+  /-- The native tuple of exponents for this basis. -/
+  Exponents : Type
+  /-- The additive structure on native exponent tuples. -/
+  [addCommGroup : AddCommGroup Exponents]
+  /-- Native exponent tuples are additively equivalent to exponent functions on the basis. -/
+  exponentEquiv : Exponents ≃+ (B → Dimension.Exponent)
+
+attribute [instance_reducible, instance] DimensionBasis.addCommGroup
+
+namespace DimensionBasis
+
+/-- The function-backed exponent representation for a basis without a specialized tuple. -/
+@[instance_reducible] def pi (B : Type) : DimensionBasis B where
+  Exponents := B → Dimension.Exponent
+  addCommGroup := inferInstance
+  exponentEquiv := AddEquiv.refl _
+
+end DimensionBasis
+
+/-- A dimension over a represented basis `B`. PhysLib's default basis is
+`LTMCTDimensionBase`. -/
+structure Dimension (B : Type) [DimensionBasis B] where
+  /-- The dimension's native exponent tuple. -/
+  exponents : DimensionBasis.Exponents B
 
 namespace Dimension
 
-variable {B : Type}
+variable {B : Type} [DimensionBasis B]
+
+/-- The exponent of a dimension at a base dimension. -/
+def exponent (d : Dimension B) : B → Exponent :=
+  DimensionBasis.exponentEquiv d.exponents
+
+/-- Construct a dimension from an exponent function. -/
+def ofFunction (f : B → Exponent) : Dimension B :=
+  ⟨DimensionBasis.exponentEquiv.symm f⟩
+
+@[simp]
+lemma ofFunction_exponent (f : B → Exponent) (b : B) : (ofFunction f).exponent b = f b := by
+  simp [ofFunction, exponent]
 
 @[ext]
 lemma ext {d1 d2 : Dimension B} (h : ∀ b, d1.exponent b = d2.exponent b) : d1 = d2 := by
   cases d1
   cases d2
   congr
+  apply DimensionBasis.exponentEquiv.injective
   funext b
   exact h b
 
 instance : Mul (Dimension B) where
-  mul d1 d2 := ⟨fun b => d1.exponent b + d2.exponent b⟩
+  mul d1 d2 := ⟨d1.exponents + d2.exponents⟩
 
 @[simp]
 lemma mul_exponent (d1 d2 : Dimension B) (b : B) :
-    (d1 * d2).exponent b = d1.exponent b + d2.exponent b := rfl
+    (d1 * d2).exponent b = d1.exponent b + d2.exponent b := by
+  exact congrFun (map_add DimensionBasis.exponentEquiv d1.exponents d2.exponents) b
 
 instance : One (Dimension B) where
-  one := ⟨fun _ => 0⟩
+  one := ⟨0⟩
 
 @[simp]
-lemma one_exponent (b : B) : (1 : Dimension B).exponent b = 0 := rfl
+lemma one_exponent (b : B) : (1 : Dimension B).exponent b = 0 := by
+  exact congrFun (map_zero DimensionBasis.exponentEquiv) b
 
 instance : CommGroup (Dimension B) where
   mul_assoc a b c := by
@@ -83,16 +121,19 @@ instance : CommGroup (Dimension B) where
   mul_one a := by
     ext x
     simp
-  inv d := ⟨fun b => -d.exponent b⟩
+  inv d := ⟨-d.exponents⟩
   inv_mul_cancel a := by
-    ext x
-    simp
+    cases a with
+    | mk exponents =>
+        change Dimension.mk (-exponents + exponents) = Dimension.mk 0
+        rw [neg_add_cancel]
   mul_comm a b := by
     ext x
     simp [add_comm]
 
 @[simp]
-lemma inv_exponent (d : Dimension B) (b : B) : d⁻¹.exponent b = -d.exponent b := rfl
+lemma inv_exponent (d : Dimension B) (b : B) : d⁻¹.exponent b = -d.exponent b := by
+  exact congrFun (map_neg DimensionBasis.exponentEquiv d.exponents) b
 
 @[simp]
 lemma div_exponent (d1 d2 : Dimension B) (b : B) :
@@ -107,11 +148,12 @@ lemma npow_exponent (d : Dimension B) (n : ℕ) (b : B) :
   | succ n ih => rw [pow_succ, mul_exponent, ih, succ_nsmul]
 
 instance : Pow (Dimension B) ℚ where
-  pow d q := ⟨fun b => d.exponent b * Exponent.ofRat q⟩
+  pow d q := ofFunction fun b => d.exponent b * Exponent.ofRat q
 
 @[simp]
 lemma qpow_exponent (d : Dimension B) (q : ℚ) (b : B) :
-    (d ^ q).exponent b = d.exponent b * Exponent.ofRat q := rfl
+    (d ^ q).exponent b = d.exponent b * Exponent.ofRat q := by
+  exact ofFunction_exponent _ _
 
 /-- Decidable equality of dimensions over a finite basis `B`. -/
 instance [Fintype B] : DecidableEq (Dimension B) := fun d1 d2 =>
@@ -120,26 +162,26 @@ instance [Fintype B] : DecidableEq (Dimension B) := fun d1 d2 =>
 
 /-- The base-dimension vector for `b : B`: exponent `1` at `b`, `0` elsewhere. This
   is the generic analogue of the named generators `L𝓭`, `T𝓭`, … -/
-def single [DecidableEq B] (b : B) : Dimension B := ⟨Pi.single b 1⟩
+def single [DecidableEq B] (b : B) : Dimension B := ofFunction (Pi.single b 1)
 
 @[simp]
 lemma single_exponent [DecidableEq B] (b b' : B) :
     (single b).exponent b' = if b' = b then 1 else 0 := by
-  simp only [single, Pi.single_apply]
+  simp only [single, ofFunction_exponent, Pi.single_apply]
 
 /-- Change of basis along a map `f : B → B'` of base dimensions: reindex a dimension
   over `B` into one over `B'` by placing each exponent at its image. For an embedding
   `f` (injective) this preserves every exponent (`extend_exponent_apply`), so a
   dimension in one system re-expresses faithfully in an extending one. -/
-def extend {B' : Type} [Fintype B] [DecidableEq B'] (f : B → B') (d : Dimension B) :
-    Dimension B' :=
-  ⟨fun b' => ∑ b, if f b = b' then d.exponent b else 0⟩
+def extend {B' : Type} [DimensionBasis B'] [Fintype B] [DecidableEq B']
+    (f : B → B') (d : Dimension B) : Dimension B' :=
+  ofFunction fun b' => ∑ b, if f b = b' then d.exponent b else 0
 
 @[simp]
-lemma extend_exponent_apply {B' : Type} [Fintype B] [DecidableEq B'] {f : B → B'}
-    (hf : Function.Injective f) (d : Dimension B) (b : B) :
+lemma extend_exponent_apply {B' : Type} [DimensionBasis B'] [Fintype B] [DecidableEq B']
+    {f : B → B'} (hf : Function.Injective f) (d : Dimension B) (b : B) :
     (extend f d).exponent (f b) = d.exponent b := by
-  simp only [extend]
+  simp only [extend, ofFunction_exponent]
   rw [Finset.sum_eq_single b (fun b'' _ hne => by simp [hf.ne hne]) (by simp)]
   simp
 
@@ -164,13 +206,13 @@ that sends a base dimension to an inequivalent one is *not* expressible as eithe
 -/
 
 /-- `extend f` packaged as a monoid homomorphism of dimensions. -/
-def extendHom {B' : Type} [Fintype B] [DecidableEq B'] (f : B → B') :
+def extendHom {B' : Type} [DimensionBasis B'] [Fintype B] [DecidableEq B'] (f : B → B') :
     Dimension B →* Dimension B' where
   toFun := extend f
   map_one' := by ext b'; simp [extend]
   map_mul' d1 d2 := by
     ext b'
-    simp only [extend, mul_exponent]
+    simp only [extend, ofFunction_exponent, mul_exponent]
     rw [← Finset.sum_add_distrib]
     refine Finset.sum_congr rfl fun b _ => ?_
     split_ifs <;> simp
@@ -180,7 +222,7 @@ def extendHom {B' : Type} [Fintype B] [DecidableEq B'] (f : B → B') :
   inverses and rational powers); injectivity makes it a faithful inclusion of the basis
   `B` into `B'`. Cross-basis dimension injections are produced as `Embedding`s so that
   dimension-preservation holds by construction. -/
-structure Embedding (B B' : Type) where
+structure Embedding (B B' : Type) [DimensionBasis B] [DimensionBasis B'] where
   /-- The underlying dimension-preserving homomorphism. -/
   toHom : Dimension B →* Dimension B'
   /-- The homomorphism is injective (a faithful embedding). -/
@@ -190,7 +232,7 @@ structure Embedding (B B' : Type) where
   dimensions. As a `MonoidHom` it is truth-preserving, but it is lossy — it reduces a
   richer basis `B'` onto a coarser basis `B`, collapsing the base dimensions that `B`
   does not track. -/
-structure Projection (B' B : Type) where
+structure Projection (B' B : Type) [DimensionBasis B'] [DimensionBasis B] where
   /-- The underlying dimension-preserving homomorphism. -/
   toHom : Dimension B' →* Dimension B
   /-- The homomorphism is surjective (the reduction hits every dimension of `B`). -/
@@ -199,7 +241,8 @@ structure Projection (B' B : Type) where
 /-- An injective *basis* map `f : B → B'` induces a dimension embedding, via `extend`.
   This is the label-level case: it sends each base dimension of `B` to a base dimension
   of `B'`, so it is automatically dimension-preserving and faithful. -/
-def Embedding.ofBasis {B B' : Type} [Fintype B] [DecidableEq B']
+def Embedding.ofBasis {B B' : Type} [DimensionBasis B] [DimensionBasis B']
+    [Fintype B] [DecidableEq B']
     (f : B → B') (hf : Function.Injective f) : Embedding B B' where
   toHom := extendHom f
   inj := by

--- a/Physlib/Units/Dimension.lean
+++ b/Physlib/Units/Dimension.lean
@@ -20,7 +20,7 @@ A `Dimension B` is parameterised by a *basis* `B` of base dimensions equipped wi
 `Exponent` to every base dimension `b : B`. The parameterisation is purely in
 the dimensional *algebra*: `Dimension B` is a `CommGroup` for every represented basis `B`
 (multiplication adds exponents, inversion negates them), so quantities can be typed by
-dimensions over any basis. The commutative-group and `ℚ`-power structure, decidable
+dimensions over any basis. The commutative-group, `Exponent`- and `ℚ`-power structures, decidable
 equality (`DecidableEq`), the base vectors `single b`, and the change-of-basis map
 `extend` are all generic in `B`.
 
@@ -153,6 +153,17 @@ instance : Pow (Dimension B) ℚ where
 @[simp]
 lemma qpow_exponent (d : Dimension B) (q : ℚ) (b : B) :
     (d ^ q).exponent b = d.exponent b * Exponent.ofRat q := by
+  exact ofFunction_exponent _ _
+
+/-- Raising a dimension to an `Exponent` power. Unlike the `ℚ`-valued power, this preserves
+reducible arithmetic for concrete fractional exponents. -/
+@[default_instance 10000]
+instance : Pow (Dimension B) Exponent where
+  pow d c := ofFunction fun b => d.exponent b * c
+
+@[simp]
+lemma epow_exponent (d : Dimension B) (c : Exponent) (b : B) :
+    (d ^ c).exponent b = d.exponent b * c := by
   exact ofFunction_exponent _ _
 
 /-- Decidable equality of dimensions over a finite basis `B`. -/

--- a/Physlib/Units/Examples.lean
+++ b/Physlib/Units/Examples.lean
@@ -118,7 +118,7 @@ lemma energyMassWithDimNot_not_isDimensionallyCorrect :
     changing from `SI` to `SIPrimed` with values of `E`, `m` and `c` all equal to `1`. -/
   use SI, SIPrimed, ⟨1⟩, ⟨1⟩, ⟨1⟩
   unfold EnergyMassWithDimNot
-  norm_num [WithDim.scaleUnit_val, M𝓭, NNReal.smul_def]
+  norm_num [WithDim.scaleUnit_val, M𝓭, NNReal.smul_def, map_ofNat]
 
 /-!
 

--- a/Physlib/Units/Examples.lean
+++ b/Physlib/Units/Examples.lean
@@ -118,7 +118,7 @@ lemma energyMassWithDimNot_not_isDimensionallyCorrect :
     changing from `SI` to `SIPrimed` with values of `E`, `m` and `c` all equal to `1`. -/
   use SI, SIPrimed, ⟨1⟩, ⟨1⟩, ⟨1⟩
   unfold EnergyMassWithDimNot
-  norm_num [WithDim.scaleUnit_val, M𝓭, NNReal.smul_def, map_ofNat]
+  norm_num [WithDim.scaleUnit_val, M𝓭, NNReal.smul_def]
 
 /-!
 

--- a/Physlib/Units/Exponent.lean
+++ b/Physlib/Units/Exponent.lean
@@ -48,6 +48,12 @@ namespace Exponent
 def equivRat : Exponent ≃ ℚ :=
   Equiv.mk Exponent.toRat Exponent.mk Eq.refl Eq.refl
 
+/-- Regard a rational number as a dimension exponent. -/
+def ofRat (q : ℚ) : Exponent := ⟨q⟩
+
+@[simp]
+lemma ofRat_toRat (q : ℚ) : (ofRat q).toRat = q := rfl
+
 /-- Fuel-bounded Euclidean algorithm used to make exponent normalization reducible. -/
 def gcdAux : Nat → Nat → Nat → Nat
   | 0, _, n => n
@@ -178,6 +184,15 @@ instance instField : Field Exponent := by
   case mul => apply mul_equiv
   case div => apply div_equiv
   all_goals rfl
+
+/-- The ring equivalence between dimension exponents and rational numbers. -/
+def ringEquivRat : Exponent ≃+* ℚ where
+  toEquiv := equivRat
+  map_add' := add_equiv
+  map_mul' := mul_equiv
+
+/-- Regard a dimension exponent as a rational number. -/
+instance : Coe Exponent ℚ := ⟨ringEquivRat⟩
 
 instance : CharZero Exponent where
   cast_injective _ _ equality := Nat.cast_injective <| congrArg equivRat equality

--- a/Physlib/Units/Exponent.lean
+++ b/Physlib/Units/Exponent.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Algebra.Field.TransferInstance
 public import Mathlib.Algebra.Field.Rat
+public import Mathlib.Algebra.Order.Ring.InjSurj
+public import Mathlib.Algebra.Order.Ring.Rat
 /-!
 
 # Reducible rational arithmetic for dimension exponents
@@ -41,6 +43,11 @@ structure Exponent where
   /-- The rational number represented by the exponent. -/
   toRat : ℚ
 deriving DecidableEq
+
+attribute [coe] Exponent.toRat
+
+instance : Repr Exponent where
+  reprPrec x := reprPrec x.toRat
 
 namespace Exponent
 
@@ -192,17 +199,68 @@ def ringEquivRat : Exponent ≃+* ℚ where
   map_mul' := mul_equiv
 
 /-- Regard a dimension exponent as a rational number. -/
-instance : Coe Exponent ℚ := ⟨ringEquivRat⟩
+instance : Coe Exponent ℚ := ⟨Exponent.toRat⟩
+
+@[simp, norm_cast]
+lemma coe_inj {a b : Exponent} : (a : ℚ) = b ↔ a = b :=
+  ringEquivRat.injective.eq_iff
+
+@[simp, norm_cast]
+lemma coe_zero : ((0 : Exponent) : ℚ) = 0 := map_zero ringEquivRat
+
+@[simp, norm_cast]
+lemma coe_one : ((1 : Exponent) : ℚ) = 1 := map_one ringEquivRat
+
+@[simp, norm_cast]
+lemma coe_ofNat (n : ℕ) [n.AtLeastTwo] : ((ofNat(n) : Exponent) : ℚ) = ofNat(n) :=
+  map_ofNat ringEquivRat n
+
+@[simp, norm_cast]
+lemma coe_add (a b : Exponent) : ((a + b : Exponent) : ℚ) = a + b :=
+  map_add ringEquivRat a b
+
+@[simp, norm_cast]
+lemma coe_sub (a b : Exponent) : ((a - b : Exponent) : ℚ) = a - b :=
+  map_sub ringEquivRat a b
+
+@[simp, norm_cast]
+lemma coe_neg (a : Exponent) : ((-a : Exponent) : ℚ) = -a :=
+  map_neg ringEquivRat a
+
+@[simp, norm_cast]
+lemma coe_mul (a b : Exponent) : ((a * b : Exponent) : ℚ) = a * b :=
+  map_mul ringEquivRat a b
+
+@[simp, norm_cast]
+lemma coe_inv (a : Exponent) : ((a⁻¹ : Exponent) : ℚ) = (a : ℚ)⁻¹ :=
+  inv_equiv a
+
+@[simp, norm_cast]
+lemma coe_div (a b : Exponent) : ((a / b : Exponent) : ℚ) = (a : ℚ) / b :=
+  div_equiv a b
+
+instance : LinearOrder Exponent := equivRat.linearOrder
+
+@[simp, norm_cast]
+lemma coe_le_coe {a b : Exponent} : (a : ℚ) ≤ b ↔ a ≤ b := Iff.rfl
+
+@[simp, norm_cast]
+lemma coe_lt_coe {a b : Exponent} : (a : ℚ) < b ↔ a < b := Iff.rfl
+
+instance : IsStrictOrderedRing Exponent :=
+  Function.Injective.isStrictOrderedRing ringEquivRat
+    (map_zero ringEquivRat) (map_one ringEquivRat) (map_add ringEquivRat) (map_mul ringEquivRat)
+    coe_le_coe coe_lt_coe
 
 instance : CharZero Exponent where
   cast_injective _ _ equality := Nat.cast_injective <| congrArg equivRat equality
 
--- Test induced field compatibility with custom operations
-example : add = instField.add := rfl
-example : sub = instField.sub := rfl
-example : inv = instField.inv := rfl
-example : mul = instField.mul := rfl
-example : div = instField.div := rfl
+-- These regressions pin the field structure to the reducible operations above.
+lemma add_eq_instField_add : add = instField.add := rfl
+lemma sub_eq_instField_sub : sub = instField.sub := rfl
+lemma inv_eq_instField_inv : inv = instField.inv := rfl
+lemma mul_eq_instField_mul : mul = instField.mul := rfl
+lemma div_eq_instField_div : div = instField.div := rfl
 
 /-!
 
@@ -210,15 +268,16 @@ example : div = instField.div := rfl
 
 -/
 
-example :
+lemma tuple_arithmetic_defeq :
     let Length : Exponent × Exponent := (1, 0)
     let Time : Exponent × Exponent := (0, 1)
     let Speed := Length - Time
     Length = Time + Speed := rfl
 
-example : ((2 / 3 + 5 / 7) * (11 / 13 - 1 / 2) : Exponent) = 87 / 182 := rfl
+lemma rational_arithmetic_defeq :
+    ((2 / 3 + 5 / 7) * (11 / 13 - 1 / 2) : Exponent) = 87 / 182 := rfl
 
-example : ((-3 / 4 : Exponent)⁻¹ + 5 / 6) = -1 / 2 := rfl
+lemma inverse_arithmetic_defeq : ((-3 / 4 : Exponent)⁻¹ + 5 / 6) = -1 / 2 := rfl
 
 end Dimension.Exponent
 

--- a/Physlib/Units/Exponent.lean
+++ b/Physlib/Units/Exponent.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 Raunak Chhatwal. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Raunak Chhatwal
+-/
+module
+
+public import Mathlib.Algebra.Field.TransferInstance
+public import Mathlib.Algebra.Field.Rat
+/-!
+
+# Reducible rational arithmetic for dimension exponents
+
+This module defines `Exponent`, a wrapper around the rational numbers whose arithmetic is
+reducible. This lets concrete arithmetic on dimension exponents hold by definitional equality.
+
+The corresponding rational operations are irreducible in Lean. Locally unsealing them does not
+export their reducibility to downstream modules, while globally changing the reducibility of an
+imported declaration requires `allowUnsafeReducibility`. The wrapper instead owns transparent
+operations while remaining equivalent to `ℚ`.
+
+The reducibility guarantee applies to the custom addition, subtraction, multiplication, inversion,
+and division below. Other operations supplied by the `Field` instance are transferred from `ℚ`.
+In particular, rational scalar multiplication and negative integer powers may require propositional
+reasoning rather than `rfl`.
+
+-/
+
+@[expose] public section
+
+namespace Dimension
+
+/-!
+
+## A. Definition
+
+-/
+
+/-- A rational dimension exponent with reducible arithmetic. -/
+structure Exponent where
+  /-- The rational number represented by the exponent. -/
+  toRat : ℚ
+deriving DecidableEq
+
+namespace Exponent
+
+/-- The equivalence between `Exponent` and the rational numbers. -/
+def equivRat : Exponent ≃ ℚ :=
+  Equiv.mk Exponent.toRat Exponent.mk Eq.refl Eq.refl
+
+/-- Fuel-bounded Euclidean algorithm used to make exponent normalization reducible. -/
+def gcdAux : Nat → Nat → Nat → Nat
+  | 0, _, n => n
+  | fuel + 1, m, n => if m = 0 then n else gcdAux fuel (n % m) m
+
+private lemma gcdAux_eq_nat_gcd (fuel m n : Nat) (m_lt_fuel : m < fuel) :
+    gcdAux fuel m n = Nat.gcd m n := by
+  induction fuel generalizing m n with
+  | zero => omega
+  | succ fuel ih =>
+      rw [gcdAux, Nat.gcd_def]
+      split
+      · rfl
+      · apply ih; have := Nat.mod_lt n (Nat.zero_lt_of_ne_zero ‹m ≠ 0›); omega
+
+/-- Reducible greatest common divisor used when normalizing an exponent. -/
+def gcd (m n : Nat) : Nat :=
+  gcdAux (m + 1) m n
+
+/-- The reducible exponent GCD agrees with `Nat.gcd`. -/
+lemma gcd_eq_nat_gcd (m n : Nat) : gcd m n = Nat.gcd m n := by
+  exact gcdAux_eq_nat_gcd (m + 1) m n (Nat.lt_add_one m)
+
+/-- Construct an exponent by normalizing a numerator and a nonzero denominator. -/
+def normalize (num : Int) (den : Nat) (den_ne_zero : den ≠ 0) : Exponent :=
+  let g := gcd num.natAbs den
+  let g_eq : g = num.natAbs.gcd den := gcd_eq_nat_gcd num.natAbs den
+  ⟨Rat.maybeNormalize num den g
+    (Rat.normalize.dvd_num g_eq)
+    (Rat.normalize.dvd_den g_eq)
+    (Rat.normalize.den_nz den_ne_zero g_eq)
+    (Rat.normalize.reduced den_ne_zero g_eq)⟩
+
+lemma normalize_toRat (num : Int) (den : Nat) (den_ne_zero : den ≠ 0) :
+    (normalize num den den_ne_zero).toRat = Rat.normalize num den den_ne_zero := by
+  unfold normalize Rat.normalize
+  simp only [gcd_eq_nat_gcd]
+
+/-- The normalized numerator of an exponent. -/
+@[reducible] def num (x : Exponent) : Int :=
+  x.toRat.num
+
+/-- The normalized denominator of an exponent. -/
+@[reducible] def den (x : Exponent) : Nat :=
+  x.toRat.den
+
+/-!
+
+## B. Arithmetic
+
+-/
+
+/-- Reducible addition of dimension exponents. -/
+def add (a b : Exponent) : Exponent :=
+  normalize (a.num * b.den + b.num * a.den) (a.den * b.den)
+    (Nat.mul_ne_zero a.toRat.den_nz b.toRat.den_nz)
+
+instance : Add Exponent := Add.mk add
+
+lemma add_equiv (a b : Exponent) : equivRat (add a b) = equivRat a + equivRat b := by
+  rw [Rat.add_def]
+  exact normalize_toRat _ _ _
+
+/-- Reducible subtraction of dimension exponents. -/
+def sub (a b : Exponent) : Exponent :=
+  add a ⟨-b.toRat⟩
+
+instance : Sub Exponent := Sub.mk sub
+
+lemma sub_equiv (a b : Exponent) : equivRat (sub a b) = equivRat a - equivRat b := by
+  rw [sub, add_equiv]
+  simp [equivRat, sub_eq_add_neg]
+
+/-- Reducible multiplication of dimension exponents. -/
+def mul (a b : Exponent) : Exponent :=
+  normalize (a.num * b.num) (a.den * b.den)
+    (Nat.mul_ne_zero a.toRat.den_nz b.toRat.den_nz)
+
+instance : Mul Exponent := Mul.mk mul
+
+lemma mul_equiv (a b : Exponent) : equivRat (mul a b) = equivRat a * equivRat b := by
+  rw [Rat.mul_def]
+  exact normalize_toRat _ _ _
+
+/-- Reducible inversion of a dimension exponent, with `0⁻¹ = 0`. -/
+def inv (a : Exponent) : Exponent :=
+  if ne_zero : a.toRat ≠ 0 then
+    have num_ne_zero : a.num ≠ 0 := ne_zero ∘ Rat.num_eq_zero.mp
+    ⟨{ num := a.num.sign * a.den
+       den := a.num.natAbs
+       den_nz := by exact Nat.ne_of_gt (Int.natAbs_pos.mpr num_ne_zero)
+       reduced := by simpa [Int.natAbs_mul, Int.natAbs_sign_of_ne_zero num_ne_zero]
+         using a.toRat.reduced.symm }⟩
+  else a
+
+instance : Inv Exponent := Inv.mk inv
+
+lemma inv_equiv (a : Exponent) : equivRat (inv a) = (equivRat a)⁻¹ := by
+  by_cases ne_zero : a.toRat ≠ 0
+  · apply Rat.ext <;> simp [inv, ne_zero, equivRat, Rat.num_inv, Rat.den_inv]
+  · push Not at ne_zero
+    apply Rat.ext <;> simp [inv, ne_zero, equivRat]
+
+/-- Reducible division of dimension exponents. -/
+def div (a b : Exponent) : Exponent :=
+  mul a (inv b)
+
+instance : Div Exponent := Div.mk div
+
+lemma div_equiv (a b : Exponent) : equivRat (div a b) = equivRat a / equivRat b := by
+  rw [div, mul_equiv, inv_equiv, div_eq_mul_inv]
+
+/-!
+
+## C. Field structure
+
+-/
+
+instance instField : Field Exponent := by
+  letI := equivRat.field
+  apply equivRat.injective.field
+  · rfl
+  · rfl
+  all_goals intros
+  case add => apply add_equiv
+  case sub => apply sub_equiv
+  case inv => apply inv_equiv
+  case mul => apply mul_equiv
+  case div => apply div_equiv
+  all_goals rfl
+
+instance : CharZero Exponent where
+  cast_injective _ _ equality := Nat.cast_injective <| congrArg equivRat equality
+
+-- Test induced field compatibility with custom operations
+example : add = instField.add := rfl
+example : sub = instField.sub := rfl
+example : inv = instField.inv := rfl
+example : mul = instField.mul := rfl
+example : div = instField.div := rfl
+
+/-!
+
+## D. Definitional equality tests
+
+-/
+
+example :
+    let Length : Exponent × Exponent := (1, 0)
+    let Time : Exponent × Exponent := (0, 1)
+    let Speed := Length - Time
+    Length = Time + Speed := rfl
+
+example : ((2 / 3 + 5 / 7) * (11 / 13 - 1 / 2) : Exponent) = 87 / 182 := rfl
+
+example : ((-3 / 4 : Exponent)⁻¹ + 5 / 6) = -1 / 2 := rfl
+
+end Dimension.Exponent
+
+end

--- a/Physlib/Units/ISQBridge.lean
+++ b/Physlib/Units/ISQBridge.lean
@@ -42,14 +42,14 @@ namespace Dimension
   send PhysLib's charge generator to the derived ISQ charge `I · T` (the current
   exponent is the charge exponent, and the time exponent absorbs it). -/
 def toISQFun (d : Dimension LTMCTDimensionBase) : Dimension ISQDimensionBase :=
-  ⟨fun
+  ofFunction fun
     | .length => d.exponent .length
     | .mass => d.exponent .mass
     | .time => d.exponent .time + d.exponent .charge
     | .current => d.exponent .charge
     | .temperature => d.exponent .temperature
     | .amount => 0
-    | .luminousIntensity => 0⟩
+    | .luminousIntensity => 0
 
 /-- The dimension-preserving embedding of PhysLib dimensions into the ISQ dimensions. -/
 def toISQHom : Dimension LTMCTDimensionBase →* Dimension ISQDimensionBase where
@@ -57,7 +57,7 @@ def toISQHom : Dimension LTMCTDimensionBase →* Dimension ISQDimensionBase wher
   map_one' := by ext b; cases b <;> simp [toISQFun]
   map_mul' d1 d2 := by
     ext b
-    cases b <;> simp only [toISQFun, mul_exponent]
+    cases b <;> simp only [toISQFun, ofFunction_exponent, mul_exponent]
     all_goals ring
 
 /-- `toISQHom` applied to a dimension is `toISQFun`. -/
@@ -67,12 +67,12 @@ lemma toISQHom_apply (d : Dimension LTMCTDimensionBase) : toISQHom d = toISQFun 
   electric current as charge/time (the charge exponent is the current exponent, and the
   time exponent subtracts it), and drop amount of substance and luminous intensity. -/
 def fromISQFun (d : Dimension ISQDimensionBase) : Dimension LTMCTDimensionBase :=
-  ⟨fun
+  ofFunction fun
     | .length => d.exponent .length
     | .time => d.exponent .time - d.exponent .current
     | .mass => d.exponent .mass
     | .charge => d.exponent .current
-    | .temperature => d.exponent .temperature⟩
+    | .temperature => d.exponent .temperature
 
 /-- The truth-preserving reduction of ISQ dimensions onto PhysLib's. -/
 def fromISQHom : Dimension ISQDimensionBase →* Dimension LTMCTDimensionBase where
@@ -80,7 +80,7 @@ def fromISQHom : Dimension ISQDimensionBase →* Dimension LTMCTDimensionBase wh
   map_one' := by ext b; cases b <;> simp [fromISQFun]
   map_mul' d1 d2 := by
     ext b
-    cases b <;> simp only [fromISQFun, mul_exponent]
+    cases b <;> simp only [fromISQFun, ofFunction_exponent, mul_exponent]
     all_goals ring
 
 /-- `fromISQHom` applied to a dimension is `fromISQFun`. -/
@@ -92,7 +92,7 @@ lemma fromISQHom_comp_toISQHom :
     fromISQHom.comp toISQHom = MonoidHom.id (Dimension LTMCTDimensionBase) := by
   refine MonoidHom.ext fun d => Dimension.ext fun b => ?_
   cases b <;> simp only [MonoidHom.comp_apply, MonoidHom.id_apply, toISQHom_apply,
-    fromISQHom_apply, fromISQFun, toISQFun]
+    fromISQHom_apply, fromISQFun, toISQFun, ofFunction_exponent]
   all_goals ring
 
 /-- `toISQHom` is injective: PhysLib dimensions include faithfully into ISQ. -/
@@ -104,16 +104,16 @@ lemma toISQHom_injective : Function.Injective toISQHom := by
     simpa only [toISQHom_apply] using hb
   ext b
   cases b with
-  | length => simpa only [toISQFun] using key .length
+  | length => simpa only [toISQFun, ofFunction_exponent] using key .length
   | time =>
       apply Exponent.ringEquivRat.injective
       have ht := congrArg Exponent.ringEquivRat (key .time)
       have hc := congrArg Exponent.ringEquivRat (key .current)
-      simp only [toISQFun, map_add] at ht hc
+      simp only [toISQFun, ofFunction_exponent, map_add] at ht hc
       linarith
-  | mass => simpa only [toISQFun] using key .mass
-  | charge => simpa only [toISQFun] using key .current
-  | temperature => simpa only [toISQFun] using key .temperature
+  | mass => simpa only [toISQFun, ofFunction_exponent] using key .mass
+  | charge => simpa only [toISQFun, ofFunction_exponent] using key .current
+  | temperature => simpa only [toISQFun, ofFunction_exponent] using key .temperature
 
 /-- `fromISQHom` is surjective: every PhysLib dimension is the reduction of some ISQ
   dimension (namely its own embedding). -/
@@ -143,6 +143,6 @@ lemma isqToLTMCT_comp_ltmctToISQ :
 lemma toISQHom_C𝓭 : toISQHom C𝓭 = ISQDimensionBase.charge := by
   ext b
   cases b <;> simp [toISQHom_apply, toISQFun, C𝓭, ofLTMCTDimensionBase,
-    ISQDimensionBase.charge, single_exponent]
+    ISQDimensionBase.charge, single_exponent, length, time, mass, charge, temperature]
 
 end Dimension

--- a/Physlib/Units/ISQBridge.lean
+++ b/Physlib/Units/ISQBridge.lean
@@ -106,10 +106,9 @@ lemma toISQHom_injective : Function.Injective toISQHom := by
   cases b with
   | length => simpa only [toISQFun, ofFunction_exponent] using key .length
   | time =>
-      apply Exponent.ringEquivRat.injective
-      have ht := congrArg Exponent.ringEquivRat (key .time)
-      have hc := congrArg Exponent.ringEquivRat (key .current)
-      simp only [toISQFun, ofFunction_exponent, map_add] at ht hc
+      have ht := key .time
+      have hc := key .current
+      simp only [toISQFun, ofFunction_exponent] at ht hc
       linarith
   | mass => simpa only [toISQFun, ofFunction_exponent] using key .mass
   | charge => simpa only [toISQFun, ofFunction_exponent] using key .current
@@ -142,7 +141,6 @@ lemma isqToLTMCT_comp_ltmctToISQ :
   maps to the *derived* ISQ charge `I · T`. -/
 lemma toISQHom_C𝓭 : toISQHom C𝓭 = ISQDimensionBase.charge := by
   ext b
-  cases b <;> simp [toISQHom_apply, toISQFun, C𝓭, ofLTMCTDimensionBase,
-    ISQDimensionBase.charge, single_exponent, length, time, mass, charge, temperature]
+  cases b <;> simp [toISQHom_apply, toISQFun, C𝓭, ISQDimensionBase.charge, single_exponent]
 
 end Dimension

--- a/Physlib/Units/ISQBridge.lean
+++ b/Physlib/Units/ISQBridge.lean
@@ -106,9 +106,10 @@ lemma toISQHom_injective : Function.Injective toISQHom := by
   cases b with
   | length => simpa only [toISQFun] using key .length
   | time =>
-      have ht := key .time
-      have hc := key .current
-      simp only [toISQFun] at ht hc
+      apply Exponent.ringEquivRat.injective
+      have ht := congrArg Exponent.ringEquivRat (key .time)
+      have hc := congrArg Exponent.ringEquivRat (key .current)
+      simp only [toISQFun, map_add] at ht hc
       linarith
   | mass => simpa only [toISQFun] using key .mass
   | charge => simpa only [toISQFun] using key .current

--- a/Physlib/Units/ISQDimensionBase.lean
+++ b/Physlib/Units/ISQDimensionBase.lean
@@ -62,6 +62,8 @@ instance : Fintype ISQDimensionBase where
   elems := {.length, .mass, .time, .current, .temperature, .amount, .luminousIntensity}
   complete := fun x => by cases x <;> decide
 
+instance : DimensionBasis ISQDimensionBase := DimensionBasis.pi _
+
 namespace ISQDimensionBase
 
 /-- The ISQ has seven base quantities. -/

--- a/Physlib/Units/LTMCTDimensionBase.lean
+++ b/Physlib/Units/LTMCTDimensionBase.lean
@@ -44,9 +44,28 @@ inductive LTMCTDimensionBase where
   | temperature
 deriving DecidableEq
 
+namespace LTMCTDimensionBase
+
 instance : Fintype LTMCTDimensionBase where
   elems := {.length, .time, .mass, .charge, .temperature}
   complete := fun x => by cases x <;> decide
+
+open Dimension in
+/-- The fixed five-component exponent tuple for PhysLib's default dimension basis. -/
+abbrev Exponents := Exponent × Exponent × Exponent × Exponent × Exponent
+
+instance : DimensionBasis LTMCTDimensionBase where
+  Exponents := Exponents
+  addCommGroup := inferInstance
+  exponentEquiv :=
+    { toFun := fun ⟨l, t, m, c, temp⟩ => fun
+        | .length => l | .time => t | .mass => m | .charge => c | .temperature => temp
+      invFun f := ⟨f .length, f .time, f .mass, f .charge, f .temperature⟩
+      left_inv e := by rcases e; rfl
+      right_inv f := by funext b; cases b <;> rfl
+      map_add' _ _ := by funext b; cases b <;> rfl }
+
+end LTMCTDimensionBase
 
 namespace Dimension
 
@@ -60,26 +79,37 @@ the familiar `.length`, `.time`, `.mass`, `.charge`, `.temperature` API is avail
 -/
 
 /-- The length exponent of a `LTMCTDimensionBase` dimension. -/
-def length (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .length
+def length (d : Dimension LTMCTDimensionBase) : Exponent := d.exponents.1
 /-- The time exponent of a `LTMCTDimensionBase` dimension. -/
-def time (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .time
+def time (d : Dimension LTMCTDimensionBase) : Exponent := d.exponents.2.1
 /-- The mass exponent of a `LTMCTDimensionBase` dimension. -/
-def mass (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .mass
+def mass (d : Dimension LTMCTDimensionBase) : Exponent := d.exponents.2.2.1
 /-- The charge exponent of a `LTMCTDimensionBase` dimension. -/
-def charge (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .charge
+def charge (d : Dimension LTMCTDimensionBase) : Exponent := d.exponents.2.2.2.1
 /-- The temperature exponent of a `LTMCTDimensionBase` dimension. -/
-def temperature (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .temperature
+def temperature (d : Dimension LTMCTDimensionBase) : Exponent := d.exponents.2.2.2.2
+
+@[simp]
+lemma exponent_length (d : Dimension LTMCTDimensionBase) : d.exponent .length = d.length := rfl
+
+@[simp]
+lemma exponent_time (d : Dimension LTMCTDimensionBase) : d.exponent .time = d.time := rfl
+
+@[simp]
+lemma exponent_mass (d : Dimension LTMCTDimensionBase) : d.exponent .mass = d.mass := rfl
+
+@[simp]
+lemma exponent_charge (d : Dimension LTMCTDimensionBase) : d.exponent .charge = d.charge := rfl
+
+@[simp]
+lemma exponent_temperature (d : Dimension LTMCTDimensionBase) :
+    d.exponent .temperature = d.temperature := rfl
 
 /-- Build a `LTMCTDimensionBase` dimension from its five exponents, in the order
   `⟨length, time, mass, charge, temperature⟩`. -/
 def ofLTMCTDimensionBase (length time mass charge temperature : Exponent) :
     Dimension LTMCTDimensionBase :=
-  ⟨fun
-    | .length => length
-    | .time => time
-    | .mass => mass
-    | .charge => charge
-    | .temperature => temperature⟩
+  ⟨(length, time, mass, charge, temperature)⟩
 
 @[simp]
 lemma ofLTMCTDimensionBase_length (l t m c θ : Exponent) :
@@ -153,46 +183,46 @@ lemma inv_temperature (d : Dimension LTMCTDimensionBase) : d⁻¹.temperature = 
 @[simp]
 lemma div_length (d1 d2 : Dimension LTMCTDimensionBase) :
     (d1 / d2).length = d1.length - d2.length := by
-  simp only [length, div_exponent]
+  simpa only [exponent_length] using div_exponent d1 d2 .length
 
 @[simp]
 lemma div_time (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).time = d1.time - d2.time := by
-  simp only [time, div_exponent]
+  simpa only [exponent_time] using div_exponent d1 d2 .time
 
 @[simp]
 lemma div_mass (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).mass = d1.mass - d2.mass := by
-  simp only [mass, div_exponent]
+  simpa only [exponent_mass] using div_exponent d1 d2 .mass
 
 @[simp]
 lemma div_charge (d1 d2 : Dimension LTMCTDimensionBase) :
     (d1 / d2).charge = d1.charge - d2.charge := by
-  simp only [charge, div_exponent]
+  simpa only [exponent_charge] using div_exponent d1 d2 .charge
 
 @[simp]
 lemma div_temperature (d1 d2 : Dimension LTMCTDimensionBase) :
     (d1 / d2).temperature = d1.temperature - d2.temperature := by
-  simp only [temperature, div_exponent]
+  simpa only [exponent_temperature] using div_exponent d1 d2 .temperature
 
 @[simp]
 lemma npow_length (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).length = n • d.length := by
-  simp only [length, npow_exponent]
+  simpa only [exponent_length] using npow_exponent d n .length
 
 @[simp]
 lemma npow_time (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).time = n • d.time := by
-  simp only [time, npow_exponent]
+  simpa only [exponent_time] using npow_exponent d n .time
 
 @[simp]
 lemma npow_mass (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).mass = n • d.mass := by
-  simp only [mass, npow_exponent]
+  simpa only [exponent_mass] using npow_exponent d n .mass
 
 @[simp]
 lemma npow_charge (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).charge = n • d.charge := by
-  simp only [charge, npow_exponent]
+  simpa only [exponent_charge] using npow_exponent d n .charge
 
 @[simp]
 lemma npow_temperature (d : Dimension LTMCTDimensionBase) (n : ℕ) :
     (d ^ n).temperature = n • d.temperature := by
-  simp only [temperature, npow_exponent]
+  simpa only [exponent_temperature] using npow_exponent d n .temperature
 
 /-- The dimension corresponding to length. -/
 def L𝓭 : Dimension LTMCTDimensionBase := ofLTMCTDimensionBase 1 0 0 0 0
@@ -249,18 +279,18 @@ corresponding base dimension, exhibiting them as instances of the basis-generic 
 -/
 
 lemma L𝓭_eq_single : L𝓭 = single .length := by
-  ext b; cases b <;> simp [L𝓭, ofLTMCTDimensionBase, single_exponent]
+  ext b; cases b <;> simp [L𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
 
 lemma T𝓭_eq_single : T𝓭 = single .time := by
-  ext b; cases b <;> simp [T𝓭, ofLTMCTDimensionBase, single_exponent]
+  ext b; cases b <;> simp [T𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
 
 lemma M𝓭_eq_single : M𝓭 = single .mass := by
-  ext b; cases b <;> simp [M𝓭, ofLTMCTDimensionBase, single_exponent]
+  ext b; cases b <;> simp [M𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
 
 lemma C𝓭_eq_single : C𝓭 = single .charge := by
-  ext b; cases b <;> simp [C𝓭, ofLTMCTDimensionBase, single_exponent]
+  ext b; cases b <;> simp [C𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
 
 lemma Θ𝓭_eq_single : Θ𝓭 = single .temperature := by
-  ext b; cases b <;> simp [Θ𝓭, ofLTMCTDimensionBase, single_exponent]
+  ext b; cases b <;> simp [Θ𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
 
 end Dimension

--- a/Physlib/Units/LTMCTDimensionBase.lean
+++ b/Physlib/Units/LTMCTDimensionBase.lean
@@ -180,49 +180,53 @@ lemma inv_charge (d : Dimension LTMCTDimensionBase) : d⁻¹.charge = -d.charge 
 @[simp]
 lemma inv_temperature (d : Dimension LTMCTDimensionBase) : d⁻¹.temperature = -d.temperature := rfl
 
+private lemma component_npow (component : Dimension LTMCTDimensionBase → Exponent)
+    (b : LTMCTDimensionBase) (h : ∀ d, d.exponent b = component d)
+    (d : Dimension LTMCTDimensionBase) (n : ℕ) :
+    component (d ^ n) = n • component d := by
+  calc
+    component (d ^ n) = (d ^ n).exponent b := (h _).symm
+    _ = n • d.exponent b := npow_exponent d n b
+    _ = n • component d := congrArg (n • ·) (h _)
+
 @[simp]
 lemma div_length (d1 d2 : Dimension LTMCTDimensionBase) :
-    (d1 / d2).length = d1.length - d2.length := by
-  simpa only [exponent_length] using div_exponent d1 d2 .length
+    (d1 / d2).length = d1.length - d2.length := rfl
 
 @[simp]
-lemma div_time (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).time = d1.time - d2.time := by
-  simpa only [exponent_time] using div_exponent d1 d2 .time
+lemma div_time (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).time = d1.time - d2.time := rfl
 
 @[simp]
-lemma div_mass (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).mass = d1.mass - d2.mass := by
-  simpa only [exponent_mass] using div_exponent d1 d2 .mass
+lemma div_mass (d1 d2 : Dimension LTMCTDimensionBase) : (d1 / d2).mass = d1.mass - d2.mass := rfl
 
 @[simp]
 lemma div_charge (d1 d2 : Dimension LTMCTDimensionBase) :
-    (d1 / d2).charge = d1.charge - d2.charge := by
-  simpa only [exponent_charge] using div_exponent d1 d2 .charge
+    (d1 / d2).charge = d1.charge - d2.charge := rfl
 
 @[simp]
 lemma div_temperature (d1 d2 : Dimension LTMCTDimensionBase) :
-    (d1 / d2).temperature = d1.temperature - d2.temperature := by
-  simpa only [exponent_temperature] using div_exponent d1 d2 .temperature
+    (d1 / d2).temperature = d1.temperature - d2.temperature := rfl
 
 @[simp]
 lemma npow_length (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).length = n • d.length := by
-  simpa only [exponent_length] using npow_exponent d n .length
+  exact component_npow length .length exponent_length d n
 
 @[simp]
 lemma npow_time (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).time = n • d.time := by
-  simpa only [exponent_time] using npow_exponent d n .time
+  exact component_npow time .time exponent_time d n
 
 @[simp]
 lemma npow_mass (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).mass = n • d.mass := by
-  simpa only [exponent_mass] using npow_exponent d n .mass
+  exact component_npow mass .mass exponent_mass d n
 
 @[simp]
 lemma npow_charge (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).charge = n • d.charge := by
-  simpa only [exponent_charge] using npow_exponent d n .charge
+  exact component_npow charge .charge exponent_charge d n
 
 @[simp]
 lemma npow_temperature (d : Dimension LTMCTDimensionBase) (n : ℕ) :
     (d ^ n).temperature = n • d.temperature := by
-  simpa only [exponent_temperature] using npow_exponent d n .temperature
+  exact component_npow temperature .temperature exponent_temperature d n
 
 /-- The dimension corresponding to length. -/
 def L𝓭 : Dimension LTMCTDimensionBase := ofLTMCTDimensionBase 1 0 0 0 0
@@ -278,19 +282,14 @@ corresponding base dimension, exhibiting them as instances of the basis-generic 
 
 -/
 
-lemma L𝓭_eq_single : L𝓭 = single .length := by
-  ext b; cases b <;> simp [L𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
+lemma L𝓭_eq_single : L𝓭 = single .length := rfl
 
-lemma T𝓭_eq_single : T𝓭 = single .time := by
-  ext b; cases b <;> simp [T𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
+lemma T𝓭_eq_single : T𝓭 = single .time := rfl
 
-lemma M𝓭_eq_single : M𝓭 = single .mass := by
-  ext b; cases b <;> simp [M𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
+lemma M𝓭_eq_single : M𝓭 = single .mass := rfl
 
-lemma C𝓭_eq_single : C𝓭 = single .charge := by
-  ext b; cases b <;> simp [C𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
+lemma C𝓭_eq_single : C𝓭 = single .charge := rfl
 
-lemma Θ𝓭_eq_single : Θ𝓭 = single .temperature := by
-  ext b; cases b <;> simp [Θ𝓭, ofLTMCTDimensionBase, length, time, mass, charge, temperature]
+lemma Θ𝓭_eq_single : Θ𝓭 = single .temperature := rfl
 
 end Dimension

--- a/Physlib/Units/LTMCTDimensionBase.lean
+++ b/Physlib/Units/LTMCTDimensionBase.lean
@@ -60,19 +60,20 @@ the familiar `.length`, `.time`, `.mass`, `.charge`, `.temperature` API is avail
 -/
 
 /-- The length exponent of a `LTMCTDimensionBase` dimension. -/
-def length (d : Dimension LTMCTDimensionBase) : ℚ := d.exponent .length
+def length (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .length
 /-- The time exponent of a `LTMCTDimensionBase` dimension. -/
-def time (d : Dimension LTMCTDimensionBase) : ℚ := d.exponent .time
+def time (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .time
 /-- The mass exponent of a `LTMCTDimensionBase` dimension. -/
-def mass (d : Dimension LTMCTDimensionBase) : ℚ := d.exponent .mass
+def mass (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .mass
 /-- The charge exponent of a `LTMCTDimensionBase` dimension. -/
-def charge (d : Dimension LTMCTDimensionBase) : ℚ := d.exponent .charge
+def charge (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .charge
 /-- The temperature exponent of a `LTMCTDimensionBase` dimension. -/
-def temperature (d : Dimension LTMCTDimensionBase) : ℚ := d.exponent .temperature
+def temperature (d : Dimension LTMCTDimensionBase) : Exponent := d.exponent .temperature
 
 /-- Build a `LTMCTDimensionBase` dimension from its five exponents, in the order
   `⟨length, time, mass, charge, temperature⟩`. -/
-def ofLTMCTDimensionBase (length time mass charge temperature : ℚ) : Dimension LTMCTDimensionBase :=
+def ofLTMCTDimensionBase (length time mass charge temperature : Exponent) :
+    Dimension LTMCTDimensionBase :=
   ⟨fun
     | .length => length
     | .time => time
@@ -81,23 +82,23 @@ def ofLTMCTDimensionBase (length time mass charge temperature : ℚ) : Dimension
     | .temperature => temperature⟩
 
 @[simp]
-lemma ofLTMCTDimensionBase_length (l t m c θ : ℚ) :
+lemma ofLTMCTDimensionBase_length (l t m c θ : Exponent) :
     (ofLTMCTDimensionBase l t m c θ).length = l := rfl
 
 @[simp]
-lemma ofLTMCTDimensionBase_time (l t m c θ : ℚ) :
+lemma ofLTMCTDimensionBase_time (l t m c θ : Exponent) :
     (ofLTMCTDimensionBase l t m c θ).time = t := rfl
 
 @[simp]
-lemma ofLTMCTDimensionBase_mass (l t m c θ : ℚ) :
+lemma ofLTMCTDimensionBase_mass (l t m c θ : Exponent) :
     (ofLTMCTDimensionBase l t m c θ).mass = m := rfl
 
 @[simp]
-lemma ofLTMCTDimensionBase_charge (l t m c θ : ℚ) :
+lemma ofLTMCTDimensionBase_charge (l t m c θ : Exponent) :
     (ofLTMCTDimensionBase l t m c θ).charge = c := rfl
 
 @[simp]
-lemma ofLTMCTDimensionBase_temperature (l t m c θ : ℚ) :
+lemma ofLTMCTDimensionBase_temperature (l t m c θ : Exponent) :
     (ofLTMCTDimensionBase l t m c θ).temperature = θ := rfl
 
 @[simp]

--- a/Physlib/Units/ParametricDimensionExamples.lean
+++ b/Physlib/Units/ParametricDimensionExamples.lean
@@ -17,28 +17,23 @@ illustrates two consequences.
 
 A recurring question is how to compare a quantity of dimension `length` with a
 product of a quantity of dimension `length / time` and a quantity of dimension
-`time`. The two dimensions are *equal*, but this equality is a **group
-cancellation law** on the rational exponents — it holds *propositionally*, never
-*definitionally*:
+`time`. In the fixed-tuple representation of `LTMCTDimensionBase`, reducible exponent
+arithmetic makes this concrete cancellation a definitional equality:
 
-* `(L𝓭 / T𝓭) * T𝓭 = L𝓭` cannot be closed by `rfl`: cancellation is not a
-  reduction rule.
-* nor by `decide`: the exponents are rational, so the kernel has nothing to
-  evaluate.
+* `(L𝓭 / T𝓭) * T𝓭 = L𝓭` is closed by `rfl`.
+* `WithDim ((L𝓭 / T𝓭) * T𝓭) ℝ` and `WithDim L𝓭 ℝ` are therefore definitionally
+  equal types.
 
-Consequently `WithDim ((L𝓭 / T𝓭) * T𝓭) ℝ` and `WithDim L𝓭 ℝ` are genuinely
-different types, and a bare `x = v * t` is a type error. The bridge is
-`WithDim.cast`, whose default argument discharges the propositional dimension
-equality automatically, so the comparison is a one-liner. This is not a
-limitation of the representation: no representation of `Dimension` makes the
-equality definitional, so a cast on a proven equality is the correct idiom.
+Consequently a bare `x = v * t` is well-typed for these concrete dimensions. For a
+representation where the same cancellation holds only propositionally, `WithDim.cast`
+bridges the two dimension-indexed types.
 
 ## A non-standard basis
 
-Because `Dimension` is parametric, the same dimensional algebra and the same
-`cast`-based comparison are available over *any* basis — not just the physical
-`LTMCTDimensionBase`. The unit-scaling layer (`LTMCTUnitChoices`, `dimScale`) is not needed
-for either the algebra or the comparison, so neither is referenced here.
+Because `Dimension` is parametric, the same dimensional algebra and `cast`-based
+comparison are available over any represented basis, not just the physical
+`LTMCTDimensionBase`. The unit-scaling layer (`LTMCTUnitChoices`, `dimScale`) is not
+needed for either the algebra or the comparison, so neither is referenced here.
 
 This module is illustrative and should not be imported by other modules.
 
@@ -50,20 +45,18 @@ open Dimension
 
 namespace ParametricDimensionExamples
 
-/-- The dimension equality `(length / time) · time = length` holds
-propositionally, by cancellation of the rational exponents. -/
-example : (L𝓭 / T𝓭) * T𝓭 = L𝓭 := by ext; simp
+/-- The concrete dimension equality `(length / time) · time = length` holds by
+definitional equality. -/
+example : (L𝓭 / T𝓭) * T𝓭 = L𝓭 := rfl
 
-/-- The dimensions are equal, but the two `WithDim` *types* are not
-definitionally equal, so `WithDim.cast` bridges them. Its default argument proves
-`(L𝓭 / T𝓭) * T𝓭 = L𝓭` with no manual proof. -/
-noncomputable example (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : WithDim L𝓭 ℝ :=
-  (v * t).cast
+/-- The two concrete `WithDim` types are definitionally equal, so multiplication has
+the required result type without a cast. -/
+example (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : WithDim L𝓭 ℝ :=
+  v * t
 
-/-- The end-to-end comparison: a length equals a velocity times a time, once the
-product is cast to the length dimension. -/
+/-- The end-to-end comparison: a length equals a velocity times a time directly. -/
 example (x : WithDim L𝓭 ℝ) (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : Prop :=
-  x = (v * t).cast
+  x = v * t
 
 /-!
 ## The same comparison over a non-standard basis
@@ -79,11 +72,13 @@ inductive Info
   /-- The symbol base dimension. -/
   | symbol
 
+instance : DimensionBasis Info := DimensionBasis.pi _
+
 /-- The `bit` base dimension. -/
-def bitDim : Dimension Info := ⟨fun | .bit => 1 | .symbol => 0⟩
+def bitDim : Dimension Info := Dimension.ofFunction fun | .bit => 1 | .symbol => 0
 
 /-- The `symbol` base dimension. -/
-def symbolDim : Dimension Info := ⟨fun | .bit => 0 | .symbol => 1⟩
+def symbolDim : Dimension Info := Dimension.ofFunction fun | .bit => 0 | .symbol => 1
 
 /-- Cancellation works identically over the non-standard basis. -/
 example : (bitDim / symbolDim) * symbolDim = bitDim := by ext; simp

--- a/Physlib/Units/ParametricDimensionExamples.lean
+++ b/Physlib/Units/ParametricDimensionExamples.lean
@@ -58,6 +58,17 @@ example (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : WithDim L�
 example (x : WithDim L𝓭 ℝ) (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : Prop :=
   x = v * t
 
+/-- Two half-powers of length multiply definitionally to length. The unannotated exponent also
+regresses the default away from natural-number division. -/
+example : (L𝓭 ^ (1 / 2)) * (L𝓭 ^ (1 / 2)) = L𝓭 := rfl
+
+/-- Reducible dimension powers also cancel for non-half fractional exponents. -/
+example : (L𝓭 ^ (2 / 3 : Exponent)) * (L𝓭 ^ (1 / 3 : Exponent)) = L𝓭 := rfl
+
+/-- Quantities carrying half-powers of length multiply directly to a length. -/
+example (a b : WithDim (L𝓭 ^ (1 / 2)) ℝ) : WithDim L𝓭 ℝ :=
+  a * b
+
 /-!
 ## The same comparison over a non-standard basis
 

--- a/Physlib/Units/ParametricUnits.lean
+++ b/Physlib/Units/ParametricUnits.lean
@@ -59,7 +59,7 @@ noncomputable def dimScale [DimensionBasis B] [Fintype B]
   toFun d := ∏ b, (u1.scale b / u2.scale b) ^ (d.exponent b : ℝ)
   map_one' := by simp
   map_mul' d1 d2 := by
-    simp only [Dimension.mul_exponent, map_add, Rat.cast_add]
+    simp only [Dimension.mul_exponent, Dimension.Exponent.coe_add, Rat.cast_add]
     rw [← Finset.prod_mul_distrib]
     exact Finset.prod_congr rfl fun b _ =>
       NNReal.rpow_add (u1.ratio_ne_zero u2 b) _ _

--- a/Physlib/Units/ParametricUnits.lean
+++ b/Physlib/Units/ParametricUnits.lean
@@ -54,7 +54,8 @@ lemma ratio_ne_zero (u1 u2 : UnitScale B) (b : B) : u1.scale b / u2.scale b ≠ 
   dimension `d` rescales by `∏ b, (u1 b / u2 b) ^ d.exponent b` when changing the
   unit choice from `u1` to `u2`. This is the basis-generic form of
   `LTMCTUnitChoices.dimScale`. -/
-noncomputable def dimScale [Fintype B] (u1 u2 : UnitScale B) : Dimension B →* ℝ≥0 where
+noncomputable def dimScale [DimensionBasis B] [Fintype B]
+    (u1 u2 : UnitScale B) : Dimension B →* ℝ≥0 where
   toFun d := ∏ b, (u1.scale b / u2.scale b) ^ (d.exponent b : ℝ)
   map_one' := by simp
   map_mul' d1 d2 := by
@@ -64,18 +65,19 @@ noncomputable def dimScale [Fintype B] (u1 u2 : UnitScale B) : Dimension B →* 
       NNReal.rpow_add (u1.ratio_ne_zero u2 b) _ _
 
 @[simp]
-lemma dimScale_self [Fintype B] (u : UnitScale B) (d : Dimension B) :
+lemma dimScale_self [DimensionBasis B] [Fintype B] (u : UnitScale B) (d : Dimension B) :
     dimScale u u d = 1 := by
   simp only [dimScale, MonoidHom.coe_mk, OneHom.coe_mk]
   refine Finset.prod_eq_one fun b _ => ?_
   rw [div_self (u.scale_pos b).ne', NNReal.one_rpow]
 
 @[simp]
-lemma dimScale_one [Fintype B] (u1 u2 : UnitScale B) :
+lemma dimScale_one [DimensionBasis B] [Fintype B] (u1 u2 : UnitScale B) :
     dimScale u1 u2 1 = 1 := map_one _
 
 /-- The scaling is transitive (a cocycle in the unit choices). -/
-lemma dimScale_transitive [Fintype B] (u1 u2 u3 : UnitScale B) (d : Dimension B) :
+lemma dimScale_transitive [DimensionBasis B] [Fintype B]
+    (u1 u2 u3 : UnitScale B) (d : Dimension B) :
     dimScale u1 u2 d * dimScale u2 u3 d = dimScale u1 u3 d := by
   simp only [dimScale, MonoidHom.coe_mk, OneHom.coe_mk, ← Finset.prod_mul_distrib]
   refine Finset.prod_congr rfl fun b _ => ?_

--- a/Physlib/Units/ParametricUnits.lean
+++ b/Physlib/Units/ParametricUnits.lean
@@ -58,7 +58,7 @@ noncomputable def dimScale [Fintype B] (u1 u2 : UnitScale B) : Dimension B →* 
   toFun d := ∏ b, (u1.scale b / u2.scale b) ^ (d.exponent b : ℝ)
   map_one' := by simp
   map_mul' d1 d2 := by
-    simp only [Dimension.mul_exponent, Rat.cast_add]
+    simp only [Dimension.mul_exponent, map_add, Rat.cast_add]
     rw [← Finset.prod_mul_distrib]
     exact Finset.prod_congr rfl fun b _ =>
       NNReal.rpow_add (u1.ratio_ne_zero u2 b) _ _

--- a/Physlib/Units/UnitSystem.lean
+++ b/Physlib/Units/UnitSystem.lean
@@ -229,6 +229,7 @@ lemma dimScale_eq_toScale_dimScale (u1 u2 : LTMCTUnitChoices) (d : Dimension LTM
   rw [dimScale_apply, length_ratio, time_ratio, mass_ratio, charge_ratio, temperature_ratio,
     UnitScale.dimScale, MonoidHom.coe_mk, OneHom.coe_mk, prod_univ_LTMCTDimensionBase]
   simp only [Dimension.length, Dimension.time, Dimension.mass, Dimension.charge,
-    Dimension.temperature]
+    Dimension.temperature, Dimension.exponent_length, Dimension.exponent_time,
+    Dimension.exponent_mass, Dimension.exponent_charge, Dimension.exponent_temperature]
 
 end LTMCTUnitChoices

--- a/Physlib/Units/WithDim/Basic.lean
+++ b/Physlib/Units/WithDim/Basic.lean
@@ -26,14 +26,15 @@ routes through `LTMCTUnitChoices.dimScale`, is provided for the standard basis
 open NNReal
 
 /-- The type `M` carrying an instance of a dimension `d`. -/
-structure WithDim {B : Type} (d : Dimension B) (M : Type) where
+structure WithDim {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) where
   /-- The underlying value of `M`. -/
   val : M
 
 namespace WithDim
 
 @[ext]
-lemma ext {B : Type} {d : Dimension B} {M} (x1 x2 : WithDim d M) (h : x1.val = x2.val) :
+lemma ext {B : Type} [DimensionBasis B] {d : Dimension B} {M}
+    (x1 x2 : WithDim d M) (h : x1.val = x2.val) :
     x1 = x2 := by
   cases x1
   cases x2
@@ -50,50 +51,58 @@ lemma dim_apply (d : Dimension LTMCTDimensionBase) (M : Type) :
 ## Inherited instances
 -/
 
-instance {B : Type} (d : Dimension B) (M : Type) [Inhabited M] : Inhabited (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Inhabited M] :
+    Inhabited (WithDim d M) where
   default := ⟨default⟩
 
-instance {B : Type} (d : Dimension B) (M : Type) [Zero M] : Zero (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Zero M] :
+    Zero (WithDim d M) where
   zero := ⟨0⟩
 
 @[simp]
-lemma val_zero {B : Type} {d : Dimension B} {M : Type} [Zero M] :
+lemma val_zero {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [Zero M] :
     (0 : WithDim d M).val = 0 := rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [Add M] : Add (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Add M] :
+    Add (WithDim d M) where
   add m1 m2 := ⟨m1.val + m2.val⟩
 
 @[simp]
-lemma val_add {B : Type} {d : Dimension B} {M : Type} [Add M] (m1 m2 : WithDim d M) :
+lemma val_add {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [Add M]
+    (m1 m2 : WithDim d M) :
     (m1 + m2).val = m1.val + m2.val := rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [Neg M] : Neg (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Neg M] :
+    Neg (WithDim d M) where
   neg m := ⟨-m.val⟩
 
 @[simp]
-lemma val_neg {B : Type} {d : Dimension B} {M : Type} [Neg M] (m : WithDim d M) :
+lemma val_neg {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [Neg M]
+    (m : WithDim d M) :
     (-m).val = -m.val := rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [Sub M] : Sub (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Sub M] :
+    Sub (WithDim d M) where
   sub m1 m2 := ⟨m1.val - m2.val⟩
 
 @[simp]
-lemma val_sub {B : Type} {d : Dimension B} {M : Type} [Sub M] (m1 m2 : WithDim d M) :
+lemma val_sub {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [Sub M]
+    (m1 m2 : WithDim d M) :
     (m1 - m2).val = m1.val - m2.val := rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddSemigroup M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddSemigroup M] :
     AddSemigroup (WithDim d M) where
   add_assoc m1 m2 m3 := by
     ext
     simp [add_assoc]
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddCommSemigroup M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddCommSemigroup M] :
     AddCommSemigroup (WithDim d M) where
   add_comm m1 m2 := by
     ext
     simp [add_comm]
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddMonoid M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddMonoid M] :
     AddMonoid (WithDim d M) where
   zero_add m := by
     ext
@@ -103,13 +112,13 @@ instance {B : Type} (d : Dimension B) (M : Type) [AddMonoid M] :
     simp [add_zero]
   nsmul := nsmulRec
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddCommMonoid M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddCommMonoid M] :
     AddCommMonoid (WithDim d M) where
   add_comm m1 m2 := by
     ext
     simp [add_comm]
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddGroup M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddGroup M] :
     AddGroup (WithDim d M) where
   sub_eq_add_neg m1 m2 := by
     ext
@@ -119,27 +128,31 @@ instance {B : Type} (d : Dimension B) (M : Type) [AddGroup M] :
     simp [neg_add_cancel]
   zsmul := zsmulRec
 
-instance {B : Type} (d : Dimension B) (M : Type) [AddCommGroup M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [AddCommGroup M] :
     AddCommGroup (WithDim d M) where
   add_comm m1 m2 := by
     ext
     simp [add_comm]
 
-instance {B : Type} (d : Dimension B) (M : Type) [LE M] : LE (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [LE M] :
+    LE (WithDim d M) where
   le m1 m2 := m1.val ≤ m2.val
 
 @[simp]
-lemma le_def {B : Type} {d : Dimension B} {M : Type} [LE M] (m1 m2 : WithDim d M) :
+lemma le_def {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [LE M]
+    (m1 m2 : WithDim d M) :
     m1 ≤ m2 ↔ m1.val ≤ m2.val := Iff.rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [LT M] : LT (WithDim d M) where
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [LT M] :
+    LT (WithDim d M) where
   lt m1 m2 := m1.val < m2.val
 
 @[simp]
-lemma lt_def {B : Type} {d : Dimension B} {M : Type} [LT M] (m1 m2 : WithDim d M) :
+lemma lt_def {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [LT M]
+    (m1 m2 : WithDim d M) :
     m1 < m2 ↔ m1.val < m2.val := Iff.rfl
 
-instance {B : Type} (d : Dimension B) (M : Type) [Preorder M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [Preorder M] :
     Preorder (WithDim d M) where
   le_refl m := by
     exact le_refl m.val
@@ -150,13 +163,13 @@ instance {B : Type} (d : Dimension B) (M : Type) [Preorder M] :
     change m1.val < m2.val ↔ m1.val ≤ m2.val ∧ ¬ m2.val ≤ m1.val
     exact lt_iff_le_not_ge
 
-instance {B : Type} (d : Dimension B) (M : Type) [PartialOrder M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [PartialOrder M] :
     PartialOrder (WithDim d M) where
   le_antisymm m1 m2 h12 h21 := by
     ext
     exact le_antisymm h12 h21
 
-instance {B : Type} (d : Dimension B) (M : Type) [MulAction ℝ≥0 M] :
+instance {B : Type} [DimensionBasis B] (d : Dimension B) (M : Type) [MulAction ℝ≥0 M] :
     MulAction ℝ≥0 (WithDim d M) where
   smul a m := ⟨a • m.val⟩
   one_smul m := ext _ _ (one_smul ℝ≥0 m.val)
@@ -165,15 +178,15 @@ instance {B : Type} (d : Dimension B) (M : Type) [MulAction ℝ≥0 M] :
     exact mul_smul a b m.val
 
 @[simp]
-lemma smul_val {B : Type} {d : Dimension B} {M : Type} [MulAction ℝ≥0 M]
+lemma smul_val {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} [MulAction ℝ≥0 M]
     (a : ℝ≥0) (m : WithDim d M) :
     (a • m).val = a • m.val := rfl
 
-instance {B : Type} {d1 d2 : Dimension B} :
+instance {B : Type} [DimensionBasis B] {d1 d2 : Dimension B} :
     HMul (WithDim d1 ℝ) (WithDim d2 ℝ) (WithDim (d1 * d2) ℝ) where
   hMul m1 m2 := ⟨m1.val * m2.val⟩
 
-lemma withDim_hMul_val {B : Type} {d1 d2 : Dimension B}
+lemma withDim_hMul_val {B : Type} [DimensionBasis B] {d1 d2 : Dimension B}
     (m1 : WithDim d1 ℝ) (m2 : WithDim d2 ℝ) :
     (m1 * m2).val = m1.val * m2.val := rfl
 
@@ -192,13 +205,14 @@ instance {d1 d2 : Dimension LTMCTDimensionBase} :
 open UnitDependent
 
 @[simp]
-lemma val_mul_eq_mul {B : Type} {d1 d2 : Dimension B}
+lemma val_mul_eq_mul {B : Type} [DimensionBasis B] {d1 d2 : Dimension B}
     (m1 : WithDim d1 ℝ) (m2 : WithDim d2 ℝ) :
     m1.val * m2.val = (m1 * m2).val := by
   simp only [withDim_hMul_val]
 
 @[simp]
-lemma val_pow_two_eq_mul {B : Type} {d1 : Dimension B} (m1 : WithDim d1 ℝ) :
+lemma val_pow_two_eq_mul {B : Type} [DimensionBasis B] {d1 : Dimension B}
+    (m1 : WithDim d1 ℝ) :
     m1.val ^ 2 = (m1 * m1).val := by
   rw [sq]
   rfl
@@ -229,12 +243,13 @@ lemma scaleUnit_val {d : Dimension LTMCTDimensionBase} (M : Type) [MulAction ℝ
 
 -/
 
-noncomputable instance {B : Type} (d1 d2 : Dimension B) :
+noncomputable instance {B : Type} [DimensionBasis B] (d1 d2 : Dimension B) :
     HDiv (WithDim d1 ℝ) (WithDim d2 ℝ) (WithDim (d1 * d2⁻¹) ℝ) where
   hDiv m1 m2 := ⟨m1.val / m2.val⟩
 
 @[simp]
-lemma val_div_val {B : Type} {d1 d2 : Dimension B} (m1 : WithDim d1 ℝ) (m2 : WithDim d2 ℝ) :
+lemma val_div_val {B : Type} [DimensionBasis B] {d1 d2 : Dimension B}
+    (m1 : WithDim d1 ℝ) (m2 : WithDim d2 ℝ) :
     (m1.val / m2.val) = (m1 / m2).val := rfl
 
 @[simp]
@@ -267,11 +282,11 @@ lemma scaleUnit_dim_eq_zero {d : Dimension LTMCTDimensionBase} (m : WithDim d �
 set_option linter.unusedVariables false in
 /-- The casting from `WithDim d M` to `WithDim d2 M` when `d = d2`. -/
 @[nolint unusedArguments]
-def cast {B : Type} {d d2 : Dimension B} {M : Type} (m : WithDim d M)
+def cast {B : Type} [DimensionBasis B] {d d2 : Dimension B} {M : Type} (m : WithDim d M)
     (h : d = d2 := by ext <;> {simp; try ring}) : WithDim d2 M := ⟨m.val⟩
 
 @[simp]
-lemma cast_refl {B : Type} {d : Dimension B} {M : Type} (m : WithDim d M) :
+lemma cast_refl {B : Type} [DimensionBasis B] {d : Dimension B} {M : Type} (m : WithDim d M) :
     cast m rfl = m := rfl
 
 @[simp]


### PR DESCRIPTION
# Reducible rational arithmetic for dimension exponents

Ideally, the product of speed and time should type-check as length. This does not happen at present because the product of their dimensions is not definitionally equal to the length dimension:

```lean
example (v : WithDim (L𝓭 / T𝓭) ℝ) (t : WithDim T𝓭 ℝ) : WithDim L𝓭 ℝ :=
  v * t -- Type mismatch `v * t` has type `WithDim (L𝓭 / T𝓭 * T𝓭) ℝ` but is expected to have type `WithDim L𝓭 ℝ` (Lean 4)
```

The root cause is that dimension arithmetic uses rational arithmetic, whose operations are irreducible in Lean:

```lean
example : (2 : ℕ) + 2 = 4 := rfl -- succeeds
example : (2 : ℚ) + 2 = 4 := rfl -- fails
```

Locally unsealing rational arithmetic does not export reducibility to downstream modules, while globally changing the reducibility of imported declarations requires allowUnsafeReducibility. This PR instead introduces a wrapper around ℚ with reducible arithmetic, enabling:

```lean
example :
  let Length : Exponent × Exponent := (1, 0)
  let Time : Exponent × Exponent := (0, 1)
  let Speed := Length - Time
  Length = Time + Speed := rfl
```

This enables definitional equality for tuple- or structure-based dimensions, but unfortunately not for Physlib's current parametric dimensions. Lean's definitional equality is less effective at comparing unapplied functions than concrete data structures, while the parametric approach relies on function representation to maintain basis independence. I would therefore like to follow this PR with a simpler, non-parametric formalization of dimensions using Exponent.