### PR TITLE
refactor(Time): make Time an affine space, add time origin to reference frames

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -520,8 +520,8 @@ public import Physlib.SpaceAndTime.SpaceTime.LorentzAction
 public import Physlib.SpaceAndTime.SpaceTime.TimeSlice
 public import Physlib.SpaceAndTime.Time.Basic
 public import Physlib.SpaceAndTime.Time.Derivatives
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Physlib.SpaceAndTime.Time.MatrixDerivatives
-public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.SpaceAndTime.Time.TimeMan
 public import Physlib.SpaceAndTime.Time.TimeTransMan
 public import Physlib.SpaceAndTime.Time.TimeUnit

--- a/Physlib.lean
+++ b/Physlib.lean
@@ -521,6 +521,7 @@ public import Physlib.SpaceAndTime.SpaceTime.TimeSlice
 public import Physlib.SpaceAndTime.Time.Basic
 public import Physlib.SpaceAndTime.Time.Derivatives
 public import Physlib.SpaceAndTime.Time.MatrixDerivatives
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.SpaceAndTime.Time.TimeMan
 public import Physlib.SpaceAndTime.Time.TimeTransMan
 public import Physlib.SpaceAndTime.Time.TimeUnit

--- a/Physlib/ClassicalMechanics/Force.lean
+++ b/Physlib/ClassicalMechanics/Force.lean
@@ -44,11 +44,11 @@ variable {d : ℕ} {frame : ReferenceFrame d} {Object : Type}
 /-- A time-dependent force acting on an object. -/
 structure Force (frame : ReferenceFrame d) (Object : Type) where
   /-- The force vector. -/
-  value : Time → frame.Vector
+  value : ℝ → frame.Vector
   /-- The target object. -/
   target : Object
 
-instance : CoeFun (frame.Force Object) (fun _ => Time → frame.Vector) where
+instance : CoeFun (frame.Force Object) (fun _ => ℝ → frame.Vector) where
   coe := Force.value
 
 /-- A force between two objects. -/
@@ -57,7 +57,7 @@ structure InternalForce (frame : ReferenceFrame d) (Object : Type) extends frame
   source : Object
   source_ne_target : source ≠ target
 
-instance : CoeFun (frame.InternalForce Object) (fun _ => Time → frame.Vector) where
+instance : CoeFun (frame.InternalForce Object) (fun _ => ℝ → frame.Vector) where
   coe force := force.value
 
 instance : Coe (frame.InternalForce Object) (frame.Force Object) where
@@ -72,6 +72,6 @@ def InternalForce.reverse (force : frame.InternalForce Object) : frame.InternalF
 
 /-- The net force on `object`. -/
 def netForce (object : Object) (internalForces : Multiset (frame.InternalForce Object))
-    (externalForces : Multiset (frame.Force Object)) (t : Time) : frame.Vector :=
+    (externalForces : Multiset (frame.Force Object)) (t : ℝ) : frame.Vector :=
   let forces := internalForces.map InternalForce.toForce + externalForces
   ∑ force : forces with force.1.target = object, force.1 t

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
@@ -6,7 +6,7 @@ Authors: Aadarsh Agarwal
 module
 
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
 /-!
 

--- a/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
+++ b/Physlib/ClassicalMechanics/Pendulum/SimplePendulum/Geometric/Trajectory.lean
@@ -6,7 +6,7 @@ Authors: Aadarsh Agarwal
 module
 
 public import Physlib.ClassicalMechanics.Pendulum.SimplePendulum.Geometric.Basic
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
 /-!
 

--- a/Physlib/ClassicalMechanics/PointParticle/Basic.lean
+++ b/Physlib/ClassicalMechanics/PointParticle/Basic.lean
@@ -5,9 +5,7 @@ Authors: Raunak Chhatwal
 -/
 module
 
-public import Mathlib.Algebra.Order.Positive.Field
 public import Physlib.SpaceAndTime.ReferenceFrame
-public import Physlib.SpaceAndTime.Time.Derivatives
 /-!
 # Point particles
 
@@ -31,7 +29,7 @@ laws are imposed when particles and forces are assembled in
 Position and its first time derivative are required to be differentiable when the
 frame is inertial. This ensures that the velocity and acceleration used in
 Newtonian systems are genuine derivatives. The trajectories in this definition
-are defined for all `Time`.
+are defined for all real-valued time coordinates relative to the frame's time origin.
 -/
 
 @[expose] public noncomputable section
@@ -50,9 +48,9 @@ structure Particle (frame : ReferenceFrame d) where
   /-- The particle's mass. -/
   mass : ℝ+
   /-- The particle's position in frame coordinates. -/
-  pos : Time → frame.Vector
+  pos : ℝ → frame.Vector
   pos_twice_differentiable :
-    frame.IsInertial → Differentiable ℝ pos ∧ Differentiable ℝ (Time.deriv pos)
+    frame.IsInertial → Differentiable ℝ pos ∧ Differentiable ℝ (deriv pos)
 
 namespace Particle
 
@@ -63,8 +61,8 @@ instance [h : Fact frame.IsInertial] : Fact (Differentiable ℝ particle.pos) :=
   ⟨particle.pos_twice_differentiable h.out |>.left⟩
 
 /-- The particle's velocity. -/
-def velocity [_h : Fact (Differentiable ℝ particle.pos)] : Time → frame.Vector :=
-  Time.deriv particle.pos
+def velocity [_h : Fact (Differentiable ℝ particle.pos)] : ℝ → frame.Vector :=
+  deriv particle.pos
 
 /-- Velocity is differentiable in an inertial frame. -/
 instance [h : Fact frame.IsInertial] : Fact (Differentiable ℝ particle.velocity) :=
