### PR TITLE
feat(EMPotential): differentiability of derivatives of the electromagnetic potential

### DIFF
--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -286,17 +286,12 @@ noncomputable instance {d} :
 
 ### A.4. Differentiability
 
-We show that the components of the potential, and of its derivatives, are differentiable
-(or smooth) if the potential is.
+We show that the potential and its derivatives are differentiable (or smooth) if the potential
+is, in the forms `fun_prop` cannot derive on its own. Differentiability of a component
+`fun x => A x μ` of a differentiable potential is found by `fun_prop` directly.
 -/
 
 open ContDiff
-
-@[fun_prop]
-lemma differentiable_component {d : ℕ}
-    (A : ElectromagneticPotential d) (hA : Differentiable ℝ A) (μ : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => A x μ) := by
-  exact (SpaceTime.differentiable_vector _).mpr hA μ
 
 @[fun_prop]
 lemma differentiable_action {d} (Λ : LorentzGroup d) (A : ElectromagneticPotential d)

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -311,47 +311,35 @@ lemma contDiff_action {d} (Λ : LorentzGroup d) (A : ElectromagneticPotential d)
     (hA.comp (ContinuousLinearMap.contDiff (Lorentz.Vector.actionCLM Λ⁻¹)))
 
 @[fun_prop]
-lemma differentiable_deriv_component {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ 2 A) (μ ν : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => ∂_ μ A x ν) := by
-  have h : ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [SpaceTime.differentiable_vector]
-    fun_prop
-  exact h ν
-
-@[fun_prop]
 lemma differentiable_deriv_component_of_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ A x ν) := by
-  apply differentiable_deriv_component (hA.of_le (ENat.LEInfty.out)) μ ν
-
-@[fun_prop]
-lemma contDiff_deriv_component {n} {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ (n + 1) A) (μ ν : Fin 1 ⊕ Fin d) :
-    ContDiff ℝ n (fun x => ∂_ μ A x ν) := by
-  have h : ∀ ν, ContDiff ℝ n fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [SpaceTime.contDiff_vector]
-    fun_prop
-  exact h ν
+  have h : ContDiff ℝ 2 A := hA.of_le ENat.LEInfty.out
+  fun_prop
 
 @[fun_prop]
 lemma contDiff_deriv_component_of_smooth {n : ℕ} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
-    ContDiff ℝ n (fun x => ∂_ μ A x ν) :=
-  contDiff_deriv_component (hA.of_le (mod_cast le_top)) μ ν
+    ContDiff ℝ n (fun x => ∂_ μ A x ν) := by
+  have h : ContDiff ℝ (n + 1) A := hA.of_le (mod_cast le_top)
+  fun_prop
 
 /-!
 
 #### A.4.1. Differentiability of the derivative of the potential
 
-The derivatives `∂_ μ A x ν` of the potential are themselves differentiable if the
-potential is `C^3`, and `C^n` if the potential is `C^{n+2}`. This is what is needed to
-make sense of second derivatives of the potential, as appear for example in Maxwell's equations.
+The derivatives `∂_ μ A x ν` of the potential are `C^n` if the potential is `C^{n+2}`.
+This is what is needed to make sense of second derivatives of the potential, as appear for
+example in Maxwell's equations. Differentiability for a `C^3` potential follows by `fun_prop`
+from these lemmas and `SpaceTime.differentiable_deriv`, so is not stated separately.
 
 A second derivative of a component can be written in two ways: as `∂_ μ (fun x => ∂_ ν A x ρ) x`,
 the derivative of the real-valued component `∂_ ν A x ρ` (the `_component` lemmas), or as
 `∂_ μ (∂_ ν A) x ρ`, the component of the derivative of the vector-valued `∂_ ν A`
 (the `_apply` lemmas). The two agree for a `C^2` potential by `SpaceTime.deriv_apply_eq`.
+
+The differentiability of the first-derivative components `∂_ μ A x ν` for a `C^2` (or
+`C^{n+1}`) potential is found by `fun_prop` directly, so only the smooth variants are stated.
 
 -/
 
