### PR TITLE
docs: fix broken contribution links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 [![](https://img.shields.io/badge/Getting-Started-darkgreen)](https://physlib.io/GettingStarted.html)
 [![](https://img.shields.io/badge/The-Website-darkgreen)](https://physlib.io)
-[![](https://img.shields.io/badge/How_To-Get_Involved-darkgreen)](https://physlib.io/GetInvolved.html)
+[![](https://img.shields.io/badge/How_To-Get_Involved-darkgreen)](https://physlib.io/get-involved)
 [![](https://img.shields.io/badge/Physlib_Zulip-Discussion-darkgreen)](https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib/)
-[![](https://img.shields.io/badge/TODO-List-darkgreen)](https://physlib.io/TODOList)
+[![](https://img.shields.io/badge/TODO-List-darkgreen)](https://physlib.io/todo)
 
 
 [![](https://img.shields.io/badge/View_The-Stats-blue)](https://physlib.io/Stats)
@@ -116,9 +116,9 @@ and add them to the .bib file.
 
 If you unsure where you would like to contribute, you may find ideas on:
 - our [open issues](https://github.com/leanprover-community/physlib/issues).
-- our [todo list](https://physlib.io/TODOList)
-- our [Get Involved page](https://physlib.io/GetInvolved.html)
-- the [quantumInfo todo page](./QuantumInfo/WildeTODO.md)
+- our [todo list](https://physlib.io/todo)
+- our [Get Involved page](https://physlib.io/get-involved)
+- the [quantumInfo todo page](./docs/WildeTODO.md)
 > [!NOTE]
 > If stuck at any point there are lots of people happly to help on the [Physlib zulip](https://leanprover.zulipchat.com/#narrow/channel/479953-Physlib)
 


### PR DESCRIPTION
## Summary

Closes #1624.

Fix five link destinations in `README.md`:
- Both TODO list links: `/TODOList` → `/todo`.
- Both Get Involved links: `/GetInvolved.html` → `/get-involved`.
- QuantumInfo checklist: `./QuantumInfo/WildeTODO.md` → `./docs/WildeTODO.md`.

Existing link text and badge images are unchanged. No Lean definitions or lemmas are added, removed, or modified.

## Reviewer map

Review the two changed badge links, then the three links under **Contributing to Physlib**. `README.md` is the only changed file.

## Validation

- Confirmed the old website URLs return HTTP 404 and the replacements return HTTP 200.
- Confirmed `docs/WildeTODO.md` exists in the repository.
- Checked that the diff contains exactly the five intended replacements.
- `git diff --check` and `./scripts/lint-style.sh` passed.
- Lean build and Lean-based linters were not run locally: Lean/Lake is not installed in this environment. This is a documentation-only change.

AI-assisted with GitHub Copilot (GPT-6 Astra); the broken links were identified by the human contributor.
