### PR TITLE
docs(Relativity): correct dimension in Levi-Civita contraction module docstring

### DIFF
--- a/Physlib/Relativity/Tensors/LeviCivita/Contractions.lean
+++ b/Physlib/Relativity/Tensors/LeviCivita/Contractions.lean
@@ -15,7 +15,7 @@ public import Physlib.Meta.TODO.Basic
 ## i. Overview
 
 This file proves the "epsilon-epsilon" contraction identities for the rank-four Levi-Civita
-tensor `leviCivita` (notation `ε4`) in `d = 3`, stated in terms of the standard-basis
+tensor `leviCivita` (notation `ε4`) in `d = 4`, stated in terms of the standard-basis
 components of `ε4` itself (`realLorentzTensor.leviCivita_basis_repr_apply`).
 
 The underlying facts about the `generalizedKroneckerDelta` alone, with no


### PR DESCRIPTION
Corrects docstring for Levi-Civita contraction identities, which described `ε4` as living in `d = 3`.

The file’s results are in four dimensions. The full contraction is 24 = 4!, and the components are indexed by `Fin 4`.

Per @jstoobysmith’s comments on the issue, only the dimension was wrong.

Closes #1533

First contribution to Physlib so I figured I’d stick to docstrings. Happy to adjust anything. 