### PR TITLE
EVJJI theorem twoState_entropy_eq

### DIFF
--- a/Physlib/StatisticalMechanics/CanonicalEnsemble/TwoState.lean
+++ b/Physlib/StatisticalMechanics/CanonicalEnsemble/TwoState.lean
@@ -6,7 +6,6 @@ Authors: Matteo Cipollina, Joseph Tooby-Smith
 module
 
 public import Physlib.StatisticalMechanics.CanonicalEnsemble.Finite
-public import Physlib.Meta.Informal.Basic
 /-!
 
 # Two-state canonical ensemble
@@ -98,10 +97,37 @@ lemma twoState_meanEnergy_eq (E₀ E₁ : ℝ) (T : Temperature) :
   simp [Fin.sum_univ_two, twoState_probability_fst, twoState_probability_snd]
   ring
 
-/-- A simplification of the `entropy` of the two-state canonical ensemble. -/
-informal_lemma twoState_entropy_eq where
-  tag := "EVJJI"
-  deps := [``twoState, ``thermodynamicEntropy]
+/-- A simplification of the `entropy` of the two-state canonical ensemble.
+
+Since `β 0 = 0`, at `T = 0` the right-hand side evaluates to `Constants.kB * Real.log 2`.
+See `twoState_entropy_eq_T_neq_zero` for the same statement carrying `T ≠ 0`. -/
+lemma twoState_entropy_eq (E₀ E₁ : ℝ) (T : Temperature) :
+    (twoState E₀ E₁).thermodynamicEntropy T =
+      Constants.kB * (Real.log (2 * Real.cosh (β T * (E₁ - E₀) / 2))
+        - β T * (E₁ - E₀) / 2 * Real.tanh (β T * (E₁ - E₀) / 2)) := by
+  rw [thermodynamicEntropy_eq_shannonEntropy, shannonEntropy]
+  set x := β T * (E₁ - E₀) / 2
+  have h2c : (2 : ℝ) * Real.cosh x ≠ 0 := by positivity
+  have hp0 : (twoState E₀ E₁).probability T 0 = Real.exp x / (2 * Real.cosh x) := by
+    rw [twoState_probability_fst, Real.tanh_eq_sinh_div_cosh, Real.sinh_eq, Real.cosh_eq]
+    field_simp
+    ring
+  have hp1 : (twoState E₀ E₁).probability T 1 = Real.exp (-x) / (2 * Real.cosh x) := by
+    rw [twoState_probability_snd, Real.tanh_eq_sinh_div_cosh, Real.sinh_eq, Real.cosh_eq]
+    field_simp
+    ring
+  rw [Fin.sum_univ_two, hp0, hp1, Real.log_div (Real.exp_ne_zero _) h2c,
+    Real.log_div (Real.exp_ne_zero _) h2c, Real.log_exp, Real.log_exp]
+  rw [Real.tanh_eq_sinh_div_cosh, Real.sinh_eq, Real.cosh_eq]
+  field_simp
+  ring
+
+/-- An instance of `twoState_entropy_eq` assuming T ≠ 0 -/
+lemma twoState_entropy_eq_T_neq_zero (E₀ E₁ : ℝ) (T : Temperature) (_ : T ≠ 0) :
+    (twoState E₀ E₁).thermodynamicEntropy T =
+      Constants.kB * (Real.log (2 * Real.cosh (β T * (E₁ - E₀) / 2))
+        - β T * (E₁ - E₀) / 2 * Real.tanh (β T * (E₁ - E₀) / 2)) :=
+  twoState_entropy_eq E₀ E₁ T
 
 /-- A simplification of the `helmholtzFreeEnergy` of the two-state canonical ensemble. -/
 lemma twoState_helmholtzFreeEnergy_eq (E₀ E₁ : ℝ) (T : Temperature) :


### PR DESCRIPTION
Formalizes the informal lemma tagged `EVJJI`: a closed form for the
thermodynamic entropy of the two-state canonical ensemble.

Added, both in `Physlib/StatisticalMechanics/CanonicalEnsemble/TwoState.lean`:

- `twoState_entropy_eq` with `x = β T * (E₁ - E₀) / 2`, gives
  `S = kB * (log (2 * cosh x) - x * tanh x)`. Proved through
  `thermodynamicEntropy_eq_shannonEntropy`, which carries no side conditions,
  rather than through the Helmholtz free energy. That route needs
  `0 < T.val`, `IsFiniteMeasure`, and integrability.

- `twoState_entropy_eq_T_neq_zero` is the same statement carrying `T ≠ 0`, so
  downstream results on positive temperatures get a matching signature without
  having to know the unconditional version is safe at zero.

Removed the `Physlib.Meta.Informal.Basic` import, now unused in the file.

I left the primary result unconditional, matching the choice made for
`twoState_helmholtzFreeEnergy_eq` in #1474. Since `β 0 = 0`, the RHS is
`kB * log 2` at `T = 0`; the docstring notes this.

Notes to reviewer: look first at the statement, since that's the part that has to be right.
Then `hp0` and `hp1`, the two occupation probabilities in closed form. The rest
is algebra. The corollary and the import removal are a line each.

Second contribution to Physlib. Happy to adjust anything. I'm not particularly attached to the `T ≠ 0` restatement if you'd rather it weren't there.