### PR TITLE
feat: time derivative of trajectories into torsors as derivVec

### DIFF
--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nikolai Kashcheev, Joseph Tooby-Smith
+Authors: Nikolai Kashcheev, Zhi Kai Pong, Joseph Tooby-Smith
 -/
 module
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -22,6 +22,8 @@ In this module we define and prove basic lemmas about derivatives of functions o
 
 - `deriv` : The derivative of a function `Time → M` at a given time.
 - `manifoldDeriv` : The derivative of a function from `Time` to a manifold.
+- `derivVec` : The derivative of a function from `Time` into a torsor, such as `Space d`,
+  valued in the vector space of displacements of that torsor.
 - `hasDerivAt_comp_toRealCLE_symm` : The time derivative as a `HasDerivAt` on `ℝ`, for a curve
   reparametrised through the canonical equivalence `toRealCLE.symm : ℝ ≃L[ℝ] Time`.
 - `deriv_comp_toRealCLE_of_hasDerivAt` : Its converse, a `HasDerivAt` on `ℝ` read as the time
@@ -35,10 +37,12 @@ In this module we define and prove basic lemmas about derivatives of functions o
   - A.1. Derivatives of functions into vector spaces
   - A.2. The derivative through the canonical equivalence with `ℝ`
   - A.3. Derivatives of functions into manifolds
+  - A.4. Derivatives of functions into torsors
 - B. Linearlity properties of the derivative
 - C. Derivative of constant functions
 - D. Smoothness properties and the reversal of time
 - E. Derivatives of components
+- F. Derivatives of trajectories into `Space`
 
 ## iv. References
 
