### PR TITLE
docs: fix ContrMod docstring (real vectors, not complex)

### DIFF
--- a/Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Modules.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Modules.lean
@@ -43,18 +43,18 @@ lemma ext {ψ ψ' : ContrMod d} (h : ψ.val = ψ'.val) : ψ = ψ' := by
   subst h
   rfl
 
-/-- The equivalence between `ContrℝModule` and `Fin 1 ⊕ Fin d → ℂ`. -/
+/-- The equivalence between `ContrMod` and `Fin 1 ⊕ Fin d → ℝ`. -/
 def toFin1dℝFun : ContrMod d ≃ (Fin 1 ⊕ Fin d → ℝ) where
   toFun v := v.val
   invFun f := ⟨f⟩
   left_inv _ := rfl
   right_inv _ := rfl
 
-/-- The instance of `AddCommGroup` on `ContrℝModule` defined via its equivalence
+/-- The instance of `AddCommGroup` on `ContrMod` defined via its equivalence
   with `Fin 1 ⊕ Fin d → ℝ`. -/
 instance : AddCommGroup (ContrMod d) := Equiv.addCommGroup toFin1dℝFun
 
-/-- The instance of `Module` on `ContrℝModule` defined via its equivalence
+/-- The instance of `Module` on `ContrMod` defined via its equivalence
   with `Fin 1 ⊕ Fin d → ℝ`. -/
 instance : Module ℝ (ContrMod d) := Equiv.module ℝ toFin1dℝFun
 
@@ -64,11 +64,11 @@ lemma val_add (ψ ψ' : ContrMod d) : (ψ + ψ').val = ψ.val + ψ'.val := rfl
 @[simp]
 lemma val_smul (r : ℝ) (ψ : ContrMod d) : (r • ψ).val = r • ψ.val := rfl
 
-/-- The linear equivalence between `ContrℝModule` and `(Fin 1 ⊕ Fin d → ℝ)`. -/
+/-- The linear equivalence between `ContrMod` and `(Fin 1 ⊕ Fin d → ℝ)`. -/
 def toFin1dℝEquiv : ContrMod d ≃ₗ[ℝ] (Fin 1 ⊕ Fin d → ℝ) :=
   Equiv.linearEquiv ℝ toFin1dℝFun
 
-/-- The underlying element of `Fin 1 ⊕ Fin d → ℝ` of a element in `ContrℝModule` defined
+/-- The underlying element of `Fin 1 ⊕ Fin d → ℝ` of a element in `ContrMod` defined
   through the linear equivalence `toFin1dℝEquiv`. -/
 abbrev toFin1dℝ (ψ : ContrMod d) := toFin1dℝEquiv ψ
 
@@ -79,7 +79,7 @@ lemma toFin1dℝ_eq_val (ψ : ContrMod d) : ψ.toFin1dℝ = ψ.val := by rfl
 
 -/
 
-/-- The standard basis of `ContrℝModule` indexed by `Fin 1 ⊕ Fin d`. -/
+/-- The standard basis of `ContrMod` indexed by `Fin 1 ⊕ Fin d`. -/
 def stdBasis : Basis (Fin 1 ⊕ Fin d) ℝ (ContrMod d) := Basis.ofEquivFun toFin1dℝEquiv
 
 @[simp]
@@ -173,7 +173,7 @@ lemma mulVec_mulVec (M N : Matrix (Fin 1 ⊕ Fin d) (Fin 1 ⊕ Fin d) ℝ) (v : 
 
 ## The norm
 
-(Not the Minkowski norm, but the norm of a vector in `ContrℝModule d`.)
+(Not the Minkowski norm, but the norm of a vector in `ContrMod d`.)
 -/
 
 /-- A `NormedAddCommGroup` structure on `ContrMod`. This is not an instance, as we
@@ -197,7 +197,7 @@ def toSpace (v : ContrMod d) : EuclideanSpace ℝ (Fin d) := WithLp.toLp 2 (v.va
 
 -/
 
-/-- The representation of the Lorentz group acting on `ContrℝModule d`. -/
+/-- The representation of the Lorentz group acting on `ContrMod d`. -/
 def rep : Representation ℝ (LorentzGroup d) (ContrMod d) where
   toFun g := Matrix.toLinAlgEquiv stdBasis g
   map_one' := EmbeddingLike.map_eq_one_iff.mpr rfl


### PR DESCRIPTION
### Summary
`toFin1dℝFun` was documented as an equivalence between `ContrℝModule` and complex-valued functions. The type is `ContrMod d ≃ (Fin 1 ⊕ Fin d → ℝ)`. Update that docstring and the other stale `ContrℝModule` names in this file.

### Validation
- Doc comments now match `ContrMod` and `ℝ` in `Physlib/Relativity/Tensors/RealTensor/Vector/Pre/Modules.lean`.

Fixes #1508

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.