@@ -72,11 +70,11 @@ instance [h : Fact frame.IsInertial] : Fact (Differentiable ℝ particle.velocit
 
 /-- The particle's acceleration. -/
 def acceleration [Fact (Differentiable ℝ particle.pos)]
-    [_h : Fact (Differentiable ℝ particle.velocity)] : Time → frame.Vector :=
-  Time.deriv particle.velocity
+    [_h : Fact (Differentiable ℝ particle.velocity)] : ℝ → frame.Vector :=
+  deriv particle.velocity
 
-/-- The particle's position in affine space. -/
-def pointInSpace (t : Time) : Space d :=
-  Vector.dispEquiv t (particle.pos t) +ᵥ frame.origin t
+/-- The particle's position in affine space at frame time coordinate `t`. -/
+def pointInSpace (t : ℝ) : Space d :=
+  Vector.dispEquiv t (particle.pos t) +ᵥ frame.origin (frame.timeEquiv t)
 
 end ClassicalMechanics.ReferenceFrame.Particle

--- a/Physlib/ClassicalMechanics/PointParticle/NewtonianSystem/Basic.lean
+++ b/Physlib/ClassicalMechanics/PointParticle/NewtonianSystem/Basic.lean
@@ -85,7 +85,7 @@ abbrev Particle : Type := system.particles
 
 namespace Particle
 
-variable {system : NewtonianSystem d} (particle : system.Particle) (t : Time)
+variable {system : NewtonianSystem d} (particle : system.Particle) (t : ℝ)
 
 /-- The particle's mass. -/
 def mass : ℝ+ := particle.1.mass
@@ -126,9 +126,9 @@ variable {system : NewtonianSystem d} (force : system.Force)
 instance : Coe system.Force (system.frame.Force system.Particle) := Coe.mk inner
 
 /-- The force at `t`. -/
-def value (t : Time) : system.Vector := force.inner.value t
+def value (t : ℝ) : system.Vector := force.inner.value t
 
-instance : CoeFun system.Force (fun _ => Time → system.Vector) where
+instance : CoeFun system.Force (fun _ => ℝ → system.Vector) where
   coe := value
 
 /-- The force's target. -/
@@ -153,7 +153,7 @@ variable {system : NewtonianSystem d} (force : system.InternalForce)
 instance : Coe system.InternalForce system.Force := Coe.mk .inl
 
 /-- The force at `t`. -/
-def value (t : Time) : system.Vector := force.1.value t
+def value (t : ℝ) : system.Vector := force.1.value t
 
 /-- The force's target. -/
 def target : system.Particle := force.1.target
@@ -184,7 +184,7 @@ end InternalForce
 ## D. Aggregate quantities
 -/
 
-variable (t : Time)
+variable (t : ℝ)
 
 /-- Total mass. -/
 def mass : ℝ :=

--- a/Physlib/FluidDynamics/Basic.lean
+++ b/Physlib/FluidDynamics/Basic.lean
@@ -6,7 +6,7 @@ Authors: Florian Wiesner
 module
 
 public import Physlib.SpaceAndTime.Space.Basic
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 /-!
 
 # Basic field types for fluid dynamics

--- a/Physlib/FluidDynamics/Basic.lean
+++ b/Physlib/FluidDynamics/Basic.lean
@@ -6,7 +6,7 @@ Authors: Florian Wiesner
 module
 
 public import Physlib.SpaceAndTime.Space.Basic
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 /-!
 
 # Basic field types for fluid dynamics

--- a/Physlib/SpaceAndTime/GalileanGroup/Basic.lean
+++ b/Physlib/SpaceAndTime/GalileanGroup/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import Physlib.SpaceAndTime.Space.EuclideanGroup.Basic
 public import Physlib.SpaceAndTime.Space.Origin
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 
 /-!
 # The Galilean group

--- a/Physlib/SpaceAndTime/GalileanGroup/Basic.lean
+++ b/Physlib/SpaceAndTime/GalileanGroup/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import Physlib.SpaceAndTime.Space.EuclideanGroup.Basic
 public import Physlib.SpaceAndTime.Space.Origin
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 
 /-!
 # The Galilean group

--- a/Physlib/SpaceAndTime/ReferenceFrame.lean
+++ b/Physlib/SpaceAndTime/ReferenceFrame.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.LinearAlgebra.AffineSpace.Basis
 public import Mathlib.Topology.Algebra.Module.TransferInstance
 public import Physlib.SpaceAndTime.Space.Basic
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 /-!
 # Reference frames
 

--- a/Physlib/SpaceAndTime/ReferenceFrame.lean
+++ b/Physlib/SpaceAndTime/ReferenceFrame.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.LinearAlgebra.AffineSpace.Basis
 public import Mathlib.Topology.Algebra.Module.TransferInstance
 public import Physlib.SpaceAndTime.Space.Basic
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.Basic
 /-!
 # Reference frames
 
@@ -19,14 +19,8 @@ point requires an origin and a basis for measuring displacements from that origi
 This distinction is built into `Space d`, which is an affine space. Two points determine a
 displacement, but no point is automatically the zero point. The chosen origin therefore belongs to
 the frame, not to space itself. Similarly, a displacement has coordinate components only after a
-basis has been chosen.
-
-Real-valued coordinates in all frames use the same implicit units of space and time. Different
-reference frames represent different coordinate grids, not changes to this shared unit convention.
-`Time` already includes an implicit choice of time unit, origin, and orientation. With this common
-choice, `Time` is also the time coordinate in every frame and should be used directly in place of
-frame-relative time coordinates. A frame therefore carries no additional time origin or time basis.
-This convention applies to vector functions of time and all other time-dependent quantities.
+basis has been chosen. Real-valued coordinates in all frames use the same implicit units of space
+and time. Different frames represent different coordinate grids, not different units.
 
 Most applications should use frames that are both inertial and orthonormal. In orthonormal frames,
 the norm and inner product of coordinate vectors are given by the familiar Euclidean formulas. The
@@ -51,8 +45,10 @@ A reference frame can be pictured as a coordinate grid carried through time. It 
 motion is described, not an additional physical object moving with the particles.
 -/
 
-/-- A time-indexed choice of affine origin and displacement basis in `d`-dimensional space. -/
+/-- A time origin and a time-indexed spatial origin and basis in `d`-dimensional space. -/
 structure ReferenceFrame (d : ℕ) where
+  /-- The instant assigned time coordinate zero. -/
+  timeOrigin : Time
   /-- The point assigned coordinate zero at each time. -/
   origin : Time → Space d
   /-- The basis used to turn displacement vectors into coordinate components at each time. -/
@@ -65,22 +61,31 @@ span the whole space. One reference point is chosen as the origin, and the displ
 the remaining points form the coordinate basis. The resulting frame need not be inertial or
 orthonormal. -/
 def ReferenceFrame.fromReferencePoints
+    (timeOrigin : Time)
     (referencePoints : Finset (Time → Space d))
     (independence : ∀ t, AffineIndependent ℝ fun point : referencePoints => point.val t)
     (spans_space : ∀ t, affineSpan ℝ {point.val t | point : referencePoints} = ⊤) :
     ReferenceFrame d :=
   let affineBasis (t : Time) : AffineBasis referencePoints ℝ (Space d) :=
     ⟨fun point => point.val t, independence t, spans_space t⟩
-  let reference_points_not_empty := (affineBasis 0).nonempty
+  let reference_points_not_empty := (affineBasis timeOrigin).nonempty
   let origin := Classical.choice reference_points_not_empty
   letI := Fintype.ofFinite {point : referencePoints // point ≠ origin}
   let basis t := (affineBasis t).basisOf origin
   let other_reference_points_size_eq_dim :
       Fintype.card {point : referencePoints // point ≠ origin} = d :=
-    by simpa using (Module.finrank_eq_card_basis <| basis 0).symm
+    by simpa using (Module.finrank_eq_card_basis <| basis timeOrigin).symm
   let basisReindexed t :=
     (basis t).reindex (Fintype.equivFinOfCardEq other_reference_points_size_eq_dim)
-  { origin := origin, basis := basisReindexed }
+  { timeOrigin := timeOrigin, origin := origin, basis := basisReindexed }
+
+namespace ReferenceFrame
+
+variable {frame : ReferenceFrame d}
+
+/-- Convert a frame's real-valued time coordinate into an instant in affine time. -/
+def timeEquiv (frame : ReferenceFrame d) : ℝ ≃ᵃ[ℝ] Time :=
+  AffineEquiv.vaddConst ℝ frame.timeOrigin
 
 /-!
 ## B. Inertial reference frames
@@ -89,10 +94,6 @@ In Newtonian mechanics, an inertial coordinate grid does not rotate or change sc
 moves in a straight line at constant velocity. These conditions restrict the frame, not the
 particles described in that frame.
 -/
-
-namespace ReferenceFrame
-
-variable {frame : ReferenceFrame d}
 
 /-- Whether the frame basis induces the same inner product on coordinates at every time. -/
 def IsMetricConserved (frame : ReferenceFrame d) : Prop :=
@@ -114,7 +115,7 @@ instance [h : Fact frame.Orthonormal] : Fact frame.IsMetricConserved := ⟨h.out
 structure IsInertial (frame : ReferenceFrame d) : Prop where
   /-- Elapsed time times `velocity` is exactly the origin's displacement. -/
   origin_moves_uniformly :
-    ∃ velocity, ∀ t₁ t₂, frame.origin t₂ -ᵥ frame.origin t₁ = (t₂ - t₁).val • velocity
+    ∃ velocity, ∀ t₁ t₂, frame.origin t₂ -ᵥ frame.origin t₁ = (t₂ -ᵥ t₁) • velocity
   /-- The coordinate axes neither rotate nor change scale with time. -/
   basis_conserved : ∀ t₁ t₂, frame.basis t₁ = frame.basis t₂
 
@@ -165,9 +166,9 @@ def componentLinearEquiv : frame.Vector ≃ₗ[ℝ] (Fin d → ℝ) :=
   {componentEquiv with map_add' _ _ := rfl, map_smul' _ _ := rfl}
 
 /-- Equivalence between frame vectors and geometric displacements in space,
-defined by the frame's basis at `t`. -/
-def dispEquiv (t : Time) : frame.Vector ≃ₗ[ℝ] EuclideanSpace ℝ (Fin d) :=
-  componentLinearEquiv.trans (frame.basis t).equivFun.symm
+defined by the frame's basis at time coordinate `t`. -/
+def dispEquiv (t : ℝ) : frame.Vector ≃ₗ[ℝ] EuclideanSpace ℝ (Fin d) :=
+  componentLinearEquiv.trans (frame.basis (frame.timeEquiv t)).equivFun.symm
 
 /-- Use the same topology for frame vectors as components' product topology. -/
 instance : TopologicalSpace frame.Vector := componentEquiv.topologicalSpace
@@ -182,9 +183,10 @@ instance : FiniteDimensional ℝ frame.Vector :=
   FiniteDimensional.of_injective componentLinearEquiv.toLinearMap componentEquiv.injective
 
 /-- Continuous equivalence between frame vectors and geometric displacements in space,
-defined by the frame's basis at `t`. -/
-def contDispEquiv (t : Time) : frame.Vector ≃L[ℝ] EuclideanSpace ℝ (Fin d) :=
-  (componentContLinearEquiv frame).trans (frame.basis t).equivFun.toContinuousLinearEquiv.symm
+defined by the frame's basis at time coordinate `t`. -/
+def contDispEquiv (t : ℝ) : frame.Vector ≃L[ℝ] EuclideanSpace ℝ (Fin d) :=
+  (componentContLinearEquiv frame).trans
+    (frame.basis (frame.timeEquiv t)).equivFun.toContinuousLinearEquiv.symm
 
 /-- The physical norm on frame vectors, pulled back from geometric displacement space. -/
 instance [_h : Fact frame.IsMetricConserved] : NormedAddCommGroup frame.Vector :=
@@ -207,7 +209,7 @@ instance [Fact frame.IsMetricConserved] : InnerProductSpace ℝ frame.Vector whe
 lemma norm_euclidean_if_orthonormal [h : Fact frame.Orthonormal] :
     ∀ v : frame.Vector, ‖v‖^2 = ∑ i, (v.components i)^2 := by
   intro v
-  let basis := (frame.basis 0).toOrthonormalBasis (h.out 0)
+  let basis := (frame.basis (frame.timeEquiv 0)).toOrthonormalBasis (h.out _)
   calc
     _ = ‖basis.repr.symm (WithLp.toLp 2 v.components)‖ ^ 2 := by rfl
     _ = ‖WithLp.toLp 2 v.components‖ ^ 2 := by rw [basis.repr.symm.norm_map]
@@ -217,7 +219,7 @@ lemma norm_euclidean_if_orthonormal [h : Fact frame.Orthonormal] :
 lemma inner_euclidean_if_orthonormal [h : Fact frame.Orthonormal] :
     ∀ v w : frame.Vector, inner ℝ v w = ∑ i, v.components i * w.components i := by
   intro v w
-  let basis := (frame.basis 0).toOrthonormalBasis (h.out 0)
+  let basis := (frame.basis (frame.timeEquiv 0)).toOrthonormalBasis (h.out _)
   calc
     _ = inner ℝ (basis.repr.symm <| WithLp.toLp 2 v.components)
         (basis.repr.symm <| WithLp.toLp 2 w.components) := by rfl

--- a/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
+++ b/Physlib/SpaceAndTime/ReferenceFrame/API-map.yaml
@@ -8,8 +8,9 @@ Overview: |
     displacement, and a displacement acquires numerical components only once
     axes have been picked. Space carries a zero point of its own, but an
     observer is under no obligation to use it: which point the coordinates call
-    zero is part of the observer's choice. A reference frame is that pair of
-    choices, an origin and a set of axes, carried along through time.
+    zero is part of the observer's choice. Likewise, no instant of time is
+    canonically zero. A reference frame is that collection of choices: a time
+    origin, and an origin and a set of axes carried along through time.
 
     An inertial frame is one whose grid is not being pushed around. Its axes are
     the same at every time, and its origin drifts in a straight line at constant
@@ -39,9 +40,9 @@ References: []
 
 Requirements:
 
-  - description: "The key data structure `ReferenceFrame d`, recording an affine origin and a displacement basis at each time, is defined."
+  - description: "The key data structure `ReferenceFrame d`, recording a time origin together with an affine origin and a displacement basis at each time, is defined."
     done: true
-    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame, ReferenceFrame.origin, ReferenceFrame.basis)"
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame, ReferenceFrame.timeOrigin, ReferenceFrame.origin, ReferenceFrame.basis)"
 
   - description: "The API contains a construction of a frame from the trajectories of a collection of reference points forming an affine basis at each time."
     done: true
@@ -92,8 +93,8 @@ Requirements:
     location: "Physlib/SpaceAndTime/ReferenceFrame.lean (norm_euclidean_if_orthonormal, inner_euclidean_if_orthonormal)"
 
   - description: "The API shall contain a choice of time origin for a frame, so that time translations can act on frames."
-    done: false
-    location: N/A
+    done: true
+    location: "Physlib/SpaceAndTime/ReferenceFrame.lean (ReferenceFrame.timeOrigin, ReferenceFrame.timeEquiv)"
 
   - description: "The API shall contain the defining property of an inertial frame's origin velocity, and the origin and basis of a frame built from reference points."
     done: false

--- a/Physlib/SpaceAndTime/Space/IsDistBounded.lean
+++ b/Physlib/SpaceAndTime/Space/IsDistBounded.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Integrals.RadialAngularMeasure
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 public import Mathlib.Analysis.Distribution.SchwartzSpace.Deriv
 /-!

--- a/Physlib/SpaceAndTime/Space/IsDistBounded.lean
+++ b/Physlib/SpaceAndTime/Space/IsDistBounded.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Physlib.SpaceAndTime.Space.Integrals.RadialAngularMeasure
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 public import Mathlib.Analysis.Distribution.SchwartzSpace.Deriv
 /-!

--- a/Physlib/SpaceAndTime/SpaceTime/Basic.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Physlib.Relativity.SpeedOfLight
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Tensorial
 public import Physlib.SpaceAndTime.Space.Integrals.Basic
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Physlib.Meta.Informal.Basic
 /-!
 # Spacetime

--- a/Physlib/SpaceAndTime/SpaceTime/Basic.lean
+++ b/Physlib/SpaceAndTime/SpaceTime/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Physlib.Relativity.SpeedOfLight
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Tensorial
 public import Physlib.SpaceAndTime.Space.Integrals.Basic
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.Meta.Informal.Basic
 /-!
 # Spacetime

--- a/Physlib/SpaceAndTime/Time/API-map.yaml
+++ b/Physlib/SpaceAndTime/Time/API-map.yaml
@@ -7,7 +7,7 @@ Overview: |
     representing instants of time with a given (but arbitrary) choice of units and
     orientation. It is an affine space over `ℝ`: two instants determine a real elapsed
     time, and no instant is canonically zero. Choosing the implicit origin `Time.mk 0`
-    gives the scalar version of time most often used in non-relativistic physics,
+    gives the version of time most often used in non-relativistic physics,
     forming a 1d real inner-product space. The API also contains the time
     derivative `∂ₜ` of functions on `Time`, and the related types `TimeMan`,
     `TimeTransMan` and `TimeUnit`, versions of time with fewer choices made,
@@ -31,19 +31,19 @@ Requirements:
 
   - description: "The API contains an instance of a vector space (module) on `Time`, given the implicit origin `Time.mk 0`, with an orthonormal basis and continuous linear/isometric equivalences to `ℝ`."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Scalar.lean (AddCommGroup Time, Module ℝ Time, basis : OrthonormalBasis (Fin 1) ℝ Time, toRealCLM, toRealCLE, toRealLIE)"
+    location: "Physlib/SpaceAndTime/Time/InnerProductSpace.lean (AddCommGroup Time, Module ℝ Time, basis : OrthonormalBasis (Fin 1) ℝ Time, toRealCLM, toRealCLE, toRealLIE)"
 
   - description: "The API contains an ordering on `Time`."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Scalar.lean (LE Time, PartialOrder Time)"
+    location: "Physlib/SpaceAndTime/Time/InnerProductSpace.lean (LE Time, PartialOrder Time)"
 
   - description: "The API contains a norm on `Time`, and an inner product making it a 1d real inner-product space."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Scalar.lean (Norm Time, NormedAddCommGroup Time, NormedSpace ℝ Time, InnerProductSpace ℝ Time)"
+    location: "Physlib/SpaceAndTime/Time/InnerProductSpace.lean (Norm Time, NormedAddCommGroup Time, NormedSpace ℝ Time, InnerProductSpace ℝ Time)"
 
   - description: "The API contains a measure-theoretic structure on `Time` (a Borel measurable space, with the volume measure equal to the Haar measure associated with the basis)."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Scalar.lean (MeasurableSpace Time, BorelSpace Time, volume_eq_basis_addHaar, val_measurePreserving)"
+    location: "Physlib/SpaceAndTime/Time/InnerProductSpace.lean (MeasurableSpace Time, BorelSpace Time, volume_eq_basis_addHaar, val_measurePreserving)"
 
   - description: "The API contains the derivatives of functions from `Time` to normed spaces, with linearity, constant-function, quotient and smoothness lemmas, and compatibility with Euclidean and Lorentz-vector components."
     done: true

--- a/Physlib/SpaceAndTime/Time/API-map.yaml
+++ b/Physlib/SpaceAndTime/Time/API-map.yaml
@@ -4,8 +4,10 @@ Title: Time
 
 Overview: |
     The key data structure is `Time`, a structure with a single field `val : ℝ`
-    representing time with a given (but arbitrary) choice of units, origin and
-    orientation — the version of time most often used in non-relativistic physics,
+    representing instants of time with a given (but arbitrary) choice of units and
+    orientation. It is an affine space over `ℝ`: two instants determine a real elapsed
+    time, and no instant is canonically zero. Choosing the implicit origin `Time.mk 0`
+    gives the scalar version of time most often used in non-relativistic physics,
     forming a 1d real inner-product space. The API also contains the time
     derivative `∂ₜ` of functions on `Time`, and the related types `TimeMan`,
     `TimeTransMan` and `TimeUnit`, versions of time with fewer choices made,
@@ -19,25 +21,29 @@ References: []
 
 Requirements:
 
-  - description: "The key data structure `Time` (a structure with a single field `val : ℝ`, representing time with an arbitrary but fixed choice of units and origin) is defined."
+  - description: "The key data structure `Time` (a structure with a single field `val : ℝ`, representing instants of time with an arbitrary but fixed choice of units and orientation) is defined."
     done: true
     location: "Physlib/SpaceAndTime/Time/Basic.lean (Time)"
 
-  - description: "The API contains an instance of a vector space (module) on `Time`, with an orthonormal basis and continuous linear/isometric equivalences to `ℝ`."
+  - description: "The API contains the affine structure on `Time` over `ℝ`, with real-valued translations of instants and real-valued elapsed times between instants."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Basic.lean (AddCommGroup Time, Module ℝ Time, basis : OrthonormalBasis (Fin 1) ℝ Time, toRealCLM, toRealCLE, toRealLIE)"
+    location: "Physlib/SpaceAndTime/Time/Basic.lean (VAdd ℝ Time, VSub ℝ Time, AddTorsor ℝ Time, vadd_val, vsub_eq_val)"
+
+  - description: "The API contains an instance of a vector space (module) on `Time`, given the implicit origin `Time.mk 0`, with an orthonormal basis and continuous linear/isometric equivalences to `ℝ`."
+    done: true
+    location: "Physlib/SpaceAndTime/Time/Scalar.lean (AddCommGroup Time, Module ℝ Time, basis : OrthonormalBasis (Fin 1) ℝ Time, toRealCLM, toRealCLE, toRealLIE)"
 
   - description: "The API contains an ordering on `Time`."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Basic.lean (LE Time, PartialOrder Time)"
+    location: "Physlib/SpaceAndTime/Time/Scalar.lean (LE Time, PartialOrder Time)"
 
   - description: "The API contains a norm on `Time`, and an inner product making it a 1d real inner-product space."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Basic.lean (Norm Time, NormedAddCommGroup Time, NormedSpace ℝ Time, InnerProductSpace ℝ Time)"
+    location: "Physlib/SpaceAndTime/Time/Scalar.lean (Norm Time, NormedAddCommGroup Time, NormedSpace ℝ Time, InnerProductSpace ℝ Time)"
 
   - description: "The API contains a measure-theoretic structure on `Time` (a Borel measurable space, with the volume measure equal to the Haar measure associated with the basis)."
     done: true
-    location: "Physlib/SpaceAndTime/Time/Basic.lean (MeasurableSpace Time, BorelSpace Time, volume_eq_basis_addHaar, val_measurePreserving)"
+    location: "Physlib/SpaceAndTime/Time/Scalar.lean (MeasurableSpace Time, BorelSpace Time, volume_eq_basis_addHaar, val_measurePreserving)"
 
   - description: "The API contains the derivatives of functions from `Time` to normed spaces, with linearity, constant-function, quotient and smoothness lemmas, and compatibility with Euclidean and Lorentz-vector components."
     done: true

--- a/Physlib/SpaceAndTime/Time/Basic.lean
+++ b/Physlib/SpaceAndTime/Time/Basic.lean
@@ -16,7 +16,7 @@ such a duration to an instant produces another instant. There is no distinguishe
 
 The field `Time.val` is an implementation coordinate, not a frame-relative time
 coordinate. A reference frame chooses its own time origin. Import
-`Physlib.SpaceAndTime.Time.Scalar` to use the additional scalar structure with the
+`Physlib.SpaceAndTime.Time.InnerProductSpace` to use the inner product space structure with the
 implicit origin `Time.mk 0`, including addition of instants, norms, and derivatives.
 -/
 

--- a/Physlib/SpaceAndTime/Time/Basic.lean
+++ b/Physlib/SpaceAndTime/Time/Basic.lean
@@ -5,457 +5,59 @@ Authors: Joseph Tooby-Smith
 -/
 module
 
-public import Mathlib.Analysis.Calculus.FDeriv.Linear
-public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+public import Mathlib.Data.Real.Basic
+public import Mathlib.LinearAlgebra.AffineSpace.Defs
 /-!
-# Time
+# Affine time
 
-## i. Overview
+`Time` represents instants with a fixed but arbitrary unit and orientation. It is an
+affine space over `ℝ`: two instants determine a real-valued elapsed time, and adding
+such a duration to an instant produces another instant. There is no distinguished zero.
 
-In this module we define the type `Time`, corresponding to time in a given
-(but arbitrary) set of units, with a given (but arbitrary) choice of origin (time zero),
-and a choice of orientation (i.e. a positive time direction).
-
-We note that this is the version of time most often used in undergraduate and
-non-mathematical physics.
-
-The choice of units or origin can be made on a case-by-case basis, as
-long as they are done consistently. However, since the choice of units and origin is
-left implicit, Lean will not catch inconsistencies in the choice of units or origin when
-working with `Time`.
-
-For example, for the classical mechanics system corresponding to the harmonic oscillator,
-one can take the origin of time to be the time at which the initial conditions are specified,
-and the units can be taken as anything as long as the units chosen for time `t` and
-the angular frequency `ω` are consistent.
-
-With this notion of `Time`, becomes a 1d vector space over `ℝ` with an inner product.
-
-Within other modules e.g. `TimeMan` and `TimeTransMan`, we define
-versions of time with less choices made, and relate them to `Time` via a choice of units
-or origin.
-
-## ii. Key results
-
-- `Time` : The type representing time with a choice of units and origin.
-
-## iii. Table of contents
-
-- A. The definition of `Time`
-- B. Instances on Time
-  - B.1. Natural numbers as elements of `Time`
-  - B.2. Real numbers as elements of `Time`
-  - B.3. Time is inhabited
-  - B.4. The order on `Time`
-  - B.5. Addition of times
-  - B.6. Negation of times
-  - B.7. Subtraction of times
-  - B.8. Scalar multiplication of time
-  - B.9. Module on `Time`
-  - B.10. Norm of time
-  - B.11. Inner product on `Time`
-  - B.12. Decidability of `Time`
-  - B.13. Measurability of `Time`
-- C. Basis of `Time`
-- D. Maps from `Time` to `ℝ`
-
-## iv. References
-
-* None.
+The field `Time.val` is an implementation coordinate, not a frame-relative time
+coordinate. A reference frame chooses its own time origin. Import
+`Physlib.SpaceAndTime.Time.Scalar` to use the additional scalar structure with the
+implicit origin `Time.mk 0`, including addition of instants, norms, and derivatives.
 -/
 
 @[expose] public section
 
 /-!
-
-## A. The definition of `Time`
-
+# A. The `Time` type
 -/
 
-/-- The type `Time` represents the time in a given (but arbitrary) set of units, and
-  with a given (but arbitrary) choice of origin. -/
+/-- An instant in time with a given unit and orientation, but no distinguished origin. -/
 @[ext]
 structure Time where
-  /-- The underlying real number associated with a point in time. -/
+  /-- The implementation coordinate associated with an instant. -/
   val : ℝ
 
 namespace Time
 
 lemma val_injective : Function.Injective val := fun _ _ h => Time.ext h
 
-/-!
-
-## B. Instances on Time
-
--/
+instance : Nonempty Time := ⟨⟨0⟩⟩
 
 /-!
-
-### B.1. Natural numbers as elements of `Time`
-
+# B. The affine structure
 -/
 
-instance : NatCast Time where
-  natCast n := ⟨n⟩
-
-/-- The casting of a natural number to an element of `Time`. This corresponds to a choice of
-(1) zero point in time, and (2) a choice of metric on time (defining `1`). -/
-instance {n : ℕ} : OfNat Time n where
-  ofNat := ⟨n⟩
+instance : VAdd ℝ Time where
+  vadd dt t := ⟨dt + t.val⟩
 
 @[simp]
-lemma natCast_val {n : ℕ} : val n = n := rfl
+lemma vadd_val (dt : ℝ) (t : Time) : (dt +ᵥ t).val = dt + t.val := rfl
+
+instance : VSub ℝ Time where
+  vsub t₁ t₂ := t₁.val - t₂.val
 
 @[simp]
-lemma natCast_zero : ((0 : ℕ) : Time) = 0 := rfl
-
-@[simp]
-lemma natCast_one : ((1 : ℕ) : Time) = 1 := rfl
-
-@[simp]
-lemma ofNat_val {n : ℕ} : val (OfNat.ofNat n : Time) = n := rfl
-
-lemma one_ne_zero : (1 : Time) ≠ (0 : Time) :=
-  mt (congrArg val) (Nat.cast_injective.ne Nat.one_ne_zero)
-
-@[simp]
-lemma zero_val : val 0 = 0 := by exact_mod_cast ofNat_val (n := 0)
-
-@[simp]
-lemma eq_zero_iff (t : Time) : t = 0 ↔ t.val = 0 := by simp [Time.ext_iff]
-
-@[simp]
-lemma one_val : val 1 = 1 := by exact_mod_cast ofNat_val (n := 1)
-
-@[simp]
-lemma eq_one_iff (t : Time) : t = 1 ↔ t.val = 1 := by simp [Time.ext_iff]
-
-/-!
-
-### B.2. Real numbers as elements of `Time`
-
--/
-
-instance : Coe ℝ Time where
-  coe r := ⟨r⟩
-
-instance : Coe Time ℝ where
-  coe := Time.val
-
-lemma realCast_val {r : ℝ} : (r : Time).val = r := rfl
-
-@[simp]
-lemma realCast_of_natCast {n : ℕ} : ((n : ℝ) : Time) = n := rfl
-
-/-!
-
-### B.3. Time is inhabited
-
--/
-
-instance : Inhabited Time where
-  default := 0
-
-@[simp]
-lemma default_eq_zero : default = 0 := rfl
-
-/-!
-
-### B.4. The order on `Time`
-
--/
-
-/-- The choice of an orientation on `Time`. -/
-instance : LE Time where
-  le t1 t2 := t1.val ≤ t2.val
-
-lemma le_def (t1 t2 : Time) :
-    t1 ≤ t2 ↔ t1.val ≤ t2.val := Iff.rfl
-
-instance : PartialOrder Time where
-  le_refl t := by simp [le_def]
-  le_trans t1 t2 t3 := by simp [le_def]; exact le_trans
-  le_antisymm t1 t2 h1 h2 := by simp_all [le_def]; ext; exact le_antisymm h1 h2
-
-lemma lt_def (t1 t2 : Time) :
-    t1 < t2 ↔ t1.val < t2.val := by simp only [lt_iff_le_not_ge, le_def]
-
-/-!
-
-### B.5. Addition of times
-
--/
-
-instance : Add Time where
-  add t1 t2 := ⟨t1.val + t2.val⟩
-
-@[simp]
-lemma add_val (t1 t2 : Time) :
-    (t1 + t2).val = t1.val + t2.val := rfl
-
-/-!
-
-### B.6. Negation of times
-
--/
-
-instance : Neg Time where
-  neg t := ⟨-t.val⟩
-
-@[simp]
-lemma neg_val (t : Time) :
-    (-t).val = -t.val := rfl
-
-/-!
-
-### B.7. Subtraction of times
-
--/
-
-instance : Sub Time where
-  sub t1 t2 := ⟨t1.val - t2.val⟩
-
-@[simp]
-lemma sub_val (t1 t2 : Time) :
-    (t1 - t2).val = t1.val - t2.val := rfl
-
-/-!
-
-### B.8. Scalar multiplication of time
-
--/
-
-instance : SMul ℝ Time where
-  smul k t := ⟨k * t.val⟩
-
-@[simp]
-lemma smul_real_val (k : ℝ) (t : Time) :
-    (k • t).val = k * t.val := rfl
-
-/-!
-
-### B.9. Module on `Time`
-
--/
-
-instance : AddGroup Time where
-  add_assoc t1 t2 t3 := by ext; simp [add_assoc]
-  zero_add t := by ext; simp [zero_add]
-  add_zero t := by ext; simp [add_zero]
-  neg_add_cancel t := by ext; simp [neg_add_cancel]
-  nsmul := nsmulRec
-  zsmul := zsmulRec
-
-instance : AddCommGroup Time where
-  add_comm := by intros; ext; simp [add_comm]
-
-instance : Module ℝ Time where
-  one_smul t := by ext; simp
-  smul_add k t1 t2 := by ext; simp [mul_add]
-  smul_zero k := by ext; simp [mul_zero]
-  add_smul k1 k2 t := by ext; simp [add_mul]
-  mul_smul k1 k2 t := by ext; simp [mul_assoc]
-  zero_smul t := by ext; simp
-
-/-!
-
-### B.10. Norm of time
-
--/
-
-instance : Norm Time where
-  norm t := ‖t.val‖
-
-lemma norm_eq_val (t : Time) :
-    ‖t‖ = ‖t.val‖ := rfl
-
-instance : Dist Time where
-  dist t1 t2 := ‖t1 - t2‖
-
-lemma dist_eq_val (t1 t2 : Time) :
-    dist t1 t2 = ‖t1.val - t2.val‖ := rfl
-
-lemma dist_eq_real_dist (t1 t2 : Time) :
-    dist t1 t2 = dist t1.val t2.val := by rfl
-
-instance : SeminormedAddCommGroup Time where
-  dist_self t := by simp [dist_eq_real_dist]
-  dist_comm t1 t2 := by simp [dist_eq_real_dist, dist_comm]
-  dist_triangle := by simp [dist_eq_real_dist, dist_triangle]
-  dist_eq t1 t2 := by
-    simp [dist_eq_val, norm_eq_val]
-    rw [abs_eq_iff_mul_self_eq]
-    ring
-
-instance : NormedAddCommGroup Time where
-  eq_of_dist_eq_zero := by
-    intro a b h
-    simp [dist, norm] at h
-    ext
-    rw [sub_eq_zero] at h
-    exact h
-  dist_eq t1 t2 := by
-    simp [dist_eq_val, norm_eq_val]
-    rw [abs_eq_iff_mul_self_eq]
-    ring
-
-instance : NormedSpace ℝ Time where
-  norm_smul_le k t := by simp [abs_mul, norm]
-
-/-!
-
-### B.11. Inner product on `Time`
-
--/
-
-open InnerProductSpace
-
-instance : Inner ℝ Time where
-  inner t1 t2 := t1.val * t2.val
-
-@[simp]
-lemma inner_def (t1 t2 : Time) :
-    ⟪t1, t2⟫_ℝ = t1.val * t2.val := rfl
-
-noncomputable instance : InnerProductSpace ℝ Time where
-  norm_sq_eq_re_inner := by intros; simp [norm]; ring
-  conj_inner_symm := by intros; simp [inner_def]; ring
-  add_left := by intros; simp [inner_def, add_mul]
-  smul_left := by intros; simp [inner_def]; ring
-
-/-!
-
-### B.12. Decidability of `Time`
-
--/
-
-noncomputable instance : DecidableEq Time := fun t1 t2 =>
-  decidable_of_iff (t1.val = t2.val) (Time.ext_iff.symm)
-
-/-!
-
-### B.13. Measurability of `Time`
-
--/
-instance : MeasurableSpace Time := borel Time
-
-instance : BorelSpace Time where
-  measurable_eq := by rfl
-
-/-!
-
-## C. Basis of `Time`
-
--/
-open MeasureTheory
-
-/-- The orthonomral basis on `Time` defined by `1`. -/
-noncomputable def basis : OrthonormalBasis (Fin 1) ℝ Time where
-  repr := {
-    toFun := fun x => WithLp.toLp 2 (fun _ => x)
-    invFun := fun f => ⟨f 0⟩
-    left_inv := by
-      intro x
-      rfl
-    right_inv := by
-      intro f
-      ext i
-      fin_cases i
-      rfl
-    map_add' := by
-      intro f g
-      ext i
-      fin_cases i
-      rfl
-    map_smul' := by
-      intro c f
-      ext i
-      fin_cases i
-      rfl
-    norm_map' := by
-      intro x
-      simp only [Fin.isValue, LinearEquiv.coe_mk, LinearMap.coe_mk, AddHom.coe_mk]
-      rw [@PiLp.norm_eq_of_L2]
-      simp only [Finset.univ_unique, Fin.default_eq_zero, Fin.isValue, Real.norm_eq_abs, sq_abs,
-        Finset.sum_const, Finset.card_singleton, one_smul]
-      rw [Real.sqrt_sq_eq_abs]
-      rfl
-  }
-
-@[simp]
-lemma basis_apply_eq_one (i : Fin 1) :
-    basis i = 1 := by
-  fin_cases i
-  simp [basis]
-  rfl
-
-@[simp]
-lemma rank_eq_one : Module.rank ℝ Time = 1 :=
-  rank_eq_one_iff.mpr ⟨1, one_ne_zero, fun v => ⟨v.val, Time.ext (by simp)⟩⟩
-
-@[simp]
-lemma finRank_eq_one : Module.finrank ℝ Time = 1 :=
-  Module.rank_eq_one_iff_finrank_eq_one.mp rank_eq_one
-
-instance : FiniteDimensional ℝ Time := Module.finite_of_rank_eq_one rank_eq_one
-
-lemma volume_eq_basis_addHaar :
-    (volume (α := Time)) = basis.toBasis.addHaar := basis.addHaar_eq_volume.symm
-
-/-!
-
-## D. Maps from `Time` to `ℝ`
-
--/
-
-/-- The continuous linear map from `Time` to `ℝ`. -/
-noncomputable def toRealCLM : Time →L[ℝ] ℝ := LinearMap.toContinuousLinearMap
-  {
-  toFun := Time.val
-  map_add' := by simp
-  map_smul' := by simp }
-
-/-- The continuous linear equivalence from `Time` to `ℝ`. -/
-noncomputable def toRealCLE : Time ≃L[ℝ] ℝ := LinearEquiv.toContinuousLinearEquiv
-  {
-  toFun := Time.val
-  invFun := fun x => ⟨x⟩
-  left_inv x := by rfl
-  right_inv x := by rfl
-  map_add' := by simp
-  map_smul' := by simp
-  }
-
-/-- The linear isometry equivalence from `Time` to `ℝ`. -/
-noncomputable def toRealLIE : Time ≃ₗᵢ[ℝ] ℝ where
-  toFun := Time.val
-  invFun := fun x => ⟨x⟩
-  left_inv x := by rfl
-  right_inv x := by rfl
-  map_add' := by simp
-  map_smul' := by simp
-  norm_map' x := by
-    simp
-    rfl
-
-lemma eq_one_smul (t : Time) :
-    t = t.val • 1 := Time.ext (by simp)
-
-@[fun_prop]
-lemma val_measurable : Measurable Time.val := toRealCLE.continuous.measurable
-
-lemma val_measurableEmbedding : MeasurableEmbedding Time.val :=
-  toRealCLE.toHomeomorph.measurableEmbedding
-
-lemma val_measurePreserving : MeasurePreserving Time.val volume volume :=
-  LinearIsometryEquiv.measurePreserving toRealLIE
-
-@[fun_prop]
-lemma val_differentiable : Differentiable ℝ Time.val := toRealCLM.differentiable
-
-@[simp]
-lemma fderiv_val (t : Time) : fderiv ℝ Time.val t 1 = 1 := by
-  rw [show Time.val = ⇑toRealCLM from rfl, ContinuousLinearMap.fderiv]
-  simp [toRealCLM]
+lemma vsub_eq_val (t₁ t₂ : Time) : t₁ -ᵥ t₂ = t₁.val - t₂.val := rfl
+
+instance : AddTorsor ℝ Time where
+  zero_vadd t := by ext; simp
+  add_vadd dt₁ dt₂ t := by ext; simp [add_assoc]
+  vsub_vadd' t₁ t₂ := by ext; simp
+  vadd_vsub' dt t := by simp
 
 end Time

--- a/Physlib/SpaceAndTime/Time/Basic.lean
+++ b/Physlib/SpaceAndTime/Time/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Data.Real.Basic
 public import Mathlib.LinearAlgebra.AffineSpace.Defs
 /-!
-# Affine time
+# Time
 
 `Time` represents instants with a fixed but arbitrary unit and orientation. It is an
 affine space over `ℝ`: two instants determine a real-valued elapsed time, and adding

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -7,7 +7,7 @@ module
 
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 public import Physlib.SpaceAndTime.Space.Module
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Mathlib.Analysis.Calculus.Deriv.Inv
 public import Mathlib.Analysis.InnerProductSpace.Calculus
 /-!

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -7,7 +7,7 @@ module
 
 public import Physlib.Relativity.Tensors.RealTensor.Vector.Basic
 public import Physlib.SpaceAndTime.Space.Module
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Mathlib.Analysis.Calculus.Deriv.Inv
 public import Mathlib.Analysis.InnerProductSpace.Calculus
 /-!

--- a/Physlib/SpaceAndTime/Time/InnerProductSpace.lean
+++ b/Physlib/SpaceAndTime/Time/InnerProductSpace.lean
@@ -9,12 +9,12 @@ public import Mathlib.Analysis.Calculus.FDeriv.Linear
 public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 public import Physlib.SpaceAndTime.Time.Basic
 /-!
-# Scalar structure on time
+# Time as an inner product space
 
 ## i. Overview
 
-In this module we equip the affine type `Time` with scalar structure, choosing the
-implicit origin represented by `Time.mk 0`. The units and orientation agree with the
+In this module we equip the affine type `Time` with a real inner product space structure,
+choosing the implicit origin represented by `Time.mk 0`. The units and orientation agree with the
 real-valued displacements defined in `Physlib.SpaceAndTime.Time.Basic`.
 
 We note that this is the version of time most often used in undergraduate and
@@ -38,7 +38,7 @@ or origin.
 
 ## ii. Key results
 
-- `toRealCLE` : The continuous linear equivalence with real-valued scalar time.
+- `toRealCLE` : The continuous linear equivalence from `Time` to `ℝ`.
 
 ## iii. Table of contents
 

--- a/Physlib/SpaceAndTime/Time/Scalar.lean
+++ b/Physlib/SpaceAndTime/Time/Scalar.lean
@@ -1,0 +1,446 @@
+/-
+Copyright (c) 2025 Joseph Tooby-Smith. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith
+-/
+module
+
+public import Mathlib.Analysis.Calculus.FDeriv.Linear
+public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+public import Physlib.SpaceAndTime.Time.Basic
+/-!
+# Scalar structure on time
+
+## i. Overview
+
+In this module we equip the affine type `Time` with scalar structure, choosing the
+implicit origin represented by `Time.mk 0`. The units and orientation agree with the
+real-valued displacements defined in `Physlib.SpaceAndTime.Time.Basic`.
+
+We note that this is the version of time most often used in undergraduate and
+non-mathematical physics.
+
+The choice of units or origin can be made on a case-by-case basis, as
+long as they are done consistently. However, since the choice of units and origin is
+left implicit, Lean will not catch inconsistencies in the choice of units or origin when
+working with `Time`.
+
+For example, for the classical mechanics system corresponding to the harmonic oscillator,
+one can take the origin of time to be the time at which the initial conditions are specified,
+and the units can be taken as anything as long as the units chosen for time `t` and
+the angular frequency `ω` are consistent.
+
+With this choice, `Time` becomes a 1d vector space over `ℝ` with an inner product.
+
+Within other modules e.g. `TimeMan` and `TimeTransMan`, we define
+versions of time with less choices made, and relate them to `Time` via a choice of units
+or origin.
+
+## ii. Key results
+
+- `toRealCLE` : The continuous linear equivalence with real-valued scalar time.
+
+## iii. Table of contents
+
+- A. Instances on Time
+  - A.1. Natural numbers as elements of `Time`
+  - A.2. Real numbers as elements of `Time`
+  - A.3. Time is inhabited
+  - A.4. The order on `Time`
+  - A.5. Addition of times
+  - A.6. Negation of times
+  - A.7. Subtraction of times
+  - A.8. Scalar multiplication of time
+  - A.9. Module on `Time`
+  - A.10. Norm of time
+  - A.11. Inner product on `Time`
+  - A.12. Decidability of `Time`
+  - A.13. Measurability of `Time`
+- B. Basis of `Time`
+- C. Maps from `Time` to `ℝ`
+
+## iv. References
+
+* None.
+-/
+
+@[expose] public section
+
+namespace Time
+
+/-!
+
+## A. Instances on Time
+
+-/
+
+/-!
+
+### A.1. Natural numbers as elements of `Time`
+
+-/
+
+instance : NatCast Time where
+  natCast n := ⟨n⟩
+
+/-- The casting of a natural number to an element of `Time`. This corresponds to a choice of
+(1) zero point in time, and (2) a choice of metric on time (defining `1`). -/
+instance {n : ℕ} : OfNat Time n where
+  ofNat := ⟨n⟩
+
+@[simp]
+lemma natCast_val {n : ℕ} : val n = n := rfl
+
+@[simp]
+lemma natCast_zero : ((0 : ℕ) : Time) = 0 := rfl
+
+@[simp]
+lemma natCast_one : ((1 : ℕ) : Time) = 1 := rfl
+
+@[simp]
+lemma ofNat_val {n : ℕ} : val (OfNat.ofNat n : Time) = n := rfl
+
+lemma one_ne_zero : (1 : Time) ≠ (0 : Time) :=
+  mt (congrArg val) (Nat.cast_injective.ne Nat.one_ne_zero)
+
+@[simp]
+lemma zero_val : val 0 = 0 := by exact_mod_cast ofNat_val (n := 0)
+
+@[simp]
+lemma eq_zero_iff (t : Time) : t = 0 ↔ t.val = 0 := by simp [Time.ext_iff]
+
+@[simp]
+lemma one_val : val 1 = 1 := by exact_mod_cast ofNat_val (n := 1)
+
+@[simp]
+lemma eq_one_iff (t : Time) : t = 1 ↔ t.val = 1 := by simp [Time.ext_iff]
+
+/-!
+
+### A.2. Real numbers as elements of `Time`
+
+-/
+
+instance : Coe ℝ Time where
+  coe r := ⟨r⟩
+
+instance : Coe Time ℝ where
+  coe := Time.val
+
+lemma realCast_val {r : ℝ} : (r : Time).val = r := rfl
+
+@[simp]
+lemma realCast_of_natCast {n : ℕ} : ((n : ℝ) : Time) = n := rfl
+
+/-!
+
+### A.3. Time is inhabited
+
+-/
+
+instance : Inhabited Time where
+  default := 0
+
+@[simp]
+lemma default_eq_zero : default = 0 := rfl
+
+/-!
+
+### A.4. The order on `Time`
+
+-/
+
+/-- The choice of an orientation on `Time`. -/
+instance : LE Time where
+  le t1 t2 := t1.val ≤ t2.val
+
+lemma le_def (t1 t2 : Time) :
+    t1 ≤ t2 ↔ t1.val ≤ t2.val := Iff.rfl
+
+instance : PartialOrder Time where
+  le_refl t := by simp [le_def]
+  le_trans t1 t2 t3 := by simp [le_def]; exact le_trans
+  le_antisymm t1 t2 h1 h2 := by simp_all [le_def]; ext; exact le_antisymm h1 h2
+
+lemma lt_def (t1 t2 : Time) :
+    t1 < t2 ↔ t1.val < t2.val := by simp only [lt_iff_le_not_ge, le_def]
+
+/-!
+
+### A.5. Addition of times
+
+-/
+
+instance : Add Time where
+  add t1 t2 := ⟨t1.val + t2.val⟩
+
+@[simp]
+lemma add_val (t1 t2 : Time) :
+    (t1 + t2).val = t1.val + t2.val := rfl
+
+/-!
+
+### A.6. Negation of times
+
+-/
+
+instance : Neg Time where
+  neg t := ⟨-t.val⟩
+
+@[simp]
+lemma neg_val (t : Time) :
+    (-t).val = -t.val := rfl
+
+/-!
+
+### A.7. Subtraction of times
+
+-/
+
+instance : Sub Time where
+  sub t1 t2 := ⟨t1.val - t2.val⟩
+
+@[simp]
+lemma sub_val (t1 t2 : Time) :
+    (t1 - t2).val = t1.val - t2.val := rfl
+
+/-!
+
+### A.8. Scalar multiplication of time
+
+-/
+
+instance : SMul ℝ Time where
+  smul k t := ⟨k * t.val⟩
+
+@[simp]
+lemma smul_real_val (k : ℝ) (t : Time) :
+    (k • t).val = k * t.val := rfl
+
+/-!
+
+### A.9. Module on `Time`
+
+-/
+
+instance : AddGroup Time where
+  add_assoc t1 t2 t3 := by ext; simp [add_assoc]
+  zero_add t := by ext; simp [zero_add]
+  add_zero t := by ext; simp [add_zero]
+  neg_add_cancel t := by ext; simp [neg_add_cancel]
+  nsmul := nsmulRec
+  zsmul := zsmulRec
+
+instance : AddCommGroup Time where
+  add_comm := by intros; ext; simp [add_comm]
+
+instance : Module ℝ Time where
+  one_smul t := by ext; simp
+  smul_add k t1 t2 := by ext; simp [mul_add]
+  smul_zero k := by ext; simp [mul_zero]
+  add_smul k1 k2 t := by ext; simp [add_mul]
+  mul_smul k1 k2 t := by ext; simp [mul_assoc]
+  zero_smul t := by ext; simp
+
+/-!
+
+### A.10. Norm of time
+
+-/
+
+instance : Norm Time where
+  norm t := ‖t.val‖
+
+lemma norm_eq_val (t : Time) :
+    ‖t‖ = ‖t.val‖ := rfl
+
+instance : Dist Time where
+  dist t1 t2 := ‖t1 - t2‖
+
+lemma dist_eq_val (t1 t2 : Time) :
+    dist t1 t2 = ‖t1.val - t2.val‖ := rfl
+
+lemma dist_eq_real_dist (t1 t2 : Time) :
+    dist t1 t2 = dist t1.val t2.val := by rfl
+
+instance : SeminormedAddCommGroup Time where
+  dist_self t := by simp [dist_eq_real_dist]
+  dist_comm t1 t2 := by simp [dist_eq_real_dist, dist_comm]
+  dist_triangle := by simp [dist_eq_real_dist, dist_triangle]
+  dist_eq t1 t2 := by
+    simp [dist_eq_val, norm_eq_val]
+    rw [abs_eq_iff_mul_self_eq]
+    ring
+
+instance : NormedAddCommGroup Time where
+  eq_of_dist_eq_zero := by
+    intro a b h
+    simp [dist, norm] at h
+    ext
+    rw [sub_eq_zero] at h
+    exact h
+  dist_eq t1 t2 := by
+    simp [dist_eq_val, norm_eq_val]
+    rw [abs_eq_iff_mul_self_eq]
+    ring
+
+instance : NormedSpace ℝ Time where
+  norm_smul_le k t := by simp [abs_mul, norm]
+
+/-!
+
+### A.11. Inner product on `Time`
+
+-/
+
+open InnerProductSpace
+
+instance : Inner ℝ Time where
+  inner t1 t2 := t1.val * t2.val
+
+@[simp]
+lemma inner_def (t1 t2 : Time) :
+    ⟪t1, t2⟫_ℝ = t1.val * t2.val := rfl
+
+noncomputable instance : InnerProductSpace ℝ Time where
+  norm_sq_eq_re_inner := by intros; simp [norm]; ring
+  conj_inner_symm := by intros; simp [inner_def]; ring
+  add_left := by intros; simp [inner_def, add_mul]
+  smul_left := by intros; simp [inner_def]; ring
+
+/-!
+
+### A.12. Decidability of `Time`
+
+-/
+
+noncomputable instance : DecidableEq Time := fun t1 t2 =>
+  decidable_of_iff (t1.val = t2.val) (Time.ext_iff.symm)
+
+/-!
+
+### A.13. Measurability of `Time`
+
+-/
+instance : MeasurableSpace Time := borel Time
+
+instance : BorelSpace Time where
+  measurable_eq := by rfl
+
+/-!
+
+## B. Basis of `Time`
+
+-/
+open MeasureTheory
+
+/-- The orthonomral basis on `Time` defined by `1`. -/
+noncomputable def basis : OrthonormalBasis (Fin 1) ℝ Time where
+  repr := {
+    toFun := fun x => WithLp.toLp 2 (fun _ => x)
+    invFun := fun f => ⟨f 0⟩
+    left_inv := by
+      intro x
+      rfl
+    right_inv := by
+      intro f
+      ext i
+      fin_cases i
+      rfl
+    map_add' := by
+      intro f g
+      ext i
+      fin_cases i
+      rfl
+    map_smul' := by
+      intro c f
+      ext i
+      fin_cases i
+      rfl
+    norm_map' := by
+      intro x
+      simp only [Fin.isValue, LinearEquiv.coe_mk, LinearMap.coe_mk, AddHom.coe_mk]
+      rw [@PiLp.norm_eq_of_L2]
+      simp only [Finset.univ_unique, Fin.default_eq_zero, Fin.isValue, Real.norm_eq_abs, sq_abs,
+        Finset.sum_const, Finset.card_singleton, one_smul]
+      rw [Real.sqrt_sq_eq_abs]
+      rfl
+  }
+
+@[simp]
+lemma basis_apply_eq_one (i : Fin 1) :
+    basis i = 1 := by
+  fin_cases i
+  simp [basis]
+  rfl
+
+@[simp]
+lemma rank_eq_one : Module.rank ℝ Time = 1 :=
+  rank_eq_one_iff.mpr ⟨1, one_ne_zero, fun v => ⟨v.val, Time.ext (by simp)⟩⟩
+
+@[simp]
+lemma finRank_eq_one : Module.finrank ℝ Time = 1 :=
+  Module.rank_eq_one_iff_finrank_eq_one.mp rank_eq_one
+
+instance : FiniteDimensional ℝ Time := Module.finite_of_rank_eq_one rank_eq_one
+
+lemma volume_eq_basis_addHaar :
+    (volume (α := Time)) = basis.toBasis.addHaar := basis.addHaar_eq_volume.symm
+
+/-!
+
+## C. Maps from `Time` to `ℝ`
+
+-/
+
+/-- The continuous linear map from `Time` to `ℝ`. -/
+noncomputable def toRealCLM : Time →L[ℝ] ℝ := LinearMap.toContinuousLinearMap
+  {
+  toFun := Time.val
+  map_add' := by simp
+  map_smul' := by simp }
+
+/-- The continuous linear equivalence from `Time` to `ℝ`. -/
+noncomputable def toRealCLE : Time ≃L[ℝ] ℝ := LinearEquiv.toContinuousLinearEquiv
+  {
+  toFun := Time.val
+  invFun := fun x => ⟨x⟩
+  left_inv x := by rfl
+  right_inv x := by rfl
+  map_add' := by simp
+  map_smul' := by simp
+  }
+
+/-- The linear isometry equivalence from `Time` to `ℝ`. -/
+noncomputable def toRealLIE : Time ≃ₗᵢ[ℝ] ℝ where
+  toFun := Time.val
+  invFun := fun x => ⟨x⟩
+  left_inv x := by rfl
+  right_inv x := by rfl
+  map_add' := by simp
+  map_smul' := by simp
+  norm_map' x := by
+    simp
+    rfl
+
+lemma eq_one_smul (t : Time) :
+    t = t.val • 1 := Time.ext (by simp)
+
+@[fun_prop]
+lemma val_measurable : Measurable Time.val := toRealCLE.continuous.measurable
+
+lemma val_measurableEmbedding : MeasurableEmbedding Time.val :=
+  toRealCLE.toHomeomorph.measurableEmbedding
+
+lemma val_measurePreserving : MeasurePreserving Time.val volume volume :=
+  LinearIsometryEquiv.measurePreserving toRealLIE
+
+@[fun_prop]
+lemma val_differentiable : Differentiable ℝ Time.val := toRealCLM.differentiable
+
+@[simp]
+lemma fderiv_val (t : Time) : fderiv ℝ Time.val t 1 = 1 := by
+  rw [show Time.val = ⇑toRealCLM from rfl, ContinuousLinearMap.fderiv]
+  simp [toRealCLM]
+
+end Time

--- a/Physlib/SpaceAndTime/Time/TimeTransMan.lean
+++ b/Physlib/SpaceAndTime/Time/TimeTransMan.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Geometry.Manifold.Diffeomorph
 public import Physlib.Meta.TODO.Basic
-public import Physlib.SpaceAndTime.Time.Scalar
+public import Physlib.SpaceAndTime.Time.InnerProductSpace
 public import Physlib.SpaceAndTime.Time.TimeUnit
 /-!
 

--- a/Physlib/SpaceAndTime/Time/TimeTransMan.lean
+++ b/Physlib/SpaceAndTime/Time/TimeTransMan.lean
@@ -6,6 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Mathlib.Geometry.Manifold.Diffeomorph
+public import Physlib.Meta.TODO.Basic
 public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.SpaceAndTime.Time.TimeUnit
 /-!
@@ -46,6 +47,8 @@ This map is a diffeomorphism (to be shown).
 -/
 
 @[expose] public section
+
+TODO "Remove `TimeTransMan` in favor of affine `Time`."
 
 /-- The type `TimeTransMan` represents the time manifold with an orientation and
   a transitive action of the reals. -/

--- a/Physlib/SpaceAndTime/Time/TimeTransMan.lean
+++ b/Physlib/SpaceAndTime/Time/TimeTransMan.lean
@@ -6,7 +6,7 @@ Authors: Joseph Tooby-Smith
 module
 
 public import Mathlib.Geometry.Manifold.Diffeomorph
-public import Physlib.SpaceAndTime.Time.Basic
+public import Physlib.SpaceAndTime.Time.Scalar
 public import Physlib.SpaceAndTime.Time.TimeUnit
 /-!
 

--- a/docs/API_MAP_GUIDE.md
+++ b/docs/API_MAP_GUIDE.md
@@ -68,7 +68,7 @@ linter) find the exact declarations that realize the requirement. The grammar
 is: one or more file groups, each a file path followed by a parenthesized,
 comma-separated list of names.
 
-    Physlib/SpaceAndTime/Time/Scalar.lean (AddCommGroup Time, toRealCLM)
+    Physlib/SpaceAndTime/Time/InnerProductSpace.lean (AddCommGroup Time, toRealCLM)
 
 Rules:
 

--- a/docs/API_MAP_GUIDE.md
+++ b/docs/API_MAP_GUIDE.md
@@ -68,7 +68,7 @@ linter) find the exact declarations that realize the requirement. The grammar
 is: one or more file groups, each a file path followed by a parenthesized,
 comma-separated list of names.
 
-    Physlib/SpaceAndTime/Time/Basic.lean (Time, AddCommGroup Time, toRealCLM)
+    Physlib/SpaceAndTime/Time/Scalar.lean (AddCommGroup Time, toRealCLM)
 
 Rules:
 


### PR DESCRIPTION
## Summary

Follow-up to the time-origin discussion in #1612. There, `ReferenceFrame` carried no time data and its docstring declared `Time` equivalent to time coordinates in every frame. This PR removes that convention: `Time` becomes an affine space over `ℝ`, each `ReferenceFrame` carries its own `timeOrigin`, and frame-relative quantities become functions of the frame's real-valued time coordinate.

## Motivation

* **Time is affine, like space.** `ReferenceFrame.lean` already argues that a point of `Space d` is not a coordinate: two points determine a displacement, but the zero point belongs to the frame. The same holds for instants of time. Two instants determine a real elapsed duration, but no instant is canonically zero. `AddTorsor ℝ Time` encodes this, and `Time.val` is demoted to an implementation coordinate.
* **The time origin belongs to the frame; the time basis does not.** A Galilean transformation may translate time but never rescales or reverses it, so a frame records `timeOrigin : Time` and nothing else about time. Unit and orientation stay global, exactly as spatial units are shared across frames.
* **Coordinates are real numbers.** Positions, velocities, and forces are already frame coordinate tuples (`frame.Vector`), not points of `Space d`. Their time argument should likewise be the frame coordinate `ℝ`, not the absolute `Time`. `ReferenceFrame.timeEquiv` converts back when an absolute instant is needed.
* **Existing uses of `Time` are preserved.** The full scalar structure moves to `Time.Scalar`, with imports updated where needed. `Time.Basic` contains the affine structure, so `ReferenceFrame` only depends on it.