### PR TITLE
docs: drop undefined Pauli tensor notation from module header

### DIFF
--- a/Physlib/Relativity/PauliMatrices/Basic.lean
+++ b/Physlib/Relativity/PauliMatrices/Basic.lean
@@ -18,15 +18,7 @@ The pauli matrices are defined ultimately through
   The notation `σ` can be used as short hand.
 
 A tensorial structure is put on `Fin 1 ⊕ Fin 3 → Matrix (Fin 2) (Fin 2) ℂ` to allow the
-use of index notation. We then define the following notation:
-
-- `σ^^^` is the tensorial version of the Pauli matrices, which is a complex Lorentz tensor
-  of type `ℂT[.up, .upL, .upR]`.
-
-and the following abbreviations:
-- `σ_^^` is the Pauli matrices as a complex Lorentz tensor of type `ℂT[.down, .upL, .upR]`.
-- `σ___` is the Pauli matrices as a complex Lorentz tensor of type `ℂT[.down, .downR, .downL]`.
-- `σ^__` is the Pauli matrices as a complex Lorentz tensor of type `ℂT[.up, .downR, .downL]`.
+use of index notation.
 
 -/
 


### PR DESCRIPTION
### Summary
The `PauliMatrices/Basic.lean` module header claimed tensor notations (`σ^^^`, `σ_^^`, …) that are not defined in this file. Keep the `pauliMatrix` / `σ` description and drop the false abbreviations.

### Validation
- Header now matches definitions in this file.

Fixes #1505

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

Made with [Cursor](https://cursor.com)