### PR TITLE
feat(QuantumMechanics/Blackbody): Added Canonical Definition Planck's law

### DIFF
--- a/Physlib.lean
+++ b/Physlib.lean
@@ -324,6 +324,7 @@ public import Physlib.QFT.QED.AnomalyCancellation.Odd.Parameterization
 public import Physlib.QFT.QED.AnomalyCancellation.Permutations
 public import Physlib.QFT.QED.AnomalyCancellation.Sorts
 public import Physlib.QFT.QED.AnomalyCancellation.VectorLike
+public import Physlib.QuantumMechanics.Blackbody.PlancksLaw
 public import Physlib.QuantumMechanics.FiniteTarget
 public import Physlib.QuantumMechanics.FreeParticle.Basic
 public import Physlib.QuantumMechanics.HarmonicOscillator.Basic

--- a/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
+++ b/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
@@ -79,3 +79,9 @@ lemma spectralRadiance_pos (c : SpeedOfLight) (ν : ℝ) (T : Temperature)
         div_pos (mul_pos h_pos ν_pos) (mul_pos kB_pos (by exact_mod_cast T_pos))
       exact mul_pos (pow_pos c.val_pos 2)
        (sub_pos.mpr (by simpa using Real.exp_strictMono expo_term))
+
+/-- For a given ν frequency, the spectral radiance of a blackbody is 0 at
+    absolute zero temperature. -/
+lemma spectralRadiance_absZero (c : SpeedOfLight) (ν : ℝ) :
+    spectralRadiance c ν ⟨0⟩ = 0 := by
+    simp [spectralRadiance]

--- a/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
+++ b/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
@@ -36,6 +36,7 @@ where `h` is Planck's constant, `c` the speed of light, and `k_B` the Boltzmann 
 - `spectralRadiance` : The spectral radiance per unit frequency of blackbody radiation.
 - `spectralRadiance_pos` : The spectral radiance is positive for positive frequency
   and temperature.
+- `spectralRadiance_absZero` : The spectral radiance is 0 at absolute zero.
 
 ## iii. Table of contents
 

--- a/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
+++ b/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Samyak Rai. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samyak Rai
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Exponential
+public import Physlib.Meta.Informal.Basic
+public import Physlib.Thermodynamics.Temperature.Basic
+public import Physlib.StatisticalMechanics.BoltzmannConstant
+public import Physlib.Relativity.SpeedOfLight
+public import Physlib.QuantumMechanics.PlanckConstant
+
+/-!
+
+# Planck's Law
+
+In this module we define Planck's law for blackbody radiation: The spectral density of
+electromagnetic radiation emitted by a black body in thermal equilibrium at a given
+temperature T, when there is no net flow of matter or energy between the body and
+its environment.
+
+## i. Overview
+
+According to Planck's distribution law, the spectral energy radiance
+(per unit frequency) for a black body at given temperature `T` as a function of frequence `ν`
+ is given by
+
+    `B(ν, T) = 2 h ν³ / c² · 1 / (e^{h ν / (k_B T)} - 1)`
+
+where `h` is Planck's constant, `c` the speed of light, and `k_B` the Boltzmann constant.
+
+## ii. Key results
+
+- `spectralRadiance` : The spectral radiance per unit frequency of blackbody radiation.
+- `spectralRadiance_pos` : The spectral radiance is positive for positive frequency
+  and temperature.
+
+## iii. Table of contents
+
+- A. The spectral radiance
+
+## iv. References
+
+* https://en.wikipedia.org/wiki/Planck%27s_law
+
+-/
+
+@[expose] public section
+
+
+namespace Constants
+
+/-!
+## A. The spectral radiance
+-/
+
+open Constants
+
+/-- The spectral radiance per unit frequency of blackbody radiation at frequency `ν`
+    and temperature `T`, for a system of units in which the speed of light is `c`:
+
+    `B(ν, T) = 2 h ν³ / c² · 1 / (e^{h ν / (k_B T)} - 1)`
+
+    By the homogeneity and isotropy of blackbody radiation, the spectral radiance
+    is independent of position and direction, so it depends only on frequency
+    and temperature.  -/
+noncomputable def spectralRadiance (c : SpeedOfLight) (ν : ℝ) (T : Temperature) : ℝ :=
+    2 * h * ν ^ 3 / ((c : ℝ) ^ 2 * (Real.exp (h * ν / (kB * (T : ℝ))) - 1))
+
+/-- The spectral radiance of blackbody radiation is positive for positive frequency
+    and positive temperature. -/
+lemma spectralRadiance_pos (c : SpeedOfLight) (ν : ℝ) (T : Temperature)
+    (ν_pos : 0 < ν) (T_pos : 0 < T.val) : 0 < spectralRadiance c ν T := by
+    refine div_pos ?numerator ?denominator
+    · exact mul_pos (mul_pos (by norm_num) h_pos) (pow_pos ν_pos 3)
+    · have expo_term : 0 < h * ν / (kB * (T : ℝ)) :=
+        div_pos (mul_pos h_pos ν_pos) (mul_pos kB_pos (by exact_mod_cast T_pos))
+      exact mul_pos (pow_pos c.val_pos 2)
+       (sub_pos.mpr (by simpa using Real.exp_strictMono expo_term))

