### PR TITLE
feat(OperatorAlgebra): Reorganize State & Measurement

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -353,6 +353,8 @@ public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Jordan
 public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Lie
 public import Physlib.QuantumMechanics.OperatorAlgebra.States.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.States.Statistics
+public import Physlib.QuantumMechanics.OperatorAlgebra.States.Uncertainty
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -348,8 +348,11 @@ public import Physlib.QuantumMechanics.InfiniteSquareWell.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Dynamics.Automorphism
 public import Physlib.QuantumMechanics.OperatorAlgebra.HilbertSpace
+public import Physlib.QuantumMechanics.OperatorAlgebra.Measurement.POVM
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Basic
 public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Jordan
 public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Lie
+public import Physlib.QuantumMechanics.OperatorAlgebra.States.Basic
 public import Physlib.QuantumMechanics.Operators.AngularMomentum
 public import Physlib.QuantumMechanics.Operators.Commutation
 public import Physlib.QuantumMechanics.Operators.Covariance

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Basic.lean
@@ -21,11 +21,8 @@ chosen:
 * **classical**: `C(M)`, continuous functions on phase space `M` — commutative, matching how
   classical observables always commute. E.g. position and momentum are just two such functions.
 
-The basic notions of observable, positive element, effect, state, unitary, channel, and finite
-POVM depend only on the observable algebra.
-
-This file only defines the vocabulary. Elementary results about each notion live in their own
-file (`Observable.lean`, `Effect.lean`, `State.lean`, ...).
+Unitary elements and channels are the algebraic starting point for dynamics.
+Observables, states, and measurements live in their respective subdirectories.
 
 -/
 
@@ -44,39 +41,9 @@ section ObservableAlgebra
 
 variable {A : Type*} [OperatorAlgebra A]
 
