### PR TITLE
refactor(SpaceAndTime): move cmap and cmap_apply to Space/SmoothFunctions

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -511,6 +511,7 @@ public import Physlib.SpaceAndTime.Space.Norm.IteratedLaplacian
 public import Physlib.SpaceAndTime.Space.Norm.Regularized
 public import Physlib.SpaceAndTime.Space.Origin
 public import Physlib.SpaceAndTime.Space.Slice
+public import Physlib.SpaceAndTime.Space.SmoothFunctions
 public import Physlib.SpaceAndTime.Space.Translations
 public import Physlib.SpaceAndTime.SpaceTime.Basic
 public import Physlib.SpaceAndTime.SpaceTime.Boosts

--- a/Physlib/ClassicalMechanics/RigidBody/Basic.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Basic.lean
@@ -5,7 +5,7 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Physlib.SpaceAndTime.Space.Module
+public import Physlib.SpaceAndTime.Space.SmoothFunctions
 public import Physlib.Meta.Informal.Basic
 public import Mathlib.Geometry.Manifold.Algebra.SmoothFunctions
 /-!
@@ -32,6 +32,7 @@ centre of mass.
 @[expose] public section
 
 open Manifold InnerProductSpace
+open Space (cmap cmap_apply)
 
 TODO "The definition of a rigid body is currently defined via linear maps
   from the space of smooth functions to ℝ. When possible, it should be change
@@ -65,20 +66,6 @@ noncomputable def inertiaTensor {d : ℕ} (R : RigidBody d) :
 lemma inertiaTensor_symmetric {d : ℕ} (R : RigidBody d) (i j : Fin d) :
     R.inertiaTensor i j = R.inertiaTensor j i := by
   simp only [inertiaTensor, eq_comm, mul_comm]
-
-TODO "Move `cmap` and `cmap_apply` to a more general location, such as a file in
-  `SpaceAndTime/Space/` or `Mathematics/`. Alternatively, define a version of `ρ` taking an
-  unbundled `(f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f)` in place of a `ContMDiffMap`."
-
-/-- Bundle a smooth real-valued function on `Space d` as an element of the space of test
-functions. Keeping this as a named constructor ensures the resulting type head stays
-`ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/
-def cmap {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) :
-    C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯ := ⟨f, hf.contMDiff⟩
-
-@[simp]
-lemma cmap_apply {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) (y : Space d) :
-    cmap f hf y = f y := rfl
 
 /-- The first moment of the mass distribution about its own centre of mass vanishes:
 for nonzero mass, `ρ` of the centred `j`-th coordinate function is zero. -/

--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -37,6 +37,7 @@ smooth for any motion; for differentiable motions it agrees with the honest poin
 @[expose] public section
 
 open Time Manifold Matrix RigidBody InnerProductSpace
+open Space (cmap cmap_apply)
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
   Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -28,6 +28,7 @@ a rigid motion into a translation of the centre of mass plus a rotation about it
 @[expose] public section
 
 open Time Manifold Matrix RigidBody InnerProductSpace
+open Space (cmap cmap_apply)
 
 attribute [local instance] Matrix.linftyOpNormedAddCommGroup Matrix.linftyOpNormedSpace
   Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra

--- a/Physlib/SpaceAndTime/Space/SmoothFunctions.lean
+++ b/Physlib/SpaceAndTime/Space/SmoothFunctions.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 Giuseppe Sorge. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Giuseppe Sorge
+-/
+module
+
+public import Physlib.SpaceAndTime.Space.Module
+public import Mathlib.Geometry.Manifold.ContMDiffMap
+/-!
+
+# Smooth real-valued functions on space
+
+`Space.cmap` bundles a smooth real-valued function on `Space d`, given as a plain function
+together with a `ContDiff` proof, into the space of bundled smooth maps
+`C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯`. Such bundled maps are, for instance, the test
+functions on which the mass distribution of a rigid body acts.
+
+-/
+
+@[expose] public section
+
+open Manifold
+
+namespace Space
+
+/-- Bundle a smooth real-valued function on `Space d` as an element of the space of bundled
+smooth maps. Keeping this as a named constructor ensures the resulting type head stays
+`ContMDiffMap`, so the module/ring operations and `comp` resolve correctly. -/
+def cmap {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) :
+    C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯ := ⟨f, hf.contMDiff⟩
+
+@[simp]
+lemma cmap_apply {d : ℕ} (f : Space d → ℝ) (hf : ContDiff ℝ ⊤ f) (y : Space d) :
+    cmap f hf y = f y := rfl
+
+end Space


### PR DESCRIPTION
This PR discharges the relocation `TODO` in `Physlib/ClassicalMechanics/RigidBody/Basic.lean` (added following the final review of #1401): the test-function constructor `cmap` and its evaluation lemma `cmap_apply` move out of the rigid-body file to a general home in `SpaceAndTime/Space/`.

## Changes

- **New file `Physlib/SpaceAndTime/Space/SmoothFunctions.lean`** — `Space.cmap`, the named constructor bundling `f : Space d → ℝ` together with a `ContDiff ℝ ⊤ f` proof as an element of `C^⊤⟮𝓘(ℝ, Space d), Space d; 𝓘(ℝ, ℝ), ℝ⟯`, and the `@[simp]` evaluation lemma `Space.cmap_apply`. Both are the declarations previously in `RigidBody/Basic.lean`, unchanged except for the namespace (`RigidBody` → `Space`) and a light docstring adaptation to the new context.
- **`RigidBody/Basic.lean`** — the `TODO` and the two moved declarations removed; the direct import of `Space.Module` is replaced by the new file (which public-imports it).
- **`RigidBody/Basic.lean`, `Motion.lean`, `KineticEnergy.lean`** — each gains `open Space (cmap cmap_apply)`, so every statement and proof body is textually unchanged. The selective open borrows exactly the two names without activating `Space`'s scoped notations (`∇`, `Δ`, `𝔁`) inside the mechanics files.
- **`Physlib.lean`** — the new file imported, in sorted position.

The whole diff is +42/−15; no statement, proof, or simp-set behaviour changes.

## Why the move, and not the unbundled `ρ`

The TODO recorded two options: relocate `cmap`, or give `ρ` a version taking an unbundled `(f, hf)` pair. In the #1401 thread I suggested introducing the unbundled-`ρ` wrapper together with this relocation; on reflection I would rather not add it. Inside proofs the bundled form stays load-bearing — the König and parallel-axis computations work by applying `map_add`/`map_smul`/`map_sum` to `ρ` as a linear map on `ContMDiffMap`s — and at statement level `R.ρ (cmap f hf)` already *is* the unbundled spelling, so a dedicated `def` wrapping it would be a thin renaming def of the kind dropped at #1353. Happy to add the wrapper here if you still prefer having it.

## Naming

`SmoothFunctions.lean` deliberately echoes mathlib's `Geometry/Manifold/Algebra/SmoothFunctions.lean`: the mathlib file carries the algebra structure on spaces of smooth maps, ours carries the `Space`-specific constructor into that space.

## Reading order

`Physlib/SpaceAndTime/Space/SmoothFunctions.lean` (new file, 37 lines), then the removal hunk in `RigidBody/Basic.lean`; the remaining hunks are one-line `open`/import adjustments.
