### PR TITLE
Add lattice QFT stub module

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -104,6 +104,7 @@ public import Physlib.FluidDynamics.FluidFlow.Newtonian
 public import Physlib.FluidDynamics.ThermodynamicCauchyFlow.Basic
 public import Physlib.FluidDynamics.ThermodynamicCauchyFlow.Bernoulli
 public import Physlib.FluidDynamics.ThermodynamicCauchyFlow.Isentropic
+public import Physlib.LatticeQFT.Basic
 public import Physlib.Mathematics.Calculus.AdjFDeriv
 public import Physlib.Mathematics.Calculus.Divergence
 public import Physlib.Mathematics.Calculus.Gradient

--- a/Physlib/LatticeQFT/Basic.lean
+++ b/Physlib/LatticeQFT/Basic.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 The Physlib community. All rights reserved.
+Copyright (c) 2026 Rahul Pamula. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: The Physlib community
+Authors: Rahul Pamula
 -/
 module
 

--- a/Physlib/LatticeQFT/Basic.lean
+++ b/Physlib/LatticeQFT/Basic.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 The Physlib community. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Physlib community
+-/
+module
+
+/-!
+
+# A. Lattice QFT
+
+This module is a stub and a starting point for lattice QFT.
+
+## A.1 References
+
+- External repositories looking at lattice QFT.
+- `Physlib.QFT`
+- `Physlib.CondensedMatter.LatticeModels`
+
+-/
+
+@[expose] public section


### PR DESCRIPTION
This PR establishes a foundation for future lattice QFT work by adding a new top-level directory and stub, addressing the need for a starting point referencing external lattice QFT efforts.

### Changes
* `Physlib/LatticeQFT/Basic.lean` (Added): Creates the foundation stub for lattice QFT, including comments referencing relevant external repositories as a starting point.
* `Physlib.lean` (Modified): Added the public import for `Physlib.LatticeQFT.Basic` to ensure the new directory is tracked by the project's build system and linters.

### Reviewer Map
1. Review `Physlib/LatticeQFT/Basic.lean` to ensure the stub structure and comments accurately reflect the intention for future lattice QFT formalizations.
2. Review `Physlib.lean` to confirm the new module import is correctly placed and sorted.