-/-- An observable is a self-adjoint element of `A`: position, momentum, energy, spin, ... .
-Self-adjointness is exactly what makes an element a *measurable* quantity — it is what forces its
-spectrum, the possible measurement outcomes, to be real. -/
-noncomputable abbrev Observable (A : Type*) [OperatorAlgebra A] := selfAdjoint A
-
-/-- A positive element of `A`: an observable whose measurement outcomes are all `≥ 0`.
-Positivity is what gives observables a meaningful order (`a ≤ b` meaning `b - a` is positive). -/
-abbrev PositiveElement (A : Type*) [OperatorAlgebra A] := {a : Observable A // 0 ≤ (a : A)}
-
-/-- An effect is an observable between zero and the identity, representing a yes/no measurement
-outcome. -/
-abbrev Effect (A : Type*) [OperatorAlgebra A] := Set.Icc (0 : Observable A) 1
-
-/-- A finite POVM on `A`: the most general notion of a measurement with outcomes in `X`,
-generalizing a single yes/no `Effect` to several possible outcomes. -/
-structure POVM (A : Type*) [OperatorAlgebra A] (X : Type*) [Fintype X] where
-  /-- The effect associated with each measurement outcome. -/
-  effect : X → Effect A
-  /-- The effects resolve the identity. -/
-  sum_effect : ∑ x, (effect x : A) = 1
-
 /-- A unitary element of `A`: implements a reversible transformation of the system — a symmetry,
 or time evolution under a Hamiltonian — acting on observables by conjugation, `a ↦ U a U⋆`. -/
 noncomputable abbrev Unitary (A : Type*) [OperatorAlgebra A] := unitary A
-
-/-- A state on `A`: a positive complex-linear functional normalized by `ω 1 = 1`. `ω a` is the
-expected outcome of measuring observable `a` in this state — a state records everything that can
-be learned about the system by measurement. -/
-structure State (A : Type*) [OperatorAlgebra A] where
-  /-- The positive linear functional underlying the state. -/
-  toPositiveLinearMap : A →ₚ[ℂ] ℂ
-  /-- A state assigns expectation one to the identity observable. -/
-  map_one : toPositiveLinearMap 1 = 1
 
 /-- A channel from `A₁` to `A₂` — physicists' name for a unital completely positive (UCP) map,
 the most general notion of dynamics this framework expresses. -/

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Measurement/POVM.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Measurement/POVM.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Basic
+
+/-!
+
+# Positive operator-valued measures
+
+A finite positive operator-valued measure (POVM) assigns an effect to each
+outcome and requires that the effects sum to the identity. This is the first,
+finite-outcome measurement layer; measurable-space POVMs and measurement
+instruments belong in later modules.
+
+-/
+
+@[expose] public section
+
+namespace OperatorAlgebra
+
+/-- A finite POVM on `A`, indexed by a finite outcome type `X`. -/
+structure POVM (A : Type*) [OperatorAlgebra A] (X : Type*) [Fintype X] where
+  /-- The effect associated with each measurement outcome. -/
+  effect : X → Effect A
+  /-- The effects resolve the identity. -/
+  sum_effect : ∑ x, (effect x : A) = 1
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Basic.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Mathlib.Algebra.Lie.OfAssociative
+
+/-!
+
+# Observables
+
+An observable is a self-adjoint element of an observable algebra. It has real
+spectrum; positive observables have nonnegative spectrum. The Jordan and Lie
+products are the symmetric and antisymmetric parts of multiplication.
+
+-/
+
+@[expose] public section
+
+open scoped ComplexOrder CStarAlgebra
+
+namespace OperatorAlgebra
+
+variable {A : Type*} [OperatorAlgebra A]
+
+/-- An observable is a self-adjoint element of `A`: position, momentum, energy, spin, ... . -/
+noncomputable abbrev Observable (A : Type*) [OperatorAlgebra A] := selfAdjoint A
+
+/-- A positive observable. Its spectrum is contained in the nonnegative reals. -/
+abbrev PositiveElement (A : Type*) [OperatorAlgebra A] := {a : Observable A // 0 ≤ (a : A)}
+
+/-- An effect is an observable between zero and the identity, representing a yes/no measurement
+outcome. -/
+abbrev Effect (A : Type*) [OperatorAlgebra A] := Set.Icc (0 : Observable A) 1
+
+namespace Observable
+
+/-- The symmetrized product of two observables. -/
+noncomputable def jordan (a b : Observable A) : Observable A :=
+  realPart ((a : A) * (b : A))
+
+/-- The Jordan product on observables. -/
+scoped[OperatorAlgebra] infixl:70 " ⊙ " => Observable.jordan
+
+lemma coe_jordan (a b : Observable A) :
+    (a ⊙ b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
+  change (↑(realPart ((a : A) * (b : A))) : A) =
+    (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a)
+  rw [realPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
+
+/-- The antisymmetric observable product. -/
+noncomputable def lie (a b : Observable A) : Observable A :=
+  imaginaryPart ((a : A) * (b : A))
+
+/-- The standard bracket notation for the explicit operation `Observable.lie`. -/
+noncomputable instance instBracket : Bracket (Observable A) (Observable A) := ⟨lie⟩
+
+lemma coe_lie (a b : Observable A) :
+    (lie a b : A) =
+      (-(Complex.I / 2)) • ((a : A) * b - (b : A) * a) := by
+  change
+    (↑(imaginaryPart ((a : A) * (b : A))) : A) =
+      (-(Complex.I / 2)) • ((a : A) * (b : A) - (b : A) * (a : A))
+  rw [imaginaryPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
+  module
+
+/-- Coercion formula for the bracket notation. -/
+lemma coe_bracket (a b : Observable A) :
+    ((⁅a, b⁆ : Observable A) : A) =
+      (-(Complex.I / 2)) • ((a : A) * b - (b : A) * a) := by
+  exact coe_lie a b
+
+/-- Observable multiplication splits into its symmetric and antisymmetric parts. -/
+lemma mul_decomposition (a b : Observable A) :
+    (a : A) * b =
+      (a ⊙ b : A) + Complex.I • ((⁅a, b⁆ : Observable A) : A) := by
+  change
+    (a : A) * b =
+      ↑(realPart ((a : A) * (b : A))) +
+        Complex.I • ↑(imaginaryPart ((a : A) * (b : A)))
+  exact (realPart_add_I_smul_imaginaryPart ((a : A) * (b : A))).symm
+
+end Observable
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Jordan.lean
@@ -5,10 +5,9 @@ Authors: Tom Ole Diem
 -/
 module
 
-public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Basic
 public import Physlib.Meta.TODO.Basic
 public import Mathlib.Algebra.Jordan.Basic
-public import Mathlib.LinearAlgebra.Complex.Module
 
 /-!
 
@@ -36,19 +35,6 @@ namespace OperatorAlgebra
 variable {A : Type*} [OperatorAlgebra A]
 
 namespace Observable
-
-/-- The symmetrized product of two observables. -/
-noncomputable def jordan (a b : Observable A) : Observable A :=
-  realPart ((a : A) * (b : A))
-
-/-- The Jordan product on observables. -/
-scoped[OperatorAlgebra] infixl:70 " ⊙ " => Observable.jordan
-
-lemma coe_jordan (a b : Observable A) :
-    (a ⊙ b : A) = (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a) := by
-  change (↑(realPart ((a : A) * (b : A))) : A) =
-    (2⁻¹ : ℝ) • ((a : A) * b + (b : A) * a)
-  rw [realPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
 
 lemma jordan_comm (a b : Observable A) :
     a ⊙ b = b ⊙ a := by

--- a/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Lie.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/Observables/Lie.lean
@@ -5,9 +5,7 @@ Authors: Tom Ole Diem
 -/
 module
 
-public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
-public import Mathlib.Algebra.Lie.OfAssociative
-public import Mathlib.LinearAlgebra.Complex.Module
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Basic
 
 /-!
 
@@ -36,21 +34,6 @@ variable {A : Type*} [OperatorAlgebra A]
 namespace Observable
 
 /-! ## Lie bracket -/
-
-/-- The observable Lie bracket is the imaginary part of the algebra product. -/
-noncomputable instance instBracket :
-    Bracket (Observable A) (Observable A) :=
-  ⟨fun a b => imaginaryPart ((a : A) * (b : A))⟩
-
-@[simp]
-lemma coe_bracket (a b : Observable A) :
-    ((⁅a, b⁆ : Observable A) : A) =
-      (-(Complex.I / 2)) • ((a : A) * b - (b : A) * a) := by
-  change
-    (↑(imaginaryPart ((a : A) * (b : A))) : A) =
-      (-(Complex.I / 2)) • ((a : A) * b - (b : A) * a)
-  rw [imaginaryPart_apply_coe, star_mul, a.property.star_eq, b.property.star_eq]
-  module
 
 /-! ## Lie ring -/
 

--- a/Physlib/QuantumMechanics/OperatorAlgebra/States/Basic.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/States/Basic.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.Basic
+
+/-!
+
+# States on observable algebras
+
+A state is a normalized positive complex-linear functional. It records the
+expectation values of observables in a physical preparation.
+
+-/
+
+@[expose] public section
+
+open scoped ComplexOrder CStarAlgebra
+
+namespace OperatorAlgebra
+
+variable {A : Type*} [OperatorAlgebra A]
+
+/-- A state on `A`: a positive complex-linear functional normalized at `1`. -/
+structure State (A : Type*) [OperatorAlgebra A] where
+  /-- The positive linear functional underlying the state. -/
+  toPositiveLinearMap : A →ₚ[ℂ] ℂ
+  /-- A state assigns expectation one to the identity observable. -/
+  map_one : toPositiveLinearMap 1 = 1
+
+namespace State
+
+noncomputable instance : CoeFun (State A) (fun _ => A → ℂ) where
+  coe ω := ω.toPositiveLinearMap
+
+@[ext]
+lemma ext {ω φ : State A} (h : ∀ a, ω a = φ a) : ω = φ := by
+  cases ω
+  cases φ
+  congr
+  exact PositiveLinearMap.ext h
+
+end State
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/States/Statistics.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/States/Statistics.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.States.Basic
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Jordan
+
+/-!
+
+# State statistics
+
+A state assigns real expectation values to observables. Centering observables
+produces covariance and variance, the quantities used in uncertainty relations.
+
+-/
+
+@[expose] public section
+
+open scoped ComplexOrder InnerProductSpace
+
+namespace OperatorAlgebra
+
+variable {A : Type*} [OperatorAlgebra A]
+
+namespace State
+
+/-! ## Expectation -/
+
+/-- The real expectation functional obtained from a state on observables. -/
+noncomputable def expectation (ω : State A) : Observable A →ₗ[ℝ] ℝ where
+  toFun a := (ω.toPositiveLinearMap (a : A)).re
+  map_add' a b := by simp
+  map_smul' r a := by
+    rw [selfAdjoint.val_smul, PositiveLinearMap.map_smul_of_tower]
+    simp
+
+@[inherit_doc State.expectation]
+scoped[OperatorAlgebra] notation:max ω "⟨" a "⟩" => State.expectation ω a
+
+attribute [nolint docBlame] OperatorAlgebra.«term_⟨_⟩»
+
+lemma apply_observable_eq_expectation (ω : State A) (a : Observable A) :
+    ω (a : A) = (ω⟨a⟩ : ℂ) := by
+  apply Complex.ext
+  · rfl
+  · rw [Complex.ofReal_im]
+    have h : star (ω (a : A)) = ω (a : A) := by
+      rw [← map_star, a.property.star_eq]
+    exact Complex.conj_eq_iff_im.mp
+      (by simpa [Complex.star_def] using h)
+
+@[simp]
+lemma expectation_one (ω : State A) :
+    ω⟨(1 : Observable A)⟩ = 1 := by
+  simp [expectation, ω.map_one]
+
+/-- Positive observables have nonnegative expectation. -/
+lemma expectation_nonneg (ω : State A) {a : Observable A}
+    (ha : 0 ≤ (a : A)) :
+    0 ≤ ω⟨a⟩ :=
+  (Complex.le_def.mp (ω.toPositiveLinearMap.map_nonneg ha)).1
+
+/-! ## Centering -/
+
+/-- An observable with its expectation value subtracted. -/
+noncomputable def centered (ω : State A) (a : Observable A) : Observable A :=
+  a - ω⟨a⟩ • 1
+
+@[simp]
+lemma expectation_centered (ω : State A) (a : Observable A) :
+    ω⟨centered ω a⟩ = 0 := by
+  simp [centered]
+
+/-- Centering removes scalar multiples of the identity. -/
+@[simp]
+lemma centered_add_smul_one (ω : State A) (a : Observable A) (c : ℝ) :
+    centered ω (a + c • 1) = centered ω a := by
+  simp only [centered, map_add, map_smul, expectation_one]
+  module
+
+/-! ## Covariance and variance -/
+
+/-- Covariance is the expectation of the symmetrized product of centered observables. -/
+noncomputable def covariance (ω : State A) (a b : Observable A) : ℝ :=
+  ω⟨centered ω a ⊙ centered ω b⟩
+
+/-- Variance is covariance on the diagonal. -/
+noncomputable def variance (ω : State A) (a : Observable A) : ℝ :=
+  covariance ω a a
+
+@[simp]
+lemma covariance_self (ω : State A) (a : Observable A) :
+    covariance ω a a = variance ω a :=
+  rfl
+
+/-- Covariance is symmetric. -/
+lemma covariance_comm (ω : State A) (a b : Observable A) :
+    covariance ω a b = covariance ω b a := by
+  simp only [covariance]
+  rw [Observable.jordan_comm]
+
+/-- Adding a scalar multiple of the identity to the left observable preserves covariance. -/
+lemma covariance_add_smul_one_left (ω : State A) (a b : Observable A) (c : ℝ) :
+    covariance ω (a + c • 1) b = covariance ω a b := by
+  simp only [covariance, centered_add_smul_one]
+
+/-- Adding a scalar multiple of the identity to the right observable preserves covariance. -/
+lemma covariance_add_smul_one_right (ω : State A) (a b : Observable A) (c : ℝ) :
+    covariance ω a (b + c • 1) = covariance ω a b := by
+  simp only [covariance, centered_add_smul_one]
+
+/-- Variance is nonnegative. -/
+lemma variance_nonneg (ω : State A) (a : Observable A) :
+    0 ≤ variance ω a := by
+  rw [variance, covariance]
+  apply expectation_nonneg
+  show 0 ≤ (Observable.jordan (centered ω a) (centered ω a) : A)
+  rw [Observable.jordan_self]
+  simpa [(centered ω a).property.star_eq] using
+    star_mul_self_nonneg (centered ω a : A)
+
+end State
+
+end OperatorAlgebra

--- a/Physlib/QuantumMechanics/OperatorAlgebra/States/Uncertainty.lean
+++ b/Physlib/QuantumMechanics/OperatorAlgebra/States/Uncertainty.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 Tom Ole Diem. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Ole Diem
+-/
+module
+
+public import Physlib.QuantumMechanics.OperatorAlgebra.States.Statistics
+public import Physlib.QuantumMechanics.OperatorAlgebra.Observables.Lie
+public import Mathlib.Analysis.CStarAlgebra.GelfandNaimarkSegal
+
+/-!
+
+# Uncertainty relations
+
+Positivity of a state gives a Cauchy--Schwarz inequality for expectation values.
+Applied to centered observables, this yields the Robertson--Schrödinger and
+Robertson uncertainty relations.
+
+-/
+
+@[expose] public section
+
+open scoped ComplexOrder InnerProductSpace OperatorAlgebra
+
+namespace OperatorAlgebra
+
+variable {A : Type*} [OperatorAlgebra A]
+
+namespace State
+
+/-- Centering does not change the antisymmetric part of a product. -/
+@[simp]
+lemma bracket_centered (ω : State A) (a b : Observable A) :
+    ⁅centered ω a, centered ω b⁆ = ⁅a, b⁆ := by
+  simp [centered, sub_lie, lie_sub]
+
+/-- The expectation of a centered product splits into its symmetric and antisymmetric parts. -/
+lemma apply_centered_mul_centered (ω : State A) (a b : Observable A) :
+    ω ((centered ω a : A) * centered ω b) =
+      (covariance ω a b : ℂ) + Complex.I * (ω⟨⁅a, b⁆⟩ : ℂ) := by
+  rw [Observable.mul_decomposition, map_add, map_smul,
+    apply_observable_eq_expectation, apply_observable_eq_expectation,
+    bracket_centered]
+  rfl
+
+/-! ## Cauchy--Schwarz -/
+
+/-- Reversing a product of observables conjugates its state value. -/
+lemma apply_mul_comm_eq_star (ω : State A) (a b : Observable A) :
+    ω ((b : A) * a) = star (ω ((a : A) * b)) := by
+  rw [← map_star, star_mul, a.property.star_eq, b.property.star_eq]
+
+/-- GNS Cauchy--Schwarz for centered observables, before rewriting to variances. -/
+lemma centered_gns_cauchy_schwarz (ω : State A) (a b : Observable A) :
+    ‖ω ((centered ω a : A) * centered ω b)‖ *
+        ‖ω ((centered ω b : A) * centered ω a)‖ ≤
+      variance ω a * variance ω b := by
+  let φ := ω.toPositiveLinearMap
+  have h := inner_mul_inner_self_le (𝕜 := ℂ)
+    (φ.toPreGNS (centered ω a : A))
+    (φ.toPreGNS (centered ω b : A))
+  simp only [PositiveLinearMap.preGNS_inner_def,
+    PositiveLinearMap.ofPreGNS_toPreGNS,
+    (centered ω a).property.star_eq,
+    (centered ω b).property.star_eq] at h
+  rw [variance, covariance]
+  change
+    ‖φ ((centered ω a : A) * centered ω b)‖ *
+        ‖φ ((centered ω b : A) * centered ω a)‖ ≤
+      (φ ((centered ω a ⊙ centered ω a : Observable A) : A)).re *
+        (φ ((centered ω b ⊙ centered ω b : Observable A) : A)).re
+  rw [Observable.jordan_self, Observable.jordan_self]
+  exact h
+
+/-- Cauchy--Schwarz for centered observables. -/
+lemma centered_cauchy_schwarz (ω : State A) (a b : Observable A) :
+    Complex.normSq (ω ((centered ω a : A) * centered ω b)) ≤
+      variance ω a * variance ω b := by
+  calc
+    Complex.normSq (ω ((centered ω a : A) * centered ω b)) =
+        ‖ω ((centered ω a : A) * centered ω b)‖ *
+          ‖ω ((centered ω b : A) * centered ω a)‖ := by
+      rw [apply_mul_comm_eq_star]
+      simp [Complex.normSq_eq_norm_sq, pow_two]
+    _ ≤ _ := centered_gns_cauchy_schwarz ω a b
+
+/-! ## Uncertainty relations -/
+
+/-- The Robertson--Schrödinger uncertainty inequality. -/
+lemma robertson_schrodinger (ω : State A) (a b : Observable A) :
+    covariance ω a b ^ 2 + ω⟨⁅a, b⁆⟩ ^ 2 ≤
+      variance ω a * variance ω b := by
+  have h := centered_cauchy_schwarz ω a b
+  rw [apply_centered_mul_centered, Complex.normSq_apply] at h
+  simpa [pow_two] using h
+
+/-- Covariance satisfies the Cauchy--Schwarz inequality. -/
+lemma covariance_cauchy_schwarz (ω : State A) (a b : Observable A) :
+    covariance ω a b ^ 2 ≤ variance ω a * variance ω b := by
+  nlinarith [robertson_schrodinger ω a b,
+    sq_nonneg (ω⟨⁅a, b⁆⟩)]
+
+/-- The Robertson uncertainty inequality. -/
+lemma robertson (ω : State A) (a b : Observable A) :
+    ω⟨⁅a, b⁆⟩ ^ 2 ≤ variance ω a * variance ω b := by
+  nlinarith [robertson_schrodinger ω a b,
+    sq_nonneg (covariance ω a b)]
+
+end State
+
+end OperatorAlgebra


### PR DESCRIPTION
## Summary

- Move observable primitives into `Observables.Basic`.
- Organize states as `States.Basic`, `States.Statistics`, and `States.Uncertainty`.
- Add expectation, centered observables, covariance, variance, and the
  Robertson--Schrödinger and Robertson inequalities.
- Move finite-outcome POVMs into `Measurement.POVM`.
- Keep `OperatorAlgebra.Basic` focused on the algebra, unitary, and channel vocabulary.
- Expose explicit Jordan and Lie operations, with bracket notation backed by `Observable.lie`.
