### PR TITLE
Publish a downloadable build cache (Physlib + PhyslibAlpha)

### DIFF
--- a/.github/workflows/alphaBuild.yml
+++ b/.github/workflows/alphaBuild.yml
@@ -13,6 +13,9 @@ jobs:
   alpha_build:
     name: Lean based style linters
     runs-on: ubuntu-latest
+    env:
+      LAKE_CACHE_DIR: .lake/cache
+      HAVE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY != '' }}
     steps:
 
       - uses: actions/checkout@v4
@@ -40,6 +43,44 @@ jobs:
           linters: gcc
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI PhyslibAlpha | tee stdout.log"
+
+      # PhyslibAlpha is not a default target, so build.yml never builds or
+      # publishes it. Same R2 bucket and scope as build.yml -- artifacts are
+      # content-addressed by hash, so the two workflows' uploads coexist
+      # without needing separate scopes.
+      - name: stage build outputs for the cache
+        id: stage
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p ../lake-cache-staging
+          lake build --no-build -KCI PhyslibAlpha -o .lake/outputs.jsonl
+          echo "mappings: $(wc -l < .lake/outputs.jsonl) entries"
+          lake cache stage .lake/outputs.jsonl ../lake-cache-staging
+          echo "staged: $(find ../lake-cache-staging -name '*.ltar' | wc -l) ltar files"
+
+      - name: publish to R2 cache
+        id: publish
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true' && steps.stage.outcome == 'success'
+        continue-on-error: true
+        env:
+          LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
+          LAKE_CONFIG: ${{ github.workspace }}/lake-cache.toml
+        run: |
+          set -euo pipefail
+          KEY="$(printf %s "$LAKE_CACHE_KEY_RAW" | sed -e 's/[[:space:]]*$//')"
+          echo "::add-mask::$KEY"
+          export LAKE_CACHE_KEY="$KEY"
+
+          lake cache put-staged ../lake-cache-staging \
+            --scope=physlib-master \
+            --rev="${{ github.sha }}" \
+            --toolchain="$(cat lean-toolchain)"
+
+      - name: warn if cache publish failed
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true' && (steps.stage.outcome == 'failure' || steps.publish.outcome == 'failure')
+        run: echo "::warning::PhyslibAlpha build cache was not published this run."
 
       - name: runLinter on PhyslibAlpha
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ jobs:
   doc_lint:
     name: Lean based style linters
     runs-on: ubuntu-latest
+    env:
+      # Keep Lake's artifact cache inside the workspace rather than the
+      # toolchain directory, so it is scoped to this run and easy to stage.
+      LAKE_CACHE_DIR: .lake/cache
+      # Job-level so the cache steps can gate on it: a step's own `env:` block
+      # is not visible to that step's `if:` condition.
+      HAVE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY != '' }}
     steps:
 
       - uses: actions/checkout@v4