@@ -359,48 +347,27 @@ the derivative of the real-valued component `∂_ ν A x ρ` (the `_component` l
 @[fun_prop]
 lemma contDiff_deriv_deriv_component {n} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ (n + 2) A) (μ ν ρ : Fin 1 ⊕ Fin d) :
-    ContDiff ℝ n (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  SpaceTime.contDiff_deriv μ _ (contDiff_deriv_component (n := n + 1)
-    (by rw [add_assoc, one_add_one_eq_two]; exact hA) ν ρ)
-
-/-- The second derivatives `∂_ μ ∂_ ν A^ρ` of a `C^3` potential are differentiable. -/
-@[fun_prop]
-lemma differentiable_deriv_deriv_component {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ 3 A) (μ ν ρ : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  SpaceTime.differentiable_deriv μ _ (contDiff_deriv_component (n := 2) (by norm_cast) ν ρ)
-
-@[fun_prop]
-lemma differentiable_deriv_deriv_component_of_smooth {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  differentiable_deriv_deriv_component (hA.of_le ENat.LEInfty.out) μ ν ρ
+    ContDiff ℝ n (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) := by
+  have h : ContDiff ℝ (n + 1 + 1) A := by rw [add_assoc, one_add_one_eq_two]; exact hA
+  fun_prop
 
 /-- The `ρ` component of `∂_ μ (∂_ ν A)` is `C^n` for a `C^{n+2}` potential. -/
 @[fun_prop]
 lemma contDiff_deriv_deriv_apply {n} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ (n + 2) A) (μ ν ρ : Fin 1 ⊕ Fin d) :
     ContDiff ℝ n (fun x => ∂_ μ (∂_ ν A) x ρ) := by
+  have h : ContDiff ℝ (n + 1 + 1) A := by rw [add_assoc, one_add_one_eq_two]; exact hA
   have hd : Differentiable ℝ (∂_ ν A) :=
     SpaceTime.differentiable_deriv ν A (hA.of_le le_add_self)
   conv => enter [3, x]; rw [SpaceTime.deriv_apply_eq μ ρ _ hd, ← SpaceTime.deriv_eq]
   fun_prop
 
-/-- The `ρ` component of `∂_ μ (∂_ ν A)` is differentiable for a `C^3` potential. -/
-@[fun_prop]
-lemma differentiable_deriv_deriv_apply {d} {A : ElectromagneticPotential d}
-    (hA : ContDiff ℝ 3 A) (μ ν ρ : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => ∂_ μ (∂_ ν A) x ρ) := by
-  have hd : Differentiable ℝ (∂_ ν A) :=
-    SpaceTime.differentiable_deriv ν A (hA.of_le (by norm_num))
-  conv => enter [2, x]; rw [SpaceTime.deriv_apply_eq μ ρ _ hd, ← SpaceTime.deriv_eq]
-  fun_prop
-
 @[fun_prop]
 lemma differentiable_deriv_deriv_apply_of_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
-    Differentiable ℝ (fun x => ∂_ μ (∂_ ν A) x ρ) :=
-  differentiable_deriv_deriv_apply (hA.of_le ENat.LEInfty.out) μ ν ρ
+    Differentiable ℝ (fun x => ∂_ μ (∂_ ν A) x ρ) := by
+  have h : ContDiff ℝ 3 A := hA.of_le ENat.LEInfty.out
+  fun_prop
 
 /-!
 

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -25,8 +25,8 @@ spacetime to contravariant Lorentz vectors.
 
 - `ElectromagneticPotential` : is the type of electromagnetic potentials.
 - `ElectromagneticPotential.deriv` : the derivative tensor `∂_μ A^ν`.
-- `ElectromagneticPotential.contDiff_deriv_deriv_component` : the second derivatives `∂_μ ∂_ν A^ρ` are
-  `C^n` if the potential is `C^{n+2}`.
+- `ElectromagneticPotential.contDiff_deriv_deriv_component` : the second derivatives
+  `∂_μ ∂_ν A^ρ` are `C^n` if the potential is `C^{n+2}`.
 - `ElectromagneticPotential.contDiff_deriv` : the derivative tensor is `C^n` if the potential
   is `C^{n+1}`.
 
@@ -347,8 +347,12 @@ lemma contDiff_deriv_component_of_smooth {n : ℕ} {d} {A : ElectromagneticPoten
 
 The derivatives `∂_ μ A x ν` of the potential are themselves differentiable if the
 potential is `C^3`, and `C^n` if the potential is `C^{n+2}`. This is what is needed to
-make sense of second derivatives `∂_ μ (∂_ ν A) x ρ` of the potential, as appear for example
-in Maxwell's equations.
+make sense of second derivatives of the potential, as appear for example in Maxwell's equations.
+
+A second derivative of a component can be written in two ways: as `∂_ μ (fun x => ∂_ ν A x ρ) x`,
+the derivative of the real-valued component `∂_ ν A x ρ` (the `_component` lemmas), or as
+`∂_ μ (∂_ ν A) x ρ`, the component of the derivative of the vector-valued `∂_ ν A`
+(the `_apply` lemmas). The two agree for a `C^2` potential by `SpaceTime.deriv_apply_eq`.
 
 -/
 
@@ -372,6 +376,32 @@ lemma differentiable_deriv_deriv_component_of_smooth {d} {A : ElectromagneticPot
     (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
   differentiable_deriv_deriv_component (hA.of_le ENat.LEInfty.out) μ ν ρ
+
+/-- The `ρ` component of `∂_ μ (∂_ ν A)` is `C^n` for a `C^{n+2}` potential. -/
+@[fun_prop]
+lemma contDiff_deriv_deriv_apply {n} {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ (n + 2) A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    ContDiff ℝ n (fun x => ∂_ μ (∂_ ν A) x ρ) := by
+  have hd : Differentiable ℝ (∂_ ν A) :=
+    SpaceTime.differentiable_deriv ν A (hA.of_le le_add_self)
+  conv => enter [3, x]; rw [SpaceTime.deriv_apply_eq μ ρ _ hd, ← SpaceTime.deriv_eq]
+  fun_prop
+
+/-- The `ρ` component of `∂_ μ (∂_ ν A)` is differentiable for a `C^3` potential. -/
+@[fun_prop]
+lemma differentiable_deriv_deriv_apply {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ 3 A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ (∂_ ν A) x ρ) := by
+  have hd : Differentiable ℝ (∂_ ν A) :=
+    SpaceTime.differentiable_deriv ν A (hA.of_le (by norm_num))
+  conv => enter [2, x]; rw [SpaceTime.deriv_apply_eq μ ρ _ hd, ← SpaceTime.deriv_eq]
+  fun_prop
+
+@[fun_prop]
+lemma differentiable_deriv_deriv_apply_of_smooth {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ (∂_ ν A) x ρ) :=
+  differentiable_deriv_deriv_apply (hA.of_le ENat.LEInfty.out) μ ν ρ
 
 /-!
 

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -25,6 +25,10 @@ spacetime to contravariant Lorentz vectors.
 
 - `ElectromagneticPotential` : is the type of electromagnetic potentials.
 - `ElectromagneticPotential.deriv` : the derivative tensor `∂_μ A^ν`.
+- `ElectromagneticPotential.contDiff_deriv_deriv` : the second derivatives `∂_μ ∂_ν A^ρ` are
+  `C^n` if the potential is `C^{n+2}`.
+- `ElectromagneticPotential.deriv_contDiff` : the derivative tensor is `C^n` if the potential
+  is `C^{n+1}`.
 
 ## iii. Table of contents
 
@@ -33,12 +37,15 @@ spacetime to contravariant Lorentz vectors.
   - A.2. Basic constructors of the electromagnetic potential
   - A.3. The group action on the ElectromagneticPotential
   - A.4. Differentiability
-  - A.5. The action on the space-time derivatives
-  - A.6. Variational adjoint derivative of component
-  - A.7. Variational adjoint derivative of derivatives of the potential
+    - A.4.1. Differentiability of the derivative of the potential
+  - A.5. Differentiability in terms of constructors
+  - A.6. The action on the space-time derivatives
+  - A.7. Variational adjoint derivative of component
+  - A.8. Variational adjoint derivative of derivatives of the potential
 - B. The derivative tensor of the electromagnetic potential
   - B.1. Equivariance of the derivative tensor
   - B.2. The elements of the derivative tensor in terms of the basis
+  - B.3. Differentiability of the derivative tensor
 
 ## iv. References
 
@@ -280,7 +287,8 @@ noncomputable instance {d} :
 
 ### A.4. Differentiability
 
-We show that the components of field strength tensor are differentiable if the potential is.
+We show that the components of the potential, and of its derivatives, are differentiable
+(or smooth) if the potential is.
 -/
 
 open ContDiff
@@ -327,12 +335,47 @@ lemma contDiff_deriv {n} {d} {A : ElectromagneticPotential d}
     fun_prop
   exact h ν
 
-TODO "Add results related to the differentiability of the
-  derivative of the Electromagnetic potential."
+@[fun_prop]
+lemma contDiff_deriv_of_smooth {n : ℕ} {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
+    ContDiff ℝ n (fun x => ∂_ μ A x ν) :=
+  contDiff_deriv (hA.of_le (mod_cast le_top)) μ ν
 
 /-!
 
-### A.5. Differentiablity in terms of constructors
+#### A.4.1. Differentiability of the derivative of the potential
+
+The derivatives `∂_ μ A x ν` of the potential are themselves differentiable if the
+potential is `C^3`, and `C^n` if the potential is `C^{n+2}`. This is what is needed to
+make sense of second derivatives `∂_ μ (∂_ ν A) x ρ` of the potential, as appear for example
+in Maxwell's equations.
+
+-/
+
+/-- The second derivatives `∂_ μ ∂_ ν A^ρ` of a `C^{n+2}` potential are `C^n`. -/
+@[fun_prop]
+lemma contDiff_deriv_deriv {n} {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ (n + 2) A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    ContDiff ℝ n (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
+  SpaceTime.contDiff_deriv μ _ (contDiff_deriv (n := n + 1)
+    (by rw [add_assoc, one_add_one_eq_two]; exact hA) ν ρ)
+
+/-- The second derivatives `∂_ μ ∂_ ν A^ρ` of a `C^3` potential are differentiable. -/
+@[fun_prop]
+lemma differentiable_deriv_deriv {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ 3 A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
+  SpaceTime.differentiable_deriv μ _ (contDiff_deriv (n := 2) (by norm_cast) ν ρ)
+
+@[fun_prop]
+lemma differentiable_deriv_deriv_of_smooth {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
+    Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
+  differentiable_deriv_deriv (hA.of_le ENat.LEInfty.out) μ ν ρ
+
+/-!
+
+### A.5. Differentiability in terms of constructors
 
 -/
 
@@ -434,7 +477,7 @@ lemma contDiff_ofElectromagneticField {n : ℕ} (c : SpeedOfLight)
 
 /-!
 
-### A.5. The action on the space-time derivatives
+### A.6. The action on the space-time derivatives
 
 Given a ElectromagneticPotential `A^μ`, we can consider its derivative `∂_μ A^ν`.
 Under a Lorentz transformation `Λ`, this transforms as
@@ -455,7 +498,7 @@ lemma spaceTime_deriv_action_eq_sum {d} {μ ν : Fin 1 ⊕ Fin d} {x : SpaceTime
 
 /-!
 
-### A.6. Variational adjoint derivative of component
+### A.7. Variational adjoint derivative of component
 
 We find the variational adjoint derivative of the components of the potential.
 This will be used to find e.g. the variational derivative of the kinetic term,
@@ -485,7 +528,7 @@ lemma hasVarAdjDerivAt_component {d : ℕ} (μ : Fin 1 ⊕ Fin d) (A : SpaceTime
 
 /-!
 
-### A.7. Variational adjoint derivative of derivatives of the potential
+### A.8. Variational adjoint derivative of derivatives of the potential
 
 We find the variational adjoint derivative of the derivatives of the components of the potential.
 This will again be used to find the variational derivative of the kinetic term,
@@ -631,6 +674,34 @@ lemma toTensor_deriv_basis_repr_apply {d} (A : ElectromagneticPotential d)
     simp
   rw [hb, Module.Basis.repr_reindex_apply, deriv_basis_repr_apply]
   rfl
+
+/-!
+
+### B.3. Differentiability of the derivative tensor
+
+We show that the derivative tensor `∂_μ A^ν`, as a function on spacetime, is differentiable
+(or `C^n`) if the potential is `C^2` (or `C^{n+1}`).
+
+-/
+
+/-- The derivative tensor of a `C^2` potential is differentiable. -/
+@[fun_prop]
+lemma deriv_differentiable {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ 2 A) :
+    Differentiable ℝ A.deriv := by
+  unfold deriv
+  fun_prop
+
+@[fun_prop]
+lemma deriv_differentiable_of_smooth {d} {A : ElectromagneticPotential d}
+    (hA : ContDiff ℝ ∞ A) : Differentiable ℝ A.deriv :=
+  deriv_differentiable (hA.of_le ENat.LEInfty.out)
+
+/-- The derivative tensor of a `C^{n+1}` potential is `C^n`. -/
+@[fun_prop]
+lemma deriv_contDiff {n} {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ (n + 1) A) :
+    ContDiff ℝ n A.deriv := by
+  unfold deriv
+  fun_prop
 
 end ElectromagneticPotential
 

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -215,7 +215,6 @@ noncomputable def ofPotentials {d} (c : SpeedOfLight) (ϕ : Time → Space d →
     | Sum.inl 0 => ((timeSlice c).symm ϕ x) / c
     | Sum.inr i => (timeSlice c).symm A x i
 
-set_option backward.isDefEq.respectTransparency false in
 lemma ofPotentials_eq_add {d} (c : SpeedOfLight) (ϕ : Time → Space d → ℝ)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d)) :
     ofPotentials c ϕ A = ofScalarPotential c ϕ + ofVectorPotential c A := by
@@ -409,7 +408,6 @@ lemma differentiable_deriv_deriv_apply_of_smooth {d} {A : ElectromagneticPotenti
 
 -/
 
-set_option backward.isDefEq.respectTransparency false in
 lemma differentiable_ofScalarPotential {d} (c : SpeedOfLight) (φ : Time → Space d → ℝ)
     (hϕ : Differentiable ℝ ↿φ) : Differentiable ℝ (ofScalarPotential c φ) := by
   simp [ofScalarPotential]
@@ -418,7 +416,6 @@ lemma differentiable_ofScalarPotential {d} (c : SpeedOfLight) (φ : Time → Spa
   match μ with
   | Sum.inl 0 | Sum.inr _ => fun_prop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma contDiff_ofScalarPotential {n} {d} (c : SpeedOfLight) (φ : Time → Space d → ℝ)
     (hϕ : ContDiff ℝ n ↿φ) : ContDiff ℝ n (ofScalarPotential c φ) := by
   simp [ofScalarPotential]
@@ -427,7 +424,6 @@ lemma contDiff_ofScalarPotential {n} {d} (c : SpeedOfLight) (φ : Time → Space
   match μ with
   | Sum.inl 0 | Sum.inr _ => fun_prop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma differentiable_ofVectorPotential {d} (c : SpeedOfLight)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d))
     (hA : Differentiable ℝ ↿A) : Differentiable ℝ (ofVectorPotential c A) := by
@@ -437,7 +433,6 @@ lemma differentiable_ofVectorPotential {d} (c : SpeedOfLight)
   match μ with
   | Sum.inl 0 | Sum.inr _ => fun_prop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma contDiff_ofVectorPotential {n} {d} (c : SpeedOfLight)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d))
     (hA : ContDiff ℝ n ↿A) : ContDiff ℝ n (ofVectorPotential c A) := by
@@ -447,7 +442,6 @@ lemma contDiff_ofVectorPotential {n} {d} (c : SpeedOfLight)
   match μ with
   | Sum.inl 0 | Sum.inr _ => fun_prop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma differentiable_ofPotentials {d} (c : SpeedOfLight) (φ : Time → Space d → ℝ)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d)) (hϕ : Differentiable ℝ ↿φ)
     (hA : Differentiable ℝ ↿A) : Differentiable ℝ (ofPotentials c φ A) := by
@@ -457,7 +451,6 @@ lemma differentiable_ofPotentials {d} (c : SpeedOfLight) (φ : Time → Space d 
   match μ with
   | Sum.inl 0 | Sum.inr _ => fun_prop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma contDiff_ofPotentials {n} {d} (c : SpeedOfLight) (φ : Time → Space d → ℝ)
     (A : Time → Space d → EuclideanSpace ℝ (Fin d)) (hϕ : ContDiff ℝ n ↿φ)
     (hA : ContDiff ℝ n ↿A) : ContDiff ℝ n (ofPotentials c φ A) := by
@@ -644,7 +637,6 @@ are just equal to `∂_ μ A x ν`.
 -/
 
 open Tensorial
-set_option backward.isDefEq.respectTransparency false in
 /-- Evaluation of the tensor components of `∂_ μ A x ν`. -/
 lemma tensorDeriv_eval_eq {d} {A : ElectromagneticPotential d} (hA : Differentiable ℝ A)
     (x : SpaceTime d) (μ ν : Fin 1 ⊕ Fin d) :
@@ -675,7 +667,6 @@ lemma tensorDeriv_eval_eq {d} {A : ElectromagneticPotential d} (hA : Differentia
   · simp only [map_smul, h, smul_eq_mul, Finsupp.coe_smul, Pi.smul_apply]
   · simp only [map_add, h1, h2, Finsupp.coe_add, Pi.add_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma deriv_basis_repr_apply {d} {μν : (Fin 1 ⊕ Fin d) × (Fin 1 ⊕ Fin d)}
     (A : ElectromagneticPotential d)

--- a/Physlib/Electromagnetism/Kinematics/EMPotential.lean
+++ b/Physlib/Electromagnetism/Kinematics/EMPotential.lean
@@ -25,9 +25,9 @@ spacetime to contravariant Lorentz vectors.
 
 - `ElectromagneticPotential` : is the type of electromagnetic potentials.
 - `ElectromagneticPotential.deriv` : the derivative tensor `∂_μ A^ν`.
-- `ElectromagneticPotential.contDiff_deriv_deriv` : the second derivatives `∂_μ ∂_ν A^ρ` are
+- `ElectromagneticPotential.contDiff_deriv_deriv_component` : the second derivatives `∂_μ ∂_ν A^ρ` are
   `C^n` if the potential is `C^{n+2}`.
-- `ElectromagneticPotential.deriv_contDiff` : the derivative tensor is `C^n` if the potential
+- `ElectromagneticPotential.contDiff_deriv` : the derivative tensor is `C^n` if the potential
   is `C^{n+1}`.
 
 ## iii. Table of contents
@@ -312,7 +312,7 @@ lemma contDiff_action {d} (Λ : LorentzGroup d) (A : ElectromagneticPotential d)
     (hA.comp (ContinuousLinearMap.contDiff (Lorentz.Vector.actionCLM Λ⁻¹)))
 
 @[fun_prop]
-lemma differentiable_deriv {d} {A : ElectromagneticPotential d}
+lemma differentiable_deriv_component {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ 2 A) (μ ν : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ A x ν) := by
   have h : ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
@@ -321,13 +321,13 @@ lemma differentiable_deriv {d} {A : ElectromagneticPotential d}
   exact h ν
 
 @[fun_prop]
-lemma differentiable_deriv_of_smooth {d} {A : ElectromagneticPotential d}
+lemma differentiable_deriv_component_of_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ A x ν) := by
-  apply differentiable_deriv (hA.of_le (ENat.LEInfty.out)) μ ν
+  apply differentiable_deriv_component (hA.of_le (ENat.LEInfty.out)) μ ν
 
 @[fun_prop]
-lemma contDiff_deriv {n} {d} {A : ElectromagneticPotential d}
+lemma contDiff_deriv_component {n} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ (n + 1) A) (μ ν : Fin 1 ⊕ Fin d) :
     ContDiff ℝ n (fun x => ∂_ μ A x ν) := by
   have h : ∀ ν, ContDiff ℝ n fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
@@ -336,10 +336,10 @@ lemma contDiff_deriv {n} {d} {A : ElectromagneticPotential d}
   exact h ν
 
 @[fun_prop]
-lemma contDiff_deriv_of_smooth {n : ℕ} {d} {A : ElectromagneticPotential d}
+lemma contDiff_deriv_component_of_smooth {n : ℕ} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :
     ContDiff ℝ n (fun x => ∂_ μ A x ν) :=
-  contDiff_deriv (hA.of_le (mod_cast le_top)) μ ν
+  contDiff_deriv_component (hA.of_le (mod_cast le_top)) μ ν
 
 /-!
 
@@ -354,24 +354,24 @@ in Maxwell's equations.
 
 /-- The second derivatives `∂_ μ ∂_ ν A^ρ` of a `C^{n+2}` potential are `C^n`. -/
 @[fun_prop]
-lemma contDiff_deriv_deriv {n} {d} {A : ElectromagneticPotential d}
+lemma contDiff_deriv_deriv_component {n} {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ (n + 2) A) (μ ν ρ : Fin 1 ⊕ Fin d) :
     ContDiff ℝ n (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  SpaceTime.contDiff_deriv μ _ (contDiff_deriv (n := n + 1)
+  SpaceTime.contDiff_deriv μ _ (contDiff_deriv_component (n := n + 1)
     (by rw [add_assoc, one_add_one_eq_two]; exact hA) ν ρ)
 
 /-- The second derivatives `∂_ μ ∂_ ν A^ρ` of a `C^3` potential are differentiable. -/
 @[fun_prop]
-lemma differentiable_deriv_deriv {d} {A : ElectromagneticPotential d}
+lemma differentiable_deriv_deriv_component {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ 3 A) (μ ν ρ : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  SpaceTime.differentiable_deriv μ _ (contDiff_deriv (n := 2) (by norm_cast) ν ρ)
+  SpaceTime.differentiable_deriv μ _ (contDiff_deriv_component (n := 2) (by norm_cast) ν ρ)
 
 @[fun_prop]
-lemma differentiable_deriv_deriv_of_smooth {d} {A : ElectromagneticPotential d}
+lemma differentiable_deriv_deriv_component_of_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν ρ : Fin 1 ⊕ Fin d) :
     Differentiable ℝ (fun x => ∂_ μ (fun x => ∂_ ν A x ρ) x) :=
-  differentiable_deriv_deriv (hA.of_le ENat.LEInfty.out) μ ν ρ
+  differentiable_deriv_deriv_component (hA.of_le ENat.LEInfty.out) μ ν ρ
 
 /-!
 
@@ -686,19 +686,19 @@ We show that the derivative tensor `∂_μ A^ν`, as a function on spacetime, is
 
 /-- The derivative tensor of a `C^2` potential is differentiable. -/
 @[fun_prop]
-lemma deriv_differentiable {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ 2 A) :
+lemma differentiable_deriv {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ 2 A) :
     Differentiable ℝ A.deriv := by
   unfold deriv
   fun_prop
 
 @[fun_prop]
-lemma deriv_differentiable_of_smooth {d} {A : ElectromagneticPotential d}
+lemma differentiable_deriv_of_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) : Differentiable ℝ A.deriv :=
-  deriv_differentiable (hA.of_le ENat.LEInfty.out)
+  differentiable_deriv (hA.of_le ENat.LEInfty.out)
 
 /-- The derivative tensor of a `C^{n+1}` potential is `C^n`. -/
 @[fun_prop]
-lemma deriv_contDiff {n} {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ (n + 1) A) :
+lemma contDiff_deriv {n} {d} {A : ElectromagneticPotential d} (hA : ContDiff ℝ (n + 1) A) :
     ContDiff ℝ n A.deriv := by
   unfold deriv
   fun_prop

--- a/Physlib/Electromagnetism/Kinematics/ElectricField.lean
+++ b/Physlib/Electromagnetism/Kinematics/ElectricField.lean
@@ -166,7 +166,7 @@ lemma electricField_eq_toFieldStrength_eval {c : SpeedOfLight}
       rw [Space.deriv_eq_fderiv_basis, fderiv_const_mul]
       simp [← Space.deriv_eq_fderiv_basis]
       · fun_prop
-      · exact differentiable_component A hA _
+      · fun_prop
   · exact 2
   · rw [SpaceTime.deriv_sum_inl c]
     simp only [ContinuousLinearEquiv.apply_symm_apply]

--- a/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
+++ b/Physlib/Electromagnetism/Kinematics/FieldStrength.lean
@@ -396,13 +396,8 @@ open ContDiff
 lemma toFieldStrength_eval_differentiable {d} {A : ElectromagneticPotential d}
     {μ ν : Fin 1 ⊕ Fin d} (hA : ContDiff ℝ 2 A) :
     Differentiable ℝ (fun x => toField {A.toFieldStrength x | [μ] [ν]}ᵀ) := by
-  have diff_partial (μ) :
-      ∀ ν, Differentiable ℝ fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [SpaceTime.differentiable_vector]
-    exact Differentiable.clm_apply
-      (((contDiff_succ_iff_fderiv (n := 1)).mp hA).2.2.differentiable (by simp)) (by fun_prop)
-  simp only [toFieldStrength_eval_apply_eq_single, SpaceTime.deriv_eq]
-  exact ((diff_partial _ _).const_mul _).sub ((diff_partial _ _).const_mul _)
+  simp only [toFieldStrength_eval_apply_eq_single]
+  fun_prop
 
 lemma toFieldStrength_eval_differentiable_space {d} {A : ElectromagneticPotential d}
     {μ ν : Fin 1 ⊕ Fin d} (hA : ContDiff ℝ 2 A) (t : Time) {c : SpeedOfLight} :
@@ -423,11 +418,8 @@ lemma toFieldStrength_eval_differentiable_time {d} {A : ElectromagneticPotential
 lemma toFieldStrength_eval_contDiff {d} {n : WithTop ℕ∞} {A : ElectromagneticPotential d}
     {μ ν : Fin 1 ⊕ Fin d} (hA : ContDiff ℝ (n + 1) A) :
     ContDiff ℝ n (fun x => toField {A.toFieldStrength x | [μ] [ν]}ᵀ) := by
-  have h (μ) : ∀ ν, ContDiff ℝ n fun x => (fderiv ℝ A x) (Lorentz.Vector.basis μ) ν := by
-    rw [SpaceTime.contDiff_vector]
-    exact ContDiff.clm_apply (ContDiff.fderiv_right (m := n) hA (by rfl)) (by fun_prop)
-  simp only [toFieldStrength_eval_apply_eq_single, SpaceTime.deriv_eq]
-  exact (contDiff_const.mul (h _ _)).sub (contDiff_const.mul (h _ _))
+  simp only [toFieldStrength_eval_apply_eq_single]
+  fun_prop
 
 lemma toFieldStrength_eval_smooth {d} {A : ElectromagneticPotential d}
     (hA : ContDiff ℝ ∞ A) (μ ν : Fin 1 ⊕ Fin d) :


### PR DESCRIPTION
Resolves the `EMPotential.lean` TODO on differentiability of the derivative of the potential.

The guiding rule is that a lemma is stated only where `fun_prop` cannot get there on its own. Three such gaps exist: `fun_prop` does not lower `ContDiff ℝ ∞` to a finite order (the `_of_smooth` lemmas), it cannot unify a symbolic `n + 2` with `?m + 1` (the `C^{n+2}` second-derivative lemmas, in both the `_component` and the `_apply` shape), and it will not `unfold deriv` (the tensor lemmas `differentiable_deriv`, `contDiff_deriv`). Everything a bare `fun_prop` already proves, including three pre-existing component lemmas, is removed under the same rule.

Naming follows the object: plain names for the tensor `A.deriv`, `_component` for "take the component, then differentiate", `_apply` for "differentiate, then take the component".

Riding along: two `FieldStrength.lean` proofs now use `fun_prop` instead of re-deriving component differentiability, and the stale `respectTransparency` options in `EMPotential.lean` are dropped.

prepared by claude, sanity checked and suggested cleanup by myself