### PR TITLE
fix(Tensors): rank the tensor action above the Tensorial action

### DIFF
--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -171,7 +171,6 @@ the speed with which an electromagnetic wave propagates is invariant under Loren
 
 -/
 
-set_option maxHeartbeats 600000 in
 lemma isExtrema_lorentzGroup_apply_iff {𝓕 : FreeSpace}
     (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d) (hJ : ContDiff ℝ ∞ J)

--- a/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
+++ b/Physlib/Electromagnetism/Dynamics/IsExtrema.lean
@@ -172,7 +172,6 @@ the speed with which an electromagnetic wave propagates is invariant under Loren
 -/
 
 set_option maxHeartbeats 600000 in
-set_option backward.isDefEq.respectTransparency false in
 lemma isExtrema_lorentzGroup_apply_iff {𝓕 : FreeSpace}
     (A : ElectromagneticPotential d)
     (hA : ContDiff ℝ ∞ A) (J : LorentzCurrentDensity d) (hJ : ContDiff ℝ ∞ J)

--- a/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
+++ b/Physlib/Electromagnetism/Dynamics/KineticTerm.lean
@@ -97,7 +97,6 @@ We show that the kinetic energy is Lorentz invariant.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma kineticTerm_equivariant {d} {𝓕 : FreeSpace} (A : ElectromagneticPotential d)
     (Λ : LorentzGroup d)
     (hf : Differentiable ℝ A) (x : SpaceTime d) :

--- a/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
+++ b/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
@@ -199,7 +199,6 @@ as taking the field strength and then transforming the resulting tensor.
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma toFieldStrength_equivariant {d} (A : ElectromagneticPotential d) (Λ : LorentzGroup d)
     (hf : Differentiable ℝ A) (x : SpaceTime d) :
     (Λ • A).toFieldStrength x = Λ • A.toFieldStrength (Λ⁻¹ • x) := by

--- a/Physlib/Relativity/Tensors/Basic.lean
+++ b/Physlib/Relativity/Tensors/Basic.lean
@@ -426,13 +426,16 @@ end Pure
 
 -/
 