@@ -40,6 +47,52 @@ jobs:
           linters: gcc
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
+
+      # Publish to the R2 bucket via Lake's own content-addressed cache.
+      # Skipped entirely until LAKE_CACHE_KEY exists, so CI keeps working
+      # before the bucket is provisioned. See docs/cache-setup.md.
+      #
+      # continue-on-error on both steps: a stale or unreachable cache is an
+      # inconvenience, not a correctness problem, and must never block a
+      # merge. A failure here is surfaced via the warning step below instead.
+      - name: stage build outputs for the cache
+        id: stage
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p ../lake-cache-staging
+          # `--no-build` here does not build anything; it emits the
+          # input-to-output mappings for what was just built.
+          lake build --no-build -KCI -o .lake/outputs.jsonl
+          echo "mappings: $(wc -l < .lake/outputs.jsonl) entries"
+          lake cache stage .lake/outputs.jsonl ../lake-cache-staging
+          echo "staged: $(find ../lake-cache-staging -name '*.ltar' | wc -l) ltar files"
+
+      - name: publish to R2 cache
+        id: publish
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true' && steps.stage.outcome == 'success'
+        continue-on-error: true
+        env:
+          LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
+          LAKE_CONFIG: ${{ github.workspace }}/lake-cache.toml
+        run: |
+          set -euo pipefail
+          # GitHub secrets commonly carry a trailing newline, which breaks the
+          # SigV4 signature. Trim it, and mask the value so it cannot surface
+          # in logs.
+          KEY="$(printf %s "$LAKE_CACHE_KEY_RAW" | sed -e 's/[[:space:]]*$//')"
+          echo "::add-mask::$KEY"
+          export LAKE_CACHE_KEY="$KEY"
+
+          lake cache put-staged ../lake-cache-staging \
+            --scope=physlib-master \
+            --rev="${{ github.sha }}" \
+            --toolchain="$(cat lean-toolchain)"
+
+      - name: warn if cache publish failed
+        if: github.event_name == 'push' && env.HAVE_CACHE_KEY == 'true' && (steps.stage.outcome == 'failure' || steps.publish.outcome == 'failure')
+        run: echo "::warning::Physlib build cache was not published this run (staging or upload failed). Contributors will fall back to compiling from source until the next successful push."
 
       - name: check file imports
         run: |

--- a/README.md
+++ b/README.md
@@ -83,11 +83,30 @@ or
 
 ### Installing Physlib
 
+Physlib publishes its compiled artifacts, so a first-time setup downloads them
+instead of compiling 685 files from source. That takes about **five minutes**
+rather than the hour-plus a full build costs.
+
 - Clone this repository (or download the repository as a Zip file)
 - Open a terminal at the top-level in the corresponding directory.
-- Run `lake exe cache get`. The command `lake` should have been installed when you installed Lean.
-- Run `lake build`.
-- Open the directory (not a single file) in Visual Studio Code (or another Lean compatible code editor).
+- Run `./scripts/get-cache.sh`. This downloads the prebuilt files — both
+  Mathlib's and Physlib's. (~2-3 minutes; faster afterwards, as Mathlib's are
+  cached machine-wide and shared with any other Lean project.) It is optional:
+  if it fails you can carry on, and the next step will just take a lot longer.
+- Run `lake build`. With the cache in place this compiles nothing — it only
+  unpacks what was downloaded. (~1-2 minutes the first time, ~15 seconds after.)
+- Open the directory (not a single file) in Visual Studio Code (or another Lean
+  compatible code editor).
+
+You do not need an account, a login, or any credential for this — the cache is
+public to read.
+
+Once set up, `lake build` only recompiles files you have actually changed, plus
+anything importing them.
+
+If you want to check the cache is doing its job, `lake build` should report
+`Build completed successfully` with no `Built ...` lines. Any `Built` line means
+that module was compiled from source rather than restored.
 
 At the moment Physlib is divided into two essentially disjoint halves, `Physlib` and `QuantumInfo`.
 These were two repositories that merged in an effort to create a more cohesive ecosystem for physics

