### PR TITLE
feat(Units): component lemmas for the Exponent power of a dimension

### DIFF
--- a/Physlib/Units/LTMCTDimensionBase.lean
+++ b/Physlib/Units/LTMCTDimensionBase.lean
@@ -189,7 +189,7 @@ private lemma component_npow (component : Dimension LTMCTDimensionBase → Expon
     _ = n • d.exponent b := npow_exponent d n b
     _ = n • component d := congrArg (n • ·) (h _)
 
-private lemma component_epow (component : Dimension LTMCTDimensionBase → Exponent)
+lemma component_epow (component : Dimension LTMCTDimensionBase → Exponent)
     (b : LTMCTDimensionBase) (h : ∀ d, d.exponent b = component d)
     (d : Dimension LTMCTDimensionBase) (c : Exponent) :
     component (d ^ c) = component d * c := by

--- a/Physlib/Units/LTMCTDimensionBase.lean
+++ b/Physlib/Units/LTMCTDimensionBase.lean
@@ -189,6 +189,15 @@ private lemma component_npow (component : Dimension LTMCTDimensionBase → Expon
     _ = n • d.exponent b := npow_exponent d n b
     _ = n • component d := congrArg (n • ·) (h _)
 
+private lemma component_epow (component : Dimension LTMCTDimensionBase → Exponent)
+    (b : LTMCTDimensionBase) (h : ∀ d, d.exponent b = component d)
+    (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    component (d ^ c) = component d * c := by
+  calc
+    component (d ^ c) = (d ^ c).exponent b := (h _).symm
+    _ = d.exponent b * c := epow_exponent d c b
+    _ = component d * c := congrArg (· * c) (h _)
+
 @[simp]
 lemma div_length (d1 d2 : Dimension LTMCTDimensionBase) :
     (d1 / d2).length = d1.length - d2.length := rfl
@@ -227,6 +236,38 @@ lemma npow_charge (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).charge 
 lemma npow_temperature (d : Dimension LTMCTDimensionBase) (n : ℕ) :
     (d ^ n).temperature = n • d.temperature := by
   exact component_npow temperature .temperature exponent_temperature d n
+
+/-- The length component of an `Exponent` power. Since `Pow (Dimension B) Exponent` is the
+  default instance, an unascribed numeric exponent elaborates to this power rather than to
+  the `ℕ` one, so `npow_length` does not apply to it and this lemma is what `simp` needs. -/
+@[simp]
+lemma epow_length (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    (d ^ c).length = d.length * c := by
+  exact component_epow length .length exponent_length d c
+
+/-- The time component of an `Exponent` power. -/
+@[simp]
+lemma epow_time (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    (d ^ c).time = d.time * c := by
+  exact component_epow time .time exponent_time d c
+
+/-- The mass component of an `Exponent` power. -/
+@[simp]
+lemma epow_mass (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    (d ^ c).mass = d.mass * c := by
+  exact component_epow mass .mass exponent_mass d c
+
+/-- The charge component of an `Exponent` power. -/
+@[simp]
+lemma epow_charge (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    (d ^ c).charge = d.charge * c := by
+  exact component_epow charge .charge exponent_charge d c
+
+/-- The temperature component of an `Exponent` power. -/
+@[simp]
+lemma epow_temperature (d : Dimension LTMCTDimensionBase) (c : Exponent) :
+    (d ^ c).temperature = d.temperature * c := by
+  exact component_epow temperature .temperature exponent_temperature d c
 
 /-- The dimension corresponding to length. -/
 def L𝓭 : Dimension LTMCTDimensionBase := ofLTMCTDimensionBase 1 0 0 0 0


### PR DESCRIPTION
Closes #1580.

## What this does

Adds `epow_length`, `epow_time`, `epow_mass`, `epow_charge`, `epow_temperature` — the
`Exponent`-power twins of the existing `npow_*` component lemmas — derived through a
`component_epow` helper that mirrors `component_npow` line for line. One file, +41 lines,
no existing declaration touched.

This is `Toy3` from https://github.com/NicolasRouquette/PL1580, **without** the notation, as
you asked in #1580.

## Why

`Pow (Dimension B) Exponent` carries `@[default_instance 10000]`, so an unascribed numeric
exponent elaborates to an `Exponent` power, not to the `ℕ` one. The `npow_*` lemmas match the
`ℕ` power only, so nothing in the `simp` set reached the component of such a power. Removing
the five new lemmas from the `simp` set recovers that state:

```lean
section
attribute [-simp] epow_length epow_time epow_mass epow_charge epow_temperature

-- `simp` makes no progress on the issue's own case
example (d : Dimension LTMCTDimensionBase) : (d ^ 2).length = d.length * 2 := by
  fail_if_success simp
  rfl

-- nor on a general `Exponent` exponent
example (d : Dimension LTMCTDimensionBase) (c : Exponent) : (d ^ c).length = d.length * c := by
  fail_if_success simp
  rfl

-- on the half-power it rewrites `1/2` to `2⁻¹` on both sides, but still does not close it
example (d : Dimension LTMCTDimensionBase) : (d ^ (1/2)).length = d.length * (1/2) := by
  fail_if_success (simp; done)
  rfl
end
```

## Evidence

Every goal below is also true by `rfl`, so a bare `by simp` would demonstrate nothing about
the lemma. Each is paired instead: `simp` cannot reach the goal on its own, and can with the
lemma named.

```lean
example (d : Dimension LTMCTDimensionBase) (c : Exponent) : (d ^ c).length = d.length * c := by
  fail_if_success simp only []
  simp only [epow_length]

example (d : Dimension LTMCTDimensionBase) (c : Exponent) : (d ^ c).time = d.time * c := by
  fail_if_success simp only []
  simp only [epow_time]

example (d : Dimension LTMCTDimensionBase) (c : Exponent) : (d ^ c).mass = d.mass * c := by
  fail_if_success simp only []
  simp only [epow_mass]

example (d : Dimension LTMCTDimensionBase) (c : Exponent) : (d ^ c).charge = d.charge * c := by
  fail_if_success simp only []
  simp only [epow_charge]

example (d : Dimension LTMCTDimensionBase) (c : Exponent) :
    (d ^ c).temperature = d.temperature * c := by
  fail_if_success simp only []
  simp only [epow_temperature]

-- `npow_length` does not match an unascribed literal — this is what #1580 reported
example (d : Dimension LTMCTDimensionBase) : (d ^ 2).length = d.length * 2 := by
  fail_if_success simp only [npow_length]
  simp only [epow_length]

-- and the `ℕ` power is untouched: an ascribed exponent still routes to `npow_length`
example (d : Dimension LTMCTDimensionBase) (n : ℕ) : (d ^ n).length = n • d.length := by
  fail_if_success simp only [epow_length]
  simp only [npow_length]
```

`lake build` and `lake exe lint_all` exit 0; `./scripts/lint-style.sh` clean.

## Two things deliberately left out

- **The `d ^[1/2]` notation** (`Toy3`'s Q3), per your call in #1580.
- **`qpow_*` component lemmas.** The `ℚ` power is never selected for an unascribed literal —
  only an explicit `q : ℚ` reaches it — so it needs no defaulting rescue, and five more
  `@[simp]` lemmas for it would be speculative. See the last section.

I also gave `component_epow` the same `private` visibility as `component_npow`.

The reason: `LTMCTDimensionBase` is the only basis in Physlib with named component
projections — `ISQDimensionBase` and the `ParametricDimensionExamples` bases go through
`exponent` directly, where the existing basis-generic `epow_exponent` already applies — so
there is no caller for a public or basis-generic version today.

## On deleting `Pow (Dimension B) ℚ`

You floated this in #1580. Having checked it: the instance is removable at very low cost, and
this PR does not depend on the answer either way.

`Pow (Dimension B) ℚ` and `Pow (Dimension B) Exponent` have the same body, differing only in
where `ofRat` is applied (`Physlib/Units/Dimension.lean`):

```
instance : Pow (Dimension B) ℚ where
  pow d q := ofFunction fun b => d.exponent b * Exponent.ofRat q

@[default_instance 10000]
instance : Pow (Dimension B) Exponent where
  pow d c := ofFunction fun b => d.exponent b * c
```

So the `ℚ` power is definitionally the `Exponent` power at `ofRat`:

```lean
example (d : Dimension LTMCTDimensionBase) (q : ℚ) :
    d ^ q = d ^ (Dimension.Exponent.ofRat q) := rfl
```

**Inside Physlib, deleting it costs nothing at all.** Not a survey: I deleted the instance
and `qpow_exponent` together and ran `lake build`, which completed with exit 0 across
`Physlib`, `PhyslibAlpha`, and `QuantumInfo`. Nothing in the library raises a `Dimension` to
a ℚ-typed exponent, and `qpow_exponent` has no use outside its own declaration.

**Downstream, the port is mechanical but I can only speak for one case.** A statement of the
shape `b.dim = a.dim ^ (p : ℚ)` — a half-power certificate, say — restates as
`b.dim = a.dim ^ Exponent.ofRat p` and is the *same proposition* by `rfl`, so the exponent
stays rational in the signature and nothing weakens. I ported one such certificate in a
library of mine and it took two edits: `Exponent.ofRat p` in the statement, and
`epow_exponent` in place of `qpow_exponent` in the `simp only`. The rest of the proof was
untouched. That is one data point, not a claim about every downstream user.

So the trade is: whoever holds a genuine `q : ℚ` writes an extra `Exponent.ofRat`, against
one fewer competing `Pow` instance on `Dimension` — which is most of what made #1580 hard to
answer in the first place. This looks favorable to me, but it is your call and it is not this
PR.

Either way `epow_*` is what you asked for as `Toy3`. These lemmas are about the `Exponent`
power, which is the one unascribed literals actually select, and that is true whether the ℚ
instance stays or goes.