--- a/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
+++ b/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
@@ -24,7 +24,7 @@ its environment.
 ## i. Overview
 
 According to Planck's distribution law, the spectral energy radiance
-(per unit frequency) for a black body at given temperature `T` as a function of frequence `ν`
+(per unit frequency) for a black body at given temperature `T` as a function of frequency `ν`
  is given by
 
     `B(ν, T) = 2 h ν³ / c² · 1 / (e^{h ν / (k_B T)} - 1)`

--- a/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
+++ b/Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean
@@ -50,7 +50,7 @@ where `h` is Planck's constant, `c` the speed of light, and `k_B` the Boltzmann 
 @[expose] public section
 
 
-namespace Constants
+namespace Blackbody
 
 /-!
 ## A. The spectral radiance
@@ -65,14 +65,21 @@ open Constants
 
     By the homogeneity and isotropy of blackbody radiation, the spectral radiance
     is independent of position and direction, so it depends only on frequency
-    and temperature.  -/
+    and temperature.
+
+    Extended by zero outside the physical domain; zero is the unique continuous
+    extension since the Rayleigh–Jeans limit vanishes -/
 noncomputable def spectralRadiance (c : SpeedOfLight) (ν : ℝ) (T : Temperature) : ℝ :=
-    2 * h * ν ^ 3 / ((c : ℝ) ^ 2 * (Real.exp (h * ν / (kB * (T : ℝ))) - 1))
+    if 0 < ν ∧ 0 < (T : ℝ) then
+      2 * h * ν ^ 3 / ((c : ℝ) ^ 2 * (Real.exp (h * ν / (kB * (T : ℝ))) - 1))
+    else 0
 
 /-- The spectral radiance of blackbody radiation is positive for positive frequency
     and positive temperature. -/
 lemma spectralRadiance_pos (c : SpeedOfLight) (ν : ℝ) (T : Temperature)
     (ν_pos : 0 < ν) (T_pos : 0 < T.val) : 0 < spectralRadiance c ν T := by
+    have if_cond : 0 < ν ∧ 0 < (T : ℝ) := ⟨ν_pos, by exact_mod_cast T_pos⟩
+    rw [spectralRadiance, if_pos if_cond]
     refine div_pos ?numerator ?denominator
     · exact mul_pos (mul_pos (by norm_num) h_pos) (pow_pos ν_pos 3)
     · have expo_term : 0 < h * ν / (kB * (T : ℝ)) :=
@@ -80,8 +87,11 @@ lemma spectralRadiance_pos (c : SpeedOfLight) (ν : ℝ) (T : Temperature)
       exact mul_pos (pow_pos c.val_pos 2)
        (sub_pos.mpr (by simpa using Real.exp_strictMono expo_term))
 
-/-- For a given ν frequency, the spectral radiance of a blackbody is 0 at
-    absolute zero temperature. -/
+/-- Explicit promise for Spectral Radiance vanishing at absolute zero Temperature. -/
 lemma spectralRadiance_absZero (c : SpeedOfLight) (ν : ℝ) :
     spectralRadiance c ν ⟨0⟩ = 0 := by
-    simp [spectralRadiance]
+    rw [spectralRadiance, if_neg]
+    rintro ⟨ν_pos, T_zero⟩
+    exact lt_irrefl _ T_zero
+
+end Blackbody


### PR DESCRIPTION
## Description of Changes

New Directory at:
`Physlib/QuantumMechanics/Blackbody` to store further blackbody radiation related definitions and proofs.

New Files at:
`Physlib/QuantumMechanics/Blackbody/PlancksLaw.lean` Added definitions and positive and zero values lemmas for Spectral Radiance due to Planck's Law

Modified File at:
`Physlib.lean` added import for Planck's Law

## Reviewer Guide

I have added frequency with Real number type right now but plan to make changes to that later when frequency is implemented. Also the conversion between frequency and wavelength can be added after that.