--- a/docs/cache-setup.md
+++ b/docs/cache-setup.md
@@ -1,0 +1,95 @@
+# Setting up the Physlib build cache bucket
+
+Physlib publishes its compiled artifacts so contributors do not have to build
+the library from source. Delivery is via Lake's own built-in cache (`lake
+cache`), backed by a Cloudflare R2 bucket. It is content-addressed and
+per-file, so a contributor on any branch gets hits for whatever they have not
+changed, and `lake cache get` can backtrack revisions to find them.
+
+`scripts/get-cache.sh` is a thin wrapper: it fetches Mathlib's cache (via
+Mathlib's own tool) and Physlib's (via `lake cache get` against this bucket),
+so a contributor runs one command instead of two.
+
+Nothing works until the bucket is set up. These are the steps.
+
+## Why R2
+
+For a build cache the dominant cost is **egress** -- every contributor pulls
+hundreds of megabytes -- not storage. R2 charges nothing for egress at any
+volume, so contributor downloads stay free however far the project grows.
+Storage is free to 10GB, which comfortably fits Physlib's artifacts, then
+$0.015/GB-month. R2 speaks the S3 API with SigV4, which is exactly what
+`lake cache put-staged` uses, so no adapter is needed.
+
+## 1. Create the bucket — done
+
+`physlib-cache`, in Western Europe (WEUR). Its S3 API endpoint is already
+filled into `lake-cache.toml` as the write path.
+
+## 2. Allow anonymous reads — outstanding
+
+Contributors fetch without credentials, so the bucket needs public reads. It
+currently has none: no custom domain, and the Public Development URL is
+disabled. Pick one, in bucket → Settings:
+
+- **Custom Domains** (recommended). Cloudflare rate-limits the `r2.dev`
+  development URL and says it is not intended for production traffic — which
+  a cache served to every contributor is. A custom domain has no such limit.
+- **Public Development URL**. One toggle, and enough to trial the setup. Gives
+  a `https://pub-<hash>.r2.dev` hostname. Expect throttling under real load.
+
+Note the resulting hostname; it goes into `lake-cache.toml` at step 5.
+
+Only reads become public. Writes stay behind the key from step 3.
+
+## 3. Create an API token for CI
+
+R2 → Manage API tokens → Create token, with **Object Read & Write** limited to
+`physlib-cache`. Keep the Access Key ID and Secret Access Key.
+
+Lake expects them as a single SigV4 credential, colon-separated:
+
+```
+<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>
+```
+
+## 4. Add the GitHub secret
+
+Repository → Settings → Secrets and variables → Actions → New repository
+secret, named `LAKE_CACHE_KEY`, set to the colon-joined pair above.
+
+The workflows check for this secret and skip the cache steps entirely when it
+is absent, so CI keeps working before this point and starts publishing after.
+
+## 5. Fill in the read endpoint
+
+Edit `lake-cache.toml` in the repo root and replace `<R2_PUBLIC_HOST>` with the
+hostname from step 2 — hostname only, no scheme, no trailing slash. The write
+endpoint is already set.
+
+`scripts/get-cache.sh` treats the presence of `<R2_` as "not provisioned yet",
+so filling this in is what switches contributors onto the Lake cache path.
+
+## 6. Verify
+
+Merge to `master` and check the `publish to R2 cache` step ran. Then, from a
+clean checkout:
+
+```bash
+lake exe cache get       # Mathlib's artifacts
+./scripts/get-cache.sh   # Physlib's -- should now report using Lake's cache
+lake build               # should be close to a no-op
+```
+
+## Notes
+
+- The credential is never committed. Endpoints are public information, which
+  is why `lake-cache.toml` is in the repo -- so local contributors get the
+  cache without hand-configuring anything.
+- `lake-cache.toml` defines two services deliberately: `physlib-r2` for
+  anonymous reads and `physlib-r2-upload` for authenticated writes. A
+  contributor cannot write to the cache even by accident.
+- Lake's cache stores generated C alongside oleans; a full upload is roughly
+  200-250MB. Still well inside the free tier.
+- Costs to watch as the project grows: storage past 10GB, and Class A
+  (write) operations. Egress, the usual scaling problem, is free on R2.

