### PR TITLE
refactor(ClassicalMechanics): switch to derivVec for rigid-body velocities and momentum

### DIFF
--- a/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/KineticEnergy.lean
@@ -122,11 +122,11 @@ lemma kineticEnergy_integrand_split {d : ℕ} (M : RigidBodyMotion d) (t : Time)
     cmap_apply, smul_eq_mul]
   rw [show (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ)
         = (M.velocityClosedForm t y : Fin d → ℝ) ⬝ᵥ (M.velocityClosedForm t y : Fin d → ℝ) from
-      Space.inner_eq_sum _ _,
+      EuclideanSpace.inner_eq_star_dotProduct _ _,
     velocityClosedForm_val,
     show (⟪M.centerOfMassVelocity t, M.centerOfMassVelocity t⟫_ℝ)
         = (M.centerOfMassVelocity t : Fin d → ℝ) ⬝ᵥ (M.centerOfMassVelocity t : Fin d → ℝ) from
-      Space.inner_eq_sum _ _,
+      EuclideanSpace.inner_eq_star_dotProduct _ _,
     add_dotProduct, dotProduct_add, dotProduct_add,
     dotProduct_comm (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
       (M.centerOfMassVelocity t : Fin d → ℝ),

--- a/Physlib/ClassicalMechanics/RigidBody/Motion.lean
+++ b/Physlib/ClassicalMechanics/RigidBody/Motion.lean
@@ -53,22 +53,24 @@ lemma orientation_mul_transpose {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
 /-- The velocity of the centre of mass of a rigid body in motion, defined as the time-derivative
 of its centre-of-mass trajectory. This is the velocity `V` in the Landau–Lifshitz decomposition
 `v = V + Ω × r` of the velocity of a point of the body. -/
-noncomputable def centerOfMassVelocity {d : ℕ} (M : RigidBodyMotion d) : Time → Space d :=
-  ∂ₜ M.comTrajectory
+noncomputable def centerOfMassVelocity {d : ℕ} (M : RigidBodyMotion d) :
+    Time → EuclideanSpace ℝ (Fin d) :=
+  ∂ₜᵥ M.comTrajectory
 
 lemma centerOfMassVelocity_eq {d : ℕ} (M : RigidBodyMotion d) :
-    M.centerOfMassVelocity = ∂ₜ M.comTrajectory := rfl
+    M.centerOfMassVelocity = ∂ₜᵥ M.comTrajectory := rfl
 
 /-- A rigid body whose centre of mass is stationary has zero centre-of-mass velocity. -/
 lemma centerOfMassVelocity_of_comTrajectory_const {d : ℕ} (M : RigidBodyMotion d) (c : Space d)
     (h : M.comTrajectory = fun _ => c) : M.centerOfMassVelocity = 0 := by
   rw [centerOfMassVelocity_eq, h]
   funext t
-  exact Time.deriv_const c
+  exact Time.derivVec_const c
 
 /-- The linear momentum of a rigid body in motion: the total mass times the velocity of the
 centre of mass. -/
-noncomputable def linearMomentum {d : ℕ} (M : RigidBodyMotion d) : Time → Space d :=
+noncomputable def linearMomentum {d : ℕ} (M : RigidBodyMotion d) :
+    Time → EuclideanSpace ℝ (Fin d) :=
   fun t => M.mass • M.centerOfMassVelocity t
 
 lemma linearMomentum_eq {d : ℕ} (M : RigidBodyMotion d) :
@@ -167,11 +169,12 @@ lemma massDistribution_centerOfMass {d : ℕ} (M : RigidBodyMotion d) (t : Time)
 
 /-- The velocity of the material point `y` of a rigid body in motion: the inertial-frame time
 derivative of the trajectory `s ↦ displacement s y` of that point. -/
-noncomputable def velocity {d : ℕ} (M : RigidBodyMotion d) (y : Space d) : Time → Space d :=
-  fun t => ∂ₜ (fun s => M.displacement s y) t
+noncomputable def velocity {d : ℕ} (M : RigidBodyMotion d) (y : Space d) :
+    Time → EuclideanSpace ℝ (Fin d) :=
+  fun t => ∂ₜᵥ (fun s => M.displacement s y) t
 
 lemma velocity_eq {d : ℕ} (M : RigidBodyMotion d) (y : Space d) (t : Time) :
-    M.velocity y t = ∂ₜ (fun s => M.displacement s y) t := rfl
+    M.velocity y t = ∂ₜᵥ (fun s => M.displacement s y) t := rfl
 
 /-- The `i`-th component of the velocity of a body point is the time derivative of the `i`-th
 coordinate of its inertial-frame trajectory. -/
@@ -179,7 +182,7 @@ lemma velocity_apply {d : ℕ} (M : RigidBodyMotion d) (y : Space d) (t : Time) 
     (hd : Differentiable ℝ (fun s => M.displacement s y)) :
     M.velocity y t i = ∂ₜ (fun s => M.displacement s y i) t := by
   rw [velocity_eq]
-  exact (Time.deriv_space hd t i).symm
+  exact derivVec_space hd t i
 
 /-- The material point at the centre of mass moves with the centre-of-mass velocity, for any
 motion: `v(centreOfMass) = V`. This is the velocity counterpart of `massDistribution_centerOfMass`.
@@ -202,15 +205,14 @@ lemma velocity_of_orientation_const {d : ℕ} (M : RigidBodyMotion d) (y : Space
   funext t
   rw [velocity_eq, centerOfMassVelocity_eq]
   have hdisp : (fun s => M.displacement s y)
-      = fun s => (⟨fun k => ∑ j, R.1 k j * (y j - M.centerOfMass j)⟩ : Space d)
-          + M.comTrajectory s := by
+      = fun s => (WithLp.toLp 2 fun k => ∑ j, R.1 k j * (y j - M.centerOfMass j))
+          +ᵥ M.comTrajectory s := by
     funext s
     ext k
     rw [displacement_apply, h]
     simp
   rw [hdisp]
-  simp only [Time.deriv_eq]
-  rw [fderiv_const_add]
+  simp only [Time.derivVec_eq, vadd_vsub_vadd_cancel_left]
 
 /-- The velocity of a body point decomposes as `v = Ṙ (y − c) + V`: the rate of change of the
 orientation acting on the body-frame position, plus the centre-of-mass velocity. -/
@@ -246,7 +248,7 @@ lemma velocity_eq_deriv_orientation {d : ℕ} (M : RigidBodyMotion d) (y : Space
       Time.deriv_mul_const (fun s => (M.orientation s).1 i j)
         (y j - M.centerOfMass j) ((hentry i j) t))]
   simp only [Time.deriv_matrix_apply (fun s => (M.orientation s).1) t (hR t)]
-  rw [hmv, Time.deriv_space hX t i, ← centerOfMassVelocity_eq]
+  rw [hmv, ← Time.derivVec_space hX t i, ← centerOfMassVelocity_eq]
 
 /-- The closed form `Ṙ(t) (y − c) + V(t)` of the velocity of the body point `y` at time `t`.
 Unlike `velocity` — whose junk values on non-differentiable motions need not vary continuously
@@ -254,8 +256,8 @@ with `y` — it is polynomial in `y` for any motion, so its squared speed can be
 smooth integrand of the total kinetic energy; for differentiable motions the two agree, see
 `velocityClosedForm_eq_velocity`. -/
 noncomputable def velocityClosedForm {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
-    Space d :=
-  ⟨∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j⟩
+    EuclideanSpace ℝ (Fin d) :=
+  WithLp.toLp 2 (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j)
     + M.centerOfMassVelocity t
 
 /-- The `i`-th coordinate of the closed-form velocity. -/
@@ -264,7 +266,7 @@ lemma velocityClosedForm_apply {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y :
     M.velocityClosedForm t y i
       = (∂ₜ (fun s => (M.orientation s).1) t *ᵥ fun j => y j - M.centerOfMass j) i
         + M.centerOfMassVelocity t i := by
-  simp only [velocityClosedForm, Space.add_apply]
+  simp only [velocityClosedForm, PiLp.add_apply]
 
 /-- The closed-form velocity as a plain vector-valued function of the coordinates of `y`. -/
 lemma velocityClosedForm_val {d : ℕ} (M : RigidBodyMotion d) (t : Time) (y : Space d) :
@@ -286,7 +288,8 @@ lemma velocityClosedForm_eq_velocity {d : ℕ} (M : RigidBodyMotion d) (t : Time
 /-- The squared speed of a body point, in closed form, is a smooth function of the point. -/
 lemma contDiff_velocityClosedForm_inner {d : ℕ} (M : RigidBodyMotion d) (t : Time) :
     ContDiff ℝ ⊤ fun y : Space d => (⟪M.velocityClosedForm t y, M.velocityClosedForm t y⟫_ℝ) := by
-  simp only [Space.inner_eq_sum, velocityClosedForm_apply, Matrix.mulVec, dotProduct]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
+    velocityClosedForm_apply, Matrix.mulVec, dotProduct]
   fun_prop
 
 end RigidBodyMotion


### PR DESCRIPTION
`Time.deriv` sends `Time → M` to `Time → M`, so a trajectory of points previously had its velocity typed as a point. `RigidBodyMotion.centerOfMassVelocity` was `Time → Space d`, and `linearMomentum` inherited it, making momentum a position. This PR retypes them using `derivVec` (#1592), so velocities and momentum are valued in the displacement space `EuclideanSpace ℝ (Fin d)`.

AI disclosure: assisted in checking and PR summary, code is written by myself