@@ -158,6 +162,45 @@ lemma manifoldDeriv_const {E H N : Type} [NormedAddCommGroup E] [NormedSpace ℝ
 
 /-!
 
+### A.4. Derivatives of functions into torsors
+
+A trajectory in physical space is a curve of points, and its velocity is a displacement per
+unit time, that is a vector. For a torsor `P` over a vector space `V`, for example
+`Space d` over `EuclideanSpace ℝ (Fin d)`, the derivative of a curve `f : Time → P` is
+therefore valued in `V` rather than in `P`. It is defined by differentiating the displacement
+curve `s ↦ f s -ᵥ f t`, which is `V`-valued, so that no origin of `P` is ever chosen. The
+reference point used to form the displacement is irrelevant, see `derivVec_eq_fderiv_vsub`.
+
+-/
+
+/-- The time derivative of a trajectory into a torsor `P` over a vector space `V`,
+valued in `V`. For a trajectory `f : Time → Space d` this is the velocity, a spatial vector in
+`EuclideanSpace ℝ (Fin d)` rather than a point of `Space d`. -/
+noncomputable def derivVec {V P : Type} [AddCommGroup V] [Module ℝ V] [TopologicalSpace V]
+    [AddTorsor V P] (f : Time → P) : Time → V :=
+  fun t => fderiv ℝ (fun s => f s -ᵥ f t) t 1
+
+@[inherit_doc derivVec]
+scoped notation "∂ₜᵥ" => derivVec
+
+lemma derivVec_eq {V P : Type} [AddCommGroup V] [Module ℝ V] [TopologicalSpace V]
+    [AddTorsor V P] (f : Time → P) (t : Time) :
+    ∂ₜᵥ f t = fderiv ℝ (fun s => f s -ᵥ f t) t 1 := rfl
+
+/-- The derivative of a trajectory into a torsor does not depend on the reference point used
+to form the displacement: any base point `p` gives the same derivative. The normed hypotheses on
+`V` here come from `fderiv_add_const`; the definition itself needs only a topological vector
+space. -/
+lemma derivVec_eq_fderiv_vsub {V P : Type} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [AddTorsor V P] (f : Time → P) (p : P) (t : Time) :
+    ∂ₜᵥ f t = fderiv ℝ (fun s => f s -ᵥ p) t 1 := by
+  have h : (fun s => f s -ᵥ f t) = fun s => (f s -ᵥ p) + (p -ᵥ f t) := by
+    funext s
+    rw [vsub_add_vsub_cancel]
+  rw [derivVec_eq, h, fderiv_add_const]
+
+/-!
+
 ## B. Linearlity properties of the derivative
 
 -/
@@ -216,6 +259,13 @@ lemma deriv_const [NormedAddCommGroup M] [NormedSpace ℝ M] (m : M) :
     ∂ₜ (fun _ => m) t = 0 := by
   rw [deriv]
   simp
+
+/-- A trajectory constant at a point of a torsor has zero derivative. -/
+@[simp]
+lemma derivVec_const {V P : Type} [AddCommGroup V] [Module ℝ V] [TopologicalSpace V]
+    [AddTorsor V P] (p : P) :
+    ∂ₜᵥ (fun _ => p) t = (0 : V) := by
+  simp [derivVec]
 
 /-!
 
@@ -324,5 +374,44 @@ lemma deriv_space {d : ℕ} {f : Time → Space d}
     (hf : Differentiable ℝ f) (t : Time) (i : Fin d) :
     deriv (fun s => f s i) t = deriv f t i :=
   (Space.fderiv_space_components i f hf t 1).symm
+
+/-!
+
+## F. Derivatives of trajectories into `Space`
+
+For a trajectory `f : Time → Space d` of points in space, the torsor derivative `∂ₜᵥ f` is
+valued in the displacement space `EuclideanSpace ℝ (Fin d)`. Componentwise it agrees with the
+time derivatives of the coordinates, and under the identification of `Space d` with its
+displacement space given by the (arbitrary) zero point it recovers the vector space derivative
+`∂ₜ f`. The latter bridges `∂ₜᵥ` to the existing `∂ₜ` API.
+
+Note that `Space d` carries two `AddTorsor` instances: the intended one over
+`EuclideanSpace ℝ (Fin d)`, and one over itself coming from the module structure on `Space d`.
+Instance resolution selects the former, so `∂ₜᵥ` of a trajectory in `Space d` is valued in
+`EuclideanSpace ℝ (Fin d)` as intended.
+
+-/
+
+/-- The components of the torsor derivative of a trajectory in `Space d` are the time
+derivatives of the coordinates of the trajectory. -/
+lemma derivVec_space {f : Time → Space d} (hf : Differentiable ℝ f) (t : Time) (i : Fin d) :
+    ∂ₜᵥ f t i = ∂ₜ (fun s => f s i) t := by
+  have hv : Differentiable ℝ (fun s => (f s -ᵥ f t : EuclideanSpace ℝ (Fin d))) := by
+    apply differentiable_euclid
+    intro j
+    simp only [Space.vsub_apply]
+    exact ((Space.eval_differentiable j).comp hf).sub_const (f t j)
+  rw [derivVec_eq, deriv_eq, ← fderiv_euclid hv t 1]
+  simp only [Space.vsub_apply]
+  rw [fderiv_sub_const]
+
+/-- The torsor derivative of a trajectory in `Space d` agrees with the vector space derivative
+`∂ₜ` under the identification of `Space d` with its displacement space given by the zero
+point. -/
+lemma derivVec_eq_deriv_vsub_zero {f : Time → Space d} (hf : Differentiable ℝ f) (t : Time) :
+    ∂ₜᵥ f t = ∂ₜ f t -ᵥ (0 : Space d) := by
+  ext i
+  rw [derivVec_space hf t i, deriv_space hf t i, Space.vsub_apply]
+  simp
 
 end Time


### PR DESCRIPTION
Time.deriv is based on fderiv, which forces the derivative to take its values in the codomain of the function it differentiates. This has the undesirable behaviour that a trajectory `Time → Space` gets sent to `Time → Space`, but to represent velocity this is quite confusing and arguably incorrect.

This PR is an attempt to mitigate this by introducing `derivVec`, which utilises the torsor structure on space to send the derivative to `EuclideanSpace ℝ (Fin d)`.

Disclaimer: the PR and summary was prepared by myself, and AI was used in conceptualising and preparing docstrings.

I am not 100% certain of this approach and would welcome any feedback.