### PR TITLE
feat(Cosmology): flat power-law solutions of the Friedmann equations (radiation, Einstein-de Sitter)

### DIFF
--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -1,27 +1,186 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
 public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.Basic
 /-!
 
 # Exact solutions of the Friedmann equations
 
-Placeholder file collecting TODO items for the standard closed-form solutions of
-the Friedmann equations: the de Sitter, radiation-dominated, Einstein-de Sitter
-(dust) and Milne models, together with the Einstein static universe. This file
-contains only TODO items; no definitions or lemmas are formalized yet.
+## i. Overview
+
+This file collects the standard closed-form solutions of the Friedmann equations
+(`FirstOrderFriedmann` and `SecondOrderFriedmann` of `Physlib.Cosmology.FLRW.Basic`) and
+proves that they solve them: the de Sitter solution here, the radiation-dominated,
+Einstein-de Sitter and Milne models and the Einstein static universe being still TODO items.
+
+Each solution is a scale factor `a : Time → ℝ` given by an explicit function of the time
+coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridge
+`deriv_comp_toRealCLE_of_hasDerivAt` from Mathlib's `HasDerivAt` on `ℝ`.
+
+## ii. Key results
+
+- `deSitterScaleFactor`: `a(t) = a₀ exp(σ √(Λ/3) c t)` with `σ = ±1`.
+- `deSitterScaleFactor_firstOrderFriedmann`, `deSitterScaleFactor_secondOrderFriedmann`:
+  it solves both Friedmann equations with `ρ = 0`, `p = 0`, `k = 0` and `Λ > 0`.
+- `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
+  (for any `σ`, `Λ`, `c`).
+- `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
+
+## iii. Table of contents
+
+- A. Time derivatives of curves given by a function of the coordinate
+- B. The de Sitter solution
+  - B.1. The scale factor and its derivatives
+  - B.2. The Friedmann equations
+  - B.3. The Hubble and deceleration parameters
+- C. Remaining TODO items
 
 -/
 
 @[expose] public section
 
-TODO "Prove that the de Sitter solution `a(t) = a₀ exp(±√(Λ/3) c t)` (with `ρ = 0`,
-  `K = 0`, `Λ > 0`) solves the Friedmann equations, and that its deceleration
-  parameter is `q = −1`."
+namespace Cosmology.FLRW.FriedmannEquation
+
+open Real Time
+
+/-!
+
+## A. Time derivatives of curves given by a function of the coordinate
+
+A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
+its time derivative is the Mathlib derivative of `γ`.
+
+-/
+
+/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
+lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
+    ∂ₜ (fun s : Time => γ s.val) t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-!
+
+## B. The de Sitter solution
+
+-/
+
+/-!
+
+### B.1. The scale factor and its derivatives
+
+-/
+
+/-- The de Sitter scale factor `a(t) = a₀ exp(σ √(Λ/3) c t)`, for `σ = ±1`
+  (the expanding branch is `σ = 1`). -/
+noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
+  fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
+
+/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
+lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
+    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
+  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
+  refine h.congr_deriv ?_
+  simp only [id_eq]
+  ring
+
+lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
+    ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
+      fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
+  funext t
+  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+
+lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
+    ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
+      fun t => a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) *
+        Real.exp (σ * √(Λ / 3) * c * t.val) := by
+  rw [deriv_deSitterScaleFactor]
+  funext t
+  exact deriv_comp_val
+    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+
+/-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
+lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
+    (σ * √(Λ / 3) * c) ^ 2 = Λ * c ^ 2 / 3 := by
+  have hs : √(Λ / 3) ^ 2 = Λ / 3 := Real.sq_sqrt (by linarith)
+  rcases hσ with rfl | rfl <;> linear_combination c ^ 2 * hs
+
+/-!
+
+### B.2. The Friedmann equations
+
+-/
+
+/-- The de Sitter scale factor solves the first-order Friedmann equation with `ρ = 0`,
+  `k = 0` and `Λ > 0`. -/
+lemma deSitterScaleFactor_firstOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 < Λ)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    FirstOrderFriedmann (deSitterScaleFactor a₀ σ Λ c) (fun _ => 0) 0 Λ G c t := by
+  unfold FirstOrderFriedmann
+  rw [deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  rw [show a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) /
+      (a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)) = σ * √(Λ / 3) * c by field_simp,
+    sq_deSitterRate hΛ.le hσ]
+  ring
+
+/-- The de Sitter scale factor solves the second-order Friedmann equation with `ρ = 0`,
+  `p = 0` and `Λ > 0`. -/
+lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 < Λ)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    SecondOrderFriedmann (deSitterScaleFactor a₀ σ Λ c) (fun _ => 0) (fun _ => 0) Λ G c t := by
+  unfold SecondOrderFriedmann
+  rw [deriv_deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  rw [show a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) *
+      Real.exp (σ * √(Λ / 3) * c * t.val) / (a₀ * Real.exp (σ * √(Λ / 3) * c * t.val))
+      = (σ * √(Λ / 3) * c) ^ 2 by field_simp,
+    sq_deSitterRate hΛ.le hσ]
+  ring
+
+/-!
+
+### B.3. The Hubble and deceleration parameters
+
+-/
+
+/-- The Hubble parameter of the de Sitter solution is the constant `σ √(Λ/3) c`. -/
+lemma hubbleConstant_deSitterScaleFactor {a₀ σ Λ c : ℝ} (ha₀ : a₀ ≠ 0) (t : Time) :
+    hubbleConstant (deSitterScaleFactor a₀ σ Λ c) t = σ * √(Λ / 3) * c := by
+  unfold hubbleConstant
+  rw [deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  field_simp
+
+/-- The deceleration parameter of the de Sitter solution is `q = -1`. -/
+lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < Λ) (hc : 0 < c)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    decelerationParameter (deSitterScaleFactor a₀ σ Λ c) t = -1 := by
+  unfold decelerationParameter
+  rw [deriv_deriv_deSitterScaleFactor, deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  have hK : σ * √(Λ / 3) * c ≠ 0 := by
+    have hs : 0 < √(Λ / 3) := Real.sqrt_pos.mpr (by linarith)
+    rcases hσ with rfl | rfl
+    · positivity
+    · have : 0 < √(Λ / 3) * c := mul_pos hs hc
+      linarith
+  have hσ0 : σ ≠ 0 := by
+    rcases hσ with rfl | rfl <;> norm_num
+  field_simp
+
+/-!
+
+## C. Remaining TODO items
+
+-/
 
 TODO "Prove that the spatially flat radiation-dominated solution `a = (t/t₀)^(1/2)`
   solves the Friedmann equations, with `q₀ = 1` and `t₀ = 1 / (2 H₀)`."
@@ -35,3 +194,5 @@ TODO "Prove that the Milne solution `a = c t` (empty universe, `K < 0`) has
 
 TODO "Define the Einstein static universe (`∂ₜ a = ∂ₜ ∂ₜ a = 0`, forcing `K > 0`
   and `ρ_m = 2 ρ_Λ`) and prove that it is an unstable equilibrium."
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Meta.TODO.Basic
 public import Physlib.Cosmology.FLRW.Basic