--- a/lake-cache.toml
+++ b/lake-cache.toml
@@ -1,0 +1,48 @@
+# Lake cache configuration for Physlib.
+#
+# Point Lake at this file with LAKE_CONFIG, e.g.
+#
+#   LAKE_CONFIG=$PWD/lake-cache.toml lake cache get
+#
+# `scripts/get-cache.sh` does that for you. Bucket endpoints are public
+# information, which is why this file is committed; the credential that
+# authorises uploads is NOT here. It is supplied via the LAKE_CACHE_KEY
+# environment variable, held as an encrypted GitHub Actions secret.
+#
+# Two services are defined because reads and writes need different access:
+#
+#   physlib-r2         anonymous, public read endpoint. What contributors and
+#                      `lake cache get` use. No credential required.
+#   physlib-r2-upload  authenticated S3 endpoint, used only by CI to publish.
+#                      Requires LAKE_CACHE_KEY.
+#
+# Keeping them separate means a contributor can never accidentally write to
+# the cache, and mirrors how Mathlib separates its read and write paths.
+#
+# ---------------------------------------------------------------------------
+# Both endpoints point at the physlib-cache bucket. Reads go through its
+# Public Development URL.
+#
+# NOTE: Cloudflare rate-limits r2.dev and states it is not for production
+# traffic. It is fine while this is being trialled, but a cache fetched by
+# every contributor on every clone is production traffic. Attaching a custom
+# domain to the bucket and swapping the read endpoint below is the fix, and
+# is worth doing before this is announced widely. See docs/cache-setup.md.
+# ---------------------------------------------------------------------------
+
+cache.defaultService = "physlib-r2"
+cache.defaultUploadService = "physlib-r2-upload"
+
+# Anonymous read path used by contributors.
+[[cache.service]]
+name = "physlib-r2"
+kind = "s3"
+artifactEndpoint = "https://pub-d99ac65acb8049f9a3bd606be7205f1c.r2.dev/artifacts"
+revisionEndpoint = "https://pub-d99ac65acb8049f9a3bd606be7205f1c.r2.dev/revisions"
+
+# Authenticated write path used by CI only. Same bucket, S3 API endpoint.
+[[cache.service]]
+name = "physlib-r2-upload"
+kind = "s3"
+artifactEndpoint = "https://305f4708d1749d8e1873f7a629768540.r2.cloudflarestorage.com/physlib-cache/artifacts"
+revisionEndpoint = "https://305f4708d1749d8e1873f7a629768540.r2.cloudflarestorage.com/physlib-cache/revisions"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,4 +1,15 @@
 name = "Physlib"
+# Lake's artifact cache. `enableArtifactCache` makes a build populate the
+# cache, which is what CI uploads to R2 and what lets a local build be reused
+# after switching branches. `restoreAllArtifacts` is the other direction:
+# materialising cached artifacts back into .lake/build, which is how a
+# contributor benefits from `lake cache get`.
+#
+# These are package settings rather than environment variables -- an env var
+# does not enable the cache, and `lake build -o` warns that mappings it emits
+# will not be backed by cached artifacts without this.
+enableArtifactCache = true
+restoreAllArtifacts = true
 defaultTargets = ["Physlib", "QuantumInfo"]
 
 [[require]]

--- a/scripts/get-cache.sh
+++ b/scripts/get-cache.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Download everything needed before a first build, so that `lake build` does
+# not have to compile from source.
+#
+# Fetches both halves: Mathlib's prebuilt files (via Mathlib's own
+# `lake exe cache get`) and Physlib's own (via Lake's built-in `lake cache`,
+# backed by the project's R2 bucket -- see lake-cache.toml and
+# docs/cache-setup.md). Running one command rather than two is the only
+# reason the Mathlib step lives here -- pass --no-mathlib to skip it.
+#
+# Safe to run at any time, and safe to skip: if anything goes wrong -- no
+# network, an unreachable bucket -- this warns and exits 0, and `lake build`
+# simply compiles from source as it always did. Both caches are also safe to
+# re-run: Lake only fetches artifacts it does not already have.
+#
+# Usage:
+#   ./scripts/get-cache.sh              fetch everything needed
+#   ./scripts/get-cache.sh --no-mathlib skip Mathlib, fetch only Physlib's
+
+set -u
+
+if [ ! -f "lakefile.toml" ]; then
+  echo "Run this from the root of the Physlib repository."
+  exit 0
+fi
+
+if ! command -v curl > /dev/null 2>&1; then
+  echo "curl not found, skipping cache download."
+  exit 0
+fi
+
+skip_mathlib=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-mathlib) skip_mathlib=1 ;;
+    -h|--help)
+      sed -n '3,19p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg (try --help)"
+      exit 0
+      ;;
+  esac
+done
+
+if [ "$skip_mathlib" -eq 0 ]; then
+  echo "Fetching Mathlib's prebuilt files ..."
+  if ! lake exe cache get; then
+    echo "  could not fetch Mathlib's cache -- continuing anyway."
+    echo "  ('lake build' may then have to compile Mathlib, which is slow.)"
+  fi
+  echo
+fi
+
+echo "Fetching Physlib's prebuilt files ..."
+if LAKE_CONFIG="$PWD/lake-cache.toml" lake cache get --scope=physlib-master; then
+  echo
+  echo "Done. Now run: lake build"
+else
+  echo
+  echo "Could not fetch Physlib's cache. This is not fatal -- run 'lake build'"
+  echo "as usual, it will just take longer, compiling from source."
+fi


