### PR TITLE
feat(PhyslibAlpha): the Norton dome

### DIFF
--- a/PhyslibAlpha.lean
+++ b/PhyslibAlpha.lean
@@ -27,6 +27,14 @@ public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalCylinder
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SolidCylinder
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SolidSphere
 public import PhyslibAlpha.SpaceAndTime.Space.Surfaces.SphericalShell
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Basic
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Determinism
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.NewtonianSystem
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.PeanoExistence
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.PhysicalSpace
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.PosPartPow
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Solution
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Sqrt
 public import PhyslibAlpha.QuantumMechanics.QuantumHarmonicOscillator
 public import PhyslibAlpha.QuantumMechanics.HarmonicOscillator.Basic
 public import PhyslibAlpha.QuantumMechanics.HarmonicOscillator.LadderOperators

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/Basic.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/Basic.lean
@@ -1,0 +1,643 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import Physlib.ClassicalMechanics.EulerLagrange
+public import Physlib.Mathematics.Calculus.Gradient
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Sqrt
+/-!
+
+# The Norton dome
+
+## i. Overview
+
+The Norton dome is a point mass `m` sliding without friction, under gravity `g`, on a
+rotationally symmetric dome whose surface lies a depth `h(r) = (2/(3g)) r^{3/2}` below its
+apex at arc length `r`. Its force is continuous, yet a mass at rest on the apex may stay there
+forever or start sliding down at any later instant: the equation of motion has more than one
+solution with given initial data. It is the standard example of the failure of determinism in
+Newtonian mechanics and, mathematically, of the failure of uniqueness for an ODE whose
+right-hand side is continuous but not Lipschitz.
+
+Newton's laws, as stated, do not determine the motion. A Newtonian system that is to be
+deterministic must add something the laws do not state, a regularity condition on the force or
+a restriction on the admissible motions; which addition belongs to Newtonian mechanics is
+debated, and the folder does not decide it. It proves what each candidate condition buys and
+that the dome fails each. Reading order:
+
+- `NortonDome.Basic` (this file): the dome, its energies, force, equation of motion `r̈ = √r`,
+  and the failure of the Lipschitz condition at the apex.
+- `NortonDome.Solution`: rest at the apex and departure at any instant `T` are all solutions
+  from the same initial data, `exists_isSolution_ne`.
+- `NortonDome.PhysicalSpace`: the arc-length chart as a point mass constrained to the surface.
+- `NortonDome.NewtonianSystem`: the minimal `NewtonianSystem`; determinism, the first law and
+  the regularity conditions as predicates; a locally Lipschitz force gives determinism.
+- `NortonDome.Determinism`: the dome is not deterministic, violates the first law, and fails
+  each regularity condition.
+- `NortonDome.PeanoExistence`, `NortonDome.PosPartPow`, `NortonDome.Sqrt`: supporting
+  analysis. Peano's theorem is pending in Mathlib and marked `@[sorryful]`; all else is proved.
+
+The configuration is the arc length `r`, carried as for the pendulum on the Euclidean lift
+`Time → EuclideanSpace ℝ (Fin 1)`. The physical dome is `r ≥ 0`; the chart is all of `ℝ`, and
+for `r < 0` the truncated square root makes the force vanish. With `T = ½ m ṙ²` and
+`V = -m g h(r) = -(2m/3) r^{3/2}` the equation of motion is `m r̈ = -dV/dr = m √r`, so
+`r̈ = √r`: `m` and `g` cancel. Norton's profile presumes units in which the constant fixing the
+size of the dome is `1`.
+
+The force `√r` is continuous but not Lipschitz at the apex, and the potential is `C¹` but not
+`C²` there; see `NortonDome.Determinism`. So the Picard–Lindelöf hypothesis, which the pendulum
+satisfies, fails for the dome. For the same reason the Euler–Lagrange theorem
+`euler_lagrange_varGradient`, which needs a smooth Lagrangian, does not apply, and the equation
+of motion is identified only with the vanishing of the pointwise Euler–Lagrange operator.
+
+## ii. Key results
+
+- `NortonDome` holds the input data, the mass `m` and the gravitational acceleration `g`.
+- `NortonDome.height` is the depth `(2/(3g)) r^{3/2}` of the dome below its apex, with its
+  derivative `hasDerivAt_height` and `C¹` regularity `height_contDiff_one`.
+- `NortonDome.kineticEnergy`, `NortonDome.potentialEnergy` and `NortonDome.energy` are the
+  energies, with the gradient `gradient_potentialEnergy` of the potential and the time
+  derivatives `kineticEnergy_deriv`, `potentialEnergy_deriv` and `energy_deriv` along twice
+  differentiable curves.
+- `NortonDome.lagrangian` is the Lagrangian `T - V`, with its partial gradients
+  `gradient_lagrangian_position_eq` and `gradient_lagrangian_velocity_eq`.
+- `NortonDome.force` is the generalized force `m √r` conjugate to the arc length. It is
+  continuous, `force_continuous`, but not Lipschitz on any closed ball about the apex,
+  `not_lipschitzOnWith_force`.
+- `NortonDome.EquationOfMotion` is the equation of motion `m r̈ = F(r)`, with its scalar form
+  `equationOfMotion_iff_scalar`; `NortonDome.IsSolution` is a twice differentiable solution.
+- `NortonDome.equationOfMotion_iff_eulerLagrangeOp_zero` identifies the equation of motion,
+  for curves with differentiable velocity, with the vanishing of the Euler–Lagrange operator.
+- `NortonDome.IsSolution.energy_eq` is the conservation of energy along a solution.
+
+## iii. Table of contents
+
+- A. The input data
+- B. The profile of the dome
+  - B.1. The height below the apex
+  - B.2. The derivative of the profile
+- C. The energies
+  - C.1. The definitions of the energies
+  - C.2. Differentiability and the gradient of the potential
+  - C.3. Time derivatives of the energies
+- D. The Lagrangian
+- E. The force and the equation of motion
+  - E.1. The force
+  - E.2. Regularity of the force
+  - E.3. The equation of motion
+  - E.4. Solutions
+- F. The Euler–Lagrange operator
+- G. Energy conservation
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+- Malament, D. B., *Norton's slippery slope*, Philosophy of Science 75 (2008), 799–816.
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+open Real InnerProductSpace
+
+/-!
+
+## A. The input data
+
+The dome is specified by the mass of the particle and the gravitational acceleration; its shape
+is fixed by Norton's formula.
+
+-/
+
+/-- The Norton dome is specified by the mass `m` of the particle sliding on it and the
+  gravitational acceleration `g`, both positive. The configuration of the particle is the arc
+  length from the apex. -/
+structure NortonDome where
+  /-- The mass of the particle. -/
+  m : ℝ
+  /-- The gravitational acceleration. -/
+  g : ℝ
+  m_pos : 0 < m
+  g_pos : 0 < g
+
+namespace NortonDome
+
+variable (S : NortonDome)
+
+/-- The mass of the particle is not equal to zero. -/
+@[simp]
+lemma m_ne_zero : S.m ≠ 0 := S.m_pos.ne'
+
+/-- The gravitational acceleration is not equal to zero. -/
+@[simp]
+lemma g_ne_zero : S.g ≠ 0 := S.g_pos.ne'
+
+/-!
+
+## B. The profile of the dome
+
+Norton's profile is the depth `h(r) = (2/(3g)) r^{3/2}` of the surface below the apex at arc
+length `r`, written here as `(2/(3g)) √r ^ 3` so that it is defined, and vanishes, for `r ≤ 0`.
+
+-/
+
+/-!
+
+### B.1. The height below the apex
+
+-/
+
+/-- The depth of the surface of the dome below its apex at arc length `r` from the apex,
+  `(2/(3g)) r^{3/2}`. It vanishes at the apex and for negative arguments. -/
+noncomputable def height (r : ℝ) : ℝ := 2 / (3 * S.g) * √r ^ 3
+
+/-- The depth of the dome below its apex, written out. -/
+lemma height_eq (r : ℝ) : S.height r = 2 / (3 * S.g) * √r ^ 3 := rfl
+
+/-- The depth of the dome below its apex is non-negative. -/
+lemma height_nonneg (r : ℝ) : 0 ≤ S.height r := by
+  rw [height_eq]
+  have hg := S.g_pos
+  positivity
+
+/-- The depth of the dome below its apex vanishes exactly at and before the apex. -/
+lemma height_eq_zero_iff (r : ℝ) : S.height r = 0 ↔ r ≤ 0 := by
+  rw [height_eq, mul_eq_zero, pow_eq_zero_iff three_ne_zero, Real.sqrt_eq_zero']
+  simp
+
+/-!
+
+### B.2. The derivative of the profile
+
+The slope `√r / g` of the profile is continuous and vanishes at the apex, so the profile is
+`C¹`. The slope itself is not differentiable at the apex, so the profile is not `C²`.
+
+-/
+
+/-- The derivative of the depth of the dome with respect to the arc length is `√r / g`, at
+  every `r`, including the apex. -/
+lemma hasDerivAt_height (r : ℝ) : HasDerivAt S.height (√r / S.g) r := by
+  have h := (hasDerivAt_sqrt_pow_three r).const_mul (2 / (3 * S.g))
+  refine h.congr_deriv ?_
+  field_simp
+
+/-- The depth of the dome is a differentiable function of the arc length. -/
+@[fun_prop]
+lemma height_differentiable : Differentiable ℝ S.height :=
+  fun r => (S.hasDerivAt_height r).differentiableAt
+
+/-- The derivative of the depth of the dome with respect to the arc length is `√r / g`. -/
+lemma deriv_height : deriv S.height = fun r => √r / S.g :=
+  funext fun r => (S.hasDerivAt_height r).deriv
+
+/-- The depth of the dome is a `C¹` function of the arc length. -/
+lemma height_contDiff_one : ContDiff ℝ 1 S.height := by
+  rw [contDiff_one_iff_deriv, deriv_height]
+  exact ⟨S.height_differentiable, by fun_prop⟩
+
+open Time
+
+/-!
+
+## C. The energies
+
+The kinetic energy is `½ m ṙ²`, `r` being the arc length so that the speed is `|ṙ|`, and the
+potential energy is `-m g h(r)`, normalized to vanish at the apex.
+
+-/
+
+/-!
+
+### C.1. The definitions of the energies
+
+-/
+
+/-- The kinetic energy of the particle on the dome along a curve `r` of the arc length is
+  `½ m ‖ṙ‖²`. -/
+noncomputable def kineticEnergy (r : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ := fun t =>
+  (1 / (2 : ℝ)) * S.m * ⟪∂ₜ r t, ∂ₜ r t⟫_ℝ
+
+/-- The potential energy of the particle on the dome at arc length `x` from the apex is
+  `-m g h(x 0)`, the gravitational potential at depth `h` below the apex, which vanishes at the
+  apex. -/
+noncomputable def potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) : ℝ :=
+  -(S.m * S.g * S.height (x 0))
+
+/-- The energy of the particle on the dome is the kinetic energy plus the potential energy. -/
+noncomputable def energy (r : Time → EuclideanSpace ℝ (Fin 1)) : Time → ℝ := fun t =>
+  S.kineticEnergy r t + S.potentialEnergy (r t)
+
+/-- The kinetic energy of the particle on the dome, written out. -/
+lemma kineticEnergy_eq (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.kineticEnergy r = fun t => (1 / (2 : ℝ)) * S.m * ⟪∂ₜ r t, ∂ₜ r t⟫_ℝ := rfl
+
+/-- The potential energy of the particle on the dome is `-(2m/3) r^{3/2}`: the gravitational
+  acceleration cancels against the shape of the dome. -/
+lemma potentialEnergy_eq (x : EuclideanSpace ℝ (Fin 1)) :
+    S.potentialEnergy x = -(2 * S.m / 3) * √(x 0) ^ 3 := by
+  rw [potentialEnergy, height_eq]
+  field_simp
+
+/-- The energy of the particle on the dome, written out. -/
+lemma energy_eq (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.energy r = fun t => S.kineticEnergy r t + S.potentialEnergy (r t) := rfl
+
+/-- The potential energy of the particle on the dome is non-positive, the apex being the
+  highest point of the dome. -/
+lemma potentialEnergy_nonpos (x : EuclideanSpace ℝ (Fin 1)) : S.potentialEnergy x ≤ 0 := by
+  rw [potentialEnergy, neg_nonpos]
+  exact mul_nonneg (mul_pos S.m_pos S.g_pos).le (S.height_nonneg _)
+
+/-- The potential energy of the particle on the dome vanishes exactly at the apex, that is for
+  arc length `≤ 0`. -/
+lemma potentialEnergy_eq_zero_iff (x : EuclideanSpace ℝ (Fin 1)) :
+    S.potentialEnergy x = 0 ↔ x 0 ≤ 0 := by
+  rw [potentialEnergy, neg_eq_zero, mul_eq_zero, or_iff_right (mul_pos S.m_pos S.g_pos).ne',
+    height_eq_zero_iff]
+
+/-!
+
+### C.2. Differentiability and the gradient of the potential
+
+The potential energy is differentiable, with gradient `-m √r` times the unit vector of the
+arc-length coordinate. It is `C¹` but not `C²`, since `√r` is not differentiable at `0`.
+
+-/
+
+/-- The cube of the square root of the arc-length coordinate is differentiable on the Euclidean
+  lift, at every point. -/
+lemma differentiableAt_sqrt_coord_pow_three (x : EuclideanSpace ℝ (Fin 1)) :
+    DifferentiableAt ℝ (fun y : EuclideanSpace ℝ (Fin 1) => √(y 0) ^ 3) x := by
+  have h : HasFDerivAt ((fun y : ℝ => √y ^ 3) ∘ ⇑(EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1))) _ x :=
+    (hasDerivAt_sqrt_pow_three (x 0)).comp_hasFDerivAt x
+      (EuclideanSpace.proj (𝕜 := ℝ) (0 : Fin 1)).hasFDerivAt
+  exact h.differentiableAt
+
+/-- The potential energy of the particle on the dome is a differentiable function of the arc
+  length. -/
+@[fun_prop]
+lemma differentiable_potentialEnergy : Differentiable ℝ S.potentialEnergy := by
+  intro x
+  have h : S.potentialEnergy = fun y => -(2 * S.m / 3) * √(y 0) ^ 3 :=
+    funext S.potentialEnergy_eq
+  rw [h]
+  exact (differentiableAt_sqrt_coord_pow_three x).const_mul _
+
+/-- The gradient of the potential energy of the particle on the dome is `-m √r` times the unit
+  vector of the arc-length coordinate. -/
+lemma gradient_potentialEnergy (x : EuclideanSpace ℝ (Fin 1)) :
+    gradient S.potentialEnergy x = -(S.m * √(x 0)) • EuclideanSpace.single 0 1 := by
+  have h : S.potentialEnergy = fun y => -(2 * S.m / 3) * √(y 0) ^ 3 :=
+    funext S.potentialEnergy_eq
+  rw [h, gradient_const_mul _ (differentiableAt_sqrt_coord_pow_three x),
+    gradient_comp_coord 0 x (hasDerivAt_sqrt_pow_three (x 0)), smul_smul]
+  congr 1
+  ring
+
+/-- Along a curve of the arc length with differentiable velocity the kinetic energy is
+  differentiable in time. -/
+@[fun_prop]
+lemma kineticEnergy_differentiable (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr' : Differentiable ℝ (∂ₜ r)) : Differentiable ℝ (S.kineticEnergy r) := by
+  rw [kineticEnergy_eq]
+  fun_prop
+
+/-- Along a differentiable curve of the arc length the potential energy is a differentiable
+  function of the time. -/
+@[fun_prop]
+lemma potentialEnergy_differentiable (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr : Differentiable ℝ r) : Differentiable ℝ (fun t => S.potentialEnergy (r t)) :=
+  S.differentiable_potentialEnergy.comp hr
+
+/-- Along a twice differentiable curve of the arc length the energy is differentiable in
+  time. -/
+@[fun_prop]
+lemma energy_differentiable (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    (hr' : Differentiable ℝ (∂ₜ r)) : Differentiable ℝ (S.energy r) := by
+  rw [energy_eq]
+  fun_prop
+
+/-!
+
+### C.3. Time derivatives of the energies
+
+Along a twice differentiable curve, solution or not, the time derivatives of the energies are
+inner products against the velocity; the equation of motion makes the two contributions cancel.
+
+-/
+
+/-- The rate of change of the kinetic energy is the velocity paired with `m r̈`. -/
+lemma kineticEnergy_deriv (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr' : Differentiable ℝ (∂ₜ r)) :
+    ∂ₜ (S.kineticEnergy r) = fun t => ⟪∂ₜ r t, S.m • ∂ₜ (∂ₜ r) t⟫_ℝ := by
+  funext t
+  unfold kineticEnergy
+  have hd : DifferentiableAt ℝ (∂ₜ r) t := hr' t
+  rw [Time.deriv_eq, fderiv_const_mul (by fun_prop), _root_.smul_apply,
+    fderiv_inner_apply (𝕜 := ℝ) hd hd, ← Time.deriv_eq]
+  simp [inner_smul_right, real_inner_comm]
+  ring
+
+/-- The rate of change of the potential energy is the velocity paired with the gradient of the
+  potential. -/
+lemma potentialEnergy_deriv (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r) :
+    ∂ₜ (fun t => S.potentialEnergy (r t)) =
+      fun t => ⟪∂ₜ r t, gradient S.potentialEnergy (r t)⟫_ℝ := by
+  funext t
+  have hf : HasFDerivAt (fun t => S.potentialEnergy (r t)) _ t :=
+    (S.differentiable_potentialEnergy (r t)).hasFDerivAt.comp t (hr t).hasFDerivAt
+  rw [Time.deriv_eq, hf.fderiv]
+  simp [Time.deriv_eq]
+
+/-- The rate of change of the energy is the velocity paired with the sum of `m r̈` and the
+  gradient of the potential; the equation of motion is exactly the vanishing of that sum. -/
+lemma energy_deriv (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    (hr' : Differentiable ℝ (∂ₜ r)) :
+    ∂ₜ (S.energy r) =
+      fun t => ⟪∂ₜ r t, S.m • ∂ₜ (∂ₜ r) t + gradient S.potentialEnergy (r t)⟫_ℝ := by
+  unfold energy
+  funext t
+  rw [Time.deriv_eq, fderiv_fun_add (S.kineticEnergy_differentiable r hr' t)
+    (S.potentialEnergy_differentiable r hr t)]
+  simp only [_root_.add_apply, ← Time.deriv_eq, S.kineticEnergy_deriv r hr',
+    S.potentialEnergy_deriv r hr, ← inner_add_right]
+
+/-!
+
+## D. The Lagrangian
+
+The Lagrangian `L = ½ m ṙ² + m g h(r)` is a function on phase space. Unlike those of the
+harmonic oscillator and the pendulum it is only `C¹`; its partial gradients still exist, and
+are the force of section E and the momentum `m ṙ`.
+
+-/
+
+set_option linter.unusedVariables false in
+/-- The Lagrangian of the particle on the dome, `L(t, r, ṙ) = ½ m ‖ṙ‖² - V(r)`, the kinetic
+  energy minus the potential energy as a function on phase space. It does not depend on the
+  time. -/
+@[nolint unusedArguments]
+noncomputable def lagrangian (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) : ℝ :=
+  (1 / (2 : ℝ)) * S.m * ⟪v, v⟫_ℝ - S.potentialEnergy x
+
+/-- Along a curve of the arc length the Lagrangian of the particle on the dome is the kinetic
+  energy minus the potential energy. -/
+lemma lagrangian_eq_kineticEnergy_sub_potentialEnergy (t : Time)
+    (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.lagrangian t (r t) (∂ₜ r t) = S.kineticEnergy r t - S.potentialEnergy (r t) := rfl
+
+/-- The gradient of the Lagrangian of the particle on the dome in the arc length is minus the
+  gradient of the potential energy, `m √r` times the unit vector of the arc-length
+  coordinate. -/
+lemma gradient_lagrangian_position_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    gradient (fun x => S.lagrangian t x v) x = (S.m * √(x 0)) • EuclideanSpace.single 0 1 := by
+  have h : (fun y : EuclideanSpace ℝ (Fin 1) => S.lagrangian t y v) =
+      fun y => (-1 : ℝ) * S.potentialEnergy y + (1 / (2 : ℝ)) * S.m * ⟪v, v⟫_ℝ := by
+    funext y
+    rw [lagrangian]
+    ring
+  rw [h, gradient_add_const, gradient_const_mul _ (S.differentiable_potentialEnergy x),
+    gradient_potentialEnergy]
+  module
+
+/-- The gradient of the Lagrangian of the particle on the dome in the velocity is the momentum
+  `m ṙ`. -/
+lemma gradient_lagrangian_velocity_eq (t : Time) (x v : EuclideanSpace ℝ (Fin 1)) :
+    gradient (S.lagrangian t x) v = S.m • v := by
+  have h : S.lagrangian t x = fun y : EuclideanSpace ℝ (Fin 1) =>
+      ((1 / (2 : ℝ)) * S.m) * ⟪y, y⟫_ℝ + -S.potentialEnergy x := by
+    funext y
+    rw [lagrangian]
+    ring
+  rw [h, gradient_add_const, gradient_const_mul_inner_self]
+  module
+
+/-!
+
+## E. The force and the equation of motion
+
+Gravity exerts the generalized force `m √r` conjugate to the arc length, balanced against
+`m r̈`. As for the pendulum this pointwise relation is the definition of the equation of
+motion; the variational derivative of the action is not available, the Lagrangian not being
+smooth.
+
+-/
+
+/-!
+
+### E.1. The force
+
+-/
+
+/-- The generalized force on the particle on the dome conjugate to the arc length, minus the
+  gradient of the potential energy, `F = -∂V/∂r`. -/
+noncomputable def force (x : EuclideanSpace ℝ (Fin 1)) : EuclideanSpace ℝ (Fin 1) :=
+  -gradient S.potentialEnergy x
+
+/-- The force on the particle on the dome is `m √r` times the unit vector of the arc-length
+  coordinate: it points away from the apex, and vanishes there. -/
+lemma force_eq (x : EuclideanSpace ℝ (Fin 1)) :
+    S.force x = (S.m * √(x 0)) • EuclideanSpace.single 0 1 := by
+  rw [force, gradient_potentialEnergy, neg_smul, neg_neg]
+
+/-- The single component of the force on the particle on the dome is `m √r`. -/
+lemma force_apply (x : EuclideanSpace ℝ (Fin 1)) : S.force x 0 = S.m * √(x 0) := by
+  rw [force_eq]
+  simp
+
+/-- The force on the particle on the dome vanishes at the apex. -/
+lemma force_zero : S.force 0 = 0 := by
+  rw [force_eq]
+  simp
+
+/-!
+
+### E.2. Regularity of the force
+
+The force is continuous. It is not Lipschitz on any closed ball about the apex, since the square
+root is not Lipschitz on any `[0, ε]`: the Picard–Lindelöf hypothesis fails, which is the
+source of the non-uniqueness.
+
+-/
+
+/-- The force on the particle on the dome is a continuous function of the arc length. -/
+@[fun_prop]
+lemma force_continuous : Continuous S.force := by
+  have h : S.force = fun x => (S.m * √(x 0)) • EuclideanSpace.single 0 1 := funext S.force_eq
+  rw [h]
+  fun_prop
+
+/-- The distance between two multiples of the unit vector of the arc-length coordinate is the
+  distance between the coefficients. -/
+lemma dist_smul_single (a b : ℝ) :
+    dist (a • EuclideanSpace.single (0 : Fin 1) (1 : ℝ)) (b • EuclideanSpace.single 0 1) =
+      |a - b| := by
+  rw [dist_eq_norm, ← sub_smul, norm_smul, PiLp.norm_single, norm_one, mul_one,
+    Real.norm_eq_abs]
+
+/-- The force on the particle on the dome is not Lipschitz on any closed ball about the apex,
+  for any Lipschitz constant. -/
+lemma not_lipschitzOnWith_force (K : NNReal) {ε : ℝ} (hε : 0 < ε) :
+    ¬ LipschitzOnWith K S.force (Metric.closedBall 0 ε) := by
+  intro h
+  refine not_lipschitzOnWith_sqrt ⟨(K : ℝ) / S.m, div_nonneg K.2 S.m_pos.le⟩ hε ?_
+  refine LipschitzOnWith.of_dist_le_mul fun y hy z hz => ?_
+  have hmem : ∀ w ∈ Set.Icc (0 : ℝ) ε,
+      w • EuclideanSpace.single (0 : Fin 1) (1 : ℝ) ∈ Metric.closedBall 0 ε := by
+    intro w hw
+    rw [Metric.mem_closedBall, dist_zero_right, norm_smul, PiLp.norm_single, norm_one,
+      mul_one, Real.norm_eq_abs, abs_of_nonneg hw.1]
+    exact hw.2
+  have := h.dist_le_mul _ (hmem y hy) _ (hmem z hz)
+  rw [force_eq, force_eq, dist_smul_single, dist_smul_single] at this
+  simp only [PiLp.smul_apply, PiLp.single_apply, if_true, smul_eq_mul, mul_one,
+    ← mul_sub, abs_mul, abs_of_pos S.m_pos] at this
+  show dist √y √z ≤ (K : ℝ) / S.m * dist y z
+  rw [Real.dist_eq, Real.dist_eq, div_mul_eq_mul_div, le_div_iff₀ S.m_pos, mul_comm]
+  exact this
+
+/-!
+
+### E.3. The equation of motion
+
+-/
+
+/-- The equation of motion of the particle on the dome: at every instant `m r̈` equals the
+  generalized force `F(r) = m √r`. This pointwise relation is the definition; for curves with
+  differentiable velocity it is the vanishing of the Euler–Lagrange operator of the Lagrangian,
+  `equationOfMotion_iff_eulerLagrangeOp_zero`. -/
+def EquationOfMotion (r : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
+  ∀ t, S.m • ∂ₜ (∂ₜ r) t = S.force (r t)
+
+/-- The equation of motion with all terms on one side: at every instant `m r̈` plus the
+  gradient of the potential energy vanishes. This is the combination `energy_deriv` pairs with
+  the velocity. -/
+lemma equationOfMotion_iff_newtons_2nd_law (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.EquationOfMotion r ↔
+      ∀ t, S.m • ∂ₜ (∂ₜ r) t + gradient S.potentialEnergy (r t) = 0 := by
+  simp only [EquationOfMotion, force, eq_neg_iff_add_eq_zero]
+
+/-- The equation of motion of the particle on the dome in scalar form, `r̈ = √r`. Both the mass
+  and the gravitational acceleration have cancelled. -/
+lemma equationOfMotion_iff_scalar (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.EquationOfMotion r ↔ ∀ t, ∂ₜ (∂ₜ r) t 0 = √(r t 0) := by
+  simp only [EquationOfMotion]
+  refine forall_congr' fun t => ?_
+  rw [force_eq]
+  constructor
+  · intro h
+    have := congrArg (fun y : EuclideanSpace ℝ (Fin 1) => y 0) h
+    simpa [S.m_ne_zero] using this
+  · intro h
+    ext i
+    fin_cases i
+    simp [h]
+
+/-!
+
+### E.4. Solutions
+
+A solution is a twice differentiable curve, position and velocity both differentiable, satisfying
+the equation of motion: the regularity of `ClassicalMechanics.ReferenceFrame.Particle` and the
+least under which the acceleration exists. Regularity is part of the definition because the bare
+pointwise equation, whose derivatives are zero wherever they do not exist, admits rough accidental
+solutions. Smoothness is not demanded: the motions leaving the apex are `C³` but not `C⁴`.
+
+-/
+
+/-- A solution of the dome is a twice differentiable curve of the arc length, its position and
+  velocity both differentiable, satisfying the equation of motion. -/
+def IsSolution (r : Time → EuclideanSpace ℝ (Fin 1)) : Prop :=
+  Differentiable ℝ r ∧ Differentiable ℝ (∂ₜ r) ∧ S.EquationOfMotion r
+
+/-- The position along a solution of the dome is differentiable. -/
+lemma IsSolution.differentiable {S : NortonDome} {r : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution r) : Differentiable ℝ r := h.1
+
+/-- The velocity along a solution of the dome is differentiable. -/
+lemma IsSolution.deriv_differentiable {S : NortonDome} {r : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution r) : Differentiable ℝ (∂ₜ r) := h.2.1
+
+/-- A solution of the dome satisfies the equation of motion. -/
+lemma IsSolution.equationOfMotion {S : NortonDome} {r : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution r) : S.EquationOfMotion r := h.2.2
+
+/-!
+
+## F. The Euler–Lagrange operator
+
+With the gradients of section D, the pointwise Euler–Lagrange operator along any curve with
+differentiable velocity is the force minus `m r̈`, so its vanishing is the equation of motion.
+The identification of this operator with the variational derivative of the action,
+`euler_lagrange_varGradient`, needs a smooth Lagrangian and so does not apply to the dome.
+
+-/
+
+/-- Along a curve of the arc length with differentiable velocity the Euler–Lagrange operator of
+  the Lagrangian of the dome is the force minus `m r̈`. -/
+lemma eulerLagrangeOp_lagrangian (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr' : Differentiable ℝ (∂ₜ r)) :
+    eulerLagrangeOp S.lagrangian r = fun t => S.force (r t) - S.m • ∂ₜ (∂ₜ r) t := by
+  funext t
+  rw [eulerLagrangeOp]
+  simp [S.gradient_lagrangian_position_eq, S.gradient_lagrangian_velocity_eq, S.force_eq,
+    Time.deriv_smul _ S.m hr']
+
+/-- For a curve of the arc length with differentiable velocity the equation of motion of the
+  dome holds if and only if the Euler–Lagrange operator of its Lagrangian vanishes along it. -/
+lemma equationOfMotion_iff_eulerLagrangeOp_zero (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr' : Differentiable ℝ (∂ₜ r)) :
+    S.EquationOfMotion r ↔ eulerLagrangeOp S.lagrangian r = 0 := by
+  rw [S.eulerLagrangeOp_lagrangian r hr', funext_iff]
+  simp only [EquationOfMotion, Pi.zero_apply, sub_eq_zero]
+  exact forall_congr' fun t => eq_comm
+
+/-!
+
+## G. Energy conservation
+
+Along any twice differentiable curve satisfying the equation of motion the energy is constant.
+This follows from `energy_deriv`. Conservation of energy does not restore uniqueness: the motion
+at rest at the apex and every motion leaving it all have zero energy, which is proved in
+`NortonDome.Solution` as `energy_rest` and `energy_solution`.
+
+-/
+
+/-- Along a twice differentiable curve of the arc length satisfying the equation of motion the
+  time derivative of the energy of the dome vanishes. -/
+lemma energy_conservation_of_equationOfMotion (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr : Differentiable ℝ r) (hr' : Differentiable ℝ (∂ₜ r)) (h : S.EquationOfMotion r) :
+    ∂ₜ (S.energy r) = 0 := by
+  rw [S.equationOfMotion_iff_newtons_2nd_law r] at h
+  funext t
+  rw [S.energy_deriv r hr hr']
+  simp [h t]
+
+/-- Along a twice differentiable curve of the arc length satisfying the equation of motion the
+  energy of the dome at any time is equal to its initial value. -/
+lemma energy_conservation_of_equationOfMotion' (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr : Differentiable ℝ r) (hr' : Differentiable ℝ (∂ₜ r)) (h : S.EquationOfMotion r)
+    (t : Time) : S.energy r t = S.energy r 0 := by
+  apply is_const_of_fderiv_eq_zero (𝕜 := ℝ) (S.energy_differentiable r hr hr')
+  intro t
+  ext p
+  rw [p.eq_one_smul, map_smul, ← Time.deriv_eq,
+    S.energy_conservation_of_equationOfMotion r hr hr' h]
+  simp
+
+/-- The energy of the dome along a solution at any time is equal to its initial value. -/
+lemma IsSolution.energy_eq {S : NortonDome} {r : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution r) (t : Time) : S.energy r t = S.energy r 0 :=
+  S.energy_conservation_of_equationOfMotion' r h.differentiable h.deriv_differentiable
+    h.equationOfMotion t
+
+end NortonDome
+
+end ClassicalMechanics
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/Determinism.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/Determinism.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.NewtonianSystem
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Solution
+/-!
+
+# The Norton dome and the determinism of Newtonian mechanics
+
+## i. Overview
+
+A particle at rest on the apex of the Norton dome may stay there forever or slide off at any
+instant, in obedience to Newton's second law with a continuous force. This file states what
+that does and does not show, in the terms of `NortonDome.NewtonianSystem`.
+
+The dome is such a system (`toNewtonianSystem`). It is not deterministic
+(`not_isDeterministic`) and it violates the first law (`not_satisfiesFirstLaw`). Since a locally
+Lipschitz force gives determinism, the dome must fail that hypothesis and everything implying
+it, and it does (`not_hasLocallyLipschitzForce`, `not_hasLipschitzForce`, `not_hasC2Potential`).
+Its force `m √r` is continuous but has infinite slope at the apex, and its potential is `C¹`
+but not `C²`.
+
+Put together, this is `exists_continuous_force_not_isDeterministic`: a continuous force does
+not make a Newtonian system deterministic, while a locally Lipschitz force, or a `C²`
+potential, does. Newton's laws do not say which requirement, if any, belongs in the definition
+of a Newtonian system. The theorems say what each requirement buys and that the dome is what
+each excludes, and leave the choice open. Malament's proposal, a regularity condition on the
+constraint surface in physical space rather than on the potential, is not formulated here. With
+Peano's theorem, whose proof is pending in Mathlib, the dome has solutions from every initial
+datum (`hasLocalSolutions`), so its failure is one of uniqueness alone.
+
+## ii. Key results
+
+- `NortonDome.not_isDeterministic`: the dome is not deterministic.
+- `NortonDome.not_satisfiesFirstLaw`: the dome violates the first law.
+- `NortonDome.exists_continuous_force_not_isDeterministic`: Norton's claim, a Newtonian
+  system with a continuous force that is not deterministic.
+- `NortonDome.not_hasLocallyLipschitzForce`, `NortonDome.not_hasLipschitzForce` and
+  `NortonDome.not_hasC2Potential`: the dome satisfies none of the regularity conditions.
+- `NortonDome.toNewtonianSystem` is the dome as a Newtonian system, with
+  `toNewtonianSystem_force`, `toNewtonianSystem_equationOfMotion_iff` and
+  `toNewtonianSystem_isSolution_iff` identifying its force, equation of motion and solutions
+  with those of `NortonDome.Basic`.
+- `NortonDome.hasLocalSolutions` and `NortonDome.exists_hasLocalSolutions_not_isDeterministic`:
+  the dome has local solutions from every initial datum, by Peano's theorem, so its failure of
+  determinism is a failure of uniqueness alone (pending the upstream proof).
+
+## iii. Table of contents
+
+- A. The dome as a Newtonian system
+- B. The properties the dome fails
+  - B.1. Determinism and the first law
+  - B.2. The regularity conditions
+- C. Norton's claim
+- D. Existence without uniqueness
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+- Malament, D. B., *Norton's slippery slope*, Philosophy of Science 75 (2008), 799–816.
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics.NortonDome
+open Real InnerProductSpace Time
+
+variable (S : NortonDome)
+
+/-!
+
+## A. The dome as a Newtonian system
+
+The dome has a differentiable potential, so it is a Newtonian system whose force, equation of
+motion and solutions are by definition those of `NortonDome.Basic`.
+
+-/
+
+/-- The Norton dome as a conservative Newtonian system on the Euclidean lift of the arc
+  length. -/
+noncomputable def toNewtonianSystem : NewtonianSystem (EuclideanSpace ℝ (Fin 1)) where
+  m := S.m
+  potential := S.potentialEnergy
+  m_pos := S.m_pos
+  potential_differentiable := S.differentiable_potentialEnergy
+
+/-- The force of the dome as a Newtonian system is its force. -/
+lemma toNewtonianSystem_force : S.toNewtonianSystem.force = S.force := rfl
+
+/-- The equation of motion of the dome as a Newtonian system is its equation of motion. -/
+lemma toNewtonianSystem_equationOfMotion_iff (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.toNewtonianSystem.EquationOfMotion r ↔ S.EquationOfMotion r := Iff.rfl
+
+/-- The solutions of the dome as a Newtonian system are its solutions. -/
+lemma toNewtonianSystem_isSolution_iff (r : Time → EuclideanSpace ℝ (Fin 1)) :
+    S.toNewtonianSystem.IsSolution r ↔ S.IsSolution r := Iff.rfl
+
+/-!
+
+## B. The properties the dome fails
+
+-/
+
+/-!
+
+### B.1. Determinism and the first law
+
+Determinism fails by the non-uniqueness proved in `NortonDome.Solution`. The first law fails
+along the motion leaving the apex at the instant `1`: at the instant `0` it is at rest at the
+apex, where the force vanishes, and at the instant `2` it is off the apex.
+
+-/
+
+/-- The Norton dome is not deterministic. -/
+lemma not_isDeterministic : ¬ S.toNewtonianSystem.IsDeterministic := by
+  intro h
+  obtain ⟨x, y, hx, hy, h0, hv, hne⟩ := S.exists_isSolution_ne
+  exact hne (h x y hx hy 0 h0 hv)
+
+/-- The Norton dome violates Newton's first law, read as a statement about intervals of time:
+  a particle at rest at the apex, where the force vanishes, need not stay there. -/
+lemma not_satisfiesFirstLaw : ¬ S.toNewtonianSystem.SatisfiesFirstLaw := by
+  intro h
+  have h2 := h (solution 1) (S.solution_isSolution 1) 0
+    (by rw [toNewtonianSystem_force, solution_zero zero_le_one, force_zero])
+    (deriv_solution_zero zero_le_one) ((2 : ℝ) : Time)
+  have hpos := solution_apply_pos 1 (t := ((2 : ℝ) : Time)) (by rw [Time.realCast_val]; norm_num)
+  rw [h2, solution_zero zero_le_one] at hpos
+  simp at hpos
+
+/-!
+
+### B.2. The regularity conditions
+
+The force is not Lipschitz on any closed ball about the apex, `not_lipschitzOnWith_force`,
+hence not locally Lipschitz; the two stronger conditions imply a locally Lipschitz force, so
+they fail too.
+
+-/
+
+/-- The force of the Norton dome is not locally Lipschitz: it is not Lipschitz on any
+  neighbourhood of the apex. -/
+lemma not_hasLocallyLipschitzForce : ¬ S.toNewtonianSystem.HasLocallyLipschitzForce := by
+  intro h
+  obtain ⟨K, t, ht, hKt⟩ := h 0
+  obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp ht
+  exact S.not_lipschitzOnWith_force K (half_pos hε)
+    (hKt.mono ((Metric.closedBall_subset_ball (by linarith)).trans hball))
+
+/-- The force of the Norton dome is not Lipschitz. -/
+lemma not_hasLipschitzForce : ¬ S.toNewtonianSystem.HasLipschitzForce :=
+  fun h => S.not_hasLocallyLipschitzForce h.hasLocallyLipschitzForce
+
+/-- The potential of the Norton dome is not `C²`. -/
+lemma not_hasC2Potential : ¬ S.toNewtonianSystem.HasC2Potential :=
+  fun h => S.not_hasLocallyLipschitzForce h.hasLocallyLipschitzForce
+
+/-!
+
+## C. Norton's claim
+
+-/
+
+/-- Norton's claim: there is a conservative Newtonian system, with a continuous force,
+  which is not deterministic. The witness is the dome with unit mass and unit gravitational
+  acceleration. -/
+lemma exists_continuous_force_not_isDeterministic :
+    ∃ N : NewtonianSystem (EuclideanSpace ℝ (Fin 1)), Continuous N.force ∧ ¬ N.IsDeterministic :=
+  ⟨(⟨1, 1, one_pos, one_pos⟩ : NortonDome).toNewtonianSystem, force_continuous _,
+    not_isDeterministic _⟩
+
+/-!
+
+## D. Existence without uniqueness
+
+The force is continuous and the configuration space is finite-dimensional, so by Peano's
+theorem, `NewtonianSystem.hasLocalSolutions_of_continuous_force`, every initial datum has a
+local solution: the failure of determinism is purely one of uniqueness. Pending the proof of
+Peano's theorem in Mathlib, these results are marked `@[sorryful]`.
+
+-/
+
+/-- The Norton dome has local solutions from every initial position and velocity. Pending the
+  proof of Peano's theorem in Mathlib. -/
+@[sorryful]
+lemma hasLocalSolutions : S.toNewtonianSystem.HasLocalSolutions :=
+  NewtonianSystem.hasLocalSolutions_of_continuous_force _ S.force_continuous
+
+/-- Norton's claim, sharpened: there is a Newtonian system with a continuous force which has
+  local solutions from every initial datum and is not deterministic. Pending the proof of
+  Peano's theorem in Mathlib. -/
+@[sorryful]
+lemma exists_hasLocalSolutions_not_isDeterministic :
+    ∃ N : NewtonianSystem (EuclideanSpace ℝ (Fin 1)),
+      Continuous N.force ∧ N.HasLocalSolutions ∧ ¬ N.IsDeterministic :=
+  ⟨(⟨1, 1, one_pos, one_pos⟩ : NortonDome).toNewtonianSystem, force_continuous _,
+    hasLocalSolutions _, not_isDeterministic _⟩
+
+end ClassicalMechanics.NortonDome
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/NewtonianSystem.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/NewtonianSystem.lean
@@ -1,0 +1,607 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import Mathlib.Analysis.ODE.ExistUnique
+public import Physlib.Mathematics.Calculus.Gradient
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.PeanoExistence
+public import Physlib.SpaceAndTime.Time.Derivatives
+/-!
+
+# Conservative Newtonian systems and determinism
+
+## i. Overview
+
+A conservative Newtonian system is a point mass `m` in a configuration space `X` under a
+potential `V`, with equation of motion `m r̈ = -∇V(r)`. Physics takes for granted that position
+and velocity at one instant fix the motion at all instants. This file makes that a theorem and
+states what it costs.
+
+The main result is `NewtonianSystem.isDeterministic_of_hasLocallyLipschitzForce`: if the force
+is locally Lipschitz, two solutions with the same position and velocity at one instant coincide
+at every instant; in the form usually quoted,
+`NewtonianSystem.isDeterministic_of_hasC2Potential`, a `C²` potential suffices. Continuity of
+the force is not enough: the Norton dome has a continuous force and a `C¹` potential, and a
+particle at rest on its apex may stay or leave at any time (see `NortonDome.Determinism`).
+
+The `NewtonianSystem` defined here asks only for a differentiable potential, the least under
+which the equation of motion makes sense. Newton's laws, as stated, are silent on how regular
+the force must be, and the dome shows that without some regularity the equation does not
+determine the motion. A definition that is to be deterministic must add something the laws do
+not state, a regularity condition on the force or a restriction on the admissible motions;
+whether that is part of the theory or a choice about it is debated. Each candidate condition is
+a separate predicate, so that what it buys is a theorem, and the file takes no side. The
+predicates are:
+
+- `IsDeterministic`: position and velocity at one instant fix the solution.
+- `SatisfiesFirstLaw`: a body at rest where the force vanishes stays at rest. It follows from
+  determinism and is the form of the first law the dome violates. The interval reading follows
+  from the second law for every system (`IsSolution.deriv_eq_of_force_eq_zero_on`, section B.3).
+- `HasLocallyLipschitzForce`: the hypothesis of the ODE uniqueness theorem. `HasLipschitzForce`
+  and `HasC2Potential` are the stronger conditions usually assumed; each implies it and neither
+  implies the other.
+- `HasLocalSolutions`: existence, kept separate. For a continuous force on a finite-dimensional
+  configuration space it follows from Peano's theorem, whose proof is pending in Mathlib;
+  section E derives it from the statement in `NortonDome.PeanoExistence`, marked `@[sorryful]`.
+
+The proof of determinism turns the equation of motion into the first-order system
+`(r, v)' = (v, F(r)/m)` on `X × X`, applies Mathlib's local uniqueness theorem for integral
+curves, and extends to all time by connectedness of the real line. So continuity buys
+existence and local Lipschitz continuity buys uniqueness; the file records what each condition
+does, not which one is right.
+
+## ii. Key results
+
+- `NewtonianSystem.isDeterministic_of_hasLocallyLipschitzForce`: a locally Lipschitz force
+  gives determinism, hence `NewtonianSystem.satisfiesFirstLaw_of_hasLocallyLipschitzForce`
+  the first law. `NewtonianSystem.isDeterministic_of_hasC2Potential` and
+  `NewtonianSystem.isDeterministic_of_hasLipschitzForce` are the forms usually quoted; the
+  chain of implications is drawn in section D.3.
+- `NewtonianSystem.ODE_solution_unique_of_locallyLipschitz`: integral curves of a locally
+  Lipschitz vector field through a common point coincide for all time.
+- `NewtonianSystem`, `NewtonianSystem.force`, `NewtonianSystem.EquationOfMotion` and
+  `NewtonianSystem.IsSolution`: the system, the force `-∇V`, Newton's second law, and its
+  twice differentiable solutions; `NewtonianSystem.isSolution_const` is rest at an
+  equilibrium.
+- `NewtonianSystem.IsSolution.deriv_eq_of_force_eq_zero_on`: the first law read on an
+  interval, a consequence of the second law for every system.
+- `NewtonianSystem.IsDeterministic`, `NewtonianSystem.SatisfiesFirstLaw`,
+  `NewtonianSystem.HasLocallyLipschitzForce`, `NewtonianSystem.HasLipschitzForce` and
+  `NewtonianSystem.HasC2Potential`: the predicates, with
+  `NewtonianSystem.HasLipschitzForce.hasLocallyLipschitzForce` and
+  `NewtonianSystem.HasC2Potential.hasLocallyLipschitzForce`.
+- `NewtonianSystem.HasLocalSolutions` and `NewtonianSystem.hasLocalSolutions_of_continuous_force`:
+  Peano's theorem for Newtonian systems, a continuous force on a finite-dimensional
+  configuration space gives local solutions (pending the upstream proof).
+
+## iii. Table of contents
+
+- A. Conservative Newtonian systems
+  - A.1. The structure
+  - A.2. The force and the equation of motion
+  - A.3. Solutions
+- B. Determinism and the first law
+  - B.1. The properties
+  - B.2. Determinism implies the first law
+  - B.3. The interval reading of the first law
+- C. Regularity conditions
+- D. A locally Lipschitz force gives determinism
+  - D.1. The phase-space vector field
+  - D.2. The phase curve of a solution
+  - D.3. The uniqueness theorem
+- E. A continuous force gives local solutions
+  - E.1. Local existence
+  - E.2. The hypotheses of Peano's theorem
+  - E.3. The existence theorem
+
+## iv. References
+
+- Earman, J., *A Primer on Determinism*, Reidel (1986).
+- Laplace, P.-S., *Essai philosophique sur les probabilités* (1814).
+- Montague, R., *Deterministic theories*, in *Formal Philosophy*, Yale University Press (1974).
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Solution` (the same uniqueness argument
+  for the pendulum).
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics
+open Time
+
+variable {X : Type} [NormedAddCommGroup X] [InnerProductSpace ℝ X] [CompleteSpace X]
+
+/-!
+
+## A. Conservative Newtonian systems
+
+-/
+
+/-!
+
+### A.1. The structure
+
+The potential is asked to be differentiable and no more, so that the force `-∇V` exists and the
+equation of motion can be written pointwise; further regularity is added in section C. Physlib's
+general notion is `ClassicalMechanics.PointParticle.NewtonianSystem`, finitely many particles
+with explicit forces in a reference frame. The structure here is a single mass in a potential,
+which is all the dome needs; the two live in different namespaces and no file opens both.
+
+-/
+
+/-- A conservative Newtonian system on the configuration space `X`: a point mass `m` in a
+  differentiable potential `V`. Its equation of motion is Newton's second law `m r̈ = -∇V(r)`. -/
+structure NewtonianSystem (X : Type) [NormedAddCommGroup X] [InnerProductSpace ℝ X]
+    [CompleteSpace X] where
+  /-- The mass. -/
+  m : ℝ
+  /-- The potential. -/
+  potential : X → ℝ
+  m_pos : 0 < m
+  potential_differentiable : Differentiable ℝ potential
+
+namespace NewtonianSystem
+
+variable (S : NewtonianSystem X)
+
+/-- The mass of a Newtonian system is not equal to zero. -/
+@[simp]
+lemma m_ne_zero : S.m ≠ 0 := S.m_pos.ne'
+
+/-!
+
+### A.2. The force and the equation of motion
+
+-/
+
+/-- The force of a Newtonian system, minus the gradient of the potential. -/
+noncomputable def force (x : X) : X := -gradient S.potential x
+
+/-- Newton's second law for a Newtonian system: at every instant `m r̈` equals the force at
+  the position. -/
+def EquationOfMotion (r : Time → X) : Prop :=
+  ∀ t, S.m • ∂ₜ (∂ₜ r) t = S.force (r t)
+
+/-!
+
+### A.3. Solutions
+
+A solution is a twice differentiable curve, position and velocity both differentiable, satisfying
+the equation of motion: the regularity of `ClassicalMechanics.ReferenceFrame.Particle` and the
+least under which the acceleration exists. It is demanded because the pointwise equation, whose
+derivatives are zero wherever they do not exist, admits rough accidental solutions. Continuity of
+the acceleration is not demanded; for a continuous force it is automatic.
+
+-/
+
+/-- A solution of a Newtonian system is a twice differentiable curve, its position and velocity
+  both differentiable, satisfying the equation of motion. -/
+def IsSolution (r : Time → X) : Prop :=
+  Differentiable ℝ r ∧ Differentiable ℝ (∂ₜ r) ∧ S.EquationOfMotion r
+
+/-- The position along a solution is differentiable. -/
+lemma IsSolution.differentiable {S : NewtonianSystem X} {r : Time → X} (h : S.IsSolution r) :
+    Differentiable ℝ r := h.1
+
+/-- The velocity along a solution is differentiable. -/
+lemma IsSolution.deriv_differentiable {S : NewtonianSystem X} {r : Time → X}
+    (h : S.IsSolution r) : Differentiable ℝ (∂ₜ r) := h.2.1
+
+/-- A solution satisfies the equation of motion. -/
+lemma IsSolution.equationOfMotion {S : NewtonianSystem X} {r : Time → X}
+    (h : S.IsSolution r) : S.EquationOfMotion r := h.2.2
+
+/-- The curve at rest at a point where the force vanishes is a solution. -/
+lemma isSolution_const {x : X} (hx : S.force x = 0) : S.IsSolution (fun _ => x) := by
+  have h : ∂ₜ (fun _ : Time => x) = fun _ => 0 := funext fun t => Time.deriv_const x
+  refine ⟨differentiable_const x, by rw [h]; exact differentiable_const 0, fun t => ?_⟩
+  rw [h, Time.deriv_const, hx, smul_zero]
+
+/-!
+
+## B. Determinism and the first law
+
+-/
+
+/-!
+
+### B.1. The properties
+
+Determinism is the statement that position and velocity at one instant fix the motion at all
+instants. The first law, in the reading that says more than the second law, is the statement
+that a body at rest where no force acts stays at rest; section B.3 compares the readings. Both
+are properties of the system, not of a motion.
+
+The definition of determinism is the naive one. Laplace's formulation is about knowledge; the
+notion used since Montague and Earman is about models, a theory being deterministic if any two
+models agreeing at one instant agree at every instant. `IsDeterministic` is that notion, with
+the models taken to be the twice differentiable solutions of one system, defined for all time,
+and the state taken to be position and velocity. Four things follow.
+
+- It is a property of one system. That Newtonian mechanics is deterministic is a claim about
+  every system in some class, and which class is what this folder is about.
+- It is uniqueness only. A system with no solution from some initial datum, or with solutions
+  not defined for all time, counts as deterministic here, whereas on Earman's account such
+  failures of existence count against determinism. Existence is kept separate, as
+  `HasLocalSolutions`.
+- It is relative to the class of solutions. Demanding smooth or analytic solutions would
+  exclude the departing motions of the dome, which vanish on a half-line and are not `C⁴`, and
+  so restore uniqueness by fiat.
+- It does not distinguish future from past. The time-reversed motions of the dome arrive at
+  rest on the apex and stay, so the state there fixes neither past nor future; Earman's
+  futuristic and historical determinism both fail.
+
+-/
+
+/-- A Newtonian system is deterministic if any two solutions with the same position and
+  velocity at some instant coincide. This is uniqueness of twice differentiable solutions
+  defined for all time, in both directions of time and without existence; see section B.1. -/
+def IsDeterministic : Prop :=
+  ∀ x y : Time → X, S.IsSolution x → S.IsSolution y →
+    ∀ t₀, x t₀ = y t₀ → ∂ₜ x t₀ = ∂ₜ y t₀ → x = y
+
+/-- A Newtonian system satisfies the first law if a solution at rest, at some instant, at a
+  point where the force vanishes stays at that point at all instants. -/
+def SatisfiesFirstLaw : Prop :=
+  ∀ r : Time → X, S.IsSolution r → ∀ t₀, S.force (r t₀) = 0 → ∂ₜ r t₀ = 0 → ∀ t, r t = r t₀
+
+/-!
+
+### B.2. Determinism implies the first law
+
+The curve staying at the equilibrium is a solution with the same position and velocity as the
+given one at the given instant, so by determinism it is the given one.
+
+-/
+
+/-- A deterministic Newtonian system satisfies the first law. -/
+lemma IsDeterministic.satisfiesFirstLaw {S : NewtonianSystem X} (h : S.IsDeterministic) :
+    S.SatisfiesFirstLaw := by
+  intro r hr t₀ hF hv t
+  have hc := S.isSolution_const hF
+  have heq := h r (fun _ => r t₀) hr hc t₀ rfl (by rw [hv, Time.deriv_const])
+  exact congrFun heq t
+
+/-!
+
+### B.3. The interval reading of the first law
+
+The first law can be read instantaneously (no force at an instant, no acceleration then), with
+an interval in the hypothesis (no force on an interval, constant velocity on it), or with an
+interval in the conclusion (at rest at an instant where no force acts, at rest forever). The
+first two follow from the second law for every system, the second being the lemma below, and
+both hold for the dome. The third, `SatisfiesFirstLaw`, is determinism at an equilibrium; it is
+what the dome violates and what Norton's argument is about, so it is the reading taken here.
+
+-/
+
+/-- The first law read on an interval: if the force vanishes along a solution throughout the
+  interval `[a, b]`, the velocity is constant on it. This is a consequence of the second law
+  alone, and holds for every system. -/
+lemma IsSolution.deriv_eq_of_force_eq_zero_on {S : NewtonianSystem X} {r : Time → X}
+    (hr : S.IsSolution r) {a b : Time} (hF : ∀ t ∈ Set.Icc a b, S.force (r t) = 0) :
+    ∀ t ∈ Set.Icc a b, ∂ₜ r t = ∂ₜ r a := by
+  have hv : ∀ τ : ℝ, HasDerivAt (fun τ : ℝ => ∂ₜ r (toRealCLE.symm τ))
+      (∂ₜ (∂ₜ r) (toRealCLE.symm τ)) τ := fun τ =>
+    hasDerivAt_comp_toRealCLE_symm (∂ₜ r) τ (hr.deriv_differentiable _)
+  have hconst := constant_of_has_deriv_right_zero (a := toRealCLE a) (b := toRealCLE b)
+    (f := fun τ : ℝ => ∂ₜ r (toRealCLE.symm τ))
+    (continuous_iff_continuousAt.mpr fun τ => (hv τ).continuousAt).continuousOn
+    (fun τ hτ => by
+      have hmem : toRealCLE.symm τ ∈ Set.Icc a b := ⟨hτ.1, hτ.2.le⟩
+      have hacc : ∂ₜ (∂ₜ r) (toRealCLE.symm τ) = 0 := by
+        have h := hr.equationOfMotion (toRealCLE.symm τ)
+        rw [hF _ hmem] at h
+        exact (smul_eq_zero.mp h).resolve_left S.m_ne_zero
+      have h' := hv τ
+      rw [hacc] at h'
+      exact h'.hasDerivWithinAt)
+  intro t ht
+  simpa using hconst (toRealCLE t) ⟨ht.1, ht.2⟩
+
+/-!
+
+## C. Regularity conditions
+
+The hypothesis of the ODE uniqueness theorem is a locally Lipschitz force,
+`HasLocallyLipschitzForce`. The two stronger conditions usually stated are a globally Lipschitz
+force, `HasLipschitzForce`, and a `C²` potential, `HasC2Potential`, whose force is `C¹`.
+Neither implies the other: for example, `x ^ 4` has a `C¹` force of unbounded slope, and
+`x * |x| / 2` has the Lipschitz force `-|x|` but is not `C²`. The structure `NewtonianSystem`
+of section A assumes none of these conditions; they are separate predicates on it.
+
+-/
+
+/-- A Newtonian system has a locally Lipschitz force if its force is Lipschitz on a
+  neighbourhood of every point. This is the hypothesis of the uniqueness theorem for ordinary
+  differential equations. -/
+def HasLocallyLipschitzForce : Prop := LocallyLipschitz S.force
+
+/-- A Newtonian system has a Lipschitz force if its force is globally Lipschitz. -/
+def HasLipschitzForce : Prop := ∃ K : NNReal, LipschitzWith K S.force
+
+/-- A Newtonian system has a `C²` potential if its potential is twice continuously
+  differentiable; two derivatives are what the uniqueness theory of ordinary differential
+  equations uses. -/
+def HasC2Potential : Prop := ContDiff ℝ 2 S.potential
+
+/-- A Lipschitz force is locally Lipschitz. -/
+lemma HasLipschitzForce.hasLocallyLipschitzForce (h : S.HasLipschitzForce) :
+    S.HasLocallyLipschitzForce := by
+  obtain ⟨K, hK⟩ := h
+  exact hK.locallyLipschitz
+
+/-- The gradient of a `C²` potential is `C¹`. -/
+lemma HasC2Potential.contDiff_gradient (h : S.HasC2Potential) :
+    ContDiff ℝ 1 (gradient S.potential) :=
+  (InnerProductSpace.toDual ℝ X).symm.contDiff.comp
+    ((contDiff_succ_iff_fderiv (n := 1)).mp (by rw [one_add_one_eq_two]; exact h)).2.2
+
+/-- The force of a system with a `C²` potential is locally Lipschitz. -/
+lemma HasC2Potential.hasLocallyLipschitzForce (h : S.HasC2Potential) :
+    S.HasLocallyLipschitzForce :=
+  h.contDiff_gradient.locallyLipschitz.neg
+
+/-!
+
+## D. A locally Lipschitz force gives determinism
+
+The equation of motion becomes the first-order system `(r, v)' = (v, F(r)/m)` on `X × X`. If
+the force is locally Lipschitz so is this vector field, and the local uniqueness theorem
+`ODE_solution_unique_of_eventually` of Mathlib, with the connectedness of the real line, gives
+determinism, as in `SimplePendulum.equationOfMotion_unique`.
+
+-/
+
+/-!
+
+### D.1. The phase-space vector field
+
+-/
+
+/-- The phase-space vector field of a Newtonian system, sending `(r, v)` to `(v, F(r)/m)`. -/
+noncomputable def phaseVectorField (p : X × X) : X × X :=
+  (p.2, S.m⁻¹ • S.force p.1)
+
+/-- If the force of a Newtonian system is locally Lipschitz, so is its phase-space vector
+  field. -/
+lemma phaseVectorField_locallyLipschitz (h : LocallyLipschitz S.force) :
+    LocallyLipschitz S.phaseVectorField := by
+  unfold phaseVectorField
+  exact LipschitzWith.prod_snd.locallyLipschitz.prodMk
+    ((lipschitzWith_smul S.m⁻¹).locallyLipschitz.comp
+      (h.comp LipschitzWith.prod_fst.locallyLipschitz))
+
+/-!
+
+### D.2. The phase curve of a solution
+
+-/
+
+/-- The phase curve `τ ↦ (r t, ṙ t)` (with `t = toRealCLE.symm τ`) of a solution is an
+  integral curve of the phase-space vector field. -/
+lemma phaseCurve_hasDerivAt {r : Time → X} (hr : Differentiable ℝ r)
+    (hr' : Differentiable ℝ (∂ₜ r)) (h : S.EquationOfMotion r) (τ : ℝ) :
+    HasDerivAt (fun τ : ℝ => (r (toRealCLE.symm τ), ∂ₜ r (toRealCLE.symm τ)))
+      (S.phaseVectorField (r (toRealCLE.symm τ), ∂ₜ r (toRealCLE.symm τ))) τ := by
+  have hacc : ∂ₜ (∂ₜ r) (toRealCLE.symm τ) = S.m⁻¹ • S.force (r (toRealCLE.symm τ)) := by
+    rw [← h, smul_smul, inv_mul_cancel₀ S.m_ne_zero, one_smul]
+  rw [phaseVectorField, ← hacc]
+  exact (hasDerivAt_comp_toRealCLE_symm r τ (hr _)).prodMk
+    (hasDerivAt_comp_toRealCLE_symm (∂ₜ r) τ (hr' _))
+
+/-!
+
+### D.3. The uniqueness theorem
+
+Local uniqueness makes the set of instants at which two integral curves through a common point
+agree open, continuity makes it closed, and the real line is connected. Applied to the
+phase-space vector field this gives the theorem of the file, and sections B, C and D form one
+chain, each arrow a theorem:
+
+```
+HasC2Potential ────┐
+                   ├──▶ HasLocallyLipschitzForce ──▶ IsDeterministic ──▶ SatisfiesFirstLaw
+HasLipschitzForce ─┘
+```
+
+Naming follows Mathlib: `isDeterministic_of_hasC2Potential` is the arrow from
+`HasC2Potential` to `IsDeterministic`.
+
+-/
+
+/-- Integral curves of a locally Lipschitz vector field, defined at all times, which pass
+  through the same point at the same instant coincide. -/
+lemma ODE_solution_unique_of_locallyLipschitz {E : Type} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {v : E → E} (hv : LocallyLipschitz v) {f g : ℝ → E}
+    (hf : ∀ τ, HasDerivAt f (v (f τ)) τ) (hg : ∀ τ, HasDerivAt g (v (g τ)) τ)
+    {τ₀ : ℝ} (h0 : f τ₀ = g τ₀) : f = g := by
+  have hclosed : IsClosed {τ | f τ = g τ} :=
+    isClosed_eq (continuous_iff_continuousAt.mpr fun τ => (hf τ).continuousAt)
+      (continuous_iff_continuousAt.mpr fun τ => (hg τ).continuousAt)
+  have hopen : IsOpen {τ | f τ = g τ} := by
+    rw [isOpen_iff_mem_nhds]
+    intro τ₁ hτ₁
+    obtain ⟨K, s, hs, hKs⟩ := hv (f τ₁)
+    have hs' : s ∈ nhds (g τ₁) := by
+      rw [← show f τ₁ = g τ₁ from hτ₁]
+      exact hs
+    refine ODE_solution_unique_of_eventually (v := fun _ => v) (s := fun _ => s)
+      (Filter.Eventually.of_forall fun _ => hKs) ?_ ?_ hτ₁
+    · filter_upwards [(hf τ₁).continuousAt.preimage_mem_nhds hs] with τ hτ
+      exact ⟨hf τ, hτ⟩
+    · filter_upwards [(hg τ₁).continuousAt.preimage_mem_nhds hs'] with τ hτ
+      exact ⟨hg τ, hτ⟩
+  have huniv : {τ | f τ = g τ} = Set.univ :=
+    (isClopen_iff.mp ⟨hclosed, hopen⟩).resolve_left (Set.nonempty_iff_ne_empty.mp ⟨τ₀, h0⟩)
+  funext τ
+  exact Set.eq_univ_iff_forall.mp huniv τ
+
+/-- The uniqueness theorem for Newtonian systems: a Newtonian system with a locally Lipschitz
+  force is deterministic. -/
+lemma isDeterministic_of_hasLocallyLipschitzForce (h : S.HasLocallyLipschitzForce) :
+    S.IsDeterministic := by
+  intro x y hx hy t₀ h0 hv0
+  have hEq := ODE_solution_unique_of_locallyLipschitz (S.phaseVectorField_locallyLipschitz h)
+    (f := fun τ : ℝ => (x (toRealCLE.symm τ), ∂ₜ x (toRealCLE.symm τ)))
+    (g := fun τ : ℝ => (y (toRealCLE.symm τ), ∂ₜ y (toRealCLE.symm τ)))
+    (S.phaseCurve_hasDerivAt hx.differentiable hx.deriv_differentiable hx.equationOfMotion)
+    (S.phaseCurve_hasDerivAt hy.differentiable hy.deriv_differentiable hy.equationOfMotion)
+    (τ₀ := toRealCLE t₀)
+    (by simp [h0, hv0])
+  funext t
+  exact (Prod.ext_iff.mp (congrFun hEq (toRealCLE t))).1
+
+/-- Picard–Lindelöf for Newtonian systems: a Newtonian system with a Lipschitz force is
+  deterministic. -/
+lemma isDeterministic_of_hasLipschitzForce (h : S.HasLipschitzForce) : S.IsDeterministic :=
+  S.isDeterministic_of_hasLocallyLipschitzForce h.hasLocallyLipschitzForce
+
+/-- A Newtonian system with a `C²` potential is deterministic. -/
+lemma isDeterministic_of_hasC2Potential (h : S.HasC2Potential) : S.IsDeterministic :=
+  S.isDeterministic_of_hasLocallyLipschitzForce h.hasLocallyLipschitzForce
+
+/-- A Newtonian system with a locally Lipschitz force satisfies the first law. -/
+lemma satisfiesFirstLaw_of_hasLocallyLipschitzForce (h : S.HasLocallyLipschitzForce) :
+    S.SatisfiesFirstLaw :=
+  (S.isDeterministic_of_hasLocallyLipschitzForce h).satisfiesFirstLaw
+
+/-!
+
+## E. A continuous force gives local solutions
+
+Determinism is uniqueness; the complementary existence property is that every initial position
+and velocity is the initial datum of some solution for a short time. For a continuous force on
+a finite-dimensional configuration space this is Peano's theorem applied to the phase-space
+vector field, as Picard–Lindelöf gives it for the pendulum in
+`SimplePendulum.exists_local_solution`. The statement of Peano's theorem is that of
+`NortonDome.PeanoExistence`, pending in Mathlib, so the results here are marked `@[sorryful]`.
+
+-/
+
+/-!
+
+### E.1. Local existence
+
+-/
+
+/-- A Newtonian system has local solutions if for every initial position `x₀` and velocity
+  `v₀` there are `ε > 0` and a curve `r` with `r 0 = x₀` and `ṙ 0 = v₀` which, at every time
+  within `ε` of the initial instant, is differentiable together with its velocity and satisfies
+  the equation of motion. -/
+def HasLocalSolutions : Prop :=
+  ∀ x₀ v₀ : X, ∃ ε > (0 : ℝ), ∃ r : Time → X, r 0 = x₀ ∧ ∂ₜ r 0 = v₀ ∧
+    ∀ t : Time, |t.val| ≤ ε → DifferentiableAt ℝ r t ∧ DifferentiableAt ℝ (∂ₜ r) t ∧
+      S.m • ∂ₜ (∂ₜ r) t = S.force (r t)
+
+/-!
+
+### E.2. The hypotheses of Peano's theorem
+
+The phase-space vector field is continuous if the force is, and is bounded on the closed unit
+ball about the initial datum by compactness; a short enough time interval then gives the
+hypotheses of Peano's theorem.
+
+-/
+
+/-- If the force of a Newtonian system is continuous, so is its phase-space vector field. -/
+@[fun_prop]
+lemma phaseVectorField_continuous (hF : Continuous S.force) :
+    Continuous S.phaseVectorField := by
+  unfold phaseVectorField
+  fun_prop
+
+/-- For a continuous force on a finite-dimensional configuration space, the time-independent
+  phase-space vector field satisfies the hypotheses of Peano's theorem about any initial datum,
+  on a short enough symmetric time interval and the closed unit ball. -/
+lemma exists_isPeano_phaseVectorField [FiniteDimensional ℝ X] (hF : Continuous S.force)
+    (p₀ : X × X) :
+    ∃ δ > (0 : ℝ), ∃ L : NNReal,
+      IsPeano (fun q : ℝ × (X × X) => S.phaseVectorField q.2) (-δ) δ 0 p₀ 1 L := by
+  obtain ⟨C, hC⟩ := (ProperSpace.isCompact_closedBall p₀ 1).exists_bound_of_continuousOn
+    (S.phaseVectorField_continuous hF).continuousOn
+  have hL : (0 : ℝ) ≤ Real.toNNReal C := NNReal.coe_nonneg _
+  have hδ : (0 : ℝ) < 1 / (Real.toNNReal C + 1) := by positivity
+  refine ⟨1 / (Real.toNNReal C + 1), hδ, Real.toNNReal C, ⟨⟨by linarith, hδ.le⟩, ?_, ?_, ?_⟩⟩
+  · exact ((S.phaseVectorField_continuous hF).comp continuous_snd).continuousOn
+  · intro t _ x hx
+    exact (hC x hx).trans (Real.le_coe_toNNReal C)
+  · rw [NNReal.coe_one, sub_zero, zero_sub, neg_neg, max_self, mul_one_div]
+    exact div_le_one_of_le₀ (by linarith) (by positivity)
+
+/-!
+
+### E.3. The existence theorem
+
+Peano's theorem gives an integral curve through the initial datum, differentiable in the sense
+of `HasDerivWithinAt` on the closed interval, hence with an honest derivative on the open one.
+Its first component, pulled back to `Time` through `Time.toRealCLE`, is the required curve; its
+derivatives are read off with `Time.deriv_comp_toRealCLE_of_hasDerivAt`.
+
+-/
+
+/-- Peano's theorem for Newtonian systems: a Newtonian system with a continuous force on a
+  finite-dimensional configuration space has local solutions. Pending the proof of Peano's
+  theorem in Mathlib. -/
+@[sorryful]
+lemma hasLocalSolutions_of_continuous_force [FiniteDimensional ℝ X]
+    (hF : Continuous S.force) : S.HasLocalSolutions := by
+  intro x₀ v₀
+  obtain ⟨δ, hδ, L, hP⟩ := S.exists_isPeano_phaseVectorField hF (x₀, v₀)
+  obtain ⟨α, hα0, hα'⟩ := hP.exists_eq_forall_mem_Icc_hasDerivWithinAt₀
+  have hα : ∀ τ ∈ Set.Ioo (-δ) δ, HasDerivAt α (S.phaseVectorField (α τ)) τ := fun τ hτ =>
+    (hα' τ (Set.Ioo_subset_Icc_self hτ)).hasDerivAt (Icc_mem_nhds hτ.1 hτ.2)
+  have hmem : ∀ t : Time, |t.val| ≤ δ / 2 → Time.toRealCLE t ∈ Set.Ioo (-δ) δ := by
+    intro t ht
+    have := abs_le.mp ht
+    change t.val ∈ Set.Ioo (-δ) δ
+    constructor <;> linarith
+  have hd1 : ∀ t : Time, Time.toRealCLE t ∈ Set.Ioo (-δ) δ →
+      ∂ₜ (fun s => (α (Time.toRealCLE s)).1) t = (α (Time.toRealCLE t)).2 := by
+    intro t ht
+    have hfst := (ContinuousLinearMap.fst ℝ X X).hasFDerivAt.comp_hasDerivAt
+      (Time.toRealCLE t) (hα _ ht)
+    apply Time.deriv_comp_toRealCLE_of_hasDerivAt (fun τ => (α τ).1) t
+    simpa [Function.comp_def, phaseVectorField] using hfst
+  have hev : ∀ t : Time, Time.toRealCLE t ∈ Set.Ioo (-δ) δ →
+      ∂ₜ (fun s => (α (Time.toRealCLE s)).1) =ᶠ[nhds t] fun s => (α (Time.toRealCLE s)).2 := by
+    intro t ht
+    have hU : IsOpen {s : Time | Time.toRealCLE s ∈ Set.Ioo (-δ) δ} :=
+      isOpen_Ioo.preimage Time.toRealCLE.continuous
+    exact Filter.eventuallyEq_of_mem (hU.mem_nhds ht) fun s hs => hd1 s hs
+  have hd2 : ∀ t : Time, Time.toRealCLE t ∈ Set.Ioo (-δ) δ →
+      ∂ₜ (∂ₜ (fun s => (α (Time.toRealCLE s)).1)) t =
+        (S.phaseVectorField (α (Time.toRealCLE t))).2 := by
+    intro t ht
+    have hsnd := (ContinuousLinearMap.snd ℝ X X).hasFDerivAt.comp_hasDerivAt
+      (Time.toRealCLE t) (hα _ ht)
+    have h2 : ∂ₜ (fun s => (α (Time.toRealCLE s)).2) t =
+        (S.phaseVectorField (α (Time.toRealCLE t))).2 := by
+      apply Time.deriv_comp_toRealCLE_of_hasDerivAt (fun τ => (α τ).2) t
+      simpa [Function.comp_def] using hsnd
+    rw [Time.deriv_eq, (hev t ht).fderiv_eq, ← Time.deriv_eq, h2]
+  have h0 : Time.toRealCLE (0 : Time) ∈ Set.Ioo (-δ) δ := by
+    rw [map_zero]
+    constructor <;> linarith
+  refine ⟨δ / 2, half_pos hδ, fun t => (α (Time.toRealCLE t)).1, ?_, ?_, fun t ht => ?_⟩
+  · show (α (Time.toRealCLE 0)).1 = x₀
+    rw [map_zero, hα0]
+  · rw [hd1 0 h0, map_zero, hα0]
+  · have hαt := (hα _ (hmem t ht)).differentiableAt
+    refine ⟨hαt.fst.comp t Time.toRealCLE.differentiableAt, ?_, ?_⟩
+    · exact (hev t (hmem t ht)).differentiableAt_iff.mpr
+        (hαt.snd.comp t Time.toRealCLE.differentiableAt)
+    · rw [hd2 t (hmem t ht)]
+      show S.m • (S.m⁻¹ • S.force _) = _
+      rw [smul_smul, mul_inv_cancel₀ S.m_ne_zero, one_smul]
+
+end NewtonianSystem
+
+end ClassicalMechanics
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/PeanoExistence.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/PeanoExistence.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+public import Physlib.Meta.Linters.Sorry
+/-!
+
+# Peano's existence theorem (statements)
+
+## i. Overview
+
+Peano's existence theorem: the initial value problem `x' = f (t, x)`, `x t₀ = x₀` has a
+solution on a closed time interval whenever `f` is continuous on the product of that interval
+with a closed ball about `x₀` and the interval is short enough for the solution to stay in the
+ball. No Lipschitz condition is asked, and only existence is guaranteed.
+
+The theorem is not yet in Mathlib. This file records the hypotheses and the two forms of the
+conclusion as stated in the Mathlib pull request
+[#42148](https://github.com/leanprover-community/mathlib4/pull/42148), by Julian Rolfes,
+Luke Schleef, Philipp Svinger, Paul Niessner and Florian Grube, with the proofs replaced by
+`sorry` and the results marked `@[sorryful]`. Names and namespace are those of the pull
+request, so that once it is merged this file can be deleted and its uses redirected to
+Mathlib's `IsPeano` by a change of imports. `NortonDome.NewtonianSystem` uses the theorem to
+show that a Newtonian system with a continuous force has local solutions.
+
+## ii. Key results
+
+- `IsPeano` collects the hypotheses: the initial time lies in the interval, the vector field is
+  continuous on the cylinder, bounded by `L` there, and `L` times the length of the interval on
+  either side of `t₀` is at most the radius `r` of the ball.
+- `IsPeano.exists_eq_forall_mem_Icc_eq_integral` is the theorem in integral form.
+- `IsPeano.exists_eq_forall_mem_Icc_hasDerivWithinAt₀` is the theorem in differential form.
+
+## iii. Table of contents
+
+- A. The hypotheses
+- B. The theorem
+
+## iv. References
+
+- Mathlib pull request [#42148](https://github.com/leanprover-community/mathlib4/pull/42148),
+  `Mathlib/Analysis/ODE/Peano.lean`.
+- Hartman, P., *Ordinary Differential Equations*, 2nd ed., SIAM (2002), Theorem II.2.1.
+
+-/
+
+@[expose] public section
+
+open Metric Set
+open scoped NNReal
+
+/-!
+
+## A. The hypotheses
+
+-/
+
+/-- The hypotheses for Peano's existence theorem on a closed time interval and a closed ball. -/
+structure IsPeano {E : Type*} [NormedAddCommGroup E]
+    (f : ℝ × E → E) (tmin tmax t₀ : ℝ) (x₀ : E) (r L : ℝ≥0) : Prop where
+  /-- The initial time belongs to the time interval. -/
+  t₀_mem : t₀ ∈ Icc tmin tmax
+  /-- The vector field is continuous on the set product of a time interval and a closed ball. -/
+  continuousOn : ContinuousOn f (Icc tmin tmax ×ˢ closedBall x₀ r)
+  /-- `L` is an upper bound of the norm of the vector field. -/
+  norm_le : ∀ t ∈ Icc tmin tmax, ∀ x ∈ closedBall x₀ r, ‖f (t, x)‖ ≤ L
+  /-- The time interval of validity. -/
+  mul_max_le : L * max (tmax - t₀) (t₀ - tmin) ≤ r
+
+namespace IsPeano
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {f : ℝ × E → E} {tmin tmax t₀ : ℝ} {x₀ : E} {r L : ℝ≥0}
+
+/-!
+
+## B. The theorem
+
+-/
+
+/-- Peano existence theorem, integral form. A solution exists on the full time interval and
+  remains in `closedBall x₀ r`. Statement copied from Mathlib pull request #42148; the proof is
+  pending upstream. -/
+@[sorryful]
+lemma exists_eq_forall_mem_Icc_eq_integral
+    (hf : IsPeano f tmin tmax t₀ x₀ r L) :
+    ∃ α : ℝ → E, ContinuousOn α (Icc tmin tmax) ∧ MapsTo α (Icc tmin tmax) (closedBall x₀ r) ∧
+      ∀ t ∈ Icc tmin tmax, α t = x₀ + ∫ s in t₀..t, f (s, α s) := by
+  sorry
+
+/-- Peano existence theorem, differential form. A solution to the initial value problem exists
+  on the full time interval. Statement copied from Mathlib pull request #42148; the proof is
+  pending upstream. -/
+@[sorryful]
+lemma exists_eq_forall_mem_Icc_hasDerivWithinAt₀
+    (hf : IsPeano f tmin tmax t₀ x₀ r L) :
+    ∃ α : ℝ → E, α t₀ = x₀ ∧
+      ∀ t ∈ Icc tmin tmax, HasDerivWithinAt α (f (t, α t)) (Icc tmin tmax) t := by
+  sorry
+
+end IsPeano
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/PhysicalSpace.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/PhysicalSpace.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Basic
+public import Physlib.SpaceAndTime.Space.Module
+/-!
+
+# The Norton dome in physical space
+
+## i. Overview
+
+`NortonDome.Basic` writes the dynamics on the arc length `r`, with kinetic energy `½ m ṙ²` and
+potential energy `-m g h(r)`. This module identifies that chart dynamics with a point mass
+constrained to the surface of the dome, as `SimplePendulum.Geometric.PhysicalSpace` does for
+the pendulum.
+
+The motion is radial, so it suffices to work in the vertical plane through the apex, with the
+apex at the origin and the vertical coordinate measured upwards. The profile is the arc-length
+parametrised curve `s ↦ (x(s), -h(s))`, where `x'(s)² + h'(s)² = 1` and `h'(s) = √s / g` give
+`x'(s) = √(1 - s/g²)` and `x(s) = (2g²/3) (1 - (1 - s/g²)^{3/2})`. The profile exists for
+`0 ≤ s ≤ g²`; at `s = g²` it is vertical and Norton's model stops. While the arc length is in
+that range the chart kinetic energy is `½ m ‖v‖²` by unit speed, and the chart potential energy
+is the gravitational potential `m g y` at height `y`, so the chart Lagrangian is the
+constrained Lagrangian.
+
+## ii. Key results
+
+- `NortonDome.horizontal` is the horizontal distance `x(s)` of the profile from the apex, with
+  its derivative `hasDerivAt_horizontal`; `NortonDome.unit_speed` is the identity
+  `x'(s)² + h'(s)² = 1`.
+- `NortonDome.profile` is the profile curve `s ↦ (x(s), -h(s))` in the vertical plane, and
+  `NortonDome.dome` its image on `0 ≤ s ≤ g²`.
+- `NortonDome.spaceTrajectory` is the position of the particle in the plane along a chart
+  trajectory; it lies on the dome, `spaceTrajectory_mem_dome`, while the arc length is in range.
+- `NortonDome.deriv_spaceTrajectory` is the velocity of the particle in the plane, with the
+  square of its speed `norm_sq_deriv_spaceTrajectory`.
+- `NortonDome.kineticEnergy_eq_space`, `NortonDome.potentialEnergy_eq_height`,
+  `NortonDome.lagrangian_eq_space` and `NortonDome.energy_eq_space` identify the chart
+  energies and Lagrangian with those of the point mass in physical space.
+
+## iii. Table of contents
+
+- A. The profile of the dome in the plane
+  - A.1. The horizontal coordinate and the unit-speed property
+  - A.2. The profile curve and the dome
+- B. The particle's position along a trajectory
+- C. The particle's velocity and speed
+- D. The energies and the Lagrangian in physical space
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.PhysicalSpace` (the same
+  identification for the pendulum).
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics.NortonDome
+open Real InnerProductSpace Time
+
+variable (S : NortonDome)
+
+/-!
+
+## A. The profile of the dome in the plane
+
+-/
+
+/-!
+
+### A.1. The horizontal coordinate and the unit-speed property
+
+The horizontal distance from the apex has derivative `√(1 - s/g²)`; with the slope `√s / g` of
+the depth this gives unit speed.
+
+-/
+
+/-- The horizontal distance `x(s) = (2g²/3) (1 - (1 - s/g²)^{3/2})` of the profile of the dome
+  from the apex at arc length `s`. -/
+noncomputable def horizontal (s : ℝ) : ℝ := 2 * S.g ^ 2 / 3 * (1 - √(1 - s / S.g ^ 2) ^ 3)
+
+/-- The horizontal distance of the profile from the apex, written out. -/
+lemma horizontal_eq (s : ℝ) :
+    S.horizontal s = 2 * S.g ^ 2 / 3 * (1 - √(1 - s / S.g ^ 2) ^ 3) := rfl
+
+/-- The profile of the dome starts at the apex. -/
+lemma horizontal_zero : S.horizontal 0 = 0 := by
+  simp [horizontal_eq]
+
+/-- The derivative of the horizontal distance with respect to the arc length is `√(1 - s/g²)`,
+  at every `s`. -/
+lemma hasDerivAt_horizontal (s : ℝ) : HasDerivAt S.horizontal (√(1 - s / S.g ^ 2)) s := by
+  have h1 : HasDerivAt (fun y : ℝ => 1 - y / S.g ^ 2) (-(1 / S.g ^ 2)) s := by
+    simpa using ((hasDerivAt_id s).div_const (S.g ^ 2)).const_sub (1 : ℝ)
+  have h2 := (hasDerivAt_sqrt_pow_three (1 - s / S.g ^ 2)).comp s h1
+  refine ((h2.const_sub (1 : ℝ)).const_mul (2 * S.g ^ 2 / 3)).congr_deriv ?_
+  field_simp
+
+/-- The horizontal distance of the profile from the apex is a differentiable function of the
+  arc length. -/
+@[fun_prop]
+lemma horizontal_differentiable : Differentiable ℝ S.horizontal :=
+  fun s => (S.hasDerivAt_horizontal s).differentiableAt
+
+/-- Unit speed: for arc length `0 ≤ s ≤ g²` the derivatives of the horizontal distance and
+  of the depth satisfy `x'(s)² + h'(s)² = 1`, so that `s` is indeed the arc length along the
+  profile. -/
+lemma unit_speed {s : ℝ} (h0 : 0 ≤ s) (h1 : s ≤ S.g ^ 2) :
+    √(1 - s / S.g ^ 2) ^ 2 + (√s / S.g) ^ 2 = 1 := by
+  have hg := S.g_pos
+  have hs : 0 ≤ 1 - s / S.g ^ 2 := sub_nonneg.mpr ((div_le_one (by positivity)).mpr h1)
+  rw [Real.sq_sqrt hs, div_pow, Real.sq_sqrt h0]
+  field_simp
+  ring
+
+/-!
+
+### A.2. The profile curve and the dome
+
+-/
+
+/-- The profile of the dome in the vertical plane through the apex: the point at arc length
+  `s` is at horizontal distance `x(s)` from the apex and at height `-h(s)`. -/
+noncomputable def profile (s : ℝ) : Space 2 := ⟨![S.horizontal s, -S.height s]⟩
+
+/-- The horizontal coordinate of the profile of the dome. -/
+lemma profile_apply_zero (s : ℝ) : S.profile s 0 = S.horizontal s := by
+  simp [profile]
+
+/-- The vertical coordinate of the profile of the dome is minus its depth below the apex. -/
+lemma profile_apply_one (s : ℝ) : S.profile s 1 = -S.height s := by
+  simp [profile]
+
+/-- The apex of the dome is the origin. -/
+lemma profile_zero : S.profile 0 = 0 := by
+  ext i
+  fin_cases i <;> simp [profile, horizontal_zero, height_eq]
+
+/-- The dome, in the vertical plane through its apex: the image of the profile on the range
+  `0 ≤ s ≤ g²` of arc lengths on which the profile exists. -/
+noncomputable def dome : Set (Space 2) := S.profile '' Set.Icc 0 (S.g ^ 2)
+
+/-- The point of the profile at arc length `0 ≤ s ≤ g²` lies on the dome. -/
+lemma profile_mem_dome {s : ℝ} (h0 : 0 ≤ s) (h1 : s ≤ S.g ^ 2) : S.profile s ∈ S.dome :=
+  ⟨s, ⟨h0, h1⟩, rfl⟩
+
+/-!
+
+## B. The particle's position along a trajectory
+
+Along a chart trajectory `r` the particle is at the point of the profile at arc length
+`r t 0`, on the dome while that is in range.
+
+-/
+
+/-- The position of the particle in the plane along the chart trajectory `r` of the arc
+  length. -/
+noncomputable def spaceTrajectory (r : Time → EuclideanSpace ℝ (Fin 1)) : Time → Space 2 :=
+  fun t => S.profile (r t 0)
+
+/-- The horizontal position of the particle along a chart trajectory. -/
+lemma spaceTrajectory_apply_zero (r : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.spaceTrajectory r t 0 = S.horizontal (r t 0) :=
+  S.profile_apply_zero _
+
+/-- The height of the particle along a chart trajectory is minus the depth of the dome at its
+  arc length. -/
+lemma spaceTrajectory_apply_one (r : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.spaceTrajectory r t 1 = -S.height (r t 0) :=
+  S.profile_apply_one _
+
+/-- While its arc length is in the range `0 ≤ r ≤ g²` the particle is on the dome. -/
+lemma spaceTrajectory_mem_dome (r : Time → EuclideanSpace ℝ (Fin 1)) {t : Time}
+    (h0 : 0 ≤ r t 0) (h1 : r t 0 ≤ S.g ^ 2) : S.spaceTrajectory r t ∈ S.dome :=
+  S.profile_mem_dome h0 h1
+
+/-!
+
+## C. The particle's velocity and speed
+
+The velocity in the plane is the unit tangent `(x'(r), -h'(r))` times `ṙ`, so by unit speed the
+square of the speed is `ṙ²` while the arc length is in range.
+
+-/
+
+/-- Along a differentiable chart trajectory the position of the particle is differentiable in
+  time. -/
+@[fun_prop]
+lemma differentiable_spaceTrajectory (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr : Differentiable ℝ r) : Differentiable ℝ (S.spaceTrajectory r) := by
+  unfold spaceTrajectory profile
+  apply Space.mk_differentiable.comp
+  rw [differentiable_pi]
+  intro i
+  fin_cases i <;> (simp; fun_prop)
+
+/-- The velocity of the particle in the plane along a differentiable chart trajectory `r` is
+  `(√(1 - r/g²), -√r / g)` times the rate of change `ṙ` of the arc length: the unit tangent
+  vector to the profile times `ṙ`. -/
+lemma deriv_spaceTrajectory (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    (t : Time) :
+    ∂ₜᵥ (S.spaceTrajectory r) t =
+      !₂[√(1 - r t 0 / S.g ^ 2) * (∂ₜ r t) 0, -(√(r t 0) / S.g) * (∂ₜ r t) 0] := by
+  refine PiLp.ext fun i ↦ ?_
+  fin_cases i <;> apply (Time.derivVec_space (by fun_prop) t _).trans
+  · simp only [S.spaceTrajectory_apply_zero, Fin.zero_eta, Matrix.cons_val_zero]
+    exact Time.deriv_comp_coord 0 (hr t) (S.hasDerivAt_horizontal (r t 0))
+  · simp only [Fin.mk_one, S.spaceTrajectory_apply_one, Matrix.cons_val_one, Matrix.cons_val_zero]
+    rw [Time.deriv_comp_coord (f := fun x => -S.height x) 0 (hr t)
+      ((S.hasDerivAt_height (r t 0)).neg)]
+
+/-- While the arc length is in range, the square of the speed of the particle along a
+  differentiable chart trajectory is `ṙ²`. -/
+lemma norm_sq_deriv_spaceTrajectory (r : Time → EuclideanSpace ℝ (Fin 1))
+    (hr : Differentiable ℝ r) {t : Time} (h0 : 0 ≤ r t 0) (h1 : r t 0 ≤ S.g ^ 2) :
+    ‖∂ₜᵥ (S.spaceTrajectory r) t‖ ^ 2 = ((∂ₜ r t) 0) ^ 2 := by
+  rw [S.deriv_spaceTrajectory r hr t, EuclideanSpace.real_norm_sq_eq, Fin.sum_univ_two]
+  show (√(1 - r t 0 / S.g ^ 2) * (∂ₜ r t) 0) ^ 2 + (-(√(r t 0) / S.g) * (∂ₜ r t) 0) ^ 2 = _
+  linear_combination ((∂ₜ r t) 0) ^ 2 * S.unit_speed h0 h1
+
+/-!
+
+## D. The energies and the Lagrangian in physical space
+
+The chart kinetic energy is that of the particle in the plane while the arc length is in range,
+and the chart potential energy is `m g y` at its height `y` at all times; the chart Lagrangian
+is the constrained Lagrangian `T - V`.
+
+-/
+
+/-- The chart kinetic energy of the dome along a differentiable chart trajectory is the kinetic
+  energy of the particle in physical space, while the arc length is in range. -/
+lemma kineticEnergy_eq_space (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    {t : Time} (h0 : 0 ≤ r t 0) (h1 : r t 0 ≤ S.g ^ 2) :
+    S.kineticEnergy r t = (1 / (2 : ℝ)) * S.m * ‖∂ₜᵥ (S.spaceTrajectory r) t‖ ^ 2 := by
+  rw [S.norm_sq_deriv_spaceTrajectory r hr h0 h1, kineticEnergy_eq]
+  simp only [PiLp.inner_apply, Fin.sum_univ_one, RCLike.inner_apply, conj_trivial]
+  ring
+
+/-- The chart potential energy of the dome is the gravitational potential `m g y` of the
+  particle at its height `y` in physical space. -/
+lemma potentialEnergy_eq_height (r : Time → EuclideanSpace ℝ (Fin 1)) (t : Time) :
+    S.potentialEnergy (r t) = S.m * S.g * S.spaceTrajectory r t 1 := by
+  rw [potentialEnergy, S.spaceTrajectory_apply_one r t]
+  ring
+
+/-- The chart Lagrangian of the dome along a differentiable chart trajectory is the constrained
+  Lagrangian of the particle in physical space, while the arc length is in range. -/
+lemma lagrangian_eq_space (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    {t : Time} (h0 : 0 ≤ r t 0) (h1 : r t 0 ≤ S.g ^ 2) :
+    S.lagrangian t (r t) (∂ₜ r t) =
+      (1 / (2 : ℝ)) * S.m * ‖∂ₜᵥ (S.spaceTrajectory r) t‖ ^ 2
+        - S.m * S.g * S.spaceTrajectory r t 1 := by
+  rw [S.lagrangian_eq_kineticEnergy_sub_potentialEnergy t r, S.kineticEnergy_eq_space r hr h0 h1,
+    S.potentialEnergy_eq_height r t]
+
+/-- The chart energy of the dome along a differentiable chart trajectory is the total energy of
+  the particle in physical space, while the arc length is in range. -/
+lemma energy_eq_space (r : Time → EuclideanSpace ℝ (Fin 1)) (hr : Differentiable ℝ r)
+    {t : Time} (h0 : 0 ≤ r t 0) (h1 : r t 0 ≤ S.g ^ 2) :
+    S.energy r t =
+      (1 / (2 : ℝ)) * S.m * ‖∂ₜᵥ (S.spaceTrajectory r) t‖ ^ 2
+        + S.m * S.g * S.spaceTrajectory r t 1 := by
+  rw [← S.kineticEnergy_eq_space r hr h0 h1, ← S.potentialEnergy_eq_height r t]
+  rfl
+
+end ClassicalMechanics.NortonDome
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/PosPartPow.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/PosPartPow.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Deriv
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+public import Mathlib.Analysis.Calculus.Deriv.Pow
+public import Mathlib.Analysis.Calculus.Deriv.Slope
+/-!
+
+# Powers of the positive part
+
+## i. Overview
+
+The function `y ↦ max (y - c) 0 ^ (n + 2)` vanishes to the left of `c` and is a polynomial to
+its right. It is differentiable everywhere, including at `c`, and is `C^(n+1)`. Functions of
+this shape are the standard witnesses for the failure of uniqueness of ODEs with a
+non-Lipschitz right-hand side, of which the Norton dome is the physical instance.
+
+## ii. Key results
+
+- `hasDerivAt_max_sub_pow` is the derivative `(n + 2) max (y - c) 0 ^ (n + 1)`, at every point.
+- `contDiff_max_sub_pow` is the `C^(n+1)` regularity.
+
+## iii. Table of contents
+
+- A. The derivative
+- B. Regularity
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+
+-/
+
+@[expose] public section
+
+open Filter Topology
+
+/-!
+
+## A. The derivative
+
+By cases: to the left of `c` the function vanishes near the point, to the right it agrees near
+the point with `(y - c) ^ (n + 2)`, and at `c` the difference quotient is `max t 0 ^ (n + 1)`,
+which tends to zero.
+
+-/
+
+/-- The power `max (y - c) 0 ^ (n + 2)` of the positive part of `y - c` has derivative
+  `(n + 2) max (x - c) 0 ^ (n + 1)` at every `x`, including the junction `x = c`. -/
+lemma hasDerivAt_max_sub_pow (c : ℝ) (n : ℕ) (x : ℝ) :
+    HasDerivAt (fun y : ℝ => max (y - c) 0 ^ (n + 2))
+      (((n : ℝ) + 2) * max (x - c) 0 ^ (n + 1)) x := by
+  rcases lt_trichotomy x c with hx | rfl | hx
+  · have hev : (fun y : ℝ => max (y - c) 0 ^ (n + 2)) =ᶠ[𝓝 x] fun _ => 0 := by
+      filter_upwards [Iio_mem_nhds hx] with y hy
+      simp [max_eq_right (sub_nonpos.mpr (Set.mem_Iio.mp hy).le)]
+    rw [max_eq_right (sub_nonpos.mpr hx.le), zero_pow (Nat.succ_ne_zero _), mul_zero]
+    exact (hasDerivAt_const x (0 : ℝ)).congr_of_eventuallyEq hev
+  · rw [sub_self, max_self, zero_pow (Nat.succ_ne_zero _), mul_zero,
+      hasDerivAt_iff_tendsto_slope_zero]
+    have h : ∀ t : ℝ, t ≠ 0 →
+        max t 0 ^ (n + 1) = t⁻¹ • (max (x + t - x) 0 ^ (n + 2) - max (x - x) 0 ^ (n + 2)) := by
+      intro t ht
+      rw [add_sub_cancel_left, sub_self, max_self, zero_pow (Nat.succ_ne_zero _), sub_zero,
+        smul_eq_mul]
+      rcases le_or_gt t 0 with h | h
+      · simp [max_eq_right h]
+      · rw [max_eq_left h.le]
+        field_simp
+        ring
+    have hcont : Continuous (fun t : ℝ => max t 0 ^ (n + 1)) := by fun_prop
+    have hc : Tendsto (fun t : ℝ => max t 0 ^ (n + 1)) (𝓝[≠] 0) (𝓝 0) := by
+      simpa using (hcont.tendsto 0).mono_left nhdsWithin_le_nhds
+    exact hc.congr' (eventually_nhdsWithin_of_forall fun t ht => h t ht)
+  · have hev : (fun y : ℝ => max (y - c) 0 ^ (n + 2)) =ᶠ[𝓝 x] fun y => (y - c) ^ (n + 2) := by
+      filter_upwards [Ioi_mem_nhds hx] with y hy
+      rw [max_eq_left (sub_nonneg.mpr (Set.mem_Ioi.mp hy).le)]
+    rw [max_eq_left (sub_nonneg.mpr hx.le)]
+    have h1 : HasDerivAt (fun y : ℝ => y - c) 1 x := (hasDerivAt_id x).sub_const c
+    refine ((HasDerivAt.pow h1 (n + 2)).congr_of_eventuallyEq hev).congr_deriv ?_
+    show ((n + 2 : ℕ) : ℝ) * (x - c) ^ (n + 1) * 1 = _
+    push_cast
+    ring
+
+/-!
+
+## B. Regularity
+
+By induction on `n`: the derivative of the `(n + 3)`-rd power is a constant multiple of the
+`(n + 2)`-nd, which is `C^(n+1)` by the induction hypothesis.
+
+-/
+
+/-- The power `max (y - c) 0 ^ (n + 2)` of the positive part of `y - c` is `C^(n+1)`. -/
+lemma contDiff_max_sub_pow (c : ℝ) (n : ℕ) :
+    ContDiff ℝ (n + 1) (fun y : ℝ => max (y - c) 0 ^ (n + 2)) := by
+  induction n with
+  | zero =>
+    have h : ((0 : ℕ) : WithTop ℕ∞) + 1 = 1 := by simp
+    rw [h, contDiff_one_iff_deriv]
+    refine ⟨fun y => (hasDerivAt_max_sub_pow c 0 y).differentiableAt, ?_⟩
+    have hd : deriv (fun y : ℝ => max (y - c) 0 ^ (0 + 2)) =
+        fun y => (((0 : ℕ) : ℝ) + 2) * max (y - c) 0 ^ (0 + 1) :=
+      funext fun y => (hasDerivAt_max_sub_pow c 0 y).deriv
+    rw [hd]
+    fun_prop
+  | succ n ih =>
+    rw [Nat.cast_succ, contDiff_succ_iff_deriv]
+    refine ⟨fun y => (hasDerivAt_max_sub_pow c (n + 1) y).differentiableAt, by simp, ?_⟩
+    have hd : deriv (fun y : ℝ => max (y - c) 0 ^ (n + 1 + 2)) =
+        fun y => (((n + 1 : ℕ) : ℝ) + 2) * max (y - c) 0 ^ (n + 2) :=
+      funext fun y => (hasDerivAt_max_sub_pow c (n + 1) y).deriv
+    rw [hd]
+    exact ContDiff.mul contDiff_const ih
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/Solution.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/Solution.lean
@@ -1,0 +1,418 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.Basic
+public import PhyslibAlpha.ClassicalMechanics.NortonDome.PosPartPow
+/-!
+
+# The motions of the Norton dome and the failure of uniqueness
+
+## i. Overview
+
+A particle at rest on the apex of the Norton dome satisfies `r̈ = √r` by staying there forever,
+and also by staying until an arbitrary instant `T ≥ 0` and then sliding off along
+`r(t) = (t - T)⁴ / 144`: that curve is `C²`, vanishes with its derivative at `T`, and its
+second derivative `(t - T)² / 12` is `√r`. All these motions have the same initial position and
+velocity, so the initial data do not determine the motion. This is Norton's observation.
+
+For contrast, the pendulum's phase-space vector field is Lipschitz and Mathlib's
+`ODE_solution_unique_univ` gives `SimplePendulum.equationOfMotion_unique`; the force of the
+dome is not Lipschitz at the apex, `NortonDome.not_lipschitzOnWith_force`. Energy conservation
+does not help either, since every motion in the family has zero energy (`energy_solution`).
+Read backwards in time, in section E, a particle sliding up the dome may arrive at the apex at
+rest in finite time and stay there.
+
+## ii. Key results
+
+- `NortonDome.delayedQuartic` is the real function `τ ↦ max (τ - T) 0 ⁴ / 144`, with its
+  derivatives `hasDerivAt_delayedQuartic` and `hasDerivAt_deriv_delayedQuartic`, its `C²`
+  regularity `contDiff_delayedQuartic`, and the identity `sqrt_delayedQuartic`.
+- `NortonDome.solution T` is the motion leaving the apex at the instant `T`. It is a solution,
+  `solution_isSolution`, starts from rest at the apex when `0 ≤ T`, `solution_zero` and
+  `deriv_solution_zero`, and is injective in `T`, `solution_injective`.
+- `NortonDome.rest_isSolution` is the motion staying at the apex.
+- `NortonDome.exists_isSolution_ne` is the failure of uniqueness: two distinct solutions with
+  the same initial position and velocity; `NortonDome.not_isSolution_unique` restates it as
+  the negation of the uniqueness property of the pendulum. All these motions have zero energy,
+  `NortonDome.energy_rest` and `NortonDome.energy_solution`.
+- `NortonDome.IsSolution.comp_neg` is the time-reversal symmetry of the dome, and
+  `NortonDome.arrival T` the time-reversed motion, off the apex before the instant `-T`,
+  `arrival_apply_pos`, and at rest on it from then on, `arrival_of_le`.
+
+## iii. Table of contents
+
+- A. The delayed quartic
+  - A.1. Definition and sign
+  - A.2. Derivatives and regularity
+- B. The motions leaving the apex
+  - B.1. The definition and its values
+  - B.2. Derivatives and regularity
+  - B.3. The equation of motion
+  - B.4. Distinct instants give distinct motions
+- C. The motion staying at the apex
+- D. The failure of uniqueness
+- E. Time reversal and arrival at the apex
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+- `Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Solution` (uniqueness for a Lipschitz
+  force, for contrast).
+
+-/
+
+@[expose] public section
+
+namespace ClassicalMechanics.NortonDome
+open Real InnerProductSpace Time
+
+variable (S : NortonDome)
+
+/-!
+
+## A. The delayed quartic
+
+As a function of the real time `τ`, the motion leaving the apex at the instant `T` is
+`max (τ - T) 0 ⁴ / 144`; its calculus is that of the positive-part powers of
+`NortonDome.PosPartPow`.
+
+-/
+
+/-!
+
+### A.1. Definition and sign
+
+-/
+
+/-- The delayed quartic `τ ↦ max (τ - T) 0 ⁴ / 144`: zero up to the instant `T`, and
+  `(τ - T)⁴ / 144` afterwards. -/
+noncomputable def delayedQuartic (T τ : ℝ) : ℝ := max (τ - T) 0 ^ 4 / 144
+
+/-- The delayed quartic, written out. -/
+lemma delayedQuartic_eq (T τ : ℝ) : delayedQuartic T τ = max (τ - T) 0 ^ 4 / 144 := rfl
+
+/-- The delayed quartic is non-negative. -/
+lemma delayedQuartic_nonneg (T τ : ℝ) : 0 ≤ delayedQuartic T τ := by
+  rw [delayedQuartic_eq]
+  positivity
+
+/-- The delayed quartic vanishes up to the instant `T`. -/
+lemma delayedQuartic_of_le (T : ℝ) {τ : ℝ} (h : τ ≤ T) : delayedQuartic T τ = 0 := by
+  rw [delayedQuartic_eq, max_eq_right (sub_nonpos.mpr h)]
+  simp
+
+/-- The delayed quartic is positive after the instant `T`. -/
+lemma delayedQuartic_pos (T : ℝ) {τ : ℝ} (h : T < τ) : 0 < delayedQuartic T τ := by
+  rw [delayedQuartic_eq, max_eq_left (sub_nonneg.mpr h.le)]
+  have := sub_pos.mpr h
+  positivity
+
+/-- The square root of the delayed quartic is `max (τ - T) 0 ² / 12`, which is its second
+  derivative: this is the equation of motion `r̈ = √r` of the dome along it. -/
+lemma sqrt_delayedQuartic (T τ : ℝ) : √(delayedQuartic T τ) = max (τ - T) 0 ^ 2 / 12 := by
+  rw [delayedQuartic_eq, show max (τ - T) 0 ^ 4 / 144 = (max (τ - T) 0 ^ 2 / 12) ^ 2 by ring,
+    Real.sqrt_sq (by positivity)]
+
+/-!
+
+### A.2. Derivatives and regularity
+
+-/
+
+/-- The derivative of the delayed quartic is `max (τ - T) 0 ³ / 36`. -/
+lemma hasDerivAt_delayedQuartic (T τ : ℝ) :
+    HasDerivAt (delayedQuartic T) (max (τ - T) 0 ^ 3 / 36) τ := by
+  refine ((hasDerivAt_max_sub_pow T 2 τ).div_const 144).congr_deriv ?_
+  push_cast
+  ring
+
+/-- The derivative of the delayed quartic, as a function. -/
+lemma deriv_delayedQuartic (T : ℝ) :
+    deriv (delayedQuartic T) = fun τ => max (τ - T) 0 ^ 3 / 36 :=
+  funext fun τ => (hasDerivAt_delayedQuartic T τ).deriv
+
+/-- The second derivative of the delayed quartic is `max (τ - T) 0 ² / 12`. -/
+lemma hasDerivAt_deriv_delayedQuartic (T τ : ℝ) :
+    HasDerivAt (deriv (delayedQuartic T)) (max (τ - T) 0 ^ 2 / 12) τ := by
+  rw [deriv_delayedQuartic]
+  refine ((hasDerivAt_max_sub_pow T 1 τ).div_const 36).congr_deriv ?_
+  push_cast
+  ring
+
+/-- The delayed quartic is `C²`. It is in fact `C³` and not `C⁴`, which is not needed here. -/
+@[fun_prop]
+lemma contDiff_delayedQuartic (T : ℝ) : ContDiff ℝ 2 (delayedQuartic T) :=
+  ((contDiff_max_sub_pow T 2).div_const 144).of_le (by exact_mod_cast Nat.le_succ 2)
+
+/-!
+
+## B. The motions leaving the apex
+
+The motion leaving the apex at the instant `T` is the delayed quartic read on `Time`, times the
+unit vector of the arc-length coordinate.
+
+-/
+
+/-!
+
+### B.1. The definition and its values
+
+-/
+
+/-- The motion of the particle on the dome leaving the apex at the instant `T`: at rest at the
+  apex up to `T`, and at arc length `(t - T)⁴ / 144` from the apex afterwards. -/
+noncomputable def solution (T : ℝ) : Time → EuclideanSpace ℝ (Fin 1) := fun t =>
+  delayedQuartic T t.val • EuclideanSpace.single 0 1
+
+/-- The arc length along the motion leaving the apex at the instant `T` is the delayed
+  quartic. -/
+lemma solution_apply (T : ℝ) (t : Time) : solution T t 0 = delayedQuartic T t.val := by
+  simp [solution]
+
+/-- The motion leaving the apex at the instant `T` is at the apex up to `T`. -/
+lemma solution_of_le (T : ℝ) {t : Time} (h : t.val ≤ T) : solution T t = 0 := by
+  simp [solution, delayedQuartic_of_le T h]
+
+/-- The motion leaving the apex at the instant `T ≥ 0` starts at the apex. -/
+lemma solution_zero {T : ℝ} (hT : 0 ≤ T) : solution T 0 = 0 :=
+  solution_of_le T (by rw [Time.zero_val]; exact hT)
+
+/-- The motion leaving the apex at the instant `T` is off the apex after `T`. -/
+lemma solution_apply_pos (T : ℝ) {t : Time} (h : T < t.val) : 0 < solution T t 0 := by
+  rw [solution_apply]
+  exact delayedQuartic_pos T h
+
+/-!
+
+### B.2. Derivatives and regularity
+
+-/
+
+/-- The motion leaving the apex at the instant `T` is `C²`. -/
+@[fun_prop]
+lemma solution_contDiff (T : ℝ) : ContDiff ℝ 2 (solution T) := by
+  unfold solution
+  fun_prop
+
+/-- The velocity along the motion leaving the apex at the instant `T` is
+  `max (t - T) 0 ³ / 36`. -/
+lemma deriv_solution (T : ℝ) :
+    ∂ₜ (solution T) = fun t => (max (t.val - T) 0 ^ 3 / 36) • EuclideanSpace.single 0 1 := by
+  funext t
+  unfold solution
+  exact Time.deriv_comp_toRealCLE_of_hasDerivAt
+    (fun τ : ℝ => delayedQuartic T τ • EuclideanSpace.single (0 : Fin 1) (1 : ℝ)) t _
+    ((hasDerivAt_delayedQuartic T t.val).smul_const _)
+
+/-- The acceleration along the motion leaving the apex at the instant `T` is
+  `max (t - T) 0 ² / 12`. -/
+lemma deriv_deriv_solution (T : ℝ) :
+    ∂ₜ (∂ₜ (solution T)) =
+      fun t => (max (t.val - T) 0 ^ 2 / 12) • EuclideanSpace.single 0 1 := by
+  funext t
+  rw [deriv_solution]
+  have h := hasDerivAt_deriv_delayedQuartic T t.val
+  rw [deriv_delayedQuartic] at h
+  exact Time.deriv_comp_toRealCLE_of_hasDerivAt
+    (fun τ : ℝ => (max (τ - T) 0 ^ 3 / 36) • EuclideanSpace.single (0 : Fin 1) (1 : ℝ)) t _
+    (h.smul_const _)
+
+/-- The motion leaving the apex at the instant `T ≥ 0` starts from rest. -/
+lemma deriv_solution_zero {T : ℝ} (hT : 0 ≤ T) : ∂ₜ (solution T) 0 = 0 := by
+  rw [deriv_solution]
+  simp [hT]
+
+/-!
+
+### B.3. The equation of motion
+
+-/
+
+/-- The motion leaving the apex at the instant `T` satisfies the equation of motion of the
+  dome: its acceleration `max (t - T) 0 ² / 12` is the square root of its arc length. -/
+lemma solution_equationOfMotion (T : ℝ) : S.EquationOfMotion (solution T) := by
+  rw [equationOfMotion_iff_scalar]
+  intro t
+  rw [deriv_deriv_solution, solution_apply, sqrt_delayedQuartic]
+  simp
+
+/-- The motion leaving the apex at the instant `T` is a solution of the dome. -/
+lemma solution_isSolution (T : ℝ) : S.IsSolution (solution T) :=
+  ⟨(solution_contDiff T).differentiable (by simp),
+    Time.deriv_differentiable_of_contDiff_two _ (solution_contDiff T),
+    S.solution_equationOfMotion T⟩
+
+/-!
+
+### B.4. Distinct instants give distinct motions
+
+-/
+
+/-- Motions leaving the apex at distinct instants are distinct: at the later instant one is
+  still at the apex and the other is not. -/
+lemma solution_ne_of_lt {T T' : ℝ} (h : T < T') : solution T ≠ solution T' := by
+  intro heq
+  have h1 := solution_apply_pos T (t := (T' : Time)) (by rw [Time.realCast_val]; exact h)
+  rw [heq, solution_apply, delayedQuartic_of_le T' (by rw [Time.realCast_val])] at h1
+  exact lt_irrefl _ h1
+
+/-- The family of motions leaving the apex is injective in the instant of departure. -/
+lemma solution_injective : Function.Injective solution := by
+  intro T T' h
+  by_contra hne
+  rcases lt_or_gt_of_ne hne with hlt | hlt
+  · exact solution_ne_of_lt hlt h
+  · exact solution_ne_of_lt hlt h.symm
+
+/-- No motion leaving the apex is the motion staying at it. -/
+lemma solution_ne_zero (T : ℝ) : solution T ≠ 0 := by
+  intro h
+  have := solution_apply_pos T (t := ((T + 1 : ℝ) : Time)) (by rw [Time.realCast_val]; linarith)
+  rw [h] at this
+  simp at this
+
+/-!
+
+## C. The motion staying at the apex
+
+The force vanishes at the apex, so the constant curve there satisfies the equation of motion.
+
+-/
+
+/-- The motion staying at rest at the apex is a solution of the dome. -/
+lemma rest_isSolution : S.IsSolution 0 := by
+  have h : ∂ₜ (0 : Time → EuclideanSpace ℝ (Fin 1)) = 0 := funext fun _ => Time.deriv_const 0
+  refine ⟨differentiable_const 0, by rw [h]; exact differentiable_const 0, fun t => ?_⟩
+  simp [h, force_zero]
+
+/-- The motion staying at the apex has zero energy. -/
+lemma energy_rest (t : Time) : S.energy 0 t = 0 := by
+  have h : ∂ₜ (0 : Time → EuclideanSpace ℝ (Fin 1)) = 0 := funext fun _ => Time.deriv_const 0
+  simp [energy_eq, kineticEnergy_eq, potentialEnergy_eq, h]
+
+/-!
+
+## D. The failure of uniqueness
+
+Rest at the apex and departure at any instant `T ≥ 0` are distinct solutions with the same
+initial data. So the uniqueness property `SimplePendulum.IsSolution.eq_of_initial` of the
+pendulum fails for the dome, whose force violates the Picard–Lindelöf hypothesis
+(`not_lipschitzOnWith_force`).
+
+-/
+
+/-- Failure of uniqueness for the Norton dome: there are two distinct solutions of the
+  dome with the same initial position and the same initial velocity. The witnesses are the
+  motion staying at the apex and the motion leaving it at the instant `0`. -/
+lemma exists_isSolution_ne :
+    ∃ x y : Time → EuclideanSpace ℝ (Fin 1), S.IsSolution x ∧ S.IsSolution y ∧
+      x 0 = y 0 ∧ ∂ₜ x 0 = ∂ₜ y 0 ∧ x ≠ y :=
+  ⟨0, solution 0, S.rest_isSolution, S.solution_isSolution 0, by simp [solution_zero le_rfl],
+    by rw [deriv_solution_zero le_rfl]; exact Time.deriv_const 0,
+    (solution_ne_zero 0).symm⟩
+
+/-- The solutions of the Norton dome are not determined by their initial position and
+  velocity: the uniqueness property that the simple pendulum has,
+  `SimplePendulum.IsSolution.eq_of_initial`, fails for the dome. -/
+lemma not_isSolution_unique :
+    ¬ ∀ x y : Time → EuclideanSpace ℝ (Fin 1), S.IsSolution x → S.IsSolution y →
+      x 0 = y 0 → ∂ₜ x 0 = ∂ₜ y 0 → x = y := by
+  intro h
+  obtain ⟨x, y, hx, hy, h0, hv, hne⟩ := S.exists_isSolution_ne
+  exact hne (h x y hx hy h0 hv)
+
+/-- For every instant `T ≥ 0` there is a solution of the dome starting from rest at the apex
+  which is at the apex up to `T` and off it afterwards: the motions from rest at the apex form
+  a one-parameter family. -/
+lemma exists_isSolution_of_nonneg {T : ℝ} (hT : 0 ≤ T) :
+    ∃ r : Time → EuclideanSpace ℝ (Fin 1), S.IsSolution r ∧ r 0 = 0 ∧ ∂ₜ r 0 = 0 ∧
+      (∀ t : Time, t.val ≤ T → r t = 0) ∧ (∀ t : Time, T < t.val → 0 < r t 0) :=
+  ⟨solution T, S.solution_isSolution T, solution_zero hT, deriv_solution_zero hT,
+    fun _ ht => solution_of_le T ht, fun _ ht => solution_apply_pos T ht⟩
+
+/-- Every motion leaving the apex has zero energy: before the instant `T` it is at rest at the
+  apex, and the energy is conserved. Energy conservation therefore does not single out the
+  motion staying at the apex. -/
+lemma energy_solution (T : ℝ) (t : Time) : S.energy (solution T) t = 0 := by
+  have hs : ((T - 1 : ℝ) : Time).val ≤ T := by rw [Time.realCast_val]; linarith
+  rw [(S.solution_isSolution T).energy_eq t,
+    ← (S.solution_isSolution T).energy_eq ((T - 1 : ℝ) : Time)]
+  simp [energy_eq, kineticEnergy_eq, potentialEnergy_eq, deriv_solution, solution_of_le T hs]
+
+/-!
+
+## E. Time reversal and arrival at the apex
+
+The equation of motion has no velocity term, so time reversal maps solutions to solutions.
+Reversing the departure at the instant `T` gives a motion sliding up the dome, arriving at the
+apex at the instant `-T` with zero velocity, and staying there. For a locally Lipschitz force
+this is impossible; for the dome it is the non-uniqueness read backwards.
+
+-/
+
+/-- The second derivative is unchanged by the reversal of time, for a curve whose position and
+  velocity are differentiable. This is `Time.deriv_deriv_comp_neg` with its `C²` hypothesis
+  weakened to the regularity of a solution. -/
+lemma deriv_deriv_comp_neg_of_differentiable {M : Type} [NormedAddCommGroup M]
+    [NormedSpace ℝ M] (f : Time → M) (hf : Differentiable ℝ f) (hf' : Differentiable ℝ (∂ₜ f))
+    (t : Time) : ∂ₜ (∂ₜ (fun s => f (-s))) t = ∂ₜ (∂ₜ f) (-t) := by
+  rw [← neg_neg (∂ₜ (∂ₜ f) (-t)), ← Time.deriv_comp_neg _ _ (hf' _), ← Time.deriv_neg]
+  congr
+  ext
+  exact Time.deriv_comp_neg f _ (hf _)
+
+/-- The time reversal of a twice differentiable curve satisfying the equation of motion of the
+  dome satisfies it too: the equation has no velocity term. -/
+lemma equationOfMotion_comp_neg {r : Time → EuclideanSpace ℝ (Fin 1)} (hr : Differentiable ℝ r)
+    (hr' : Differentiable ℝ (∂ₜ r)) (h : S.EquationOfMotion r) :
+    S.EquationOfMotion (fun t => r (-t)) := by
+  intro t
+  rw [deriv_deriv_comp_neg_of_differentiable r hr hr' t]
+  exact h (-t)
+
+/-- The time reversal of a solution of the dome is a solution. -/
+lemma IsSolution.comp_neg {S : NortonDome} {r : Time → EuclideanSpace ℝ (Fin 1)}
+    (h : S.IsSolution r) : S.IsSolution (fun t => r (-t)) := by
+  have hneg : Differentiable ℝ (fun t : Time => -t) := by fun_prop
+  refine ⟨h.differentiable.comp hneg, ?_,
+    S.equationOfMotion_comp_neg h.differentiable h.deriv_differentiable h.equationOfMotion⟩
+  have hv : ∂ₜ (fun t => r (-t)) = fun t => -∂ₜ r (-t) :=
+    funext fun t => Time.deriv_comp_neg r t (h.differentiable _)
+  rw [hv]
+  exact (h.deriv_differentiable.comp hneg).neg
+
+/-- The motion of the particle on the dome arriving at the apex at the instant `-T`: the time
+  reversal of the motion leaving the apex at the instant `T`. -/
+noncomputable def arrival (T : ℝ) : Time → EuclideanSpace ℝ (Fin 1) := fun t => solution T (-t)
+
+/-- The motion arriving at the apex at the instant `-T` is a solution of the dome. -/
+lemma arrival_isSolution (T : ℝ) : S.IsSolution (arrival T) :=
+  (S.solution_isSolution T).comp_neg
+
+/-- The motion arriving at the apex at the instant `-T` is off the apex before that
+  instant. -/
+lemma arrival_apply_pos (T : ℝ) {t : Time} (h : t.val < -T) : 0 < arrival T t 0 :=
+  solution_apply_pos T (by rw [Time.neg_val]; linarith)
+
+/-- The motion arriving at the apex at the instant `-T` is at the apex from that instant on:
+  it reaches the apex in finite time and stays there. -/
+lemma arrival_of_le (T : ℝ) {t : Time} (h : -T ≤ t.val) : arrival T t = 0 :=
+  solution_of_le T (by rw [Time.neg_val]; linarith)
+
+/-- The motion arriving at the apex at the instant `-T` arrives with zero velocity. -/
+lemma deriv_arrival_of_le (T : ℝ) {t : Time} (h : -T ≤ t.val) : ∂ₜ (arrival T) t = 0 := by
+  unfold arrival
+  rw [Time.deriv_comp_neg _ _ ((solution_contDiff T).differentiable (by simp) _),
+    deriv_solution]
+  have h' : max ((-t).val - T) 0 = 0 := max_eq_right (by rw [Time.neg_val]; linarith)
+  simp only [h']
+  simp
+
+end ClassicalMechanics.NortonDome
+
+end

--- a/PhyslibAlpha/ClassicalMechanics/NortonDome/Sqrt.lean
+++ b/PhyslibAlpha/ClassicalMechanics/NortonDome/Sqrt.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 Zhi Kai Pong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhi Kai Pong
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Slope
+public import Mathlib.Analysis.SpecialFunctions.Sqrt
+/-!
+
+# Calculus of the real square root near zero
+
+## i. Overview
+
+Two facts about the real square root at zero, where Mathlib's calculus does not reach: the
+cube `√y ^ 3` is differentiable everywhere, with derivative `(3/2) √x`, and `√` is not
+Lipschitz on any interval `[0, ε]`. The first gives the derivative of the potential of the
+Norton dome, the second the failure of the Picard–Lindelöf hypothesis for its force.
+
+## ii. Key results
+
+- `hasDerivAt_sqrt_pow_three` is the derivative of `√y ^ 3` at every real number.
+- `not_lipschitzOnWith_sqrt` is the failure of the Lipschitz property of `√` on `[0, ε]`.
+
+## iii. Table of contents
+
+- A. The derivative of the cube of the square root
+- B. The square root is not Lipschitz at zero
+
+## iv. References
+
+- Norton, J. D., *The dome: an unexpectedly simple failure of determinism*, Philosophy of
+  Science 75 (2008), 786–798.
+
+-/
+
+@[expose] public section
+
+open Filter Topology
+
+/-!
+
+## A. The derivative of the cube of the square root
+
+To the left of zero the square root vanishes, to the right the chain rule applies, and at zero
+the difference quotient of `√t ^ 3 = t √t` is `√t`, which tends to zero.
+
+-/
+
+/-- The cube of the real square root, `√y ^ 3`, has derivative `(3/2) √x` at every real `x`. It
+  is differentiable at `0`, with derivative `0`, even though `√` is not. -/
+lemma hasDerivAt_sqrt_pow_three (x : ℝ) :
+    HasDerivAt (fun y : ℝ => √y ^ 3) (3 / 2 * √x) x := by
+  rcases lt_trichotomy x 0 with hx | rfl | hx
+  · have hev : (fun y : ℝ => √y ^ 3) =ᶠ[𝓝 x] fun _ => 0 := by
+      filter_upwards [Iio_mem_nhds hx] with y hy
+      simp [Real.sqrt_eq_zero'.mpr (Set.mem_Iio.mp hy).le]
+    rw [Real.sqrt_eq_zero'.mpr hx.le, mul_zero]
+    exact (hasDerivAt_const x (0 : ℝ)).congr_of_eventuallyEq hev
+  · rw [Real.sqrt_zero, mul_zero, hasDerivAt_iff_tendsto_slope_zero]
+    have h : ∀ t : ℝ, t ≠ 0 → √t = t⁻¹ • (√(0 + t) ^ 3 - √0 ^ 3) := by
+      intro t ht
+      rw [zero_add, Real.sqrt_zero, zero_pow three_ne_zero, sub_zero, smul_eq_mul]
+      rcases le_or_gt t 0 with h | h
+      · simp [Real.sqrt_eq_zero'.mpr h]
+      · rw [pow_succ, Real.sq_sqrt h.le, ← mul_assoc, inv_mul_cancel₀ ht, one_mul]
+    have hc : Tendsto (fun t : ℝ => √t) (𝓝[≠] 0) (𝓝 0) := by
+      simpa using (Real.continuous_sqrt.tendsto (0 : ℝ)).mono_left nhdsWithin_le_nhds
+    exact hc.congr' (eventually_nhdsWithin_of_forall fun t ht => h t ht)
+  · have hs : √x ≠ 0 := (Real.sqrt_pos.mpr hx).ne'
+    refine ((Real.hasDerivAt_sqrt hx.ne').pow 3).congr_deriv ?_
+    rw [show (3 : ℕ) - 1 = 2 from rfl, Nat.cast_ofNat]
+    field_simp
+
+/-!
+
+## B. The square root is not Lipschitz at zero
+
+A bound `√y ≤ K y` on `[0, ε]` gives `1 ≤ K √y` for every positive `y ≤ ε`, which fails at
+`y = min ε (1 / (2K + 1)²)`.
+
+-/
+
+/-- The real square root is not Lipschitz on any interval `[0, ε]` with `ε > 0`, for any
+  Lipschitz constant. -/
+lemma not_lipschitzOnWith_sqrt (K : NNReal) {ε : ℝ} (hε : 0 < ε) :
+    ¬ LipschitzOnWith K (fun y : ℝ => √y) (Set.Icc 0 ε) := by
+  intro h
+  have hK : (0 : ℝ) ≤ K := K.2
+  obtain ⟨y, hy0, hyε, hy⟩ : ∃ y : ℝ, 0 < y ∧ y ≤ ε ∧ (K : ℝ) * √y < 1 := by
+    refine ⟨min ε ((1 / (2 * (K : ℝ) + 1)) ^ 2), ?_, min_le_left _ _, ?_⟩
+    · exact lt_min hε (by positivity : (0 : ℝ) < (1 / (2 * (K : ℝ) + 1)) ^ 2)
+    have h1 : √(min ε ((1 / (2 * (K : ℝ) + 1)) ^ 2)) ≤ 1 / (2 * K + 1) := by
+      rw [Real.sqrt_le_left (by positivity)]
+      exact min_le_right _ _
+    calc (K : ℝ) * √(min ε ((1 / (2 * (K : ℝ) + 1)) ^ 2)) ≤ K * (1 / (2 * K + 1)) := by gcongr
+      _ < 1 := by
+        rw [mul_one_div, div_lt_one (by positivity)]
+        linarith
+  have := h.dist_le_mul y ⟨hy0.le, hyε⟩ 0 ⟨le_rfl, hε.le⟩
+  simp only [Real.sqrt_zero, dist_zero_right, Real.norm_eq_abs,
+    abs_of_nonneg (Real.sqrt_nonneg _), abs_of_pos hy0] at this
+  have hsq : √y * √y = y := Real.mul_self_sqrt hy0.le
+  have hs : 0 < √y := Real.sqrt_pos.mpr hy0
+  nlinarith
+
+end


### PR DESCRIPTION
- Norton's dome is a much-debated example in the philosophy of physics: a mass at rest on its apex may stay there or slide off at any instant, in obedience to Newton's laws, because the force is continuous but not Lipschitz at the apex. This formalises the dome and the non-uniqueness of its motions.
- It illustrates the arguments in the debate by making determinism and the candidate regularity conditions predicates on a minimal Newtonian system, so that what each condition buys is a theorem; which condition to adopt is left open, since that choice is not something a formalisation can settle.
- Local existence rests on a sorried statement of Peano's theorem copied from Mathlib PR #42148 under its own names, so the file should be deleted when that lands.

^written by Claude

this is a side project that I've been directing Claude to do, this probably doesn't belong in Physlib both in terms of quality and content, but I think this is a good example of what formalisation enables us to clarify, and a good reminder of the pitfalls of trying to come up with a universal framework that serves all functions i.e. sometimes there may not be one single good choice and it's our role to map out the boundary of theories instead.