-noncomputable instance : SMul G (S.Tensor c) where
+/- The action on `S.Tensor c` is given priority above `Tensorial.smulAction` (which has
+  `priority := high` so that it beats Mathlib's left action on tensor products), so that for a
+  bare tensor `g • t` elaborates to this instance, as used in the `*_equivariant` lemmas. -/
+noncomputable instance (priority := high + 1) instSMul : SMul G (S.Tensor c) where
   smul g t := PiTensorProduct.map (fun i => rep (c i) g) t
 
 lemma actionT_eq {g : G} {t : S.Tensor c} : g • t =
     PiTensorProduct.map (fun i => rep (c i) g) t := rfl
 
-noncomputable instance actionT : MulAction G (S.Tensor c) where
+noncomputable instance (priority := high + 1) actionT : MulAction G (S.Tensor c) where
   one_smul t := by
     simp [actionT_eq]
   mul_smul g g' t := by
@@ -464,9 +467,15 @@ lemma actionT_neg {g : G} {t : S.Tensor c} :
   simp only [map_neg, neg_inj]
   rfl
 
-noncomputable instance : DistribMulAction G (S.Tensor c) where
+noncomputable instance (priority := high + 1) : DistribMulAction G (S.Tensor c) where
   smul_zero g := by simp [actionT_zero]
   smul_add g t1 t2 := by simp [actionT_add]
+
+instance : SMulCommClass k G (S.Tensor c) where
+  smul_comm _ _ _ := actionT_smul.symm
+
+-- `SMulCommClass.symm` is not registered as an instance, as it would cause a loop
+instance : SMulCommClass G k (S.Tensor c) := SMulCommClass.symm _ _ _
 
 
 /-!

--- a/Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean
+++ b/Physlib/Relativity/Tensors/ComplexTensor/Metrics/Basic.lean
@@ -437,32 +437,26 @@ lemma dualRightMetric_eq_ofRat : εR' = ofRat fun f =>
 
 open TensorSpecies
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `coMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_coMetric (g : SL(2,ℂ)) : g • η' = η' := by
   rw [metricTensor_invariant]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `contrMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_contrMetric (g : SL(2,ℂ)) : g • η = η := by
   rw [metricTensor_invariant]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `leftMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_leftMetric (g : SL(2,ℂ)) : g • εL = εL := by
   rw [metricTensor_invariant]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `rightMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_rightMetric (g : SL(2,ℂ)) : g • εR = εR := by
   rw [metricTensor_invariant]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `dualLeftMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_dualLeftMetric (g : SL(2,ℂ)) : g • εL' = εL' := by
   rw [metricTensor_invariant]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The tensor `dualRightMetric` is invariant under the action of `SL(2,ℂ)`. -/
 lemma actionT_dualRightMetric (g : SL(2,ℂ)) : g • εR' = εR' := by
   rw [metricTensor_invariant]

--- a/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
+++ b/Physlib/Relativity/Tensors/RealTensor/ToComplex.lean
@@ -409,7 +409,6 @@ Finally we record that `toComplex` is equivariant for the natural action of
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The map `toComplex` is equivariant. -/
 lemma toComplex_equivariant {n} {c : Fin n → realLorentzTensor.Color}
     (v : ℝT(3, c)) (Λ : SL(2, ℂ)) :

--- a/Physlib/Relativity/Tensors/Tensorial.lean
+++ b/Physlib/Relativity/Tensors/Tensorial.lean
@@ -133,7 +133,6 @@ We now define the action of the group `G` on a type `M` carrying a tensorial ins
 noncomputable instance (priority := high) smulAction [Tensorial S c M] : SMul G M where
   smul g m := toTensor.symm (g • toTensor m)
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance mulAction [Tensorial S c M] : MulAction G M where
   one_smul m := by
     change toTensor.symm (1 • toTensor m) = _
@@ -171,7 +170,6 @@ lemma smul_toTensor_symm {g : G} {t : Tensor S c} [self : Tensorial S c M] :
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance (priority := high) distribMulAction [Tensorial S c M] :
     DistribMulAction G M where
   smul_add g m m' := by
@@ -187,7 +185,6 @@ noncomputable instance (priority := high) distribMulAction [Tensorial S c M] :
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The action of the group on a `Tensorial` instance as a linear map. -/
 noncomputable def smulLinearMap (g : G) [Tensorial S c M] : M →ₗ[k] M where
   toFun m := g • m
@@ -207,11 +204,12 @@ lemma smulLinearMap_apply {g : G} [Tensorial S c M] (m : M) :
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 instance [Tensorial S c M] : SMulCommClass k G M where
   smul_comm c g m := by
     apply toTensor.injective
     simp [toTensor_smul]
+
+instance [Tensorial S c M] : SMulCommClass G k M := SMulCommClass.symm _ _ _
 
 /-!
 
@@ -255,7 +253,6 @@ lemma toTensor_tprod {n2 : ℕ} {c2 : Fin n2 → C} {M₂ : Type}
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma smul_prod {n2 : ℕ} {c2 : Fin n2 → C} {M₂ : Type}
     [Tensorial S c M] [AddCommMonoid M₂] [Module k M₂]
     [Tensorial S c2 M₂] (g : G) (m : M) (m2 : M₂) :


### PR DESCRIPTION
## Changes

Tensors/Basic.lean: `instSMul`, `actionT` and the `DistribMulAction` on `S.Tensor c` get priority := high + 1.

`SMulCommClass k G (S.Tensor c)` and `SMulCommClass G k (S.Tensor c)` added (the second via `SMulCommClass.symm`, as in Mathlib); the G k order also added for Tensorial types.

as a result, multiple `set_option backward.isDefEq.respectTransparency false` removed and a `maxHeartbeats 600000`.

## Why: an instance diamond on `g • t`

Two `SMul G (S.Tensor c)` instances exist:

1. `Tensor.instSMul` in `Tensors/Basic.lean`, the direct action. All `*_equivariant` lemmas are
   stated with it.
2. `Tensorial.smulAction` in `Tensorial.lean`, defined for any `[Tensorial S c M]` as
   `g • m = toTensor.symm (g • toTensor m)`. Since `S.Tensor c` is `Tensorial` via `self`
   (`toTensor = LinearEquiv.refl`), it also applies to bare tensors, and with `priority := high`
   it won.

So in a goal, `g • t` carried instance 2; the lemma's left-hand side carries instance 1. They are
defeq (unfold `refl`) but not syntactically equal, hence `rw`/`simp` failed while `exact` and
the `respectTransparency false` option (unfolding fallback, paid for in heartbeats) worked.

Fix: rank instance 1 at `high + 1`. Bare tensors now use the direct action. Instance 2 keeps
`high` and still governs `Tensorial` types and `M ⊗ M₂`, where it must beat Mathlib's left-only
`TensorProduct` action (`Tensorial.smul_prod`); lowering it instead breaks that lemma.
The `SMulCommClass` instances are stated for instance 1 so `smul_comm` fires on it.

fix found by claude and confirmed/edited by myself