+public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 /-!
 
 # Exact solutions of the Friedmann equations
@@ -15,8 +16,9 @@ public import Physlib.Cosmology.FLRW.Basic
 
 This file collects the standard closed-form solutions of the Friedmann equations
 (`FirstOrderFriedmann` and `SecondOrderFriedmann` of `Physlib.Cosmology.FLRW.Basic`) and
-proves that they solve them: the de Sitter solution here, the radiation-dominated,
-Einstein-de Sitter and Milne models and the Einstein static universe being still TODO items.
+proves that they solve them: the de Sitter solution and the spatially flat power-law
+solutions (radiation-dominated and Einstein-de Sitter) here, the Milne model and the
+Einstein static universe being still TODO items.
 
 Each solution is a scale factor `a : Time → ℝ` given by an explicit function of the time
 coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridge
@@ -30,6 +32,17 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 - `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
   (for any `σ`, `Λ`, `c`).
 - `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
+- `powerLawScaleFactor`: `a(t) = (t / t₀) ^ n`, with Hubble parameter `n / t`
+  (`hubbleConstant_powerLawScaleFactor`) and deceleration parameter `(1 - n) / n`
+  (`decelerationParameter_powerLawScaleFactor`) for `t > 0`.
+- `radiationScaleFactor_firstOrderFriedmann`, `radiationScaleFactor_secondOrderFriedmann`:
+  `a = (t / t₀) ^ (1/2)` solves the flat (`k = 0`, `Λ = 0`) Friedmann equations with the
+  density `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
+  `H(t₀) = 1 / (2 t₀)`.
+- `einsteinDeSitterScaleFactor_firstOrderFriedmann`,
+  `einsteinDeSitterScaleFactor_secondOrderFriedmann`: `a = (t / t₀) ^ (2/3)` solves the flat
+  Friedmann equations with the dust density `ρ = 1 / (6 π G t²)` and `p = 0`; `q = 1 / 2` and
+  `H(t₀) = 2 / (3 t₀)`.
 
 ## iii. Table of contents
 
@@ -38,7 +51,12 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   - B.1. The scale factor and its derivatives
   - B.2. The Friedmann equations
   - B.3. The Hubble and deceleration parameters
-- C. Remaining TODO items
+- C. The spatially flat power-law solutions
+  - C.1. The power-law scale factor and its derivatives
+  - C.2. The Hubble and deceleration parameters
+  - C.3. The radiation-dominated solution
+  - C.4. The Einstein-de Sitter solution
+- D. Remaining TODO items
 
 -/
 
@@ -61,6 +79,12 @@ its time derivative is the Mathlib derivative of `γ`.
 lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
     ∂ₜ (fun s : Time => γ s.val) t = v :=
   deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
+  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
+lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
+    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
 
 /-!
 
@@ -178,16 +202,234 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. Remaining TODO items
+## C. The spatially flat power-law solutions
+
+The radiation-dominated and Einstein-de Sitter solutions are both of the form
+`a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
+parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with
+`k = 0` and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`.
 
 -/
 
-TODO "Prove that the spatially flat radiation-dominated solution `a = (t/t₀)^(1/2)`
-  solves the Friedmann equations, with `q₀ = 1` and `t₀ = 1 / (2 H₀)`."
+/-!
 
-TODO "Prove that the Einstein-de Sitter (spatially flat, dust) solution
-  `a = (t/t₀)^(2/3)` solves the Friedmann equations, with `q₀ = 1/2` and
-  `t₀ = 2 / (3 H₀)`."
+### C.1. The power-law scale factor and its derivatives
+
+-/
+
+/-- The power-law scale factor `a(t) = (t / t₀) ^ n` (real power). -/
+noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
+  fun t => (t.val / t₀) ^ n
+
+/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
+lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
+    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
+  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
+    (Or.inl (div_ne_zero hx ht₀))
+  refine h.congr_deriv ?_
+  simp only [id_eq]
+  ring
+
+/-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
+lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+    (ht : t.val ≠ 0) :
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
+  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+
+/-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
+  only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
+lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+    (ht : 0 < t.val) :
+    ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
+      n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
+  apply deriv_eq_of_hasDerivAt
+  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  refine h.congr_of_eventuallyEq ?_
+  filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
+  exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
+
+/-!
+
+### C.2. The Hubble and deceleration parameters
+
+-/
+
+/-- The Hubble parameter of the power-law solution is `n / t` for `t > 0`. -/
+lemma hubbleConstant_powerLawScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+    (ht : 0 < t.val) :
+    hubbleConstant (powerLawScaleFactor t₀ n) t = n / t.val := by
+  unfold hubbleConstant
+  rw [deriv_powerLawScaleFactor ht₀.ne' n ht.ne', powerLawScaleFactor,
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  field_simp
+
+/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `t > 0`,
+  `n ≠ 0`. -/
+lemma decelerationParameter_powerLawScaleFactor {t₀ n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+    {t : Time} (ht : 0 < t.val) :
+    decelerationParameter (powerLawScaleFactor t₀ n) t = (1 - n) / n := by
+  unfold decelerationParameter
+  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, deriv_powerLawScaleFactor ht₀.ne' n ht.ne',
+    powerLawScaleFactor, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  field_simp
+  ring
+
+/-- The density imposed on the flat power-law solution by the first-order Friedmann equation,
+  `ρ = 3 n² / (8 π G t²)`. -/
+noncomputable def powerLawDensity (G n : ℝ) : Time → ℝ :=
+  fun t => 3 * n ^ 2 / (8 * π * G * t.val ^ 2)
+
+/-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0` and the density `powerLawDensity`, for `t > 0`. -/
+lemma powerLawScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (n : ℝ) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n) 0 0 G c t := by
+  unfold FirstOrderFriedmann
+  have hH := hubbleConstant_powerLawScaleFactor ht₀ n ht
+  unfold hubbleConstant at hH
+  rw [hH, powerLawDensity]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
+
+/-- The second-order Friedmann equation for the flat power-law solution with the pressure
+  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `t > 0`. -/
+lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n)
+      (fun s => w * powerLawDensity G n s * c ^ 2) 0 G c t := by
+  unfold SecondOrderFriedmann
+  simp only [powerLawDensity]
+  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, powerLawScaleFactor,
+    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hπ := Real.pi_pos
+  rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
+  field_simp
+  ring
+
+/-!
+
+### C.3. The radiation-dominated solution
+
+-/
+
+/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
+noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
+  powerLawScaleFactor t₀ (1 / 2)
+
+/-- The density of the flat radiation-dominated solution, `ρ = 3 / (32 π G t²)`, imposed by
+  the first-order Friedmann equation. -/
+noncomputable def radiationDensity (G : ℝ) : Time → ℝ :=
+  fun t => 3 / (32 * π * G * t.val ^ 2)
+
+/-- The radiation pressure `p = ρ c² / 3`. -/
+noncomputable def radiationPressure (G c : ℝ) : Time → ℝ :=
+  fun t => radiationDensity G t * c ^ 2 / 3
+
+lemma radiationDensity_eq (G : ℝ) : radiationDensity G = powerLawDensity G (1 / 2) := by
+  funext t
+  simp only [radiationDensity, powerLawDensity]
+  ring
+
+/-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) 0 0 G c t := by
+  rw [radiationScaleFactor, radiationDensity_eq]
+  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+
+/-- The radiation-dominated solution solves the second-order Friedmann equation with
+  `p = ρ c² / 3`, `Λ = 0`, for `t > 0`. -/
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) (radiationPressure G c)
+      0 G c t := by
+  have h := powerLawScaleFactor_secondOrderFriedmann (w := 1 / 3) ht₀ hG hc
+    (by norm_num : (1 / 2 : ℝ) ≠ 0) (by norm_num) ht
+  rw [radiationScaleFactor, radiationDensity_eq]
+  convert h using 2
+  simp only [radiationPressure, radiationDensity_eq]
+  ring
+
+/-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
+lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+    (ht : 0 < t.val) :
+    decelerationParameter (radiationScaleFactor t₀) t = 1 := by
+  rw [radiationScaleFactor, decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  norm_num
+
+/-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
+lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
+    hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
+  rw [radiationScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  ring
+
+/-!
+
+### C.4. The Einstein-de Sitter solution
+
+-/
+
+/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
+noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
+  powerLawScaleFactor t₀ (2 / 3)
+
+/-- The dust density of the Einstein-de Sitter solution, `ρ = 1 / (6 π G t²)`, imposed by the
+  first-order Friedmann equation. -/
+noncomputable def einsteinDeSitterDensity (G : ℝ) : Time → ℝ :=
+  fun t => 1 / (6 * π * G * t.val ^ 2)
+
+lemma einsteinDeSitterDensity_eq (G : ℝ) :
+    einsteinDeSitterDensity G = powerLawDensity G (2 / 3) := by
+  funext t
+  simp only [einsteinDeSitterDensity, powerLawDensity]
+  ring
+
+/-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+      0 0 G c t := by
+  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
+  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+
+/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with `p = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+      (fun _ => 0) 0 G c t := by
+  have h := powerLawScaleFactor_secondOrderFriedmann (w := 0) ht₀ hG hc
+    (by norm_num : (2 / 3 : ℝ) ≠ 0) (by norm_num) ht
+  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
+  convert h using 2
+  ring
+
+/-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+    (ht : 0 < t.val) :
+    decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
+  rw [einsteinDeSitterScaleFactor,
+    decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  norm_num
+
+/-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
+lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
+    hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
+  rw [einsteinDeSitterScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  ring
+
+/-!
+
+## D. Remaining TODO items
+
+-/
 
 TODO "Prove that the Milne solution `a = c t` (empty universe, `K < 0`) has
   vanishing scalar curvature, i.e. it is Minkowski space in expanding coordinates."

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -46,6 +46,9 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   Friedmann equations with the dust density `ρ = 1 / (6 π G t²)` and `p = 0`; `q = 1 / 2` and
   `H(t₀) = 2 / (3 t₀)`.
 
+In the power-law solutions `t₀ : Time` is the normalisation epoch (`a(t₀) = 1`) and the Big
+Bang is at the origin `t.val = 0` of the time chart.
+
 ## iii. Table of contents
 
 - A. The de Sitter solution
@@ -196,6 +199,11 @@ The radiation-dominated and Einstein-de Sitter solutions are both of the form
 and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`. The general power-law solution is
 stated inline, only the two named solutions get a definition.
 
+Throughout, `t₀` is the normalisation epoch, `a(t₀) = 1`, the Big Bang sits at the origin
+`t.val = 0` of the time chart (`Time` has no distinguished origin by itself), and the values
+for `t.val ≤ 0` are junk (`Real.rpow` on a non-positive base); every statement therefore
+assumes `0 < t.val`.
+
 -/
 
 /-!
@@ -205,11 +213,11 @@ stated inline, only the two named solutions get a definition.
 -/
 
 /-- `∂ₜ (t / t₀) ^ n = n / t₀ (t / t₀) ^ (n - 1)` away from `t.val = 0`. -/
-lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
-    ∂ₜ (fun s : Time => (s.val / t₀) ^ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
-  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n)
-      (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
-    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+lemma deriv_powerLaw {t₀ : Time} (ht₀ : t₀.val ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
+    ∂ₜ (fun s : Time => (s.val / t₀.val) ^ n) t = n / t₀.val * (t.val / t₀.val) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀.val) ^ n)
+      (n / t₀.val * (t.val / t₀.val) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀.val).rpow_const (p := n)
       (Or.inl (div_ne_zero ht ht₀))
     refine h.congr_deriv ?_
     simp only [id_eq]
@@ -219,19 +227,19 @@ lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht 
 /-- `∂ₜ ∂ₜ (t / t₀) ^ n = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `0 < t.val`. The first
   derivative is only known away from `t.val = 0`, which is enough since `0 < t.val` is an open
   condition. -/
-lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+lemma deriv_deriv_powerLaw {t₀ : Time} (ht₀ : t₀.val ≠ 0) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀) ^ n)) t =
-      n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
+    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀.val) ^ n)) t =
+      n / t₀.val * ((n - 1) / t₀.val * (t.val / t₀.val) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
-      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
-    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀.val) ^ (n - 1))
+      ((n - 1) / t₀.val * (t.val / t₀.val) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀.val).rpow_const (p := n - 1)
       (Or.inl (div_ne_zero ht.ne' ht₀))
     refine h.congr_deriv ?_
     simp only [id_eq]
     ring
-  have h := h₁.const_mul (n / t₀)
+  have h := h₁.const_mul (n / t₀.val)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLaw ht₀ n (t := ⟨τ⟩) hτ
@@ -243,31 +251,31 @@ lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time
 -/
 
 /-- The Hubble parameter of the power-law solution is `n / t` for `0 < t.val`. -/
-lemma hubbleConstant_powerLaw {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+lemma hubbleConstant_powerLaw {t₀ : Time} (ht₀ : 0 < t₀.val) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    hubbleConstant (fun s : Time => (s.val / t₀) ^ n) t = n / t.val := by
+    hubbleConstant (fun s : Time => (s.val / t₀.val) ^ n) t = n / t.val := by
   unfold hubbleConstant
   rw [deriv_powerLaw ht₀.ne' n ht.ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
 
 /-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `0 < t.val`,
   `n ≠ 0`. -/
-lemma decelerationParameter_powerLaw {t₀ : ℝ} {n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+lemma decelerationParameter_powerLaw {t₀ : Time} {n : ℝ} (ht₀ : 0 < t₀.val) (hn : n ≠ 0)
     {t : Time} (ht : 0 < t.val) :
-    decelerationParameter (fun s : Time => (s.val / t₀) ^ n) t = (1 - n) / n := by
+    decelerationParameter (fun s : Time => (s.val / t₀.val) ^ n) t = (1 - n) / n := by
   unfold decelerationParameter
   rw [deriv_deriv_powerLaw ht₀.ne' n ht, deriv_powerLaw ht₀.ne' n ht.ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
   ring
 
 /-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the density `ρ = 3 n² / (8 π G t²)` that it imposes, for `0 < t.val`. -/
-lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+lemma powerLaw_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val) (hG : 0 < G)
     (n : ℝ) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+    FirstOrderFriedmann (fun s : Time => (s.val / t₀.val) ^ n)
       (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2)) 0 0 G c t := by
   unfold FirstOrderFriedmann
   have hH := hubbleConstant_powerLaw ht₀ n ht
@@ -279,15 +287,15 @@ lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (
 
 /-- The second-order Friedmann equation for the flat power-law solution with the pressure
   `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `0 < t.val`. -/
-lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+lemma powerLaw_secondOrderFriedmann {t₀ : Time} {G c n w : ℝ} (ht₀ : 0 < t₀.val) (hG : 0 < G)
     (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+    SecondOrderFriedmann (fun s : Time => (s.val / t₀.val) ^ n)
       (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2))
       (fun s => w * (3 * n ^ 2 / (8 * π * G * s.val ^ 2)) * c ^ 2) 0 G c t := by
   unfold SecondOrderFriedmann
   rw [deriv_deriv_powerLaw ht₀.ne' n ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   have hπ := Real.pi_pos
   rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
   field_simp
@@ -299,13 +307,15 @@ lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t�
 
 -/
 
-/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
-noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ (1 / 2 : ℝ)
+/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`, normalised by `a(t₀) = 1`.
+  The Big Bang is at the origin `t.val = 0` of the time chart; the values for `t.val ≤ 0` are
+  junk. -/
+noncomputable def radiationScaleFactor (t₀ : Time) : Time → ℝ :=
+  fun t => (t.val / t₀.val) ^ (1 / 2 : ℝ)
 
 /-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the density `ρ = 3 / (32 π G t²)`, for `0 < t.val`. -/
-lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
     FirstOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
       0 0 G c t := by
@@ -319,21 +329,21 @@ lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ :
 
 /-- The radiation-dominated solution solves the second-order Friedmann equation with the
   density `ρ = 3 / (32 π G t²)`, the pressure `p = ρ c² / 3` and `Λ = 0`, for `0 < t.val`. -/
-lemma radiationScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
     SecondOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
       (fun s => 3 / (32 * π * G * s.val ^ 2) * c ^ 2 / 3) 0 G c t := by
   unfold SecondOrderFriedmann radiationScaleFactor
   rw [deriv_deriv_powerLaw ht₀.ne' (1 / 2) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ (1 / 2 : ℝ) ≠ 0 :=
+  have hx : (t.val / t₀.val) ^ (1 / 2 : ℝ) ≠ 0 :=
     (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
-lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+lemma decelerationParameter_radiationScaleFactor {t₀ : Time} (ht₀ : 0 < t₀.val) {t : Time}
     (ht : 0 < t.val) :
     decelerationParameter (radiationScaleFactor t₀) t = 1 := by
   unfold radiationScaleFactor
@@ -341,8 +351,8 @@ lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
   norm_num
 
 /-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
-lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
-    hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
+lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : Time} (ht₀ : 0 < t₀.val) :
+    hubbleConstant (radiationScaleFactor t₀) t₀ = 1 / (2 * t₀.val) := by
   unfold radiationScaleFactor
   rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
@@ -353,13 +363,15 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 -/
 
-/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
-noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ (2 / 3 : ℝ)
+/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`, normalised by
+  `a(t₀) = 1`. The Big Bang is at the origin `t.val = 0` of the time chart; the values for
+  `t.val ≤ 0` are junk. -/
+noncomputable def einsteinDeSitterScaleFactor (t₀ : Time) : Time → ℝ :=
+  fun t => (t.val / t₀.val) ^ (2 / 3 : ℝ)
 
 /-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the dust density `ρ = 1 / (6 π G t²)`, for `0 < t.val`. -/
-lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
     FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       0 0 G c t := by
@@ -373,21 +385,21 @@ lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (
 
 /-- The Einstein-de Sitter solution solves the second-order Friedmann equation with the dust
   density `ρ = 1 / (6 π G t²)`, `p = 0` and `Λ = 0`, for `0 < t.val`. -/
-lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
     SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       (fun _ => 0) 0 G c t := by
   unfold SecondOrderFriedmann einsteinDeSitterScaleFactor
   rw [deriv_deriv_powerLaw ht₀.ne' (2 / 3) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ (2 / 3 : ℝ) ≠ 0 :=
+  have hx : (t.val / t₀.val) ^ (2 / 3 : ℝ) ≠ 0 :=
     (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
-lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : Time} (ht₀ : 0 < t₀.val)
     {t : Time} (ht : 0 < t.val) :
     decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
   unfold einsteinDeSitterScaleFactor
@@ -395,8 +407,8 @@ lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 
   norm_num
 
 /-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
-lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
-    hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
+lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : Time} (ht₀ : 0 < t₀.val) :
+    hubbleConstant (einsteinDeSitterScaleFactor t₀) t₀ = 2 / (3 * t₀.val) := by
   unfold einsteinDeSitterScaleFactor
   rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -32,12 +32,14 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 - `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
   (for any `σ`, `Λ`, `c`).
 - `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
-- `powerLawScaleFactor`: `a(t) = (t / t₀) ^ n`, with Hubble parameter `n / t`
-  (`hubbleConstant_powerLawScaleFactor`) and deceleration parameter `(1 - n) / n`
-  (`decelerationParameter_powerLawScaleFactor`) for `t > 0`.
+- `hubbleConstant_powerLaw`, `decelerationParameter_powerLaw`, `powerLaw_firstOrderFriedmann`,
+  `powerLaw_secondOrderFriedmann`: the flat power-law solutions `a = (t / t₀) ^ n`, stated
+  inline, have Hubble parameter `n / t` and deceleration parameter `(1 - n) / n`, and solve the
+  flat (`k = 0`, `Λ = 0`) Friedmann equations with the density `ρ = 3 n² / (8 π G t²)` and the
+  pressure `p = w ρ c²`, `1 + 3 w = 2 (1 - n) / n`, for `t > 0`.
 - `radiationScaleFactor_firstOrderFriedmann`, `radiationScaleFactor_secondOrderFriedmann`:
-  `a = (t / t₀) ^ (1/2)` solves the flat (`k = 0`, `Λ = 0`) Friedmann equations with the
-  density `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
+  `a = (t / t₀) ^ (1/2)` solves the flat Friedmann equations with the density
+  `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
   `H(t₀) = 1 / (2 t₀)`.
 - `einsteinDeSitterScaleFactor_firstOrderFriedmann`,
   `einsteinDeSitterScaleFactor_secondOrderFriedmann`: `a = (t / t₀) ^ (2/3)` solves the flat
@@ -51,7 +53,7 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   - A.2. The Friedmann equations
   - A.3. The Hubble and deceleration parameters
 - B. The spatially flat power-law solutions
-  - B.1. The power-law scale factor and its derivatives
+  - B.1. Derivatives of the power-law scale factor
   - B.2. The Hubble and deceleration parameters
   - B.3. The radiation-dominated solution
   - B.4. The Einstein-de Sitter solution
@@ -189,27 +191,24 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 ## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
-`a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
-parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with
-`k = 0` and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`.
+`a(t) = (t / t₀) ^ n`; the Hubble parameter is `n / t` and the deceleration parameter
+`(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with `k = 0`
+and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`. The general power-law solution is
+stated inline, only the two named solutions get a definition.
 
 -/
 
 /-!
 
-### B.1. The power-law scale factor and its derivatives
+### B.1. Derivatives of the power-law scale factor
 
 -/
 
-/-- The power-law scale factor `a(t) = (t / t₀) ^ n` (real power). -/
-noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ n
-
-/-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
-lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
-    (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
-  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+/-- `∂ₜ (t / t₀) ^ n = n / t₀ (t / t₀) ^ (n - 1)` away from `t.val = 0`. -/
+lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
+    ∂ₜ (fun s : Time => (s.val / t₀) ^ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n)
+      (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
     have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
       (Or.inl (div_ne_zero ht ht₀))
     refine h.congr_deriv ?_
@@ -217,11 +216,12 @@ lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t :
     ring
   exact deriv_comp_val h
 
-/-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
-  only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
-lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+/-- `∂ₜ ∂ₜ (t / t₀) ^ n = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `0 < t.val`. The first
+  derivative is only known away from `t.val = 0`, which is enough since `0 < t.val` is an open
+  condition. -/
+lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
+    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀) ^ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
   have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
@@ -234,7 +234,7 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
   have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
-  exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
+  exact deriv_powerLaw ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
@@ -242,57 +242,51 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
 
 -/
 
-/-- The Hubble parameter of the power-law solution is `n / t` for `t > 0`. -/
-lemma hubbleConstant_powerLawScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+/-- The Hubble parameter of the power-law solution is `n / t` for `0 < t.val`. -/
+lemma hubbleConstant_powerLaw {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    hubbleConstant (powerLawScaleFactor t₀ n) t = n / t.val := by
+    hubbleConstant (fun s : Time => (s.val / t₀) ^ n) t = n / t.val := by
   unfold hubbleConstant
-  rw [deriv_powerLawScaleFactor ht₀.ne' n ht.ne', powerLawScaleFactor,
-    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_powerLaw ht₀.ne' n ht.ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
 
-/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `t > 0`,
+/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `0 < t.val`,
   `n ≠ 0`. -/
-lemma decelerationParameter_powerLawScaleFactor {t₀ n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+lemma decelerationParameter_powerLaw {t₀ : ℝ} {n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
     {t : Time} (ht : 0 < t.val) :
-    decelerationParameter (powerLawScaleFactor t₀ n) t = (1 - n) / n := by
+    decelerationParameter (fun s : Time => (s.val / t₀) ^ n) t = (1 - n) / n := by
   unfold decelerationParameter
-  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, deriv_powerLawScaleFactor ht₀.ne' n ht.ne',
-    powerLawScaleFactor, Real.rpow_sub_one (div_pos ht ht₀).ne',
-    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_deriv_powerLaw ht₀.ne' n ht, deriv_powerLaw ht₀.ne' n ht.ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
   ring
 
-/-- The density imposed on the flat power-law solution by the first-order Friedmann equation,
-  `ρ = 3 n² / (8 π G t²)`. -/
-noncomputable def powerLawDensity (G n : ℝ) : Time → ℝ :=
-  fun t => 3 * n ^ 2 / (8 * π * G * t.val ^ 2)
-
 /-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0` and the density `powerLawDensity`, for `t > 0`. -/
-lemma powerLawScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+  `Λ = 0` and the density `ρ = 3 n² / (8 π G t²)` that it imposes, for `0 < t.val`. -/
+lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
     (n : ℝ) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n) 0 0 G c t := by
+    FirstOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+      (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2)) 0 0 G c t := by
   unfold FirstOrderFriedmann
-  have hH := hubbleConstant_powerLawScaleFactor ht₀ n ht
+  have hH := hubbleConstant_powerLaw ht₀ n ht
   unfold hubbleConstant at hH
-  rw [hH, powerLawDensity]
+  rw [hH]
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The second-order Friedmann equation for the flat power-law solution with the pressure
-  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `t > 0`. -/
-lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `0 < t.val`. -/
+lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
     (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n)
-      (fun s => w * powerLawDensity G n s * c ^ 2) 0 G c t := by
+    SecondOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+      (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2))
+      (fun s => w * (3 * n ^ 2 / (8 * π * G * s.val ^ 2)) * c ^ 2) 0 G c t := by
   unfold SecondOrderFriedmann
-  simp only [powerLawDensity]
-  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, powerLawScaleFactor,
-    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_deriv_powerLaw ht₀.ne' n ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   have hπ := Real.pi_pos
   rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
@@ -307,54 +301,50 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
 noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  powerLawScaleFactor t₀ (1 / 2)
-
-/-- The density of the flat radiation-dominated solution, `ρ = 3 / (32 π G t²)`, imposed by
-  the first-order Friedmann equation. -/
-noncomputable def radiationDensity (G : ℝ) : Time → ℝ :=
-  fun t => 3 / (32 * π * G * t.val ^ 2)
-
-/-- The radiation pressure `p = ρ c² / 3`. -/
-noncomputable def radiationPressure (G c : ℝ) : Time → ℝ :=
-  fun t => radiationDensity G t * c ^ 2 / 3
-
-lemma radiationDensity_eq (G : ℝ) : radiationDensity G = powerLawDensity G (1 / 2) := by
-  funext t
-  simp only [radiationDensity, powerLawDensity]
-  ring
+  fun t => (t.val / t₀) ^ (1 / 2 : ℝ)
 
 /-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma radiationScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
-    {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) 0 0 G c t := by
-  rw [radiationScaleFactor, radiationDensity_eq]
-  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+  `Λ = 0` and the density `ρ = 3 / (32 π G t²)`, for `0 < t.val`. -/
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
+      0 0 G c t := by
+  unfold FirstOrderFriedmann radiationScaleFactor
+  have hH := hubbleConstant_powerLaw ht₀ (1 / 2) ht
+  unfold hubbleConstant at hH
+  rw [hH]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
 
-/-- The radiation-dominated solution solves the second-order Friedmann equation with
-  `p = ρ c² / 3`, `Λ = 0`, for `t > 0`. -/
-lemma radiationScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
-    (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) (radiationPressure G c)
-      0 G c t := by
-  have h := powerLawScaleFactor_secondOrderFriedmann (w := 1 / 3) ht₀ hG hc
-    (by norm_num : (1 / 2 : ℝ) ≠ 0) (by norm_num) ht
-  rw [radiationScaleFactor, radiationDensity_eq]
-  convert h using 2
-  simp only [radiationPressure, radiationDensity_eq]
+/-- The radiation-dominated solution solves the second-order Friedmann equation with the
+  density `ρ = 3 / (32 π G t²)`, the pressure `p = ρ c² / 3` and `Λ = 0`, for `0 < t.val`. -/
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
+      (fun s => 3 / (32 * π * G * s.val ^ 2) * c ^ 2 / 3) 0 G c t := by
+  unfold SecondOrderFriedmann radiationScaleFactor
+  rw [deriv_deriv_powerLaw ht₀.ne' (1 / 2) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ (1 / 2 : ℝ) ≠ 0 :=
+    (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
+  have hπ := Real.pi_pos
+  field_simp
   ring
 
 /-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
 lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
     (ht : 0 < t.val) :
     decelerationParameter (radiationScaleFactor t₀) t = 1 := by
-  rw [radiationScaleFactor, decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  unfold radiationScaleFactor
+  rw [decelerationParameter_powerLaw ht₀ (by norm_num) ht]
   norm_num
 
 /-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
 lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
     hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
-  rw [radiationScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  unfold radiationScaleFactor
+  rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
 
 /-!
@@ -365,52 +355,50 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
 noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  powerLawScaleFactor t₀ (2 / 3)
-
-/-- The dust density of the Einstein-de Sitter solution, `ρ = 1 / (6 π G t²)`, imposed by the
-  first-order Friedmann equation. -/
-noncomputable def einsteinDeSitterDensity (G : ℝ) : Time → ℝ :=
-  fun t => 1 / (6 * π * G * t.val ^ 2)
-
-lemma einsteinDeSitterDensity_eq (G : ℝ) :
-    einsteinDeSitterDensity G = powerLawDensity G (2 / 3) := by
-  funext t
-  simp only [einsteinDeSitterDensity, powerLawDensity]
-  ring
+  fun t => (t.val / t₀) ^ (2 / 3 : ℝ)
 
 /-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+  `Λ = 0` and the dust density `ρ = 1 / (6 π G t²)`, for `0 < t.val`. -/
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       0 0 G c t := by
-  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
-  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+  unfold FirstOrderFriedmann einsteinDeSitterScaleFactor
+  have hH := hubbleConstant_powerLaw ht₀ (2 / 3) ht
+  unfold hubbleConstant at hH
+  rw [hH]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
 
-/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with `p = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with the dust
+  density `ρ = 1 / (6 π G t²)`, `p = 0` and `Λ = 0`, for `0 < t.val`. -/
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       (fun _ => 0) 0 G c t := by
-  have h := powerLawScaleFactor_secondOrderFriedmann (w := 0) ht₀ hG hc
-    (by norm_num : (2 / 3 : ℝ) ≠ 0) (by norm_num) ht
-  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
-  convert h using 2
+  unfold SecondOrderFriedmann einsteinDeSitterScaleFactor
+  rw [deriv_deriv_powerLaw ht₀.ne' (2 / 3) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ (2 / 3 : ℝ) ≠ 0 :=
+    (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
+  have hπ := Real.pi_pos
+  field_simp
   ring
 
 /-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
-lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
-    (ht : 0 < t.val) :
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
+    {t : Time} (ht : 0 < t.val) :
     decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
-  rw [einsteinDeSitterScaleFactor,
-    decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  unfold einsteinDeSitterScaleFactor
+  rw [decelerationParameter_powerLaw ht₀ (by norm_num) ht]
   norm_num
 
 /-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
 lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
     hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
-  rw [einsteinDeSitterScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  unfold einsteinDeSitterScaleFactor
+  rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
 
 /-!

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -46,17 +46,16 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 
 ## iii. Table of contents
 
-- A. Time derivatives of curves given by a function of the coordinate
-- B. The de Sitter solution
-  - B.1. The scale factor and its derivatives
-  - B.2. The Friedmann equations
-  - B.3. The Hubble and deceleration parameters
-- C. The spatially flat power-law solutions
-  - C.1. The power-law scale factor and its derivatives
-  - C.2. The Hubble and deceleration parameters
-  - C.3. The radiation-dominated solution
-  - C.4. The Einstein-de Sitter solution
-- D. Remaining TODO items
+- A. The de Sitter solution
+  - A.1. The scale factor and its derivatives
+  - A.2. The Friedmann equations
+  - A.3. The Hubble and deceleration parameters
+- B. The spatially flat power-law solutions
+  - B.1. The power-law scale factor and its derivatives
+  - B.2. The Hubble and deceleration parameters
+  - B.3. The radiation-dominated solution
+  - B.4. The Einstein-de Sitter solution
+- C. Remaining TODO items
 
 -/
 
@@ -68,33 +67,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives of curves given by a function of the coordinate
-
-A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
-its time derivative is the Mathlib derivative of `γ`.
-
--/
-
-/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
-lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
-    ∂ₜ (fun s : Time => γ s.val) t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
-
-/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
-  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
-lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
-    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
-
-/-!
-
-## B. The de Sitter solution
+## A. The de Sitter solution
 
 -/
 
 /-!
 
-### B.1. The scale factor and its derivatives
+### A.1. The scale factor and its derivatives
 
 -/
 
@@ -103,19 +82,17 @@ lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
 noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
   fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
 
-/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
-lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
-    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
-  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
       fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
   funext t
-  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val)) t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul a₀
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
@@ -123,8 +100,15 @@ lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
         Real.exp (σ * √(Λ / 3) * c * t.val) := by
   rw [deriv_deSitterScaleFactor]
   funext t
-  exact deriv_comp_val
-    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val))
+      t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul
+      (a₀ * (σ * √(Λ / 3) * c))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
 lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
@@ -134,7 +118,7 @@ lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1
 
 /-!
 
-### B.2. The Friedmann equations
+### A.2. The Friedmann equations
 
 -/
 
@@ -169,7 +153,7 @@ lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 <
 
 /-!
 
-### B.3. The Hubble and deceleration parameters
+### A.3. The Hubble and deceleration parameters
 
 -/
 
@@ -202,7 +186,7 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. The spatially flat power-law solutions
+## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
 `a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
@@ -213,7 +197,7 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 
 /-!
 
-### C.1. The power-law scale factor and its derivatives
+### B.1. The power-law scale factor and its derivatives
 
 -/
 
@@ -221,20 +205,17 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
   fun t => (t.val / t₀) ^ n
 
-/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
-lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
-    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
-  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
-    (Or.inl (div_ne_zero hx ht₀))
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 /-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
 lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
-  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+      (Or.inl (div_ne_zero ht ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
   only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
@@ -243,14 +224,21 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
     ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
+      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+      (Or.inl (div_ne_zero ht.ne' ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
-### C.2. The Hubble and deceleration parameters
+### B.2. The Hubble and deceleration parameters
 
 -/
 
@@ -313,7 +301,7 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-!
 
-### C.3. The radiation-dominated solution
+### B.3. The radiation-dominated solution
 
 -/
 
@@ -371,7 +359,7 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-!
 
-### C.4. The Einstein-de Sitter solution
+### B.4. The Einstein-de Sitter solution
 
 -/
 
@@ -427,7 +415,7 @@ lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < 
 
 /-!
 
-## D. Remaining TODO items
+## C. Remaining TODO items
 
 -/
 

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -115,6 +115,17 @@ lemma deriv_comp_toRealCLE_of_hasDerivAt [NormedAddCommGroup M] [NormedSpace ℝ
     fderiv_eq_smul_deriv, h.deriv]
   exact Eq.trans (by rfl) (Time.one_val ▸ one_smul _ v)
 
+/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
+lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
+    ∂ₜ (fun s : Time => γ s.val) t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
+  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
+lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
+    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
+
 /-!
 
 ### A.3. Derivatives of functions into manifolds


### PR DESCRIPTION
## AI disclosure

**AI disclosure.** This PR was generated with Claude Fable 5.1 (Claude Code) under my
supervision, following `AI-POLICY.md` and `AGENTS.md`. I have read every definition and lemma
statement and vouch that they state what the docstrings say. The statements were fixed before
the proofs were written and checked symbolically (sympy) against the Friedmann equations of
`Physlib.Cosmology.FLRW.Basic`; no textbook is cited, the TODO items of the file are the
specification.

**Stacked on #1632** (`flrw-solutions-1`): the diff includes the earlier commit(s); only the last commit is new here.

Resolves the radiation-dominated and Einstein-de Sitter TODOs.

Declarations added:
- `Time.deriv_eq_of_hasDerivAt` (in `SpaceAndTime/Time/Derivatives.lean`): the time derivative of any `f : Time → ℝ` from a `HasDerivAt` of
  `τ ↦ f ⟨τ⟩`.
- `powerLawScaleFactor`: `a(t) = (t / t₀) ^ n` (real power); 
  `deriv_powerLawScaleFactor` (for `t ≠ 0`), `deriv_deriv_powerLawScaleFactor` (for `t > 0`,
  through `HasDerivAt.congr_of_eventuallyEq` since `∂ₜ a` is only known away from `t = 0`).
- `hubbleConstant_powerLawScaleFactor`: `H = n / t`; `decelerationParameter_powerLawScaleFactor`:
  `q = (1 - n) / n`.
- `powerLawDensity`: `ρ = 3 n² / (8 π G t²)`, the density imposed by the first-order equation;
  `powerLawScaleFactor_firstOrderFriedmann` (`k = 0`, `Λ = 0`);
  `powerLawScaleFactor_secondOrderFriedmann` with `p = w ρ c²`, `1 + 3 w = 2 (1 - n) / n`.
- `radiationScaleFactor` (`n = 1/2`), `radiationDensity` (`3 / (32 π G t²)`),
  `radiationPressure` (`ρ c² / 3`), `radiationDensity_eq`,
  `radiationScaleFactor_firstOrderFriedmann`, `radiationScaleFactor_secondOrderFriedmann`,
  `decelerationParameter_radiationScaleFactor` (`q = 1`),
  `hubbleConstant_radiationScaleFactor_t₀` (`H(t₀) = 1 / (2 t₀)`).
- `einsteinDeSitterScaleFactor` (`n = 2/3`), `einsteinDeSitterDensity` (`1 / (6 π G t²)`),
  `einsteinDeSitterDensity_eq`, `einsteinDeSitterScaleFactor_firstOrderFriedmann`,
  `einsteinDeSitterScaleFactor_secondOrderFriedmann` (`p = 0`),
  `decelerationParameter_einsteinDeSitterScaleFactor` (`q = 1 / 2`),
  `hubbleConstant_einsteinDeSitterScaleFactor_t₀` (`H(t₀) = 2 / (3 t₀)`).

Note: the TODOs do not give the densities; they are imposed by the first-order equation with
`k = 0`, `Λ = 0` and stated explicitly.

Reviewer map: C.1 (power law and derivatives), C.2 (`H`, `q`, the two general Friedmann lemmas),
then C.3 and C.4 (instances).

**Update (Sept 11).** Applied the review remarks of #1642 across the series: no isolated general-purpose lemma (the one-off `HasDerivAt` and `rpow` helpers are inlined in the proofs that used them), and the three small bridges between `Time.deriv` and Mathlib's `HasDerivAt` now live next to the definition of the time derivative, in `Physlib/SpaceAndTime/Time/Derivatives.lean` (`deriv_comp_val`, `deriv_eq_of_hasDerivAt`, `hasDerivAt_mk_of_differentiableAt`, each introduced by the first PR of the series that needs it). Section letters shifted accordingly.

**Update (Sept 11, after the merge of #1632).** `master` was merged into this branch (no force-push). Since #1632 was merged before its review fixes were pushed, this PR now also carries those fixes for the de Sitter part of `Solutions.lean` (the bridge `deriv_comp_val` moved to `Time/Derivatives.lean`, the one-off exponential helper inlined, sections renumbered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