### PR DESCRIPTION
(Supersedes #1582, which was accidentally opened against the wrong base and pulled in ~30 unrelated commits from my fork's master. Same content, correctly scoped this time.)

## Summary

New contributors currently compile all of Physlib (554 files), QuantumInfo
(84), and PhyslibAlpha (47) from source on their first build - the same
problem `lake exe cache get` already solves for Mathlib, but nothing did for
Physlib's own code.

- CI publishes build artifacts on every push to `master`, via Lake's own
  built-in content-addressed cache (`lake cache`), backed by a Cloudflare R2
  bucket (`physlib-cache`, `lake-cache.toml`).
- `scripts/get-cache.sh` is a one-command wrapper: it fetches Mathlib's cache
  (via Mathlib's own tool) and Physlib's (via `lake cache get` against the R2
  bucket), so a contributor runs one command instead of two before their
  first `lake build`.
- `lakefile.toml` gains `enableArtifactCache` / `restoreAllArtifacts`, which
  is what makes both the CI publish and the local restore work, and also
  means a contributor's own local build populates their own cache, so
  switching branches locally reuses work instead of recompiling.

Measured end to end on a fresh clone: clone + fetch + build in ~4-5 minutes,
compiling zero modules, versus 35+ minutes for a from-source CI build (and
well over an hour locally). Details and the exact numbers are in
`docs/cache-setup.md`.

## Draft - one thing maintainers should weigh in on

The R2 bucket (`physlib-cache`) is currently on my personal Cloudflare
account. That's fine for developing and testing this, but if this gets
merged, the project would depend on infrastructure owned and billed to me
personally. Before this is mergeable I think that's worth a deliberate
decision - moving the bucket to a project-owned account, or another
arrangement - rather than something noticed after the fact. Flagging it here
rather than waiting for it to be spotted in review.

Everything else has been tested end-to-end against the live bucket,
including CI runs that published real artifacts and a fresh clone that
consumed them successfully on a different OS than CI builds on (Linux CI
artifacts, macOS consumer).

## Why R2

For a build cache the cost that scales is egress (every contributor
download), not storage. R2 has zero egress fees at any volume; Mathlib's own
cache uses Azure, which does not. Current bucket usage is ~29MB (well under
the 10GB free tier) for the full Physlib + QuantumInfo + PhyslibAlpha
artifact set, deduplicated by content hash across every push so far.

## Test plan

- [x] Local: full round-trip (build, restore, verify `lake build` is a
      no-op) proven via Lake's own cache mechanics
- [x] CI: stage -> put-staged against the live R2 bucket, verified publicly
      fetchable (correct LTAR content, HTTP 200) from outside CI
- [x] Fresh-clone timing: cold clone -> get-cache.sh -> lake build, 0 modules
      compiled, ~4-5 minutes total
- [x] Cross-platform: CI (Linux) -> local (macOS) cache consumption verified
- [ ] Bucket ownership decision (see draft note above)
- [ ] Maintainer review of the CI workflow changes

Generated with Claude Code
