### PR TITLE
feat(Cosmology): lookback time, luminosity and angular-diameter distances, Etherington, low-redshift coefficients

### DIFF
--- a/Physlib/Cosmology/FLRW/Basic.lean
+++ b/Physlib/Cosmology/FLRW/Basic.lean
@@ -177,9 +177,6 @@ TODO "Express the Hubble parameter as a function of the scale factor, `H(a)`, an
   redshift, `H(z)`, using `a = 1 / (1 + z)` with the normalization `a₀ = 1`; define the
   reduced Hubble function `E(z) = H(z) / H₀`."
 
-TODO "Prove the change-of-variable relations underlying the age and distance integrals:
-  `∂ₜ a = a * hubbleConstant a`, `dt = − dz / ((1 + z) * H)` and `dχ = c * dz / H`."
-
 /-- The deceleration parameter defined in terms of the scale factor
   as `- (dₜdₜ a) a / (dₜ a)^2`.
 

--- a/Physlib/Cosmology/FLRW/DensityParameters.lean
+++ b/Physlib/Cosmology/FLRW/DensityParameters.lean
@@ -1,40 +1,245 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
-public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.MatterContent
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 /-!
 
 # Density parameters and the standard cosmological model
 
-Placeholder file collecting TODO items for the critical density, the density
-parameters, the closure relation, and the Friedmann equation of the standard
-cosmological model written in terms of the reduced Hubble function. This file
-contains only TODO items; no definitions or lemmas are formalized yet.
+## i. Overview
+
+The first-order Friedmann equation of `Physlib.Cosmology.FLRW.Basic` can be read as a budget:
+dividing by `H²` and introducing the critical density `ρ_cr = 3 H² / (8 π G)`, the density
+parameter `Ω = ρ / ρ_cr`, the curvature density parameter `Ω_K = - k c² / (H² a²)` and the
+cosmological-constant density parameter `Ω_Λ = Λ c² / (3 H²)`, it reads `Ω + Ω_Λ + Ω_K = 1`.
+For a universe made of matter (`ρ ∝ a⁻³`) and radiation (`ρ ∝ a⁻⁴`), the Hubble parameter at
+any time is `H = H₀ E(a / a₀)` with the reduced Hubble function
+`E(x)² = Ω_Λ + Ω_m x⁻³ + Ω_r x⁻⁴ + Ω_K x⁻²` of the standard cosmological model, the density
+parameters being evaluated at the reference time `t₀`. The age of the universe is
+`t₀ = H₀⁻¹ ∫₀¹ dx / (x E(x))`, proportional to `1 / H₀`.
+
+## ii. Key results
+
+- `criticalDensity`, `densityParameter`, `curvatureDensityParameter`, `lambdaDensityParameter`.
+- `densityParameter_add_lambda_add_curvature`: the closure relation `Ω + Ω_Λ + Ω_K = 1`;
+  `densityParameter_add_curvature`: `Ω + Ω_K = 1` when `Λ = 0`.
+- `reducedHubble`: the reduced Hubble function of the standard model;
+  `sq_hubbleConstant_eq_reducedHubble`, `hubbleConstant_eq_reducedHubble`: `H = H₀ E(a / a₀)`
+  for matter and radiation obeying their scaling laws.
+- `age`: `t₀ = H₀⁻¹ ∫₀¹ dx / (x E(x))`; `age_eq`: `t₀ ∝ 1 / H₀`.
+- `equalityScaleFactorRadiationMatter`, `equalityScaleFactorMatterLambda` and the equalities
+  they realise.
+
+## iii. Table of contents
+
+- A. The critical density and the density parameters
+- B. The closure relation
+- C. The reduced Hubble function of the standard model
+- D. The age of the universe
+- E. The equality scale factors
 
 -/
 
 @[expose] public section
 
-TODO "Define the critical density `ρ_cr = 3 H² / (8 π G)`."
+namespace Cosmology.FLRW.FriedmannEquation
 
-TODO "Define the density parameter `Ω = ρ / ρ_cr` and the curvature density
-  parameter `Ω_K = − K c² / (H² a²)`."
+open Real Time
 
-TODO "Prove the closure relation `Ω + Ω_K = 1` as a rearrangement of the
-  Friedmann equation."
+/-!
 
-TODO "Define the reduced Hubble function `E(a) = H / H₀` and the normalized
-  Friedmann equation `E(a)² = Σ_x Ω_{x0} f_x(a) + Ω_{K0} / a²`."
+## A. The critical density and the density parameters
 
-TODO "Define the Friedmann equation of the standard cosmological model
-  `E(a)² = Ω_Λ + Ω_{m0} a⁻³ + Ω_{r0} a⁻⁴ + Ω_{K0} a⁻²`."
+-/
 
-TODO "Define the age of the universe `t₀ = H₀⁻¹ ∫₀¹ da / (a E(a))` and prove
-  `t₀ ∝ 1 / H₀`."
+/-- The critical density `ρ_cr = 3 H² / (8 π G)`. -/
+noncomputable def criticalDensity (a : Time → ℝ) (G : ℝ) (t : Time) : ℝ :=
+  3 * hubbleConstant a t ^ 2 / (8 * π * G)
 
-TODO "Define the radiation-matter and matter-Λ equality scale factors
-  `a_eq = Ω_{r0} / Ω_{m0}` and `a_Λ = (Ω_{m0} / Ω_Λ)^(1/3)`."
+/-- The density parameter `Ω = ρ / ρ_cr`. -/
+noncomputable def densityParameter (a ρ : Time → ℝ) (G : ℝ) (t : Time) : ℝ :=
+  ρ t / criticalDensity a G t
+
+/-- The curvature density parameter `Ω_K = - k c² / (H² a²)`. -/
+noncomputable def curvatureDensityParameter (a : Time → ℝ) (k c : ℝ) (t : Time) : ℝ :=
+  -k * c ^ 2 / (hubbleConstant a t ^ 2 * a t ^ 2)
+
+/-- The cosmological-constant density parameter `Ω_Λ = Λ c² / (3 H²)`. -/
+noncomputable def lambdaDensityParameter (a : Time → ℝ) (Λ c : ℝ) (t : Time) : ℝ :=
+  Λ * c ^ 2 / (3 * hubbleConstant a t ^ 2)
+
+/-- `Ω_Λ` is the density parameter of the fluid `ρ_Λ = Λ c² / (8 π G)`. -/
+lemma lambdaDensityParameter_eq {a : Time → ℝ} {Λ G c : ℝ} {t : Time} (hG : G ≠ 0) :
+    lambdaDensityParameter a Λ c t
+      = densityParameter a (fun _ => cosmologicalConstantDensity Λ G c) G t := by
+  unfold lambdaDensityParameter densityParameter criticalDensity cosmologicalConstantDensity
+  have hπ := Real.pi_ne_zero
+  field_simp
+
+/-!
+
+## B. The closure relation
+
+-/
+
+/-- The closure relation `Ω + Ω_Λ + Ω_K = 1`, a rearrangement of the first-order Friedmann
+  equation, for `H ≠ 0`. -/
+lemma densityParameter_add_lambda_add_curvature {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : Time}
+    (ha : a t ≠ 0) (hH : hubbleConstant a t ≠ 0)
+    (hF1 : FirstOrderFriedmann a ρ k Λ G c t) :
+    densityParameter a ρ G t + lambdaDensityParameter a Λ c t
+      + curvatureDensityParameter a k c t = 1 := by
+  unfold densityParameter lambdaDensityParameter curvatureDensityParameter criticalDensity
+  unfold FirstOrderFriedmann at hF1
+  unfold hubbleConstant at hH ⊢
+  have hπ := Real.pi_ne_zero
+  have key : ρ t / (3 * (∂ₜ a t / a t) ^ 2 / (8 * π * G)) + Λ * c ^ 2 / (3 * (∂ₜ a t / a t) ^ 2)
+      + -k * c ^ 2 / ((∂ₜ a t / a t) ^ 2 * a t ^ 2)
+      = (8 * π * G / 3 * ρ t - k * c ^ 2 / a t ^ 2 + Λ * c ^ 2 / 3) / (∂ₜ a t / a t) ^ 2 := by
+    field_simp
+    ring
+  rw [key, ← hF1, div_self (pow_ne_zero 2 hH)]
+
+/-- The closure relation `Ω + Ω_K = 1` without cosmological constant. -/
+lemma densityParameter_add_curvature {a ρ : Time → ℝ} {k G c : ℝ} {t : Time} (ha : a t ≠ 0)
+    (hH : hubbleConstant a t ≠ 0) (hF1 : FirstOrderFriedmann a ρ k 0 G c t) :
+    densityParameter a ρ G t + curvatureDensityParameter a k c t = 1 := by
+  have h := densityParameter_add_lambda_add_curvature ha hH hF1
+  have h0 : lambdaDensityParameter a 0 c t = 0 := by
+    unfold lambdaDensityParameter
+    ring
+  rw [h0, add_zero] at h
+  exact h
+
+/-!
+
+## C. The reduced Hubble function of the standard model
+
+-/
+
+/-- The reduced Hubble function `E(x) = √(Ω_Λ + Ω_m x⁻³ + Ω_r x⁻⁴ + Ω_K x⁻²)` of the standard
+  cosmological model, `x = a / a₀`. -/
+noncomputable def reducedHubble (ΩΛ Ωm Ωr ΩK x : ℝ) : ℝ :=
+  √(ΩΛ + Ωm * x ^ (-3 : ℝ) + Ωr * x ^ (-4 : ℝ) + ΩK * x ^ (-2 : ℝ))
+
+/-- `x ^ (-n) = (x ^ n)⁻¹` for `x > 0` and a natural `n`. -/
+lemma rpow_neg_natCast_of_pos {x : ℝ} (hx : 0 < x) (n : ℕ) : x ^ (-(n : ℝ)) = (x ^ n)⁻¹ := by
+  rw [Real.rpow_neg hx.le, Real.rpow_natCast]
+
+/-- The argument of the square root in `reducedHubble`, for a universe of matter and radiation
+  obeying their scaling laws, equals `H² / H₀²`: the normalised Friedmann equation. -/
+lemma sq_hubbleConstant_eq_mul_reducedHubbleSq {a ρm ρr : Time → ℝ} {k Λ G c : ℝ}
+    {t t₀ : Time} (hapos : ∀ s, 0 < a s) (hH₀ : hubbleConstant a t₀ ≠ 0)
+    (hm : ρm t = ρm t₀ * (a t₀ / a t) ^ 3) (hr : ρr t = ρr t₀ * (a t₀ / a t) ^ 4)
+    (hF1 : FirstOrderFriedmann a (fun s => ρm s + ρr s) k Λ G c t) :
+    hubbleConstant a t ^ 2 = hubbleConstant a t₀ ^ 2
+      * (lambdaDensityParameter a Λ c t₀ + densityParameter a ρm G t₀ * (a t / a t₀) ^ (-3 : ℝ)
+        + densityParameter a ρr G t₀ * (a t / a t₀) ^ (-4 : ℝ)
+        + curvatureDensityParameter a k c t₀ * (a t / a t₀) ^ (-2 : ℝ)) := by
+  have hx : 0 < a t / a t₀ := div_pos (hapos t) (hapos t₀)
+  rw [show (-3 : ℝ) = -((3 : ℕ) : ℝ) by norm_num, show (-4 : ℝ) = -((4 : ℕ) : ℝ) by norm_num,
+    show (-2 : ℝ) = -((2 : ℕ) : ℝ) by norm_num, rpow_neg_natCast_of_pos hx,
+    rpow_neg_natCast_of_pos hx, rpow_neg_natCast_of_pos hx]
+  unfold FirstOrderFriedmann at hF1
+  dsimp only at hF1
+  rw [hm, hr] at hF1
+  unfold lambdaDensityParameter densityParameter criticalDensity curvatureDensityParameter
+  unfold hubbleConstant at hH₀ ⊢
+  rw [hF1]
+  have hπ := Real.pi_ne_zero
+  have ha := (hapos t).ne'
+  have ha₀ := (hapos t₀).ne'
+  have hd₀ : ∂ₜ a t₀ ≠ 0 := (div_ne_zero_iff.mp hH₀).1
+  field_simp
+  ring
+
+/-- `H² = H₀² E(a / a₀)²` for a universe of matter and radiation obeying their scaling laws
+  (`Physlib.Cosmology.FLRW.MatterContent`), with cosmological constant and curvature. -/
+lemma sq_hubbleConstant_eq_reducedHubble {a ρm ρr : Time → ℝ} {k Λ G c : ℝ} {t t₀ : Time}
+    (hapos : ∀ s, 0 < a s) (hH₀ : hubbleConstant a t₀ ≠ 0)
+    (hm : ρm t = ρm t₀ * (a t₀ / a t) ^ 3) (hr : ρr t = ρr t₀ * (a t₀ / a t) ^ 4)
+    (hF1 : FirstOrderFriedmann a (fun s => ρm s + ρr s) k Λ G c t) :
+    hubbleConstant a t ^ 2 = hubbleConstant a t₀ ^ 2
+      * reducedHubble (lambdaDensityParameter a Λ c t₀) (densityParameter a ρm G t₀)
+        (densityParameter a ρr G t₀) (curvatureDensityParameter a k c t₀) (a t / a t₀) ^ 2 := by
+  have key := sq_hubbleConstant_eq_mul_reducedHubbleSq hapos hH₀ hm hr hF1
+  have hnn : 0 ≤ lambdaDensityParameter a Λ c t₀
+      + densityParameter a ρm G t₀ * (a t / a t₀) ^ (-3 : ℝ)
+      + densityParameter a ρr G t₀ * (a t / a t₀) ^ (-4 : ℝ)
+      + curvatureDensityParameter a k c t₀ * (a t / a t₀) ^ (-2 : ℝ) := by
+    have h2 : 0 < hubbleConstant a t₀ ^ 2 := by positivity
+    have : 0 ≤ hubbleConstant a t ^ 2 := sq_nonneg _
+    rw [key] at this
+    exact nonneg_of_mul_nonneg_right (by linarith) h2
+  unfold reducedHubble
+  rw [Real.sq_sqrt hnn]
+  exact key
+
+/-- `H = H₀ E(a / a₀)` for `H ≥ 0` and `H₀ > 0`. -/
+lemma hubbleConstant_eq_reducedHubble {a ρm ρr : Time → ℝ} {k Λ G c : ℝ} {t t₀ : Time}
+    (hapos : ∀ s, 0 < a s) (hH₀ : 0 < hubbleConstant a t₀)
+    (hH : 0 ≤ hubbleConstant a t)
+    (hm : ρm t = ρm t₀ * (a t₀ / a t) ^ 3) (hr : ρr t = ρr t₀ * (a t₀ / a t) ^ 4)
+    (hF1 : FirstOrderFriedmann a (fun s => ρm s + ρr s) k Λ G c t) :
+    hubbleConstant a t = hubbleConstant a t₀
+      * reducedHubble (lambdaDensityParameter a Λ c t₀) (densityParameter a ρm G t₀)
+        (densityParameter a ρr G t₀) (curvatureDensityParameter a k c t₀) (a t / a t₀) := by
+  have key := sq_hubbleConstant_eq_reducedHubble hapos hH₀.ne' hm hr hF1
+  rw [← mul_pow] at key
+  have hE : 0 ≤ reducedHubble (lambdaDensityParameter a Λ c t₀) (densityParameter a ρm G t₀)
+      (densityParameter a ρr G t₀) (curvatureDensityParameter a k c t₀) (a t / a t₀) :=
+    Real.sqrt_nonneg _
+  exact (pow_left_inj₀ hH (mul_nonneg hH₀.le hE) two_ne_zero).mp key
+
+/-!
+
+## D. The age of the universe
+
+-/
+
+/-- The age of the universe `t₀ = H₀⁻¹ ∫₀¹ dx / (x E(x))` for a reduced Hubble function `E`
+  (interval integral; no convergence is asserted here). -/
+noncomputable def age (H₀ : ℝ) (E : ℝ → ℝ) : ℝ :=
+  (1 / H₀) * ∫ x in (0 : ℝ)..1, 1 / (x * E x)
+
+/-- The age is proportional to `1 / H₀`. -/
+lemma age_eq (H₀ : ℝ) (E : ℝ → ℝ) : age H₀ E = (1 / H₀) * age 1 E := by
+  unfold age
+  ring
+
+/-!
+
+## E. The equality scale factors
+
+-/
+
+/-- The radiation-matter equality scale factor `a_eq = Ω_r / Ω_m`. -/
+noncomputable def equalityScaleFactorRadiationMatter (Ωr Ωm : ℝ) : ℝ := Ωr / Ωm
+
+/-- The matter-Λ equality scale factor `a_Λ = (Ω_m / Ω_Λ)^(1/3)`. -/
+noncomputable def equalityScaleFactorMatterLambda (Ωm ΩΛ : ℝ) : ℝ := (Ωm / ΩΛ) ^ (1 / 3 : ℝ)
+
+/-- At `a_eq`, the matter and radiation terms of `E²` are equal. -/
+lemma equalityScaleFactorRadiationMatter_spec {Ωr Ωm : ℝ} (hr : 0 < Ωr) (hm : 0 < Ωm) :
+    Ωm * equalityScaleFactorRadiationMatter Ωr Ωm ^ (-3 : ℝ)
+      = Ωr * equalityScaleFactorRadiationMatter Ωr Ωm ^ (-4 : ℝ) := by
+  unfold equalityScaleFactorRadiationMatter
+  have hx : 0 < Ωr / Ωm := div_pos hr hm
+  rw [show (-3 : ℝ) = -((3 : ℕ) : ℝ) by norm_num, show (-4 : ℝ) = -((4 : ℕ) : ℝ) by norm_num,
+    rpow_neg_natCast_of_pos hx, rpow_neg_natCast_of_pos hx]
+  field_simp
+
+/-- At `a_Λ`, the matter term of `E²` equals `Ω_Λ`. -/
+lemma equalityScaleFactorMatterLambda_spec {Ωm ΩΛ : ℝ} (hm : 0 < Ωm) (hL : 0 < ΩΛ) :
+    Ωm * equalityScaleFactorMatterLambda Ωm ΩΛ ^ (-3 : ℝ) = ΩΛ := by
+  unfold equalityScaleFactorMatterLambda
+  have hy : 0 < Ωm / ΩΛ := div_pos hm hL
+  rw [← Real.rpow_mul hy.le, show (1 / 3 : ℝ) * -3 = -1 by norm_num, Real.rpow_neg_one]
+  field_simp
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/DensityParameters.lean
+++ b/Physlib/Cosmology/FLRW/DensityParameters.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/DensityParameters.lean
+++ b/Physlib/Cosmology/FLRW/DensityParameters.lean
@@ -127,10 +127,6 @@ lemma densityParameter_add_curvature {a ρ : Time → ℝ} {k G c : ℝ} {t : Ti
 noncomputable def reducedHubble (ΩΛ Ωm Ωr ΩK x : ℝ) : ℝ :=
   √(ΩΛ + Ωm * x ^ (-3 : ℝ) + Ωr * x ^ (-4 : ℝ) + ΩK * x ^ (-2 : ℝ))
 
-/-- `x ^ (-n) = (x ^ n)⁻¹` for `x > 0` and a natural `n`. -/
-lemma rpow_neg_natCast_of_pos {x : ℝ} (hx : 0 < x) (n : ℕ) : x ^ (-(n : ℝ)) = (x ^ n)⁻¹ := by
-  rw [Real.rpow_neg hx.le, Real.rpow_natCast]
-
 /-- The argument of the square root in `reducedHubble`, for a universe of matter and radiation
   obeying their scaling laws, equals `H² / H₀²`: the normalised Friedmann equation. -/
 lemma sq_hubbleConstant_eq_mul_reducedHubbleSq {a ρm ρr : Time → ℝ} {k Λ G c : ℝ}
@@ -142,9 +138,11 @@ lemma sq_hubbleConstant_eq_mul_reducedHubbleSq {a ρm ρr : Time → ℝ} {k Λ 
         + densityParameter a ρr G t₀ * (a t / a t₀) ^ (-4 : ℝ)
         + curvatureDensityParameter a k c t₀ * (a t / a t₀) ^ (-2 : ℝ)) := by
   have hx : 0 < a t / a t₀ := div_pos (hapos t) (hapos t₀)
+  have hpow : ∀ j : ℕ, (a t / a t₀) ^ (-(j : ℝ)) = ((a t / a t₀) ^ j)⁻¹ := fun j => by
+    rw [Real.rpow_neg hx.le, Real.rpow_natCast]
   rw [show (-3 : ℝ) = -((3 : ℕ) : ℝ) by norm_num, show (-4 : ℝ) = -((4 : ℕ) : ℝ) by norm_num,
-    show (-2 : ℝ) = -((2 : ℕ) : ℝ) by norm_num, rpow_neg_natCast_of_pos hx,
-    rpow_neg_natCast_of_pos hx, rpow_neg_natCast_of_pos hx]
+    show (-2 : ℝ) = -((2 : ℕ) : ℝ) by norm_num, hpow,
+    hpow, hpow]
   unfold FirstOrderFriedmann at hF1
   dsimp only at hF1
   rw [hm, hr] at hF1
@@ -230,8 +228,10 @@ lemma equalityScaleFactorRadiationMatter_spec {Ωr Ωm : ℝ} (hr : 0 < Ωr) (hm
       = Ωr * equalityScaleFactorRadiationMatter Ωr Ωm ^ (-4 : ℝ) := by
   unfold equalityScaleFactorRadiationMatter
   have hx : 0 < Ωr / Ωm := div_pos hr hm
+  have hpow : ∀ j : ℕ, (Ωr / Ωm) ^ (-(j : ℝ)) = ((Ωr / Ωm) ^ j)⁻¹ := fun j => by
+    rw [Real.rpow_neg hx.le, Real.rpow_natCast]
   rw [show (-3 : ℝ) = -((3 : ℕ) : ℝ) by norm_num, show (-4 : ℝ) = -((4 : ℕ) : ℝ) by norm_num,
-    rpow_neg_natCast_of_pos hx, rpow_neg_natCast_of_pos hx]
+    hpow, hpow]
   field_simp
 
 /-- At `a_Λ`, the matter term of `E²` equals `Ω_Λ`. -/

--- a/Physlib/Cosmology/FLRW/Distances.lean
+++ b/Physlib/Cosmology/FLRW/Distances.lean
@@ -1,50 +1,232 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
 public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.Dynamics
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 /-!
 
 # Distances and redshift in FLRW cosmology
 
-Placeholder file collecting TODO items for the notions of distance used in
-cosmology (comoving, proper, and the observational luminosity and
-angular-diameter distances), together with the redshift, the horizons, and the
-lookback time. This file contains only TODO items; no definitions or lemmas are
-formalized yet.
+## i. Overview
+
+The comoving distance of a source emitting at the time `t` and observed at `t₀` is
+`χ = c ∫_t^{t₀} dτ / a(τ)`, so that `∂ₜ χ = - c / a`. The redshift is `1 + z = a(t₀) / a(t)`,
+with `∂ₜ z = -(1 + z) H`; combining the two, `∂ₜ χ = (c / (a(t₀) H)) ∂ₜ z`, which is the
+change of variables `dχ = c dz / H` (for `a(t₀) = 1`) behind the distance integrals written in
+the redshift. The proper distance `D = a χ` obeys the Hubble-Lemaître law `∂ₜ D = H D`, and the
+recession velocity equals `c` exactly at the Hubble radius `R_H = c / H`. The transverse comoving
+distance `r(χ)` is the function `S` of `Cosmology.SpatialGeometry` for the geometry of curvature
+`K`, with curvature radius `1 / √|K|`. The particle and event horizons are the comoving distances
+to the initial time and to the infinite future; the particle horizon of the Einstein-de Sitter
+universe is computed.
+
+What is not stated here: the cosmological redshift law `E ∝ 1 / a` of a photon (it needs the
+metric and the null geodesics, not yet objects of Physlib), and the comoving distance as an
+integral in `z` (it needs `H` as a function of `z`); the differential relation above is what is
+proved.
+
+## ii. Key results
+
+- `comovingDistance`, `deriv_comovingDistance`: `∂ₜ χ = - c / a`.
+- `redshift`, `deriv_redshift`: `∂ₜ z = -(1 + z) H`; `deriv_comovingDistance_eq_mul_deriv_redshift`:
+  `∂ₜ χ = (c / (a(t₀) H)) ∂ₜ z`.
+- `properDistance`, `deriv_properDistance`: the Hubble-Lemaître law; `hubbleRadius`,
+  `deriv_properDistance_eq_iff`.
+- `spatialGeometryOfCurvature`, `transverseComovingDistance` and its three closed forms.
+- `particleHorizon`, `eventHorizon`, `particleHorizon_einsteinDeSitter`.
+
+## iii. Table of contents
+
+- A. The comoving distance
+- B. The redshift and the change of variables
+- C. The proper distance and the Hubble radius
+- D. The transverse comoving distance
+- E. The horizons
 
 -/
 
 @[expose] public section
 
-TODO "Define the line-of-sight comoving distance `χ = c ∫ dt/a`, equivalently
-  `χ(z) = ∫₀ᶻ c dz'/H(z')`."
+namespace Cosmology.FLRW.FriedmannEquation
 
-TODO "Define the proper distance `D = a * χ` and prove the Hubble-Lemaître law
-  `∂ₜ D = H * D` at fixed comoving distance `χ`."
+open Real Time
 
-TODO "Define the Hubble radius `R_H = c / H`, the distance at which the recession
-  velocity equals the speed of light."
+/-!
 
-TODO "Relate the transverse comoving distance `r(χ)` to the existing
-  `Cosmology.SpatialGeometry.S`, with curvature radius `k = 1/√|K|`."
+## A. The comoving distance
 
-TODO "Define the redshift by `1 + z = a₀ / a` and prove the cosmological redshift
-  law `E ∝ 1/a` for a photon from the null geodesic equation."
+-/
 
-TODO "Define the particle (comoving) horizon `χ_p = c ∫₀ᵗ dt'/a` and the event
-  horizon `χ_e = c ∫_t^∞ dt'/a`."
+/-- The line-of-sight comoving distance `χ = c ∫_t^{t₀} dτ / a(τ)` of a source emitting at `t`
+  and observed at `t₀`. -/
+noncomputable def comovingDistance (a : Time → ℝ) (c : ℝ) (t t₀ : Time) : ℝ :=
+  c * ∫ τ in t.val..t₀.val, 1 / a ⟨τ⟩
 
-TODO "Define the lookback time `t₀ - t` and prove its model-independent expansion
-  `t₀ - t = H₀⁻¹ [z - ½(2 + q₀) z² + …]` in powers of the redshift."
+/-- For `a` continuous and positive, `∂ₜ χ = - c / a` (fundamental theorem of calculus). -/
+lemma deriv_comovingDistance {a : Time → ℝ} {c : ℝ} (hcont : Continuous a) (hapos : ∀ s, 0 < a s)
+    (t₀ t : Time) : ∂ₜ (fun s => comovingDistance a c s t₀) t = -c / a t := by
+  obtain ⟨τ⟩ := t
+  have hf : Continuous (fun τ : ℝ => 1 / a ⟨τ⟩) :=
+    continuous_const.div (hcont.comp toRealCLE.symm.continuous) fun τ => (hapos ⟨τ⟩).ne'
+  have h : HasDerivAt (fun σ : ℝ => ∫ x in σ..t₀.val, 1 / a ⟨x⟩) (-(1 / a ⟨τ⟩)) τ :=
+    intervalIntegral.integral_hasDerivAt_left (hf.intervalIntegrable _ _)
+      (hf.stronglyMeasurableAtFilter _ _) hf.continuousAt
+  refine deriv_eq_of_hasDerivAt ((h.const_mul c).congr_deriv ?_)
+  ring
 
-TODO "Define the luminosity distance `d_L = (1 + z) r(χ)` and the angular-diameter
-  distance `d_A = r(χ) / (1 + z)`."
+/-!
 
-TODO "Prove Etherington's distance-duality relation `d_L = (1 + z)² d_A`."
+## B. The redshift and the change of variables
 
-TODO "Prove the low-redshift expansions of `χ`, `d_L` and `d_A` in powers of `z`
-  in terms of the deceleration parameter `q₀`."
+-/
+
+/-- The redshift of a source emitting at `t` and observed at `t₀`: `1 + z = a(t₀) / a(t)`. -/
+noncomputable def redshift (a : Time → ℝ) (t₀ t : Time) : ℝ := a t₀ / a t - 1
+
+lemma one_add_redshift {a : Time → ℝ} (t₀ t : Time) : 1 + redshift a t₀ t = a t₀ / a t := by
+  unfold redshift
+  ring
+
+/-- `∂ₜ z = -(1 + z) H`: the change of variables `dt = - dz / ((1 + z) H)`. -/
+lemma deriv_redshift {a : Time → ℝ} {t₀ t : Time} (hd : DifferentiableAt ℝ a t) (ha : a t ≠ 0) :
+    ∂ₜ (redshift a t₀) t = -(1 + redshift a t₀ t) * hubbleConstant a t := by
+  obtain ⟨τ⟩ := t
+  have hA := hasDerivAt_mk_of_differentiableAt hd
+  have h := ((hasDerivAt_const τ (a t₀)).div hA ha).sub_const 1
+  refine (deriv_eq_of_hasDerivAt (f := redshift a t₀) h).trans ?_
+  unfold redshift hubbleConstant
+  field_simp
+  ring
+
+/-- `∂ₜ a = a H`. -/
+lemma deriv_eq_mul_hubbleConstant {a : Time → ℝ} {t : Time} (ha : a t ≠ 0) :
+    ∂ₜ a t = a t * hubbleConstant a t := by
+  unfold hubbleConstant
+  field_simp
+
+/-- `∂ₜ χ = (c / (a(t₀) H)) ∂ₜ z`: with `a(t₀) = 1`, this is the change of variables
+  `dχ = c dz / H` (both derivatives are negative: `χ` and `z` decrease with the emission time). -/
+lemma deriv_comovingDistance_eq_mul_deriv_redshift {a : Time → ℝ} {c : ℝ} (hcont : Continuous a)
+    (hapos : ∀ s, 0 < a s) {t₀ t : Time} (hd : DifferentiableAt ℝ a t)
+    (hH : hubbleConstant a t ≠ 0) :
+    ∂ₜ (fun s => comovingDistance a c s t₀) t
+      = c / (a t₀ * hubbleConstant a t) * ∂ₜ (redshift a t₀) t := by
+  rw [deriv_comovingDistance hcont hapos, deriv_redshift hd (hapos t).ne', one_add_redshift]
+  have ha := (hapos t).ne'
+  have ha₀ := (hapos t₀).ne'
+  field_simp
+
+/-!
+
+## C. The proper distance and the Hubble radius
+
+-/
+
+/-- The proper distance `D = a χ` at fixed comoving distance `χ`. -/
+noncomputable def properDistance (a : Time → ℝ) (χ : ℝ) (t : Time) : ℝ := a t * χ
+
+/-- The Hubble-Lemaître law `∂ₜ D = H D`. -/
+lemma deriv_properDistance {a : Time → ℝ} {χ : ℝ} {t : Time} (hd : DifferentiableAt ℝ a t)
+    (ha : a t ≠ 0) : ∂ₜ (properDistance a χ) t = hubbleConstant a t * properDistance a χ t := by
+  obtain ⟨τ⟩ := t
+  have hA := hasDerivAt_mk_of_differentiableAt hd
+  refine (deriv_eq_of_hasDerivAt (f := properDistance a χ) (hA.mul_const χ)).trans ?_
+  unfold hubbleConstant properDistance
+  field_simp
+
+/-- The Hubble radius `R_H = c / H`. -/
+noncomputable def hubbleRadius (a : Time → ℝ) (c : ℝ) (t : Time) : ℝ := c / hubbleConstant a t
+
+/-- The recession velocity `∂ₜ D` equals `c` exactly at the Hubble radius. -/
+lemma deriv_properDistance_eq_iff {a : Time → ℝ} {χ c : ℝ} {t : Time} (hd : DifferentiableAt ℝ a t)
+    (ha : a t ≠ 0) (hH : hubbleConstant a t ≠ 0) :
+    ∂ₜ (properDistance a χ) t = c ↔ properDistance a χ t = hubbleRadius a c t := by
+  rw [deriv_properDistance hd ha, hubbleRadius, eq_div_iff hH]
+  constructor <;> intro h <;> linarith [h]
+
+/-!
+
+## D. The transverse comoving distance
+
+-/
+
+/-- The spatial geometry of curvature parameter `K`, in the conventions of `SpatialGeometry`
+  (`Spherical k` with `k < 0`, `Saddle k` with `k > 0`; the function `S` is even in `k`), with
+  curvature radius `1 / √|K|`. -/
+noncomputable def spatialGeometryOfCurvature (K : ℝ) : SpatialGeometry :=
+  if hK : 0 < K then
+    .Spherical (-(1 / √K)) (neg_neg_of_pos (one_div_pos.mpr (Real.sqrt_pos.mpr hK)))
+  else if hK' : K < 0 then
+    .Saddle (1 / √(-K)) (one_div_pos.mpr (Real.sqrt_pos.mpr (neg_pos.mpr hK')))
+  else .Flat
+
+/-- The transverse comoving distance `r(χ) = S(χ)` for the geometry of curvature `K`. -/
+noncomputable def transverseComovingDistance (K χ : ℝ) : ℝ :=
+  SpatialGeometry.S (spatialGeometryOfCurvature K) χ
+
+/-- For `K > 0`, `r(χ) = (1 / √K) sin (√K χ)`. -/
+lemma transverseComovingDistance_of_pos {K : ℝ} (hK : 0 < K) (χ : ℝ) :
+    transverseComovingDistance K χ = 1 / √K * Real.sin (√K * χ) := by
+  unfold transverseComovingDistance spatialGeometryOfCurvature
+  rw [dif_pos hK]
+  simp only [SpatialGeometry.S]
+  have hs : √K ≠ 0 := (Real.sqrt_pos.mpr hK).ne'
+  rw [show χ / -(1 / √K) = -(√K * χ) by field_simp, Real.sin_neg]
+  ring
+
+/-- For `K = 0`, `r(χ) = χ`. -/
+lemma transverseComovingDistance_zero (χ : ℝ) : transverseComovingDistance 0 χ = χ := by
+  unfold transverseComovingDistance spatialGeometryOfCurvature
+  rw [dif_neg (lt_irrefl 0), dif_neg (lt_irrefl 0)]
+  simp only [SpatialGeometry.S]
+
+/-- For `K < 0`, `r(χ) = (1 / √(-K)) sinh (√(-K) χ)`. -/
+lemma transverseComovingDistance_of_neg {K : ℝ} (hK : K < 0) (χ : ℝ) :
+    transverseComovingDistance K χ = 1 / √(-K) * Real.sinh (√(-K) * χ) := by
+  unfold transverseComovingDistance spatialGeometryOfCurvature
+  rw [dif_neg (not_lt.mpr hK.le), dif_pos hK]
+  simp only [SpatialGeometry.S]
+  have hs : √(-K) ≠ 0 := (Real.sqrt_pos.mpr (neg_pos.mpr hK)).ne'
+  rw [show χ / (1 / √(-K)) = √(-K) * χ by field_simp]
+
+/-!
+
+## E. The horizons
+
+-/
+
+/-- The particle horizon at `t`: the comoving distance to the initial time `tᵢ`. -/
+noncomputable def particleHorizon (a : Time → ℝ) (c : ℝ) (tᵢ t : Time) : ℝ :=
+  comovingDistance a c tᵢ t
+
+/-- The event horizon at `t`: `c ∫_t^∞ dτ / a(τ)` (Lebesgue integral over `(t, ∞)`, equal to
+  `0` when not integrable). -/
+noncomputable def eventHorizon (a : Time → ℝ) (c : ℝ) (t : Time) : ℝ :=
+  c * ∫ τ in Set.Ioi t.val, 1 / a ⟨τ⟩
+
+/-- The particle horizon of the Einstein-de Sitter universe from `t = 0` is finite,
+  `3 c t₀^(2/3) t^(1/3)`. -/
+lemma particleHorizon_einsteinDeSitter {t₀ c : ℝ} (ht₀ : 0 < t₀) {t : Time} (ht : 0 < t.val) :
+    particleHorizon (einsteinDeSitterScaleFactor t₀) c ⟨0⟩ t
+      = 3 * c * t₀ ^ (2 / 3 : ℝ) * t.val ^ (1 / 3 : ℝ) := by
+  unfold particleHorizon comovingDistance einsteinDeSitterScaleFactor powerLawScaleFactor
+  dsimp only
+  have hcongr : Set.EqOn (fun τ : ℝ => 1 / (τ / t₀) ^ (2 / 3 : ℝ))
+      (fun τ : ℝ => t₀ ^ (2 / 3 : ℝ) * τ ^ (-(2 / 3) : ℝ)) (Set.uIcc 0 t.val) := by
+    intro τ hτ
+    rw [Set.uIcc_of_le ht.le] at hτ
+    have h0 : 0 ≤ τ := hτ.1
+    simp only
+    rw [Real.div_rpow h0 ht₀.le, one_div, inv_div, Real.rpow_neg h0, div_eq_mul_inv]
+  rw [intervalIntegral.integral_congr hcongr, intervalIntegral.integral_const_mul,
+    integral_rpow (Or.inl (by norm_num)), Real.zero_rpow (by norm_num)]
+  norm_num
+  ring
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Distances.lean
+++ b/Physlib/Cosmology/FLRW/Distances.lean
@@ -5,7 +5,6 @@ Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
-public import Physlib.Meta.TODO.Basic
 public import Physlib.Cosmology.FLRW.Dynamics
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
@@ -24,12 +23,17 @@ recession velocity equals `c` exactly at the Hubble radius `R_H = c / H`. The tr
 distance `r(χ)` is the function `S` of `Cosmology.SpatialGeometry` for the geometry of curvature
 `K`, with curvature radius `1 / √|K|`. The particle and event horizons are the comoving distances
 to the initial time and to the infinite future; the particle horizon of the Einstein-de Sitter
-universe is computed.
+universe is computed. The luminosity distance `d_L = (1 + z) r(χ)` and the angular-diameter
+distance `d_A = r(χ) / (1 + z)` satisfy Etherington's relation `d_L = (1 + z)² d_A`. The
+low-redshift expansions of the lookback time and of the distances are given through their
+coefficients: the first and second derivatives of `z` and `χ` at the observation time, and the
+resulting `dχ/dz = c / (a₀ H₀)`, `d²χ/dz² = - c (1 + q₀) / (a₀ H₀)` at `z = 0`.
 
 What is not stated here: the cosmological redshift law `E ∝ 1 / a` of a photon (it needs the
 metric and the null geodesics, not yet objects of Physlib), and the comoving distance as an
 integral in `z` (it needs `H` as a function of `z`); the differential relation above is what is
-proved.
+proved. The Taylor expansions themselves (with remainder, through the inverse of `t ↦ z(t)`) are
+not stated: only their coefficients are.
 
 ## ii. Key results
 
@@ -40,6 +44,13 @@ proved.
   `deriv_properDistance_eq_iff`.
 - `spatialGeometryOfCurvature`, `transverseComovingDistance` and its three closed forms.
 - `particleHorizon`, `eventHorizon`, `particleHorizon_einsteinDeSitter`.
+- `lookbackTime`; `deriv_redshift_self`, `deriv_deriv_redshift_self`: `∂ₜ z = - H₀` and
+  `∂ₜ ∂ₜ z = H₀² (2 + q₀)` at `t₀`, the coefficients of `t₀ - t = H₀⁻¹ [z - ½ (2 + q₀) z² + …]`.
+- `luminosityDistance`, `angularDiameterDistance`, `luminosityDistance_eq`: Etherington.
+- `deriv_deriv_comovingDistance_self`, `comovingDistance_coeff_one`, `comovingDistance_coeff_two`:
+  `dχ/dz = c / (a₀ H₀)` and `d²χ/dz² = - c (1 + q₀) / (a₀ H₀)` at `z = 0`;
+  `luminosityDistance_coeff_two`, `angularDiameterDistance_coeff_two`: the second-order
+  coefficients `c (1 - q₀) / (a₀ H₀)` and `- c (3 + q₀) / (a₀ H₀)` of `d_L` and `d_A` (flat case).
 
 ## iii. Table of contents
 
@@ -48,6 +59,9 @@ proved.
 - C. The proper distance and the Hubble radius
 - D. The transverse comoving distance
 - E. The horizons
+- F. The lookback time and its expansion
+- G. The luminosity and angular-diameter distances
+- H. The low-redshift expansions of the distances
 
 -/
 
@@ -227,6 +241,142 @@ lemma particleHorizon_einsteinDeSitter {t₀ c : ℝ} (ht₀ : 0 < t₀) {t : Ti
   rw [intervalIntegral.integral_congr hcongr, intervalIntegral.integral_const_mul,
     integral_rpow (Or.inl (by norm_num)), Real.zero_rpow (by norm_num)]
   norm_num
+  ring
+
+/-!
+
+## F. The lookback time and its expansion
+
+-/
+
+/-- The lookback time `t₀ - t`. -/
+def lookbackTime (t₀ t : Time) : ℝ := t₀.val - t.val
+
+/-- At the observation time, `∂ₜ z = - H₀`: the first-order coefficient `dt/dz = - 1 / H₀`. -/
+lemma deriv_redshift_self {a : Time → ℝ} {t₀ : Time} (hd : DifferentiableAt ℝ a t₀)
+    (ha : a t₀ ≠ 0) : ∂ₜ (redshift a t₀) t₀ = -hubbleConstant a t₀ := by
+  rw [deriv_redshift hd ha, one_add_redshift, div_self ha]
+  ring
+
+/-- `∂ₜ z = - a(t₀) ∂ₜ a / a²` at all times, for `a` differentiable and nonzero. -/
+lemma deriv_redshift_eq {a : Time → ℝ} {t₀ : Time} (hd : Differentiable ℝ a) (hapos : ∀ s, a s ≠ 0)
+    (s : Time) : ∂ₜ (redshift a t₀) s = -(a t₀ * ∂ₜ a s) / a s ^ 2 := by
+  rw [deriv_redshift (hd s) (hapos s), one_add_redshift]
+  unfold hubbleConstant
+  have := hapos s
+  field_simp
+
+/-- At the observation time, `∂ₜ ∂ₜ z = H₀² (2 + q₀)`: the second-order coefficient
+  `d²t/dz² = (2 + q₀) / H₀` of the lookback time `t₀ - t = H₀⁻¹ [z - ½ (2 + q₀) z² + …]`. -/
+lemma deriv_deriv_redshift_self {a : Time → ℝ} {t₀ : Time} (hd : Differentiable ℝ a)
+    (hdd : DifferentiableAt ℝ (∂ₜ a) t₀) (hapos : ∀ s, a s ≠ 0) (hd0 : ∂ₜ a t₀ ≠ 0) :
+    ∂ₜ (∂ₜ (redshift a t₀)) t₀ = hubbleConstant a t₀ ^ 2 * (2 + decelerationParameter a t₀) := by
+  have hz := deriv_redshift_eq (t₀ := t₀) hd hapos
+  obtain ⟨τ₀⟩ := t₀
+  have hA := hasDerivAt_mk_of_differentiableAt (hd ⟨τ₀⟩)
+  have hA' := hasDerivAt_mk_of_differentiableAt hdd
+  have h := ((hA'.const_mul (a ⟨τ₀⟩)).div (hA.pow 2) (pow_ne_zero 2 (hapos ⟨τ₀⟩))).neg
+  refine (deriv_eq_of_hasDerivAt (f := ∂ₜ (redshift a ⟨τ₀⟩))
+    (h.congr_of_eventuallyEq (Filter.Eventually.of_forall fun σ => ?_))).trans ?_
+  · simp only [Pi.neg_apply, Pi.div_apply, Pi.pow_apply]
+    rw [hz ⟨σ⟩]
+    ring
+  · simp only [Pi.pow_apply, Nat.cast_ofNat, Nat.add_one_sub_one, pow_one]
+    unfold hubbleConstant decelerationParameter
+    have := hapos ⟨τ₀⟩
+    field_simp
+    ring
+
+/-!
+
+## G. The luminosity and angular-diameter distances
+
+-/
+
+/-- The luminosity distance `d_L = (1 + z) r(χ)`. -/
+noncomputable def luminosityDistance (K : ℝ) (a : Time → ℝ) (c : ℝ) (t₀ t : Time) : ℝ :=
+  (1 + redshift a t₀ t) * transverseComovingDistance K (comovingDistance a c t t₀)
+
+/-- The angular-diameter distance `d_A = r(χ) / (1 + z)`. -/
+noncomputable def angularDiameterDistance (K : ℝ) (a : Time → ℝ) (c : ℝ) (t₀ t : Time) : ℝ :=
+  transverseComovingDistance K (comovingDistance a c t t₀) / (1 + redshift a t₀ t)
+
+/-- Etherington's distance-duality relation `d_L = (1 + z)² d_A`. -/
+lemma luminosityDistance_eq {K : ℝ} {a : Time → ℝ} {c : ℝ} {t₀ t : Time} (ha₀ : a t₀ ≠ 0)
+    (ha : a t ≠ 0) :
+    luminosityDistance K a c t₀ t
+      = (1 + redshift a t₀ t) ^ 2 * angularDiameterDistance K a c t₀ t := by
+  have hz : 1 + redshift a t₀ t ≠ 0 := by
+    rw [one_add_redshift]
+    exact div_ne_zero ha₀ ha
+  unfold luminosityDistance angularDiameterDistance
+  field_simp
+
+/-!
+
+## H. The low-redshift expansions of the distances
+
+The comoving distance as a function of the redshift has, at `z = 0`, the derivatives
+`dχ/dz = χ' / z'` and `d²χ/dz² = (χ'' z' - χ' z'') / z'³` (primes are time derivatives at `t₀`);
+they are computed here, giving `χ = (c / (a₀ H₀)) [z - ½ (1 + q₀) z² + …]`, and, in the flat
+case `r(χ) = χ`, `d_L = (c / (a₀ H₀)) [z + ½ (1 - q₀) z² + …]` and
+`d_A = (c / (a₀ H₀)) [z - ½ (3 + q₀) z² + …]`.
+
+-/
+
+/-- At the observation time, `∂ₜ ∂ₜ χ = c H₀ / a₀`. -/
+lemma deriv_deriv_comovingDistance_self {a : Time → ℝ} {c : ℝ} (hcont : Continuous a)
+    (hapos : ∀ s, 0 < a s) {t₀ : Time} (hd : DifferentiableAt ℝ a t₀) :
+    ∂ₜ (∂ₜ (fun s => comovingDistance a c s t₀)) t₀ = c * hubbleConstant a t₀ / a t₀ := by
+  have hχ := deriv_comovingDistance (c := c) hcont hapos t₀
+  obtain ⟨τ₀⟩ := t₀
+  have hA := hasDerivAt_mk_of_differentiableAt hd
+  have h := (hasDerivAt_const τ₀ (-c)).div hA (hapos ⟨τ₀⟩).ne'
+  refine (deriv_eq_of_hasDerivAt (f := ∂ₜ (fun s => comovingDistance a c s ⟨τ₀⟩))
+    (h.congr_of_eventuallyEq (Filter.Eventually.of_forall fun σ => hχ ⟨σ⟩))).trans ?_
+  unfold hubbleConstant
+  have := (hapos ⟨τ₀⟩).ne'
+  field_simp
+  ring
+
+/-- `dχ/dz = χ' / z' = c / (a₀ H₀)` at `z = 0`. -/
+lemma comovingDistance_coeff_one {a : Time → ℝ} {c : ℝ} (hcont : Continuous a)
+    (hapos : ∀ s, 0 < a s) {t₀ : Time} (hd : DifferentiableAt ℝ a t₀)
+    (hH : hubbleConstant a t₀ ≠ 0) :
+    ∂ₜ (fun s => comovingDistance a c s t₀) t₀ / ∂ₜ (redshift a t₀) t₀
+      = c / (a t₀ * hubbleConstant a t₀) := by
+  rw [deriv_comovingDistance hcont hapos, deriv_redshift_self hd (hapos t₀).ne']
+  have := (hapos t₀).ne'
+  field_simp
+
+/-- `d²χ/dz² = (χ'' z' - χ' z'') / z'³ = - c (1 + q₀) / (a₀ H₀)` at `z = 0`. -/
+lemma comovingDistance_coeff_two {a : Time → ℝ} {c : ℝ} (hcont : Continuous a)
+    (hapos : ∀ s, 0 < a s) {t₀ : Time} (hd : Differentiable ℝ a)
+    (hdd : DifferentiableAt ℝ (∂ₜ a) t₀) (hd0 : ∂ₜ a t₀ ≠ 0) :
+    (∂ₜ (∂ₜ (fun s => comovingDistance a c s t₀)) t₀ * ∂ₜ (redshift a t₀) t₀
+      - ∂ₜ (fun s => comovingDistance a c s t₀) t₀ * ∂ₜ (∂ₜ (redshift a t₀)) t₀)
+      / ∂ₜ (redshift a t₀) t₀ ^ 3
+      = -(c * (1 + decelerationParameter a t₀) / (a t₀ * hubbleConstant a t₀)) := by
+  have hne : ∀ s, a s ≠ 0 := fun s => (hapos s).ne'
+  rw [deriv_deriv_comovingDistance_self hcont hapos (hd t₀), deriv_comovingDistance hcont hapos,
+    deriv_redshift_self (hd t₀) (hne t₀), deriv_deriv_redshift_self hd hdd hne hd0]
+  unfold hubbleConstant decelerationParameter
+  have := hne t₀
+  field_simp
+  ring
+
+/-- Flat case: the second-order coefficient of `d_L = (1 + z) χ(z)` is `2 χ₁ + χ₂`, which with
+  `χ₁ = c / (a₀ H₀)` and `χ₂ = - c (1 + q₀) / (a₀ H₀)` is `c (1 - q₀) / (a₀ H₀)`. -/
+lemma luminosityDistance_coeff_two (c a₀ H₀ q₀ : ℝ) (hH : H₀ ≠ 0) (ha : a₀ ≠ 0) :
+    2 * (c / (a₀ * H₀)) + -(c * (1 + q₀) / (a₀ * H₀)) = c * (1 - q₀) / (a₀ * H₀) := by
+  field_simp
+  ring
+
+/-- Flat case: the second-order coefficient of `d_A = χ(z) / (1 + z)` is `χ₂ - 2 χ₁`, which is
+  `- c (3 + q₀) / (a₀ H₀)`. -/
+lemma angularDiameterDistance_coeff_two (c a₀ H₀ q₀ : ℝ) (hH : H₀ ≠ 0) (ha : a₀ ≠ 0) :
+    -(c * (1 + q₀) / (a₀ * H₀)) - 2 * (c / (a₀ * H₀)) = -(c * (3 + q₀) / (a₀ * H₀)) := by
+  field_simp
   ring
 
 end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Distances.lean
+++ b/Physlib/Cosmology/FLRW/Distances.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/Distances.lean
+++ b/Physlib/Cosmology/FLRW/Distances.lean
@@ -212,13 +212,14 @@ noncomputable def eventHorizon (a : Time → ℝ) (c : ℝ) (t : Time) : ℝ :=
 
 /-- The particle horizon of the Einstein-de Sitter universe from `t = 0` is finite,
   `3 c t₀^(2/3) t^(1/3)`. -/
-lemma particleHorizon_einsteinDeSitter {t₀ c : ℝ} (ht₀ : 0 < t₀) {t : Time} (ht : 0 < t.val) :
+lemma particleHorizon_einsteinDeSitter {t₀ : Time} {c : ℝ} (ht₀ : 0 < t₀.val) {t : Time}
+    (ht : 0 < t.val) :
     particleHorizon (einsteinDeSitterScaleFactor t₀) c ⟨0⟩ t
-      = 3 * c * t₀ ^ (2 / 3 : ℝ) * t.val ^ (1 / 3 : ℝ) := by
-  unfold particleHorizon comovingDistance einsteinDeSitterScaleFactor powerLawScaleFactor
+      = 3 * c * t₀.val ^ (2 / 3 : ℝ) * t.val ^ (1 / 3 : ℝ) := by
+  unfold particleHorizon comovingDistance einsteinDeSitterScaleFactor
   dsimp only
-  have hcongr : Set.EqOn (fun τ : ℝ => 1 / (τ / t₀) ^ (2 / 3 : ℝ))
-      (fun τ : ℝ => t₀ ^ (2 / 3 : ℝ) * τ ^ (-(2 / 3) : ℝ)) (Set.uIcc 0 t.val) := by
+  have hcongr : Set.EqOn (fun τ : ℝ => 1 / (τ / t₀.val) ^ (2 / 3 : ℝ))
+      (fun τ : ℝ => t₀.val ^ (2 / 3 : ℝ) * τ ^ (-(2 / 3) : ℝ)) (Set.uIcc 0 t.val) := by
     intro τ hτ
     rw [Set.uIcc_of_le ht.le] at hτ
     have h0 : 0 ≤ τ := hτ.1

--- a/Physlib/Cosmology/FLRW/Dynamics.lean
+++ b/Physlib/Cosmology/FLRW/Dynamics.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/Dynamics.lean
+++ b/Physlib/Cosmology/FLRW/Dynamics.lean
@@ -1,43 +1,352 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
-public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.DensityParameters
+public import Physlib.Cosmology.FLRW.Solutions
+public import Mathlib.Analysis.Calculus.Deriv.MeanValue
+public import Mathlib.Topology.Order.IntermediateValue
 /-!
 
 # Dynamical criteria for FLRW cosmology
 
-Placeholder file collecting TODO items for the qualitative consequences of the
-Friedmann and acceleration equations: the energy conditions of the cosmic fluid,
-the criterion for accelerated expansion, the deceleration parameter in terms of the
-density parameters, the condition for eternal expansion, and the existence of a
-Big-Bang singularity. This file contains only TODO items; no definitions or lemmas
-are formalized yet.
+## i. Overview
+
+Qualitative consequences of the Friedmann equations of `Physlib.Cosmology.FLRW.Basic`:
+the energy conditions of the cosmic fluid; the expansion accelerates if and only if the fluid
+(with the cosmological constant folded in as a `w = -1` component) violates the strong energy
+condition; the deceleration parameter is `q = ½ Σ_x Ω_x (1 + 3 w_x)` for a finite family of
+barotropic fluids, `q = ½ (Ω_m + 2 Ω_r - 2 Ω_Λ)` for ΛCDM; a universe with `k ≤ 0`, positive
+density and `Λ ≥ 0` has `∂ₜ a ≠ 0` at all times, so that an expanding universe expands forever;
+and a decelerating universe expanding at `t₀` has `a ≤ 0` at every time earlier than
+`t₀ - a(t₀) / ∂ₜ a(t₀) = t₀ - 1 / H₀`, so that its scale factor vanishes at a finite time in the
+past if it is continuous, whereas the de Sitter scale factor is positive at all times.
+
+## ii. Key results
+
+- `NullEnergyCondition`, `WeakEnergyCondition`, `StrongEnergyCondition`,
+  `DominantEnergyCondition` and the implications between them.
+- `deriv_deriv_pos_iff`: `∂ₜ ∂ₜ a > 0 ↔ ρ + 3 p / c² < 0` (`Λ = 0`);
+  `deriv_deriv_pos_iff_lambda`: the same for the total fluid with `Λ` folded in.
+- `decelerationParameter_eq_sum`: `q = ½ Σ_i Ω_i (1 + 3 w_i)`;
+  `decelerationParameter_lambdaCDM`: `q = ½ (Ω_m + 2 Ω_r - 2 Ω_Λ)`.
+- `deriv_ne_zero_of_friedmann`, `deriv_pos_of_friedmann`: eternal expansion for `k ≤ 0`.
+- `deriv_deriv_nonpos_of_friedmann`, `scaleFactor_nonpos_of_decelerating`,
+  `exists_scaleFactor_eq_zero`: the Big-Bang bound and the existence of a zero of `a`;
+  `deSitterScaleFactor_pos`: no such zero for de Sitter.
+
+## iii. Table of contents
+
+- A. The energy conditions
+- B. Accelerated expansion and the strong energy condition
+- C. The deceleration parameter in terms of the density parameters
+- D. Eternal expansion
+- E. The Big-Bang singularity
+  - E.1. Deceleration from the second-order Friedmann equation
+  - E.2. The bound on the scale factor
+  - E.3. The de Sitter contrast
 
 -/
 
 @[expose] public section
 
-TODO "Define the energy conditions for the cosmic perfect fluid: the null `ρ + P/c² ≥ 0`,
-  weak `ρ ≥ 0 ∧ ρ + P/c² ≥ 0`, strong `ρ + P/c² ≥ 0 ∧ ρ + 3 P/c² ≥ 0`, and dominant
-  `ρ ≥ 0 ∧ |P| ≤ ρ c²` energy conditions."
+namespace Cosmology.FLRW.FriedmannEquation
 
-TODO "Prove that the expansion accelerates iff the cosmic fluid (with the cosmological
-  constant folded in as a `w = −1` component) violates the strong energy condition:
-  `∂ₜ ∂ₜ a > 0 ↔ ρ_tot + 3 P_tot / c² < 0`."
+open Real Time
 
-TODO "Prove the deceleration parameter in terms of the density parameters and equations of
-  state, for a spatially flat universe: `q = ½ Σ_x Ω_x (1 + 3 w_x)`; in particular
-  `q₀ = ½ Σ_x Ω_{x0} (1 + 3 w_x)`, giving `q₀ = ½ (Ω_{m0} + 2 Ω_{r0} − 2 Ω_Λ)` for ΛCDM."
+/-!
 
-TODO "Prove that a universe with `K ≤ 0`, nonnegative density and `Λ ≥ 0` expands forever:
-  the Friedmann right-hand side stays positive, so `∂ₜ a` never vanishes, and hence
-  `∂ₜ a > 0` at one instant implies `∂ₜ a > 0` at all later times."
+## A. The energy conditions
 
-TODO "Prove the existence of a Big-Bang singularity: a currently expanding, decelerating
-  universe (`ρ > 0`, `P ≥ 0`, `Λ = 0`) reaches `a = 0` at a finite cosmic time in the past,
-  giving a finite age `t₀ < 1 / H₀`; contrast the de Sitter case, which has no such
-  singularity."
+-/
+
+/-- The null energy condition `ρ + p / c² ≥ 0`. -/
+def NullEnergyCondition (ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop := 0 ≤ ρ t + p t / c ^ 2
+
+/-- The weak energy condition `ρ ≥ 0 ∧ ρ + p / c² ≥ 0`. -/
+def WeakEnergyCondition (ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
+  0 ≤ ρ t ∧ 0 ≤ ρ t + p t / c ^ 2
+
+/-- The strong energy condition `ρ + p / c² ≥ 0 ∧ ρ + 3 p / c² ≥ 0`. -/
+def StrongEnergyCondition (ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
+  0 ≤ ρ t + p t / c ^ 2 ∧ 0 ≤ ρ t + 3 * p t / c ^ 2
+
+/-- The dominant energy condition `ρ ≥ 0 ∧ |p| ≤ ρ c²`. -/
+def DominantEnergyCondition (ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
+  0 ≤ ρ t ∧ |p t| ≤ ρ t * c ^ 2
+
+lemma WeakEnergyCondition.of_dominant {ρ p : Time → ℝ} {c : ℝ} {t : Time} (hc : c ≠ 0)
+    (h : DominantEnergyCondition ρ p c t) : WeakEnergyCondition ρ p c t := by
+  obtain ⟨h0, h1⟩ := h
+  have hc2 : 0 < c ^ 2 := by positivity
+  have h2 : -(ρ t * c ^ 2) ≤ p t := (abs_le.mp h1).1
+  refine ⟨h0, ?_⟩
+  have : -(ρ t) ≤ p t / c ^ 2 := by
+    rw [le_div_iff₀ hc2]
+    linarith
+  linarith
+
+lemma NullEnergyCondition.of_weak {ρ p : Time → ℝ} {c : ℝ} {t : Time}
+    (h : WeakEnergyCondition ρ p c t) : NullEnergyCondition ρ p c t := h.2
+
+lemma NullEnergyCondition.of_strong {ρ p : Time → ℝ} {c : ℝ} {t : Time}
+    (h : StrongEnergyCondition ρ p c t) : NullEnergyCondition ρ p c t := h.1
+
+/-!
+
+## B. Accelerated expansion and the strong energy condition
+
+-/
+
+/-- Without cosmological constant, the expansion accelerates if and only if
+  `ρ + 3 p / c² < 0`, that is, if and only if the strong energy condition fails through its
+  second inequality. -/
+lemma deriv_deriv_pos_iff {a ρ p : Time → ℝ} {G c : ℝ} {t : Time} (hG : 0 < G) (ha : 0 < a t)
+    (hF2 : SecondOrderFriedmann a ρ p 0 G c t) :
+    0 < ∂ₜ (∂ₜ a) t ↔ ρ t + 3 * p t / c ^ 2 < 0 := by
+  unfold SecondOrderFriedmann at hF2
+  rw [← div_pos_iff_of_pos_right ha, hF2]
+  have hk : 0 < 4 * π * G / 3 := by positivity
+  simp only [zero_mul, zero_div, add_zero]
+  constructor
+  · intro h
+    by_contra hX
+    have hX' := not_lt.mp hX
+    have := mul_nonneg hk.le hX'
+    linarith
+  · intro h
+    have := mul_pos hk (neg_pos.mpr h)
+    linarith
+
+/-- With cosmological constant, the expansion accelerates if and only if the total fluid,
+  `Λ` folded in as the `w = -1` component, violates `ρ + 3 p / c² ≥ 0`. -/
+lemma deriv_deriv_pos_iff_lambda {a ρ p : Time → ℝ} {Λ G c : ℝ} {t : Time} (hG : 0 < G)
+    (hc : c ≠ 0) (ha : 0 < a t) (hF2 : SecondOrderFriedmann a ρ p Λ G c t) :
+    0 < ∂ₜ (∂ₜ a) t ↔
+      (ρ t + cosmologicalConstantDensity Λ G c)
+        + 3 * (p t + cosmologicalConstantPressure Λ G c) / c ^ 2 < 0 :=
+  deriv_deriv_pos_iff hG ha ((secondOrderFriedmann_iff_lambdaFluid hG.ne' hc).mp hF2)
+
+/-!
+
+## C. The deceleration parameter in terms of the density parameters
+
+-/
+
+/-- For a finite family of barotropic fluids `ρ_i` with `p_i = w_i ρ_i c²`, without
+  cosmological constant, `q = ½ Σ_i Ω_i (1 + 3 w_i)`. -/
+lemma decelerationParameter_eq_sum {n : ℕ} {a : Time → ℝ} {ρi : Fin n → Time → ℝ}
+    {w : Fin n → ℝ} {G c : ℝ} {t : Time} (hG : G ≠ 0) (hc : c ≠ 0) (ha : a t ≠ 0)
+    (hH : hubbleConstant a t ≠ 0)
+    (hF2 : SecondOrderFriedmann a (fun s => ∑ i, ρi i s) (fun s => ∑ i, w i * ρi i s * c ^ 2)
+      0 G c t) :
+    decelerationParameter a t = 1 / 2 * ∑ i, densityParameter a (ρi i) G t * (1 + 3 * w i) := by
+  unfold SecondOrderFriedmann at hF2
+  dsimp only at hF2
+  have hsum1 : (∑ i, ρi i t) + 3 * (∑ i, w i * ρi i t * c ^ 2) / c ^ 2
+      = ∑ i, ρi i t * (1 + 3 * w i) := by
+    rw [mul_div_assoc, Finset.sum_div, Finset.mul_sum, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    field_simp
+  rw [hsum1] at hF2
+  have ha'' := (div_eq_iff ha).mp hF2
+  have hsum2 : ∑ i, densityParameter a (ρi i) G t * (1 + 3 * w i)
+      = 8 * π * G / (3 * hubbleConstant a t ^ 2) * ∑ i, ρi i t * (1 + 3 * w i) := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    unfold densityParameter criticalDensity
+    have hπ := Real.pi_ne_zero
+    field_simp
+  rw [hsum2]
+  unfold decelerationParameter
+  unfold hubbleConstant at hH ⊢
+  rw [ha'']
+  have hπ := Real.pi_ne_zero
+  field_simp
+  ring
+
+/-- ΛCDM: matter (`w = 0`), radiation (`w = 1/3`) and the cosmological constant give
+  `q = ½ (Ω_m + 2 Ω_r - 2 Ω_Λ)`. -/
+lemma decelerationParameter_lambdaCDM {a ρm ρr : Time → ℝ} {Λ G c : ℝ} {t : Time}
+    (hc : c ≠ 0) (ha : a t ≠ 0)
+    (hF2 : SecondOrderFriedmann a (fun s => ρm s + ρr s) (fun s => ρr s * c ^ 2 / 3) Λ G c t) :
+    decelerationParameter a t = 1 / 2 * (densityParameter a ρm G t
+      + 2 * densityParameter a ρr G t - 2 * lambdaDensityParameter a Λ c t) := by
+  unfold SecondOrderFriedmann at hF2
+  dsimp only at hF2
+  have ha'' := (div_eq_iff ha).mp hF2
+  unfold decelerationParameter densityParameter lambdaDensityParameter criticalDensity
+  unfold hubbleConstant
+  rw [ha'']
+  have hπ := Real.pi_ne_zero
+  field_simp
+  ring
+
+/-!
+
+## D. Eternal expansion
+
+-/
+
+/-- For `k ≤ 0`, `Λ ≥ 0` and positive density, the first-order Friedmann equation forces
+  `H² > 0`, hence `∂ₜ a ≠ 0` at every time. -/
+lemma deriv_ne_zero_of_friedmann {a ρ : Time → ℝ} {k Λ G c : ℝ} (hk : k ≤ 0) (hΛ : 0 ≤ Λ)
+    (hρ : ∀ s, 0 < ρ s) (hapos : ∀ s, 0 < a s) (hG : 0 < G)
+    (hF1 : ∀ s, FirstOrderFriedmann a ρ k Λ G c s) (s : Time) : ∂ₜ a s ≠ 0 := by
+  have h := hF1 s
+  unfold FirstOrderFriedmann at h
+  have h1 : 0 ≤ -(k * c ^ 2 / a s ^ 2) := by
+    have ha2 : 0 < a s ^ 2 := by
+      have := hapos s
+      positivity
+    have hkc : k * c ^ 2 ≤ 0 := by nlinarith [sq_nonneg c, hk]
+    have : k * c ^ 2 / a s ^ 2 ≤ 0 := (div_le_iff₀ ha2).mpr (by linarith)
+    linarith
+  have h2 : 0 < 8 * π * G / 3 * ρ s := by
+    have := hρ s
+    positivity
+  have h3 : 0 ≤ Λ * c ^ 2 / 3 := by positivity
+  have hsq : 0 < (∂ₜ a s / a s) ^ 2 := by
+    rw [h]
+    linarith
+  have hne : ∂ₜ a s / a s ≠ 0 := by
+    intro h0
+    rw [h0] at hsq
+    simp at hsq
+  exact (div_ne_zero_iff.mp hne).1
+
+/-- If moreover `∂ₜ a` is continuous and positive at one time, it is positive at all times:
+  an expanding universe with `k ≤ 0`, `Λ ≥ 0` and positive density expands forever. -/
+lemma deriv_pos_of_friedmann {a ρ : Time → ℝ} {k Λ G c : ℝ} (hk : k ≤ 0) (hΛ : 0 ≤ Λ)
+    (hρ : ∀ s, 0 < ρ s) (hapos : ∀ s, 0 < a s) (hG : 0 < G)
+    (hF1 : ∀ s, FirstOrderFriedmann a ρ k Λ G c s) (hcont : Continuous (∂ₜ a)) {t₀ : Time}
+    (h0 : 0 < ∂ₜ a t₀) (s : Time) : 0 < ∂ₜ a s := by
+  have hne := deriv_ne_zero_of_friedmann hk hΛ hρ hapos hG hF1
+  have hf : Continuous (fun σ : ℝ => ∂ₜ a ⟨σ⟩) := hcont.comp toRealCLE.symm.continuous
+  obtain ⟨τ₀⟩ := t₀
+  obtain ⟨σ⟩ := s
+  by_contra hle
+  have hle' := not_lt.mp hle
+  have hlt : ∂ₜ a ⟨σ⟩ < 0 := lt_of_le_of_ne hle' (hne ⟨σ⟩)
+  rcases le_or_gt σ τ₀ with hστ | hστ
+  · have hmem : (0 : ℝ) ∈ Set.Icc (∂ₜ a ⟨σ⟩) (∂ₜ a ⟨τ₀⟩) := ⟨hlt.le, h0.le⟩
+    obtain ⟨x, _, hx⟩ := intermediate_value_Icc hστ hf.continuousOn hmem
+    exact hne ⟨x⟩ hx
+  · have hmem : (0 : ℝ) ∈ Set.Icc (∂ₜ a ⟨σ⟩) (∂ₜ a ⟨τ₀⟩) := ⟨hlt.le, h0.le⟩
+    obtain ⟨x, _, hx⟩ := intermediate_value_Icc' hστ.le hf.continuousOn hmem
+    exact hne ⟨x⟩ hx
+
+/-!
+
+## E. The Big-Bang singularity
+
+-/
+
+/-!
+
+### E.1. Deceleration from the second-order Friedmann equation
+
+-/
+
+/-- With `ρ ≥ 0`, `p ≥ 0`, `Λ = 0` and `a > 0`, the second-order Friedmann equation gives
+  `∂ₜ ∂ₜ a ≤ 0`. -/
+lemma deriv_deriv_nonpos_of_friedmann {a ρ p : Time → ℝ} {G c : ℝ} {t : Time} (hρ : 0 ≤ ρ t)
+    (hp : 0 ≤ p t) (ha : 0 < a t) (hG : 0 < G) (hc : c ≠ 0)
+    (hF2 : SecondOrderFriedmann a ρ p 0 G c t) : ∂ₜ (∂ₜ a) t ≤ 0 := by
+  unfold SecondOrderFriedmann at hF2
+  have ha'' := (div_eq_iff ha.ne').mp hF2
+  rw [ha'']
+  have hc2 : 0 < c ^ 2 := by positivity
+  have hX : 0 ≤ ρ t + 3 * p t / c ^ 2 := by positivity
+  have hk : 0 ≤ 4 * π * G / 3 := by positivity
+  have := mul_nonneg (mul_nonneg hk hX) ha.le
+  linarith
+
+/-!
+
+### E.2. The bound on the scale factor
+
+-/
+
+/-- The curve `σ ↦ a ⟨σ⟩` on `ℝ` is differentiable with derivative `σ ↦ ∂ₜ a ⟨σ⟩`. -/
+lemma deriv_mk_eq {a : Time → ℝ} (hd1 : Differentiable ℝ a) (σ : ℝ) :
+    deriv (fun σ : ℝ => a ⟨σ⟩) σ = ∂ₜ a ⟨σ⟩ :=
+  (hasDerivAt_mk_of_differentiableAt (hd1 ⟨σ⟩)).deriv
+
+/-- If `a` is twice differentiable with `∂ₜ ∂ₜ a ≤ 0` at all times and `∂ₜ a t₀ > 0`, then
+  `a t ≤ 0` for every `t` with `t ≤ t₀ - a t₀ / ∂ₜ a t₀`: a decelerating universe expanding
+  at `t₀` cannot have a positive scale factor earlier than `t₀ - 1 / H₀`. The proof is the
+  tangent-line bound `a t ≤ a t₀ + ∂ₜ a t₀ (t - t₀)` of a function with non-increasing
+  derivative. -/
+lemma scaleFactor_nonpos_of_decelerating {a : Time → ℝ} (hd1 : Differentiable ℝ a)
+    (hd2 : Differentiable ℝ (∂ₜ a)) (hdec : ∀ s, ∂ₜ (∂ₜ a) s ≤ 0) {t₀ : Time}
+    (h0 : 0 < ∂ₜ a t₀) {t : Time} (ht : t.val ≤ t₀.val - a t₀ / ∂ₜ a t₀) : a t ≤ 0 := by
+  obtain ⟨τ₀⟩ := t₀
+  obtain ⟨σ⟩ := t
+  dsimp only at ht
+  have hf : Differentiable ℝ (fun σ : ℝ => a ⟨σ⟩) :=
+    hd1.comp toRealCLE.symm.differentiable
+  have hf' : Differentiable ℝ (fun σ : ℝ => ∂ₜ a ⟨σ⟩) :=
+    hd2.comp toRealCLE.symm.differentiable
+  have hanti : Antitone (fun σ : ℝ => ∂ₜ a ⟨σ⟩) :=
+    antitone_of_deriv_nonpos hf' fun x => by
+      rw [(hasDerivAt_mk_of_differentiableAt (hd2 ⟨x⟩)).deriv]
+      exact hdec ⟨x⟩
+  have htan : a ⟨σ⟩ ≤ a ⟨τ₀⟩ + ∂ₜ a ⟨τ₀⟩ * (σ - τ₀) := by
+    rcases le_or_gt σ τ₀ with h | h
+    · have := Convex.mul_sub_le_image_sub_of_le_deriv (convex_Iic τ₀)
+        hf.continuous.continuousOn hf.differentiableOn (C := ∂ₜ a ⟨τ₀⟩)
+        (fun x hx => by
+          rw [deriv_mk_eq hd1]
+          rw [interior_Iic] at hx
+          exact hanti (le_of_lt hx))
+        σ (Set.mem_Iic.mpr h) τ₀ (Set.mem_Iic.mpr le_rfl) h
+      linarith
+    · have := Convex.image_sub_le_mul_sub_of_deriv_le (convex_Ici τ₀)
+        hf.continuous.continuousOn hf.differentiableOn (C := ∂ₜ a ⟨τ₀⟩)
+        (fun x hx => by
+          rw [deriv_mk_eq hd1]
+          rw [interior_Ici] at hx
+          exact hanti (le_of_lt hx))
+        τ₀ (Set.mem_Ici.mpr le_rfl) σ (Set.mem_Ici.mpr h.le) h.le
+      linarith
+  have hσ : ∂ₜ a ⟨τ₀⟩ * σ ≤ ∂ₜ a ⟨τ₀⟩ * τ₀ - a ⟨τ₀⟩ := by
+    have := mul_le_mul_of_nonneg_left ht h0.le
+    rw [mul_sub, mul_div_cancel₀ _ h0.ne'] at this
+    exact this
+  linarith
+
+/-- A decelerating universe expanding at `t₀` with `a t₀ > 0` has a zero of its scale factor
+  at some time (earlier than `t₀`), by the intermediate value theorem: the Big-Bang
+  singularity, at most `1 / H₀` in the past. -/
+lemma exists_scaleFactor_eq_zero {a : Time → ℝ} (hd1 : Differentiable ℝ a)
+    (hd2 : Differentiable ℝ (∂ₜ a)) (hdec : ∀ s, ∂ₜ (∂ₜ a) s ≤ 0) {t₀ : Time}
+    (h0 : 0 < ∂ₜ a t₀) (ha0 : 0 < a t₀) : ∃ t : Time, a t = 0 := by
+  obtain ⟨τ₀⟩ := t₀
+  obtain ⟨τ₁, hτ₁⟩ : ∃ τ₁ : ℝ, τ₁ = τ₀ - a ⟨τ₀⟩ / ∂ₜ a ⟨τ₀⟩ := ⟨_, rfl⟩
+  have hle : τ₁ ≤ τ₀ := by
+    have : 0 < a ⟨τ₀⟩ / ∂ₜ a ⟨τ₀⟩ := div_pos ha0 h0
+    linarith
+  have h1 : a ⟨τ₁⟩ ≤ 0 :=
+    scaleFactor_nonpos_of_decelerating hd1 hd2 hdec h0 (t := ⟨τ₁⟩) (by dsimp only; rw [hτ₁])
+  have hf : Continuous (fun σ : ℝ => a ⟨σ⟩) := hd1.continuous.comp toRealCLE.symm.continuous
+  have hmem : (0 : ℝ) ∈ Set.Icc (a ⟨τ₁⟩) (a ⟨τ₀⟩) := ⟨h1, ha0.le⟩
+  obtain ⟨x, _, hx⟩ := intermediate_value_Icc hle hf.continuousOn hmem
+  exact ⟨⟨x⟩, hx⟩
+
+/-!
+
+### E.3. The de Sitter contrast
+
+-/
+
+/-- The de Sitter scale factor is positive at all times: no Big-Bang singularity. -/
+lemma deSitterScaleFactor_pos {a₀ σ Λ c : ℝ} (ha₀ : 0 < a₀) (t : Time) :
+    0 < deSitterScaleFactor a₀ σ Λ c t := by
+  unfold deSitterScaleFactor
+  positivity
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Dynamics.lean
+++ b/Physlib/Cosmology/FLRW/Dynamics.lean
@@ -271,11 +271,6 @@ lemma deriv_deriv_nonpos_of_friedmann {a ρ p : Time → ℝ} {G c : ℝ} {t : T
 
 -/
 
-/-- The curve `σ ↦ a ⟨σ⟩` on `ℝ` is differentiable with derivative `σ ↦ ∂ₜ a ⟨σ⟩`. -/
-lemma deriv_mk_eq {a : Time → ℝ} (hd1 : Differentiable ℝ a) (σ : ℝ) :
-    deriv (fun σ : ℝ => a ⟨σ⟩) σ = ∂ₜ a ⟨σ⟩ :=
-  (hasDerivAt_mk_of_differentiableAt (hd1 ⟨σ⟩)).deriv
-
 /-- If `a` is twice differentiable with `∂ₜ ∂ₜ a ≤ 0` at all times and `∂ₜ a t₀ > 0`, then
   `a t ≤ 0` for every `t` with `t ≤ t₀ - a t₀ / ∂ₜ a t₀`: a decelerating universe expanding
   at `t₀` cannot have a positive scale factor earlier than `t₀ - 1 / H₀`. The proof is the
@@ -300,7 +295,7 @@ lemma scaleFactor_nonpos_of_decelerating {a : Time → ℝ} (hd1 : Differentiabl
     · have := Convex.mul_sub_le_image_sub_of_le_deriv (convex_Iic τ₀)
         hf.continuous.continuousOn hf.differentiableOn (C := ∂ₜ a ⟨τ₀⟩)
         (fun x hx => by
-          rw [deriv_mk_eq hd1]
+          rw [(hasDerivAt_mk_of_differentiableAt (hd1 ⟨x⟩)).deriv]
           rw [interior_Iic] at hx
           exact hanti (le_of_lt hx))
         σ (Set.mem_Iic.mpr h) τ₀ (Set.mem_Iic.mpr le_rfl) h
@@ -308,7 +303,7 @@ lemma scaleFactor_nonpos_of_decelerating {a : Time → ℝ} (hd1 : Differentiabl
     · have := Convex.image_sub_le_mul_sub_of_deriv_le (convex_Ici τ₀)
         hf.continuous.continuousOn hf.differentiableOn (C := ∂ₜ a ⟨τ₀⟩)
         (fun x hx => by
-          rw [deriv_mk_eq hd1]
+          rw [(hasDerivAt_mk_of_differentiableAt (hd1 ⟨x⟩)).deriv]
           rw [interior_Ici] at hx
           exact hanti (le_of_lt hx))
         τ₀ (Set.mem_Ici.mpr le_rfl) σ (Set.mem_Ici.mpr h.le) h.le

--- a/Physlib/Cosmology/FLRW/MatterContent.lean
+++ b/Physlib/Cosmology/FLRW/MatterContent.lean
@@ -1,34 +1,177 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
 public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.Basic
 /-!
 
 # Matter content of FLRW cosmology
 
-Placeholder file collecting TODO items for the matter content of a
-Friedmann-Lemaître-Robertson-Walker universe: the perfect-fluid stress-energy
-tensor, the equation of state, the continuity equation, and the resulting
-density scaling for the standard components (dust, radiation, vacuum energy).
-This file contains only TODO items; no definitions or lemmas are formalized yet.
+## i. Overview
+
+This file describes the matter content of a Friedmann-Lemaître-Robertson-Walker universe
+through the continuity equation `∂ₜ ρ + 3 H (ρ + p / c²) = 0` of the cosmic fluid and its
+relation to the two Friedmann equations of `Physlib.Cosmology.FLRW.Basic`: the continuity
+equation follows from the first-order equation (holding at all times) and the second-order
+equation, and conversely the second-order equation follows from the first-order equation and
+the continuity equation whenever `∂ₜ a ≠ 0`. The three equations are therefore not
+independent. The equation of state, the density scaling laws and the perfect-fluid
+stress-energy tensor are still TODO items.
+
+Time derivatives of curves `Time → ℝ` are computed through the bridge
+`Time.hasDerivAt_comp_toRealCLE_symm` to Mathlib's `HasDerivAt` on `ℝ`.
+
+## ii. Key results
+
+- `ContinuityEquation`: the continuity equation at an instant `t`.
+- `deriv_firstOrderFriedmann`: the time derivative of the first-order Friedmann equation,
+  `2 H (a''/a - H²) = (8 π G / 3) ρ' + 2 k c² H / a²`.
+- `continuityEquation_of_friedmann`: the continuity equation follows from the two Friedmann
+  equations.
+- `secondOrderFriedmann_of_continuityEquation`: the second-order Friedmann equation follows
+  from the first-order equation and the continuity equation when `∂ₜ a ≠ 0`.
+
+## iii. Table of contents
+
+- A. Time derivatives through the coordinate
+- B. The continuity equation
+  - B.1. The definition
+  - B.2. The derivative of the first-order Friedmann equation
+  - B.3. Continuity from the Friedmann equations
+  - B.4. The second-order Friedmann equation from continuity
+- C. Remaining TODO items
 
 -/
 
 @[expose] public section
 
+namespace Cosmology.FLRW.FriedmannEquation
+
+open Real Time
+
+/-!
+
+## A. Time derivatives through the coordinate
+
+-/
+
+/-- A curve `f : Time → ℝ` differentiable at `⟨τ⟩` gives the curve `σ ↦ f ⟨σ⟩` on `ℝ`,
+  whose Mathlib derivative at `τ` is the time derivative `∂ₜ f ⟨τ⟩`. -/
+lemma hasDerivAt_mk_of_differentiableAt {f : Time → ℝ} {τ : ℝ}
+    (hf : DifferentiableAt ℝ f ⟨τ⟩) :
+    HasDerivAt (fun σ : ℝ => f ⟨σ⟩) (∂ₜ f ⟨τ⟩) τ :=
+  hasDerivAt_comp_toRealCLE_symm f τ hf
+
+/-!
+
+## B. The continuity equation
+
+-/
+
+/-!
+
+### B.1. The definition
+
+-/
+
+/-- The continuity equation of the cosmic fluid at the instant `t`:
+  `∂ₜ ρ + 3 H (ρ + p / c²) = 0`, with `H = hubbleConstant a`. -/
+def ContinuityEquation (a ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
+  ∂ₜ ρ t + 3 * hubbleConstant a t * (ρ t + p t / c ^ 2) = 0
+
+/-!
+
+### B.2. The derivative of the first-order Friedmann equation
+
+-/
+
+/-- Differentiating the first-order Friedmann equation, assumed at all times, at `⟨τ⟩`:
+  `2 H (a''/a - H²) = (8 π G / 3) ρ' + 2 k c² H / a²`. -/
+lemma deriv_firstOrderFriedmann {a ρ : Time → ℝ} {k Λ G c τ : ℝ} (ha : a ⟨τ⟩ ≠ 0)
+    (hd1 : DifferentiableAt ℝ a ⟨τ⟩) (hd2 : DifferentiableAt ℝ (∂ₜ a) ⟨τ⟩)
+    (hdρ : DifferentiableAt ℝ ρ ⟨τ⟩) (hF1 : ∀ s, FirstOrderFriedmann a ρ k Λ G c s) :
+    2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) * (∂ₜ (∂ₜ a) ⟨τ⟩ / a ⟨τ⟩ - (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) ^ 2)
+      = 8 * π * G / 3 * ∂ₜ ρ ⟨τ⟩
+        + 2 * k * c ^ 2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) / (a ⟨τ⟩) ^ 2 := by
+  have hA := hasDerivAt_mk_of_differentiableAt hd1
+  have hA' := hasDerivAt_mk_of_differentiableAt hd2
+  have hR := hasDerivAt_mk_of_differentiableAt hdρ
+  have hL := (hA'.div hA ha).pow 2
+  have hRd := ((hR.const_mul (8 * π * G / 3)).sub
+    ((hasDerivAt_const τ (k * c ^ 2)).div (hA.pow 2) (pow_ne_zero 2 ha))).add_const
+    (Λ * c ^ 2 / 3)
+  have hu := hL.unique
+    (hRd.congr_of_eventuallyEq (Filter.Eventually.of_forall fun σ => hF1 ⟨σ⟩))
+  simp only [Pi.pow_apply, Pi.div_apply, Nat.cast_ofNat, Nat.add_one_sub_one, pow_one, zero_mul,
+    zero_sub] at hu
+  field_simp at hu ⊢
+  linear_combination hu
+
+/-!
+
+### B.3. Continuity from the Friedmann equations
+
+-/
+
+/-- The continuity equation follows from the first-order Friedmann equation, assumed at all
+  times, and the second-order Friedmann equation at `t`; `a` must be twice differentiable and
+  `ρ` differentiable at `t`. -/
+lemma continuityEquation_of_friedmann {a ρ p : Time → ℝ} {k Λ G c : ℝ} {t : Time}
+    (hG : 0 < G) (ha : a t ≠ 0) (hd1 : DifferentiableAt ℝ a t)
+    (hd2 : DifferentiableAt ℝ (∂ₜ a) t)
+    (hdρ : DifferentiableAt ℝ ρ t) (hF1 : ∀ s, FirstOrderFriedmann a ρ k Λ G c s)
+    (hF2 : SecondOrderFriedmann a ρ p Λ G c t) :
+    ContinuityEquation a ρ p c t := by
+  obtain ⟨τ⟩ := t
+  have hd := deriv_firstOrderFriedmann ha hd1 hd2 hdρ hF1
+  have h1 := hF1 ⟨τ⟩
+  unfold FirstOrderFriedmann at h1
+  unfold SecondOrderFriedmann at hF2
+  unfold ContinuityEquation hubbleConstant
+  have hπ := Real.pi_pos
+  have hG3 : 8 * π * G / 3 ≠ 0 := by positivity
+  apply mul_left_cancel₀ hG3
+  linear_combination -hd + 2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) * hF2
+    - 2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) * h1
+
+/-!
+
+### B.4. The second-order Friedmann equation from continuity
+
+-/
+
+/-- The second-order Friedmann equation at `t` follows from the first-order Friedmann
+  equation, assumed at all times, and the continuity equation at `t`, provided `∂ₜ a t ≠ 0`.
+  Together with `continuityEquation_of_friedmann`, the three equations are not independent. -/
+lemma secondOrderFriedmann_of_continuityEquation {a ρ p : Time → ℝ} {k Λ G c : ℝ}
+    {t : Time} (ha : a t ≠ 0) (hd1' : ∂ₜ a t ≠ 0) (hd1 : DifferentiableAt ℝ a t)
+    (hd2 : DifferentiableAt ℝ (∂ₜ a) t) (hdρ : DifferentiableAt ℝ ρ t)
+    (hF1 : ∀ s, FirstOrderFriedmann a ρ k Λ G c s) (hC : ContinuityEquation a ρ p c t) :
+    SecondOrderFriedmann a ρ p Λ G c t := by
+  obtain ⟨τ⟩ := t
+  have hd := deriv_firstOrderFriedmann ha hd1 hd2 hdρ hF1
+  have h1 := hF1 ⟨τ⟩
+  unfold FirstOrderFriedmann at h1
+  unfold ContinuityEquation hubbleConstant at hC
+  unfold SecondOrderFriedmann
+  have hH : 2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) ≠ 0 := by
+    have : ∂ₜ a ⟨τ⟩ / a ⟨τ⟩ ≠ 0 := div_ne_zero hd1' ha
+    positivity
+  apply mul_left_cancel₀ hH
+  linear_combination hd + 8 * π * G / 3 * hC + 2 * (∂ₜ a ⟨τ⟩ / a ⟨τ⟩) * h1
+
+/-!
+
+## C. Remaining TODO items
+
+-/
+
 TODO "Define the perfect-fluid stress-energy tensor
   `T_{μν} = (ρ + P/c²) u_μ u_ν + P g_{μν}` for the FLRW metric."
-
-TODO "Define the continuity equation `∂ₜ ρ + 3 H (ρ + P/c²) = 0` and derive it from
-  the first- and second-order Friedmann equations."
-
-TODO "Prove that the Friedmann equation, the acceleration equation and the
-  continuity equation are not independent (a consequence of the Bianchi identity
-  `∇_ν Gᵘᵛ = 0`)."
 
 TODO "Define the linear (barotropic) equation of state `P = w ρ c²` and prove the
   density scaling law `ρ = ρ₀ a^(−3(1+w))` for constant `w`."
@@ -38,3 +181,5 @@ TODO "Specialize the density scaling law to dust (`w = 0`, `ρ ∝ a⁻³`), rad
 
 TODO "Prove that the cosmological constant acts as a `w = −1` perfect fluid with
   `ρ_Λ = Λ c² / (8 π G)` and `P_Λ = −ρ_Λ c²`."
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/MatterContent.lean
+++ b/Physlib/Cosmology/FLRW/MatterContent.lean
@@ -49,18 +49,17 @@ Time derivatives of curves `Time → ℝ` are computed through the bridge
 
 ## iii. Table of contents
 
-- A. Time derivatives through the coordinate
-- B. The continuity equation
-  - B.1. The definition
-  - B.2. The derivative of the first-order Friedmann equation
-  - B.3. Continuity from the Friedmann equations
-  - B.4. The second-order Friedmann equation from continuity
-- C. The barotropic equation of state and the density scaling law
-  - C.1. The equation of state
-  - C.2. The density scaling law
-  - C.3. Dust, radiation and vacuum energy
-- D. The cosmological constant as a fluid
-- E. Remaining TODO items
+- A. The continuity equation
+  - A.1. The definition
+  - A.2. The derivative of the first-order Friedmann equation
+  - A.3. Continuity from the Friedmann equations
+  - A.4. The second-order Friedmann equation from continuity
+- B. The barotropic equation of state and the density scaling law
+  - B.1. The equation of state
+  - B.2. The density scaling law
+  - B.3. Dust, radiation and vacuum energy
+- C. The cosmological constant as a fluid
+- D. Remaining TODO items
 
 -/
 
@@ -72,26 +71,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives through the coordinate
-
--/
-
-/-- A curve `f : Time → ℝ` differentiable at `⟨τ⟩` gives the curve `σ ↦ f ⟨σ⟩` on `ℝ`,
-  whose Mathlib derivative at `τ` is the time derivative `∂ₜ f ⟨τ⟩`. -/
-lemma hasDerivAt_mk_of_differentiableAt {f : Time → ℝ} {τ : ℝ}
-    (hf : DifferentiableAt ℝ f ⟨τ⟩) :
-    HasDerivAt (fun σ : ℝ => f ⟨σ⟩) (∂ₜ f ⟨τ⟩) τ :=
-  hasDerivAt_comp_toRealCLE_symm f τ hf
-
-/-!
-
-## B. The continuity equation
+## A. The continuity equation
 
 -/
 
 /-!
 
-### B.1. The definition
+### A.1. The definition
 
 -/
 
@@ -102,7 +88,7 @@ def ContinuityEquation (a ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
 
 /-!
 
-### B.2. The derivative of the first-order Friedmann equation
+### A.2. The derivative of the first-order Friedmann equation
 
 -/
 
@@ -130,7 +116,7 @@ lemma deriv_firstOrderFriedmann {a ρ : Time → ℝ} {k Λ G c τ : ℝ} (ha : 
 
 /-!
 
-### B.3. Continuity from the Friedmann equations
+### A.3. Continuity from the Friedmann equations
 
 -/
 
@@ -157,7 +143,7 @@ lemma continuityEquation_of_friedmann {a ρ p : Time → ℝ} {k Λ G c : ℝ} {
 
 /-!
 
-### B.4. The second-order Friedmann equation from continuity
+### A.4. The second-order Friedmann equation from continuity
 
 -/
 
@@ -183,13 +169,13 @@ lemma secondOrderFriedmann_of_continuityEquation {a ρ p : Time → ℝ} {k Λ G
 
 /-!
 
-## C. The barotropic equation of state and the density scaling law
+## B. The barotropic equation of state and the density scaling law
 
 -/
 
 /-!
 
-### C.1. The equation of state
+### B.1. The equation of state
 
 -/
 
@@ -209,7 +195,7 @@ lemma deriv_of_continuityEquation_barotropic {a ρ : Time → ℝ} {w c : ℝ} {
 
 /-!
 
-### C.2. The density scaling law
+### B.2. The density scaling law
 
 -/
 
@@ -269,7 +255,7 @@ lemma continuityEquation_of_scaling {a : Time → ℝ} {w c ρ₀ a₀ : ℝ} (h
 
 /-!
 
-### C.3. Dust, radiation and vacuum energy
+### B.3. Dust, radiation and vacuum energy
 
 -/
 
@@ -303,7 +289,7 @@ lemma density_scaling_vacuum {a ρ : Time → ℝ} {c : ℝ} (hc : c ≠ 0) (hd1
 
 /-!
 
-## D. The cosmological constant as a fluid
+## C. The cosmological constant as a fluid
 
 -/
 
@@ -354,7 +340,7 @@ lemma cosmologicalConstantPressure_eq_barotropic (Λ G c : ℝ) (t : Time) :
 
 /-!
 
-## E. Remaining TODO items
+## D. Remaining TODO items
 
 -/
 

--- a/Physlib/Cosmology/FLRW/MatterContent.lean
+++ b/Physlib/Cosmology/FLRW/MatterContent.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/MatterContent.lean
+++ b/Physlib/Cosmology/FLRW/MatterContent.lean
@@ -37,13 +37,12 @@ Time derivatives of curves `Time → ℝ` are computed through the bridge
 
 ## iii. Table of contents
 
-- A. Time derivatives through the coordinate
-- B. The continuity equation
-  - B.1. The definition
-  - B.2. The derivative of the first-order Friedmann equation
-  - B.3. Continuity from the Friedmann equations
-  - B.4. The second-order Friedmann equation from continuity
-- C. Remaining TODO items
+- A. The continuity equation
+  - A.1. The definition
+  - A.2. The derivative of the first-order Friedmann equation
+  - A.3. Continuity from the Friedmann equations
+  - A.4. The second-order Friedmann equation from continuity
+- B. Remaining TODO items
 
 -/
 
@@ -55,26 +54,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives through the coordinate
-
--/
-
-/-- A curve `f : Time → ℝ` differentiable at `⟨τ⟩` gives the curve `σ ↦ f ⟨σ⟩` on `ℝ`,
-  whose Mathlib derivative at `τ` is the time derivative `∂ₜ f ⟨τ⟩`. -/
-lemma hasDerivAt_mk_of_differentiableAt {f : Time → ℝ} {τ : ℝ}
-    (hf : DifferentiableAt ℝ f ⟨τ⟩) :
-    HasDerivAt (fun σ : ℝ => f ⟨σ⟩) (∂ₜ f ⟨τ⟩) τ :=
-  hasDerivAt_comp_toRealCLE_symm f τ hf
-
-/-!
-
-## B. The continuity equation
+## A. The continuity equation
 
 -/
 
 /-!
 
-### B.1. The definition
+### A.1. The definition
 
 -/
 
@@ -85,7 +71,7 @@ def ContinuityEquation (a ρ p : Time → ℝ) (c : ℝ) (t : Time) : Prop :=
 
 /-!
 
-### B.2. The derivative of the first-order Friedmann equation
+### A.2. The derivative of the first-order Friedmann equation
 
 -/
 
@@ -113,7 +99,7 @@ lemma deriv_firstOrderFriedmann {a ρ : Time → ℝ} {k Λ G c τ : ℝ} (ha : 
 
 /-!
 
-### B.3. Continuity from the Friedmann equations
+### A.3. Continuity from the Friedmann equations
 
 -/
 
@@ -140,7 +126,7 @@ lemma continuityEquation_of_friedmann {a ρ p : Time → ℝ} {k Λ G c : ℝ} {
 
 /-!
 
-### B.4. The second-order Friedmann equation from continuity
+### A.4. The second-order Friedmann equation from continuity
 
 -/
 
@@ -166,7 +152,7 @@ lemma secondOrderFriedmann_of_continuityEquation {a ρ p : Time → ℝ} {k Λ G
 
 /-!
 
-## C. Remaining TODO items
+## B. Remaining TODO items
 
 -/
 

--- a/Physlib/Cosmology/FLRW/MatterContent.lean
+++ b/Physlib/Cosmology/FLRW/MatterContent.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Meta.TODO.Basic
 public import Physlib.Cosmology.FLRW.Basic
+public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 /-!
 
 # Matter content of FLRW cosmology
@@ -19,8 +20,10 @@ relation to the two Friedmann equations of `Physlib.Cosmology.FLRW.Basic`: the c
 equation follows from the first-order equation (holding at all times) and the second-order
 equation, and conversely the second-order equation follows from the first-order equation and
 the continuity equation whenever `∂ₜ a ≠ 0`. The three equations are therefore not
-independent. The equation of state, the density scaling laws and the perfect-fluid
-stress-energy tensor are still TODO items.
+independent. For a barotropic equation of state `p = w ρ c²` with constant `w`, the continuity
+equation gives the density scaling law `ρ ∝ a^(-3(1+w))`, specialised to dust, radiation and
+vacuum energy; and the cosmological constant is equivalent to a `w = -1` fluid of density
+`ρ_Λ = Λ c² / (8 π G)`. The perfect-fluid stress-energy tensor is still a TODO item.
 
 Time derivatives of curves `Time → ℝ` are computed through the bridge
 `Time.hasDerivAt_comp_toRealCLE_symm` to Mathlib's `HasDerivAt` on `ℝ`.
@@ -34,6 +37,15 @@ Time derivatives of curves `Time → ℝ` are computed through the bridge
   equations.
 - `secondOrderFriedmann_of_continuityEquation`: the second-order Friedmann equation follows
   from the first-order equation and the continuity equation when `∂ₜ a ≠ 0`.
+- `barotropicPressure`: `p = w ρ c²`; `density_scaling`: under the barotropic continuity
+  equation at all times, `ρ t = ρ t₀ (a t / a t₀)^(-3(1+w))`; `continuityEquation_of_scaling`:
+  the converse; `density_scaling_dust`, `density_scaling_radiation`,
+  `density_scaling_vacuum`: `ρ ∝ a⁻³`, `ρ ∝ a⁻⁴`, `ρ` constant.
+- `cosmologicalConstantDensity`, `cosmologicalConstantPressure`:
+  `ρ_Λ = Λ c² / (8 π G)`, `p_Λ = - ρ_Λ c²`; `firstOrderFriedmann_iff_lambdaFluid`,
+  `secondOrderFriedmann_iff_lambdaFluid`: the Friedmann equations with `Λ` are the Friedmann
+  equations without `Λ` for the fluid `ρ + ρ_Λ`, `p + p_Λ`;
+  `cosmologicalConstantPressure_eq_barotropic`: `p_Λ` is the `w = -1` barotropic pressure.
 
 ## iii. Table of contents
 
@@ -43,7 +55,12 @@ Time derivatives of curves `Time → ℝ` are computed through the bridge
   - B.2. The derivative of the first-order Friedmann equation
   - B.3. Continuity from the Friedmann equations
   - B.4. The second-order Friedmann equation from continuity
-- C. Remaining TODO items
+- C. The barotropic equation of state and the density scaling law
+  - C.1. The equation of state
+  - C.2. The density scaling law
+  - C.3. Dust, radiation and vacuum energy
+- D. The cosmological constant as a fluid
+- E. Remaining TODO items
 
 -/
 
@@ -166,20 +183,182 @@ lemma secondOrderFriedmann_of_continuityEquation {a ρ p : Time → ℝ} {k Λ G
 
 /-!
 
-## C. Remaining TODO items
+## C. The barotropic equation of state and the density scaling law
+
+-/
+
+/-!
+
+### C.1. The equation of state
+
+-/
+
+/-- The barotropic pressure `p = w ρ c²` with constant equation-of-state parameter `w`. -/
+noncomputable def barotropicPressure (w : ℝ) (ρ : Time → ℝ) (c : ℝ) : Time → ℝ :=
+  fun t => w * ρ t * c ^ 2
+
+/-- Under the barotropic continuity equation, `∂ₜ ρ = -3 (1 + w) H ρ`. -/
+lemma deriv_of_continuityEquation_barotropic {a ρ : Time → ℝ} {w c : ℝ} {t : Time} (hc : c ≠ 0)
+    (hC : ContinuityEquation a ρ (barotropicPressure w ρ c) c t) :
+    ∂ₜ ρ t = -3 * (1 + w) * hubbleConstant a t * ρ t := by
+  unfold ContinuityEquation barotropicPressure at hC
+  have h : w * ρ t * c ^ 2 / c ^ 2 = w * ρ t := by
+    field_simp
+  rw [h] at hC
+  linear_combination hC
+
+/-!
+
+### C.2. The density scaling law
+
+-/
+
+/-- Under the barotropic continuity equation at all times, the curve `σ ↦ ρ ⟨σ⟩ a ⟨σ⟩^(3(1+w))`
+  has zero derivative. -/
+lemma hasDerivAt_mul_rpow_of_continuityEquation {a ρ : Time → ℝ} {w c : ℝ} (hc : c ≠ 0)
+    (hd1 : Differentiable ℝ a) (hdρ : Differentiable ℝ ρ) (hapos : ∀ s, 0 < a s)
+    (hC : ∀ s, ContinuityEquation a ρ (barotropicPressure w ρ c) c s) (τ : ℝ) :
+    HasDerivAt (fun σ : ℝ => ρ ⟨σ⟩ * a ⟨σ⟩ ^ (3 * (1 + w))) 0 τ := by
+  have hA := hasDerivAt_mk_of_differentiableAt (hd1 ⟨τ⟩)
+  have hR := hasDerivAt_mk_of_differentiableAt (hdρ ⟨τ⟩)
+  have hP := hA.rpow_const (p := 3 * (1 + w)) (Or.inl (hapos ⟨τ⟩).ne')
+  refine (hR.mul hP).congr_deriv ?_
+  rw [deriv_of_continuityEquation_barotropic hc (hC ⟨τ⟩), Real.rpow_sub_one (hapos ⟨τ⟩).ne']
+  unfold hubbleConstant
+  field_simp
+  ring
+
+/-- The density scaling law: under the barotropic continuity equation at all times, with `a`
+  and `ρ` differentiable and `a > 0`, `ρ t = ρ t₀ (a t / a t₀)^(-3(1+w))`. -/
+lemma density_scaling {a ρ : Time → ℝ} {w c : ℝ} (hc : c ≠ 0) (hd1 : Differentiable ℝ a)
+    (hdρ : Differentiable ℝ ρ) (hapos : ∀ s, 0 < a s)
+    (hC : ∀ s, ContinuityEquation a ρ (barotropicPressure w ρ c) c s) (t t₀ : Time) :
+    ρ t = ρ t₀ * (a t / a t₀) ^ (-(3 * (1 + w))) := by
+  have hconst := is_const_of_deriv_eq_zero
+    (fun τ => (hasDerivAt_mul_rpow_of_continuityEquation hc hd1 hdρ hapos hC τ).differentiableAt)
+    (fun τ => (hasDerivAt_mul_rpow_of_continuityEquation hc hd1 hdρ hapos hC τ).deriv)
+  obtain ⟨τ⟩ := t
+  obtain ⟨τ₀⟩ := t₀
+  have h := hconst τ τ₀
+  beta_reduce at h
+  have h1 := Real.rpow_pos_of_pos (hapos ⟨τ⟩) (3 * (1 + w))
+  have h0 := Real.rpow_pos_of_pos (hapos ⟨τ₀⟩) (3 * (1 + w))
+  rw [Real.rpow_neg (div_pos (hapos ⟨τ⟩) (hapos ⟨τ₀⟩)).le,
+    Real.div_rpow (hapos ⟨τ⟩).le (hapos ⟨τ₀⟩).le]
+  field_simp
+  linear_combination h
+
+/-- Conversely, `ρ = ρ₀ (a / a₀)^(-3(1+w))` satisfies the barotropic continuity equation at
+  all times, for `a` differentiable and positive. -/
+lemma continuityEquation_of_scaling {a : Time → ℝ} {w c ρ₀ a₀ : ℝ} (hc : c ≠ 0) (ha₀ : a₀ ≠ 0)
+    (hd1 : Differentiable ℝ a) (hapos : ∀ s, 0 < a s) (t : Time) :
+    ContinuityEquation a (fun s => ρ₀ * (a s / a₀) ^ (-(3 * (1 + w))))
+      (barotropicPressure w (fun s => ρ₀ * (a s / a₀) ^ (-(3 * (1 + w)))) c) c t := by
+  obtain ⟨τ⟩ := t
+  have hA := hasDerivAt_mk_of_differentiableAt (hd1 ⟨τ⟩)
+  have hx : a ⟨τ⟩ / a₀ ≠ 0 := div_ne_zero (hapos ⟨τ⟩).ne' ha₀
+  have hP := ((hA.div_const a₀).rpow_const (p := -(3 * (1 + w))) (Or.inl hx)).const_mul ρ₀
+  have hd : ∂ₜ (fun s : Time => ρ₀ * (a s / a₀) ^ (-(3 * (1 + w)))) ⟨τ⟩
+      = ρ₀ * (∂ₜ a ⟨τ⟩ / a₀ * -(3 * (1 + w)) * (a ⟨τ⟩ / a₀) ^ (-(3 * (1 + w)) - 1)) :=
+    deriv_comp_toRealCLE_of_hasDerivAt (fun σ => ρ₀ * (a ⟨σ⟩ / a₀) ^ (-(3 * (1 + w)))) ⟨τ⟩ _ hP
+  unfold ContinuityEquation barotropicPressure hubbleConstant
+  rw [hd, Real.rpow_sub_one hx]
+  have ha := (hapos ⟨τ⟩).ne'
+  field_simp
+  ring
+
+/-!
+
+### C.3. Dust, radiation and vacuum energy
+
+-/
+
+/-- Dust, `w = 0`: `ρ ∝ a⁻³`. -/
+lemma density_scaling_dust {a ρ : Time → ℝ} {c : ℝ} (hc : c ≠ 0) (hd1 : Differentiable ℝ a)
+    (hdρ : Differentiable ℝ ρ) (hapos : ∀ s, 0 < a s)
+    (hC : ∀ s, ContinuityEquation a ρ (barotropicPressure 0 ρ c) c s) (t t₀ : Time) :
+    ρ t = ρ t₀ * (a t₀ / a t) ^ 3 := by
+  rw [density_scaling hc hd1 hdρ hapos hC t t₀]
+  have hx : 0 < a t / a t₀ := div_pos (hapos t) (hapos t₀)
+  rw [show -(3 * (1 + (0 : ℝ))) = -((3 : ℕ) : ℝ) by norm_num, Real.rpow_neg hx.le,
+    Real.rpow_natCast, ← inv_pow, inv_div]
+
+/-- Radiation, `w = 1/3`: `ρ ∝ a⁻⁴`. -/
+lemma density_scaling_radiation {a ρ : Time → ℝ} {c : ℝ} (hc : c ≠ 0) (hd1 : Differentiable ℝ a)
+    (hdρ : Differentiable ℝ ρ) (hapos : ∀ s, 0 < a s)
+    (hC : ∀ s, ContinuityEquation a ρ (barotropicPressure (1 / 3) ρ c) c s) (t t₀ : Time) :
+    ρ t = ρ t₀ * (a t₀ / a t) ^ 4 := by
+  rw [density_scaling hc hd1 hdρ hapos hC t t₀]
+  have hx : 0 < a t / a t₀ := div_pos (hapos t) (hapos t₀)
+  rw [show -(3 * (1 + (1 / 3 : ℝ))) = -((4 : ℕ) : ℝ) by norm_num, Real.rpow_neg hx.le,
+    Real.rpow_natCast, ← inv_pow, inv_div]
+
+/-- Vacuum energy, `w = -1`: `ρ` is constant. -/
+lemma density_scaling_vacuum {a ρ : Time → ℝ} {c : ℝ} (hc : c ≠ 0) (hd1 : Differentiable ℝ a)
+    (hdρ : Differentiable ℝ ρ) (hapos : ∀ s, 0 < a s)
+    (hC : ∀ s, ContinuityEquation a ρ (barotropicPressure (-1) ρ c) c s) (t t₀ : Time) :
+    ρ t = ρ t₀ := by
+  rw [density_scaling hc hd1 hdρ hapos hC t t₀,
+    show -(3 * (1 + (-1 : ℝ))) = 0 by norm_num, Real.rpow_zero, mul_one]
+
+/-!
+
+## D. The cosmological constant as a fluid
+
+-/
+
+/-- The density `ρ_Λ = Λ c² / (8 π G)` associated with the cosmological constant. -/
+noncomputable def cosmologicalConstantDensity (Λ G c : ℝ) : ℝ :=
+  Λ * c ^ 2 / (8 * π * G)
+
+/-- The pressure `p_Λ = - ρ_Λ c²` associated with the cosmological constant. -/
+noncomputable def cosmologicalConstantPressure (Λ G c : ℝ) : ℝ :=
+  -(cosmologicalConstantDensity Λ G c) * c ^ 2
+
+/-- The first-order Friedmann equation with `Λ` is the first-order Friedmann equation without
+  `Λ` for the density `ρ + ρ_Λ`. -/
+lemma firstOrderFriedmann_iff_lambdaFluid {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : Time}
+    (hG : G ≠ 0) :
+    FirstOrderFriedmann a ρ k Λ G c t ↔
+      FirstOrderFriedmann a (fun s => ρ s + cosmologicalConstantDensity Λ G c) k 0 G c t := by
+  unfold FirstOrderFriedmann cosmologicalConstantDensity
+  have hπ := Real.pi_ne_zero
+  have key : 8 * π * G / 3 * ρ t - k * c ^ 2 / a t ^ 2 + Λ * c ^ 2 / 3
+      = 8 * π * G / 3 * (ρ t + Λ * c ^ 2 / (8 * π * G)) - k * c ^ 2 / a t ^ 2 + 0 * c ^ 2 / 3 := by
+    field_simp
+    ring
+  rw [key]
+
+/-- The second-order Friedmann equation with `Λ` is the second-order Friedmann equation
+  without `Λ` for the density `ρ + ρ_Λ` and the pressure `p + p_Λ`. -/
+lemma secondOrderFriedmann_iff_lambdaFluid {a ρ p : Time → ℝ} {Λ G c : ℝ} {t : Time}
+    (hG : G ≠ 0) (hc : c ≠ 0) :
+    SecondOrderFriedmann a ρ p Λ G c t ↔
+      SecondOrderFriedmann a (fun s => ρ s + cosmologicalConstantDensity Λ G c)
+        (fun s => p s + cosmologicalConstantPressure Λ G c) 0 G c t := by
+  unfold SecondOrderFriedmann cosmologicalConstantPressure cosmologicalConstantDensity
+  have hπ := Real.pi_ne_zero
+  have key : -(4 * π * G / 3) * (ρ t + 3 * p t / c ^ 2) + Λ * c ^ 2 / 3
+      = -(4 * π * G / 3) * (ρ t + Λ * c ^ 2 / (8 * π * G)
+        + 3 * (p t + -(Λ * c ^ 2 / (8 * π * G)) * c ^ 2) / c ^ 2) + 0 * c ^ 2 / 3 := by
+    field_simp
+    ring
+  rw [key]
+
+/-- `p_Λ` is the barotropic pressure of `ρ_Λ` with `w = -1`. -/
+lemma cosmologicalConstantPressure_eq_barotropic (Λ G c : ℝ) (t : Time) :
+    cosmologicalConstantPressure Λ G c
+      = barotropicPressure (-1) (fun _ => cosmologicalConstantDensity Λ G c) c t := by
+  unfold cosmologicalConstantPressure barotropicPressure
+  ring
+
+/-!
+
+## E. Remaining TODO items
 
 -/
 
 TODO "Define the perfect-fluid stress-energy tensor
   `T_{μν} = (ρ + P/c²) u_μ u_ν + P g_{μν}` for the FLRW metric."
-
-TODO "Define the linear (barotropic) equation of state `P = w ρ c²` and prove the
-  density scaling law `ρ = ρ₀ a^(−3(1+w))` for constant `w`."
-
-TODO "Specialize the density scaling law to dust (`w = 0`, `ρ ∝ a⁻³`), radiation
-  (`w = 1/3`, `ρ ∝ a⁻⁴`) and vacuum energy (`w = −1`, `ρ` constant)."
-
-TODO "Prove that the cosmological constant acts as a `w = −1` perfect fluid with
-  `ρ_Λ = Λ c² / (8 π G)` and `P_Λ = −ρ_Λ c²`."
 
 end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -1,27 +1,186 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li
+Authors: Jinzheng Li, Philippe Kevorkian
 -/
 module
 
 public import Physlib.Meta.TODO.Basic
+public import Physlib.Cosmology.FLRW.Basic
 /-!
 
 # Exact solutions of the Friedmann equations
 
-Placeholder file collecting TODO items for the standard closed-form solutions of
-the Friedmann equations: the de Sitter, radiation-dominated, Einstein-de Sitter
-(dust) and Milne models, together with the Einstein static universe. This file
-contains only TODO items; no definitions or lemmas are formalized yet.
+## i. Overview
+
+This file collects the standard closed-form solutions of the Friedmann equations
+(`FirstOrderFriedmann` and `SecondOrderFriedmann` of `Physlib.Cosmology.FLRW.Basic`) and
+proves that they solve them: the de Sitter solution here, the radiation-dominated,
+Einstein-de Sitter and Milne models and the Einstein static universe being still TODO items.
+
+Each solution is a scale factor `a : Time → ℝ` given by an explicit function of the time
+coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridge
+`deriv_comp_toRealCLE_of_hasDerivAt` from Mathlib's `HasDerivAt` on `ℝ`.
+
+## ii. Key results
+
+- `deSitterScaleFactor`: `a(t) = a₀ exp(σ √(Λ/3) c t)` with `σ = ±1`.
+- `deSitterScaleFactor_firstOrderFriedmann`, `deSitterScaleFactor_secondOrderFriedmann`:
+  it solves both Friedmann equations with `ρ = 0`, `p = 0`, `k = 0` and `Λ > 0`.
+- `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
+  (for any `σ`, `Λ`, `c`).
+- `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
+
+## iii. Table of contents
+
+- A. Time derivatives of curves given by a function of the coordinate
+- B. The de Sitter solution
+  - B.1. The scale factor and its derivatives
+  - B.2. The Friedmann equations
+  - B.3. The Hubble and deceleration parameters
+- C. Remaining TODO items
 
 -/
 
 @[expose] public section
 
-TODO "Prove that the de Sitter solution `a(t) = a₀ exp(±√(Λ/3) c t)` (with `ρ = 0`,
-  `K = 0`, `Λ > 0`) solves the Friedmann equations, and that its deceleration
-  parameter is `q = −1`."
+namespace Cosmology.FLRW.FriedmannEquation
+
+open Real Time
+
+/-!
+
+## A. Time derivatives of curves given by a function of the coordinate
+
+A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
+its time derivative is the Mathlib derivative of `γ`.
+
+-/
+
+/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
+lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
+    ∂ₜ (fun s : Time => γ s.val) t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-!
+
+## B. The de Sitter solution
+
+-/
+
+/-!
+
+### B.1. The scale factor and its derivatives
+
+-/
+
+/-- The de Sitter scale factor `a(t) = a₀ exp(σ √(Λ/3) c t)`, for `σ = ±1`
+  (the expanding branch is `σ = 1`). -/
+noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
+  fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
+
+/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
+lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
+    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
+  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
+  refine h.congr_deriv ?_
+  simp only [id_eq]
+  ring
+
+lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
+    ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
+      fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
+  funext t
+  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+
+lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
+    ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
+      fun t => a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) *
+        Real.exp (σ * √(Λ / 3) * c * t.val) := by
+  rw [deriv_deSitterScaleFactor]
+  funext t
+  exact deriv_comp_val
+    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+
+/-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
+lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
+    (σ * √(Λ / 3) * c) ^ 2 = Λ * c ^ 2 / 3 := by
+  have hs : √(Λ / 3) ^ 2 = Λ / 3 := Real.sq_sqrt (by linarith)
+  rcases hσ with rfl | rfl <;> linear_combination c ^ 2 * hs
+
+/-!
+
+### B.2. The Friedmann equations
+
+-/
+
+/-- The de Sitter scale factor solves the first-order Friedmann equation with `ρ = 0`,
+  `k = 0` and `Λ > 0`. -/
+lemma deSitterScaleFactor_firstOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 < Λ)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    FirstOrderFriedmann (deSitterScaleFactor a₀ σ Λ c) (fun _ => 0) 0 Λ G c t := by
+  unfold FirstOrderFriedmann
+  rw [deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  rw [show a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) /
+      (a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)) = σ * √(Λ / 3) * c by field_simp,
+    sq_deSitterRate hΛ.le hσ]
+  ring
+
+/-- The de Sitter scale factor solves the second-order Friedmann equation with `ρ = 0`,
+  `p = 0` and `Λ > 0`. -/
+lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 < Λ)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    SecondOrderFriedmann (deSitterScaleFactor a₀ σ Λ c) (fun _ => 0) (fun _ => 0) Λ G c t := by
+  unfold SecondOrderFriedmann
+  rw [deriv_deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  rw [show a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) *
+      Real.exp (σ * √(Λ / 3) * c * t.val) / (a₀ * Real.exp (σ * √(Λ / 3) * c * t.val))
+      = (σ * √(Λ / 3) * c) ^ 2 by field_simp,
+    sq_deSitterRate hΛ.le hσ]
+  ring
+
+/-!
+
+### B.3. The Hubble and deceleration parameters
+
+-/
+
+/-- The Hubble parameter of the de Sitter solution is the constant `σ √(Λ/3) c`. -/
+lemma hubbleConstant_deSitterScaleFactor {a₀ σ Λ c : ℝ} (ha₀ : a₀ ≠ 0) (t : Time) :
+    hubbleConstant (deSitterScaleFactor a₀ σ Λ c) t = σ * √(Λ / 3) * c := by
+  unfold hubbleConstant
+  rw [deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  field_simp
+
+/-- The deceleration parameter of the de Sitter solution is `q = -1`. -/
+lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < Λ) (hc : 0 < c)
+    (ha₀ : a₀ ≠ 0) (hσ : σ = 1 ∨ σ = -1) (t : Time) :
+    decelerationParameter (deSitterScaleFactor a₀ σ Λ c) t = -1 := by
+  unfold decelerationParameter
+  rw [deriv_deriv_deSitterScaleFactor, deriv_deSitterScaleFactor]
+  simp only [deSitterScaleFactor]
+  have he := Real.exp_ne_zero (σ * √(Λ / 3) * c * t.val)
+  have hK : σ * √(Λ / 3) * c ≠ 0 := by
+    have hs : 0 < √(Λ / 3) := Real.sqrt_pos.mpr (by linarith)
+    rcases hσ with rfl | rfl
+    · positivity
+    · have : 0 < √(Λ / 3) * c := mul_pos hs hc
+      linarith
+  have hσ0 : σ ≠ 0 := by
+    rcases hσ with rfl | rfl <;> norm_num
+  field_simp
+
+/-!
+
+## C. Remaining TODO items
+
+-/
 
 TODO "Prove that the spatially flat radiation-dominated solution `a = (t/t₀)^(1/2)`
   solves the Friedmann equations, with `q₀ = 1` and `t₀ = 1 / (2 H₀)`."
@@ -35,3 +194,5 @@ TODO "Prove that the Milne solution `a = c t` (empty universe, `K < 0`) has
 
 TODO "Define the Einstein static universe (`∂ₜ a = ∂ₜ ∂ₜ a = 0`, forcing `K > 0`
   and `ρ_m = 2 ρ_Λ`) and prove that it is an unstable equilibrium."
+
+end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -434,7 +434,8 @@ curvature) is not stated here: the FLRW metric is not yet an object of Physlib.
 
 -/
 
-/-- The Milne scale factor `a(t) = c t`. -/
+/-- The Milne scale factor `a(t) = c t`. The Big Bang is at the origin `t.val = 0` of the time
+  chart; the values for `t.val ≤ 0` are not part of the model. -/
 noncomputable def milneScaleFactor (c : ℝ) : Time → ℝ :=
   fun t => c * t.val
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -16,9 +16,11 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 
 This file collects the standard closed-form solutions of the Friedmann equations
 (`FirstOrderFriedmann` and `SecondOrderFriedmann` of `Physlib.Cosmology.FLRW.Basic`) and
-proves that they solve them: the de Sitter solution and the spatially flat power-law
-solutions (radiation-dominated and Einstein-de Sitter) here, the Milne model and the
-Einstein static universe being still TODO items.
+proves that they solve them: the de Sitter solution, the spatially flat power-law
+solutions (radiation-dominated and Einstein-de Sitter), the Milne model, and the equilibrium
+relations of the Einstein static universe. The vanishing of the curvature of the Milne model
+and the instability of the Einstein static universe are still TODO items: neither the curvature
+of the FLRW metric nor a perturbation theory of the Friedmann equations is available yet.
 
 Each solution is a scale factor `a : Time → ℝ` given by an explicit function of the time
 coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridge
@@ -43,6 +45,12 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   `einsteinDeSitterScaleFactor_secondOrderFriedmann`: `a = (t / t₀) ^ (2/3)` solves the flat
   Friedmann equations with the dust density `ρ = 1 / (6 π G t²)` and `p = 0`; `q = 1 / 2` and
   `H(t₀) = 2 / (3 t₀)`.
+- `milneScaleFactor_firstOrderFriedmann`, `milneScaleFactor_secondOrderFriedmann`: the Milne
+  scale factor `a = c t` solves the empty (`ρ = 0`, `p = 0`, `Λ = 0`) Friedmann equations with
+  `k = -1`; `q = 0`.
+- `einsteinStatic_density`, `einsteinStatic_curvature`: if `∂ₜ a = ∂ₜ ∂ₜ a = 0` at `t` and the
+  Friedmann equations hold there with `p = 0`, then `ρ = Λ c² / (4 π G) = 2 ρ_Λ` and
+  `k c² / a² = 4 π G ρ`, so that `k > 0` when `ρ > 0` (`einsteinStatic_curvature_pos`).
 
 ## iii. Table of contents
 
@@ -56,7 +64,9 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   - C.2. The Hubble and deceleration parameters
   - C.3. The radiation-dominated solution
   - C.4. The Einstein-de Sitter solution
-- D. Remaining TODO items
+- D. The Milne solution
+- E. The Einstein static universe
+- F. Remaining TODO items
 
 -/
 
@@ -427,14 +437,117 @@ lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < 
 
 /-!
 
-## D. Remaining TODO items
+## D. The Milne solution
+
+The Milne universe is the empty (`ρ = 0`, `p = 0`, `Λ = 0`) solution with `k = -1` and
+`a(t) = c t` for `t > 0`. That it is Minkowski space in expanding coordinates (vanishing
+curvature) is not stated here: the FLRW metric is not yet an object of Physlib.
 
 -/
 
-TODO "Prove that the Milne solution `a = c t` (empty universe, `K < 0`) has
+/-- The Milne scale factor `a(t) = c t`. -/
+noncomputable def milneScaleFactor (c : ℝ) : Time → ℝ :=
+  fun t => c * t.val
+
+lemma deriv_milneScaleFactor (c : ℝ) : ∂ₜ (milneScaleFactor c) = fun _ => c := by
+  funext t
+  exact deriv_comp_val (((hasDerivAt_id t.val).const_mul c).congr_deriv (mul_one c))
+
+lemma deriv_deriv_milneScaleFactor (c : ℝ) : ∂ₜ (∂ₜ (milneScaleFactor c)) = fun _ => 0 := by
+  rw [deriv_milneScaleFactor]
+  funext t
+  exact deriv_comp_val (γ := fun _ => c) (hasDerivAt_const t.val c)
+
+/-- The Milne solution solves the first-order Friedmann equation with `ρ = 0`, `k = -1` and
+  `Λ = 0`, for `t > 0`. -/
+lemma milneScaleFactor_firstOrderFriedmann {G c : ℝ} (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (milneScaleFactor c) (fun _ => 0) (-1) 0 G c t := by
+  unfold FirstOrderFriedmann
+  rw [deriv_milneScaleFactor]
+  simp only [milneScaleFactor]
+  field_simp
+  ring
+
+/-- The Milne solution solves the second-order Friedmann equation with `ρ = 0`, `p = 0` and
+  `Λ = 0`. -/
+lemma milneScaleFactor_secondOrderFriedmann {G c : ℝ} (t : Time) :
+    SecondOrderFriedmann (milneScaleFactor c) (fun _ => 0) (fun _ => 0) 0 G c t := by
+  unfold SecondOrderFriedmann
+  rw [deriv_deriv_milneScaleFactor]
+  simp
+
+/-- The deceleration parameter of the Milne solution is `q = 0`. -/
+lemma decelerationParameter_milneScaleFactor (c : ℝ) (t : Time) :
+    decelerationParameter (milneScaleFactor c) t = 0 := by
+  unfold decelerationParameter
+  rw [deriv_deriv_milneScaleFactor, deriv_milneScaleFactor]
+  simp
+
+/-!
+
+## E. The Einstein static universe
+
+At an instant where `∂ₜ a = ∂ₜ ∂ₜ a = 0`, the two Friedmann equations with dust (`p = 0`)
+force the density `ρ = Λ c² / (4 π G)`, twice the density `ρ_Λ = Λ c² / (8 π G)` associated
+with the cosmological constant, and `k c² / a² = 4 π G ρ`, hence a positive curvature
+parameter when `ρ > 0`. That this equilibrium is unstable is not stated here.
+
+-/
+
+/-- The density `ρ_Λ = Λ c² / (8 π G)` associated with the cosmological constant. -/
+noncomputable def cosmologicalConstantDensity (Λ G c : ℝ) : ℝ :=
+  Λ * c ^ 2 / (8 * π * G)
+
+/-- In the Einstein static universe the dust density is `ρ = Λ c² / (4 π G) = 2 ρ_Λ`. -/
+lemma einsteinStatic_density {a ρ : Time → ℝ} {Λ G c : ℝ} {t : Time} (hG : 0 < G)
+    (h2 : ∂ₜ (∂ₜ a) t = 0) (hF2 : SecondOrderFriedmann a ρ (fun _ => 0) Λ G c t) :
+    ρ t = 2 * cosmologicalConstantDensity Λ G c := by
+  unfold SecondOrderFriedmann at hF2
+  rw [h2, zero_div] at hF2
+  simp only [mul_zero, zero_div, add_zero] at hF2
+  unfold cosmologicalConstantDensity
+  have hπ := Real.pi_pos
+  field_simp
+  linarith
+
+/-- In the Einstein static universe `k c² / a² = 4 π G ρ`. -/
+lemma einsteinStatic_curvature {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : Time}
+    (h1 : ∂ₜ a t = 0) (h2 : ∂ₜ (∂ₜ a) t = 0) (hF1 : FirstOrderFriedmann a ρ k Λ G c t)
+    (hF2 : SecondOrderFriedmann a ρ (fun _ => 0) Λ G c t) :
+    k * c ^ 2 / (a t) ^ 2 = 4 * π * G * ρ t := by
+  unfold FirstOrderFriedmann at hF1
+  unfold SecondOrderFriedmann at hF2
+  rw [h1, zero_div] at hF1
+  rw [h2, zero_div] at hF2
+  simp only [mul_zero, zero_div, add_zero] at hF1 hF2
+  linarith
+
+/-- In the Einstein static universe with positive density, the curvature parameter is
+  positive. -/
+lemma einsteinStatic_curvature_pos {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : Time} (hG : 0 < G)
+    (hc : 0 < c) (ha : a t ≠ 0) (hρ : 0 < ρ t) (h1 : ∂ₜ a t = 0) (h2 : ∂ₜ (∂ₜ a) t = 0)
+    (hF1 : FirstOrderFriedmann a ρ k Λ G c t)
+    (hF2 : SecondOrderFriedmann a ρ (fun _ => 0) Λ G c t) :
+    0 < k := by
+  have h := einsteinStatic_curvature h1 h2 hF1 hF2
+  have hpos : 0 < k * c ^ 2 / (a t) ^ 2 := by
+    rw [h]
+    positivity
+  have ha2 : 0 < (a t) ^ 2 := by positivity
+  have hc2 : 0 < c ^ 2 := by positivity
+  rw [div_pos_iff_of_pos_right ha2] at hpos
+  exact (mul_pos_iff_of_pos_right hc2).mp hpos
+
+/-!
+
+## F. Remaining TODO items
+
+-/
+
+TODO "Prove that the Milne solution `milneScaleFactor` (empty universe, `K < 0`) has
   vanishing scalar curvature, i.e. it is Minkowski space in expanding coordinates."
 
-TODO "Define the Einstein static universe (`∂ₜ a = ∂ₜ ∂ₜ a = 0`, forcing `K > 0`
-  and `ρ_m = 2 ρ_Λ`) and prove that it is an unstable equilibrium."
+TODO "Prove that the Einstein static universe (`∂ₜ a = ∂ₜ ∂ₜ a = 0`, `einsteinStatic_density`,
+  `einsteinStatic_curvature`) is an unstable equilibrium."
 
 end Cosmology.FLRW.FriedmannEquation

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -7,6 +7,7 @@ module
 
 public import Physlib.Meta.TODO.Basic
 public import Physlib.Cosmology.FLRW.Basic
+public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 /-!
 
 # Exact solutions of the Friedmann equations
@@ -15,8 +16,9 @@ public import Physlib.Cosmology.FLRW.Basic
 
 This file collects the standard closed-form solutions of the Friedmann equations
 (`FirstOrderFriedmann` and `SecondOrderFriedmann` of `Physlib.Cosmology.FLRW.Basic`) and
-proves that they solve them: the de Sitter solution here, the radiation-dominated,
-Einstein-de Sitter and Milne models and the Einstein static universe being still TODO items.
+proves that they solve them: the de Sitter solution and the spatially flat power-law
+solutions (radiation-dominated and Einstein-de Sitter) here, the Milne model and the
+Einstein static universe being still TODO items.
 
 Each solution is a scale factor `a : Time → ℝ` given by an explicit function of the time
 coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridge
@@ -30,6 +32,17 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 - `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
   (for any `σ`, `Λ`, `c`).
 - `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
+- `powerLawScaleFactor`: `a(t) = (t / t₀) ^ n`, with Hubble parameter `n / t`
+  (`hubbleConstant_powerLawScaleFactor`) and deceleration parameter `(1 - n) / n`
+  (`decelerationParameter_powerLawScaleFactor`) for `t > 0`.
+- `radiationScaleFactor_firstOrderFriedmann`, `radiationScaleFactor_secondOrderFriedmann`:
+  `a = (t / t₀) ^ (1/2)` solves the flat (`k = 0`, `Λ = 0`) Friedmann equations with the
+  density `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
+  `H(t₀) = 1 / (2 t₀)`.
+- `einsteinDeSitterScaleFactor_firstOrderFriedmann`,
+  `einsteinDeSitterScaleFactor_secondOrderFriedmann`: `a = (t / t₀) ^ (2/3)` solves the flat
+  Friedmann equations with the dust density `ρ = 1 / (6 π G t²)` and `p = 0`; `q = 1 / 2` and
+  `H(t₀) = 2 / (3 t₀)`.
 
 ## iii. Table of contents
 
@@ -38,7 +51,12 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   - B.1. The scale factor and its derivatives
   - B.2. The Friedmann equations
   - B.3. The Hubble and deceleration parameters
-- C. Remaining TODO items
+- C. The spatially flat power-law solutions
+  - C.1. The power-law scale factor and its derivatives
+  - C.2. The Hubble and deceleration parameters
+  - C.3. The radiation-dominated solution
+  - C.4. The Einstein-de Sitter solution
+- D. Remaining TODO items
 
 -/
 
@@ -61,6 +79,12 @@ its time derivative is the Mathlib derivative of `γ`.
 lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
     ∂ₜ (fun s : Time => γ s.val) t = v :=
   deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
+  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
+lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
+    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
 
 /-!
 
@@ -178,16 +202,234 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. Remaining TODO items
+## C. The spatially flat power-law solutions
+
+The radiation-dominated and Einstein-de Sitter solutions are both of the form
+`a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
+parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with
+`k = 0` and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`.
 
 -/
 
-TODO "Prove that the spatially flat radiation-dominated solution `a = (t/t₀)^(1/2)`
-  solves the Friedmann equations, with `q₀ = 1` and `t₀ = 1 / (2 H₀)`."
+/-!
 
-TODO "Prove that the Einstein-de Sitter (spatially flat, dust) solution
-  `a = (t/t₀)^(2/3)` solves the Friedmann equations, with `q₀ = 1/2` and
-  `t₀ = 2 / (3 H₀)`."
+### C.1. The power-law scale factor and its derivatives
+
+-/
+
+/-- The power-law scale factor `a(t) = (t / t₀) ^ n` (real power). -/
+noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
+  fun t => (t.val / t₀) ^ n
+
+/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
+lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
+    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
+  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
+    (Or.inl (div_ne_zero hx ht₀))
+  refine h.congr_deriv ?_
+  simp only [id_eq]
+  ring
+
+/-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
+lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+    (ht : t.val ≠ 0) :
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
+  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+
+/-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
+  only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
+lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+    (ht : 0 < t.val) :
+    ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
+      n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
+  apply deriv_eq_of_hasDerivAt
+  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  refine h.congr_of_eventuallyEq ?_
+  filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
+  exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
+
+/-!
+
+### C.2. The Hubble and deceleration parameters
+
+-/
+
+/-- The Hubble parameter of the power-law solution is `n / t` for `t > 0`. -/
+lemma hubbleConstant_powerLawScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+    (ht : 0 < t.val) :
+    hubbleConstant (powerLawScaleFactor t₀ n) t = n / t.val := by
+  unfold hubbleConstant
+  rw [deriv_powerLawScaleFactor ht₀.ne' n ht.ne', powerLawScaleFactor,
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  field_simp
+
+/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `t > 0`,
+  `n ≠ 0`. -/
+lemma decelerationParameter_powerLawScaleFactor {t₀ n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+    {t : Time} (ht : 0 < t.val) :
+    decelerationParameter (powerLawScaleFactor t₀ n) t = (1 - n) / n := by
+  unfold decelerationParameter
+  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, deriv_powerLawScaleFactor ht₀.ne' n ht.ne',
+    powerLawScaleFactor, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  field_simp
+  ring
+
+/-- The density imposed on the flat power-law solution by the first-order Friedmann equation,
+  `ρ = 3 n² / (8 π G t²)`. -/
+noncomputable def powerLawDensity (G n : ℝ) : Time → ℝ :=
+  fun t => 3 * n ^ 2 / (8 * π * G * t.val ^ 2)
+
+/-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0` and the density `powerLawDensity`, for `t > 0`. -/
+lemma powerLawScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (n : ℝ) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n) 0 0 G c t := by
+  unfold FirstOrderFriedmann
+  have hH := hubbleConstant_powerLawScaleFactor ht₀ n ht
+  unfold hubbleConstant at hH
+  rw [hH, powerLawDensity]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
+
+/-- The second-order Friedmann equation for the flat power-law solution with the pressure
+  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `t > 0`. -/
+lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n)
+      (fun s => w * powerLawDensity G n s * c ^ 2) 0 G c t := by
+  unfold SecondOrderFriedmann
+  simp only [powerLawDensity]
+  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, powerLawScaleFactor,
+    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hπ := Real.pi_pos
+  rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
+  field_simp
+  ring
+
+/-!
+
+### C.3. The radiation-dominated solution
+
+-/
+
+/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
+noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
+  powerLawScaleFactor t₀ (1 / 2)
+
+/-- The density of the flat radiation-dominated solution, `ρ = 3 / (32 π G t²)`, imposed by
+  the first-order Friedmann equation. -/
+noncomputable def radiationDensity (G : ℝ) : Time → ℝ :=
+  fun t => 3 / (32 * π * G * t.val ^ 2)
+
+/-- The radiation pressure `p = ρ c² / 3`. -/
+noncomputable def radiationPressure (G c : ℝ) : Time → ℝ :=
+  fun t => radiationDensity G t * c ^ 2 / 3
+
+lemma radiationDensity_eq (G : ℝ) : radiationDensity G = powerLawDensity G (1 / 2) := by
+  funext t
+  simp only [radiationDensity, powerLawDensity]
+  ring
+
+/-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) 0 0 G c t := by
+  rw [radiationScaleFactor, radiationDensity_eq]
+  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+
+/-- The radiation-dominated solution solves the second-order Friedmann equation with
+  `p = ρ c² / 3`, `Λ = 0`, for `t > 0`. -/
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+    (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) (radiationPressure G c)
+      0 G c t := by
+  have h := powerLawScaleFactor_secondOrderFriedmann (w := 1 / 3) ht₀ hG hc
+    (by norm_num : (1 / 2 : ℝ) ≠ 0) (by norm_num) ht
+  rw [radiationScaleFactor, radiationDensity_eq]
+  convert h using 2
+  simp only [radiationPressure, radiationDensity_eq]
+  ring
+
+/-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
+lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+    (ht : 0 < t.val) :
+    decelerationParameter (radiationScaleFactor t₀) t = 1 := by
+  rw [radiationScaleFactor, decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  norm_num
+
+/-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
+lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
+    hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
+  rw [radiationScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  ring
+
+/-!
+
+### C.4. The Einstein-de Sitter solution
+
+-/
+
+/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
+noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
+  powerLawScaleFactor t₀ (2 / 3)
+
+/-- The dust density of the Einstein-de Sitter solution, `ρ = 1 / (6 π G t²)`, imposed by the
+  first-order Friedmann equation. -/
+noncomputable def einsteinDeSitterDensity (G : ℝ) : Time → ℝ :=
+  fun t => 1 / (6 * π * G * t.val ^ 2)
+
+lemma einsteinDeSitterDensity_eq (G : ℝ) :
+    einsteinDeSitterDensity G = powerLawDensity G (2 / 3) := by
+  funext t
+  simp only [einsteinDeSitterDensity, powerLawDensity]
+  ring
+
+/-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+      0 0 G c t := by
+  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
+  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+
+/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with `p = 0`,
+  `Λ = 0`, for `t > 0`. -/
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+      (fun _ => 0) 0 G c t := by
+  have h := powerLawScaleFactor_secondOrderFriedmann (w := 0) ht₀ hG hc
+    (by norm_num : (2 / 3 : ℝ) ≠ 0) (by norm_num) ht
+  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
+  convert h using 2
+  ring
+
+/-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+    (ht : 0 < t.val) :
+    decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
+  rw [einsteinDeSitterScaleFactor,
+    decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  norm_num
+
+/-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
+lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
+    hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
+  rw [einsteinDeSitterScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  ring
+
+/-!
+
+## D. Remaining TODO items
+
+-/
 
 TODO "Prove that the Milne solution `a = c t` (empty universe, `K < 0`) has
   vanishing scalar curvature, i.e. it is Minkowski space in expanding coordinates."

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -6,7 +6,7 @@ Authors: Jinzheng Li, Philippe Kevorkian
 module
 
 public import Physlib.Meta.TODO.Basic
-public import Physlib.Cosmology.FLRW.Basic
+public import Physlib.Cosmology.FLRW.MatterContent
 public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 /-!
 
@@ -488,15 +488,12 @@ lemma decelerationParameter_milneScaleFactor (c : ℝ) (t : Time) :
 ## E. The Einstein static universe
 
 At an instant where `∂ₜ a = ∂ₜ ∂ₜ a = 0`, the two Friedmann equations with dust (`p = 0`)
-force the density `ρ = Λ c² / (4 π G)`, twice the density `ρ_Λ = Λ c² / (8 π G)` associated
-with the cosmological constant, and `k c² / a² = 4 π G ρ`, hence a positive curvature
-parameter when `ρ > 0`. That this equilibrium is unstable is not stated here.
+force the density `ρ = Λ c² / (4 π G)`, twice the density `cosmologicalConstantDensity`
+(`ρ_Λ = Λ c² / (8 π G)`, defined in `Physlib.Cosmology.FLRW.MatterContent`), and
+`k c² / a² = 4 π G ρ`, hence a positive curvature parameter when `ρ > 0`. That this
+equilibrium is unstable is not stated here.
 
 -/
-
-/-- The density `ρ_Λ = Λ c² / (8 π G)` associated with the cosmological constant. -/
-noncomputable def cosmologicalConstantDensity (Λ G c : ℝ) : ℝ :=
-  Λ * c ^ 2 / (8 * π * G)
 
 /-- In the Einstein static universe the dust density is `ρ = Λ c² / (4 π G) = 2 ρ_Λ`. -/
 lemma einsteinStatic_density {a ρ : Time → ℝ} {Λ G c : ℝ} {t : Time} (hG : 0 < G)

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -54,19 +54,18 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 
 ## iii. Table of contents
 
-- A. Time derivatives of curves given by a function of the coordinate
-- B. The de Sitter solution
-  - B.1. The scale factor and its derivatives
-  - B.2. The Friedmann equations
-  - B.3. The Hubble and deceleration parameters
-- C. The spatially flat power-law solutions
-  - C.1. The power-law scale factor and its derivatives
-  - C.2. The Hubble and deceleration parameters
-  - C.3. The radiation-dominated solution
-  - C.4. The Einstein-de Sitter solution
-- D. The Milne solution
-- E. The Einstein static universe
-- F. Remaining TODO items
+- A. The de Sitter solution
+  - A.1. The scale factor and its derivatives
+  - A.2. The Friedmann equations
+  - A.3. The Hubble and deceleration parameters
+- B. The spatially flat power-law solutions
+  - B.1. The power-law scale factor and its derivatives
+  - B.2. The Hubble and deceleration parameters
+  - B.3. The radiation-dominated solution
+  - B.4. The Einstein-de Sitter solution
+- C. The Milne solution
+- D. The Einstein static universe
+- E. Remaining TODO items
 
 -/
 
@@ -78,33 +77,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives of curves given by a function of the coordinate
-
-A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
-its time derivative is the Mathlib derivative of `γ`.
-
--/
-
-/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
-lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
-    ∂ₜ (fun s : Time => γ s.val) t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
-
-/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
-  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
-lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
-    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
-
-/-!
-
-## B. The de Sitter solution
+## A. The de Sitter solution
 
 -/
 
 /-!
 
-### B.1. The scale factor and its derivatives
+### A.1. The scale factor and its derivatives
 
 -/
 
@@ -113,19 +92,17 @@ lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
 noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
   fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
 
-/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
-lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
-    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
-  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
       fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
   funext t
-  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val)) t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul a₀
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
@@ -133,8 +110,15 @@ lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
         Real.exp (σ * √(Λ / 3) * c * t.val) := by
   rw [deriv_deSitterScaleFactor]
   funext t
-  exact deriv_comp_val
-    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val))
+      t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul
+      (a₀ * (σ * √(Λ / 3) * c))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
 lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
@@ -144,7 +128,7 @@ lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1
 
 /-!
 
-### B.2. The Friedmann equations
+### A.2. The Friedmann equations
 
 -/
 
@@ -179,7 +163,7 @@ lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 <
 
 /-!
 
-### B.3. The Hubble and deceleration parameters
+### A.3. The Hubble and deceleration parameters
 
 -/
 
@@ -212,7 +196,7 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. The spatially flat power-law solutions
+## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
 `a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
@@ -223,7 +207,7 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 
 /-!
 
-### C.1. The power-law scale factor and its derivatives
+### B.1. The power-law scale factor and its derivatives
 
 -/
 
@@ -231,20 +215,17 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
   fun t => (t.val / t₀) ^ n
 
-/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
-lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
-    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
-  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
-    (Or.inl (div_ne_zero hx ht₀))
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 /-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
 lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
-  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+      (Or.inl (div_ne_zero ht ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
   only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
@@ -253,14 +234,21 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
     ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
+      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+      (Or.inl (div_ne_zero ht.ne' ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
-### C.2. The Hubble and deceleration parameters
+### B.2. The Hubble and deceleration parameters
 
 -/
 
@@ -323,7 +311,7 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-!
 
-### C.3. The radiation-dominated solution
+### B.3. The radiation-dominated solution
 
 -/
 
@@ -381,7 +369,7 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-!
 
-### C.4. The Einstein-de Sitter solution
+### B.4. The Einstein-de Sitter solution
 
 -/
 
@@ -437,7 +425,7 @@ lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < 
 
 /-!
 
-## D. The Milne solution
+## C. The Milne solution
 
 The Milne universe is the empty (`ρ = 0`, `p = 0`, `Λ = 0`) solution with `k = -1` and
 `a(t) = c t` for `t > 0`. That it is Minkowski space in expanding coordinates (vanishing
@@ -485,7 +473,7 @@ lemma decelerationParameter_milneScaleFactor (c : ℝ) (t : Time) :
 
 /-!
 
-## E. The Einstein static universe
+## D. The Einstein static universe
 
 At an instant where `∂ₜ a = ∂ₜ ∂ₜ a = 0`, the two Friedmann equations with dust (`p = 0`)
 force the density `ρ = Λ c² / (4 π G)`, twice the density `cosmologicalConstantDensity`
@@ -537,7 +525,7 @@ lemma einsteinStatic_curvature_pos {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : T
 
 /-!
 
-## F. Remaining TODO items
+## E. Remaining TODO items
 
 -/
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Jinzheng Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jinzheng Li, Philippe Kevorkian
+Authors: Philippe Kevorkian, Jinzheng Li
 -/
 module
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -46,6 +46,9 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   Friedmann equations with the dust density `ρ = 1 / (6 π G t²)` and `p = 0`; `q = 1 / 2` and
   `H(t₀) = 2 / (3 t₀)`.
 
+In the power-law solutions `t₀ : Time` is the normalisation epoch (`a(t₀) = 1`) and the Big
+Bang is at the origin `t.val = 0` of the time chart.
+
 ## iii. Table of contents
 
 - A. The de Sitter solution
@@ -196,6 +199,11 @@ The radiation-dominated and Einstein-de Sitter solutions are both of the form
 and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`. The general power-law solution is
 stated inline, only the two named solutions get a definition.
 
+Throughout, `t₀` is the normalisation epoch, `a(t₀) = 1`, the Big Bang sits at the origin
+`t.val = 0` of the time chart (`Time` has no distinguished origin by itself), and the values
+for `t.val ≤ 0` are junk (`Real.rpow` on a non-positive base); every statement therefore
+assumes `0 < t.val`.
+
 -/
 
 /-!
@@ -205,11 +213,11 @@ stated inline, only the two named solutions get a definition.
 -/
 
 /-- `∂ₜ (t / t₀) ^ n = n / t₀ (t / t₀) ^ (n - 1)` away from `t.val = 0`. -/
-lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
-    ∂ₜ (fun s : Time => (s.val / t₀) ^ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
-  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n)
-      (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
-    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+lemma deriv_powerLaw {t₀ : Time} (ht₀ : t₀.val ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
+    ∂ₜ (fun s : Time => (s.val / t₀.val) ^ n) t = n / t₀.val * (t.val / t₀.val) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀.val) ^ n)
+      (n / t₀.val * (t.val / t₀.val) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀.val).rpow_const (p := n)
       (Or.inl (div_ne_zero ht ht₀))
     refine h.congr_deriv ?_
     simp only [id_eq]
@@ -219,19 +227,19 @@ lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht 
 /-- `∂ₜ ∂ₜ (t / t₀) ^ n = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `0 < t.val`. The first
   derivative is only known away from `t.val = 0`, which is enough since `0 < t.val` is an open
   condition. -/
-lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+lemma deriv_deriv_powerLaw {t₀ : Time} (ht₀ : t₀.val ≠ 0) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀) ^ n)) t =
-      n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
+    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀.val) ^ n)) t =
+      n / t₀.val * ((n - 1) / t₀.val * (t.val / t₀.val) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
-      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
-    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀.val) ^ (n - 1))
+      ((n - 1) / t₀.val * (t.val / t₀.val) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀.val).rpow_const (p := n - 1)
       (Or.inl (div_ne_zero ht.ne' ht₀))
     refine h.congr_deriv ?_
     simp only [id_eq]
     ring
-  have h := h₁.const_mul (n / t₀)
+  have h := h₁.const_mul (n / t₀.val)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLaw ht₀ n (t := ⟨τ⟩) hτ
@@ -243,31 +251,31 @@ lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time
 -/
 
 /-- The Hubble parameter of the power-law solution is `n / t` for `0 < t.val`. -/
-lemma hubbleConstant_powerLaw {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+lemma hubbleConstant_powerLaw {t₀ : Time} (ht₀ : 0 < t₀.val) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    hubbleConstant (fun s : Time => (s.val / t₀) ^ n) t = n / t.val := by
+    hubbleConstant (fun s : Time => (s.val / t₀.val) ^ n) t = n / t.val := by
   unfold hubbleConstant
   rw [deriv_powerLaw ht₀.ne' n ht.ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
 
 /-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `0 < t.val`,
   `n ≠ 0`. -/
-lemma decelerationParameter_powerLaw {t₀ : ℝ} {n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+lemma decelerationParameter_powerLaw {t₀ : Time} {n : ℝ} (ht₀ : 0 < t₀.val) (hn : n ≠ 0)
     {t : Time} (ht : 0 < t.val) :
-    decelerationParameter (fun s : Time => (s.val / t₀) ^ n) t = (1 - n) / n := by
+    decelerationParameter (fun s : Time => (s.val / t₀.val) ^ n) t = (1 - n) / n := by
   unfold decelerationParameter
   rw [deriv_deriv_powerLaw ht₀.ne' n ht, deriv_powerLaw ht₀.ne' n ht.ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
   ring
 
 /-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the density `ρ = 3 n² / (8 π G t²)` that it imposes, for `0 < t.val`. -/
-lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+lemma powerLaw_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val) (hG : 0 < G)
     (n : ℝ) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+    FirstOrderFriedmann (fun s : Time => (s.val / t₀.val) ^ n)
       (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2)) 0 0 G c t := by
   unfold FirstOrderFriedmann
   have hH := hubbleConstant_powerLaw ht₀ n ht
@@ -279,15 +287,15 @@ lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (
 
 /-- The second-order Friedmann equation for the flat power-law solution with the pressure
   `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `0 < t.val`. -/
-lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+lemma powerLaw_secondOrderFriedmann {t₀ : Time} {G c n w : ℝ} (ht₀ : 0 < t₀.val) (hG : 0 < G)
     (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+    SecondOrderFriedmann (fun s : Time => (s.val / t₀.val) ^ n)
       (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2))
       (fun s => w * (3 * n ^ 2 / (8 * π * G * s.val ^ 2)) * c ^ 2) 0 G c t := by
   unfold SecondOrderFriedmann
   rw [deriv_deriv_powerLaw ht₀.ne' n ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
+  have hx : (t.val / t₀.val) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   have hπ := Real.pi_pos
   rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
   field_simp
@@ -299,13 +307,15 @@ lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t�
 
 -/
 
-/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
-noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ (1 / 2 : ℝ)
+/-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`, normalised by `a(t₀) = 1`.
+  The Big Bang is at the origin `t.val = 0` of the time chart; the values for `t.val ≤ 0` are
+  junk. -/
+noncomputable def radiationScaleFactor (t₀ : Time) : Time → ℝ :=
+  fun t => (t.val / t₀.val) ^ (1 / 2 : ℝ)
 
 /-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the density `ρ = 3 / (32 π G t²)`, for `0 < t.val`. -/
-lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
     FirstOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
       0 0 G c t := by
@@ -319,21 +329,21 @@ lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ :
 
 /-- The radiation-dominated solution solves the second-order Friedmann equation with the
   density `ρ = 3 / (32 π G t²)`, the pressure `p = ρ c² / 3` and `Λ = 0`, for `0 < t.val`. -/
-lemma radiationScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
     SecondOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
       (fun s => 3 / (32 * π * G * s.val ^ 2) * c ^ 2 / 3) 0 G c t := by
   unfold SecondOrderFriedmann radiationScaleFactor
   rw [deriv_deriv_powerLaw ht₀.ne' (1 / 2) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ (1 / 2 : ℝ) ≠ 0 :=
+  have hx : (t.val / t₀.val) ^ (1 / 2 : ℝ) ≠ 0 :=
     (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
-lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
+lemma decelerationParameter_radiationScaleFactor {t₀ : Time} (ht₀ : 0 < t₀.val) {t : Time}
     (ht : 0 < t.val) :
     decelerationParameter (radiationScaleFactor t₀) t = 1 := by
   unfold radiationScaleFactor
@@ -341,8 +351,8 @@ lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
   norm_num
 
 /-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
-lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
-    hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
+lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : Time} (ht₀ : 0 < t₀.val) :
+    hubbleConstant (radiationScaleFactor t₀) t₀ = 1 / (2 * t₀.val) := by
   unfold radiationScaleFactor
   rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
@@ -353,13 +363,15 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 -/
 
-/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
-noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ (2 / 3 : ℝ)
+/-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`, normalised by
+  `a(t₀) = 1`. The Big Bang is at the origin `t.val = 0` of the time chart; the values for
+  `t.val ≤ 0` are junk. -/
+noncomputable def einsteinDeSitterScaleFactor (t₀ : Time) : Time → ℝ :=
+  fun t => (t.val / t₀.val) ^ (2 / 3 : ℝ)
 
 /-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
   `Λ = 0` and the dust density `ρ = 1 / (6 π G t²)`, for `0 < t.val`. -/
-lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
     FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       0 0 G c t := by
@@ -373,21 +385,21 @@ lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (
 
 /-- The Einstein-de Sitter solution solves the second-order Friedmann equation with the dust
   density `ρ = 1 / (6 π G t²)`, `p = 0` and `Λ = 0`, for `0 < t.val`. -/
-lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : Time} {G c : ℝ} (ht₀ : 0 < t₀.val)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
     SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       (fun _ => 0) 0 G c t := by
   unfold SecondOrderFriedmann einsteinDeSitterScaleFactor
   rw [deriv_deriv_powerLaw ht₀.ne' (2 / 3) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
     Real.rpow_sub_one (div_pos ht ht₀).ne']
-  have hx : (t.val / t₀) ^ (2 / 3 : ℝ) ≠ 0 :=
+  have hx : (t.val / t₀.val) ^ (2 / 3 : ℝ) ≠ 0 :=
     (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
-lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : Time} (ht₀ : 0 < t₀.val)
     {t : Time} (ht : 0 < t.val) :
     decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
   unfold einsteinDeSitterScaleFactor
@@ -395,8 +407,8 @@ lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 
   norm_num
 
 /-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
-lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
-    hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
+lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : Time} (ht₀ : 0 < t₀.val) :
+    hubbleConstant (einsteinDeSitterScaleFactor t₀) t₀ = 2 / (3 * t₀.val) := by
   unfold einsteinDeSitterScaleFactor
   rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -32,12 +32,14 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 - `hubbleConstant_deSitterScaleFactor`: its Hubble parameter is the constant `σ √(Λ/3) c`
   (for any `σ`, `Λ`, `c`).
 - `decelerationParameter_deSitterScaleFactor`: its deceleration parameter is `q = -1`.
-- `powerLawScaleFactor`: `a(t) = (t / t₀) ^ n`, with Hubble parameter `n / t`
-  (`hubbleConstant_powerLawScaleFactor`) and deceleration parameter `(1 - n) / n`
-  (`decelerationParameter_powerLawScaleFactor`) for `t > 0`.
+- `hubbleConstant_powerLaw`, `decelerationParameter_powerLaw`, `powerLaw_firstOrderFriedmann`,
+  `powerLaw_secondOrderFriedmann`: the flat power-law solutions `a = (t / t₀) ^ n`, stated
+  inline, have Hubble parameter `n / t` and deceleration parameter `(1 - n) / n`, and solve the
+  flat (`k = 0`, `Λ = 0`) Friedmann equations with the density `ρ = 3 n² / (8 π G t²)` and the
+  pressure `p = w ρ c²`, `1 + 3 w = 2 (1 - n) / n`, for `t > 0`.
 - `radiationScaleFactor_firstOrderFriedmann`, `radiationScaleFactor_secondOrderFriedmann`:
-  `a = (t / t₀) ^ (1/2)` solves the flat (`k = 0`, `Λ = 0`) Friedmann equations with the
-  density `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
+  `a = (t / t₀) ^ (1/2)` solves the flat Friedmann equations with the density
+  `ρ = 3 / (32 π G t²)` and the radiation pressure `p = ρ c² / 3`; `q = 1` and
   `H(t₀) = 1 / (2 t₀)`.
 - `einsteinDeSitterScaleFactor_firstOrderFriedmann`,
   `einsteinDeSitterScaleFactor_secondOrderFriedmann`: `a = (t / t₀) ^ (2/3)` solves the flat
@@ -51,7 +53,7 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   - A.2. The Friedmann equations
   - A.3. The Hubble and deceleration parameters
 - B. The spatially flat power-law solutions
-  - B.1. The power-law scale factor and its derivatives
+  - B.1. Derivatives of the power-law scale factor
   - B.2. The Hubble and deceleration parameters
   - B.3. The radiation-dominated solution
   - B.4. The Einstein-de Sitter solution
@@ -189,27 +191,24 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 ## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
-`a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
-parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with
-`k = 0` and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`.
+`a(t) = (t / t₀) ^ n`; the Hubble parameter is `n / t` and the deceleration parameter
+`(1 - n) / n`. Their densities are imposed by the first-order Friedmann equation with `k = 0`
+and `Λ = 0`: `ρ = 3 H² / (8 π G) = 3 n² / (8 π G t²)`. The general power-law solution is
+stated inline, only the two named solutions get a definition.
 
 -/
 
 /-!
 
-### B.1. The power-law scale factor and its derivatives
+### B.1. Derivatives of the power-law scale factor
 
 -/
 
-/-- The power-law scale factor `a(t) = (t / t₀) ^ n` (real power). -/
-noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
-  fun t => (t.val / t₀) ^ n
-
-/-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
-lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
-    (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
-  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+/-- `∂ₜ (t / t₀) ^ n = n / t₀ (t / t₀) ^ (n - 1)` away from `t.val = 0`. -/
+lemma deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time} (ht : t.val ≠ 0) :
+    ∂ₜ (fun s : Time => (s.val / t₀) ^ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n)
+      (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
     have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
       (Or.inl (div_ne_zero ht ht₀))
     refine h.congr_deriv ?_
@@ -217,11 +216,12 @@ lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t :
     ring
   exact deriv_comp_val h
 
-/-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
-  only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
-lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
+/-- `∂ₜ ∂ₜ (t / t₀) ^ n = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `0 < t.val`. The first
+  derivative is only known away from `t.val = 0`, which is enough since `0 < t.val` is an open
+  condition. -/
+lemma deriv_deriv_powerLaw {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
+    ∂ₜ (∂ₜ (fun s : Time => (s.val / t₀) ^ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
   have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
@@ -234,7 +234,7 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
   have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
-  exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
+  exact deriv_powerLaw ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
@@ -242,57 +242,51 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
 
 -/
 
-/-- The Hubble parameter of the power-law solution is `n / t` for `t > 0`. -/
-lemma hubbleConstant_powerLawScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
+/-- The Hubble parameter of the power-law solution is `n / t` for `0 < t.val`. -/
+lemma hubbleConstant_powerLaw {t₀ : ℝ} (ht₀ : 0 < t₀) (n : ℝ) {t : Time}
     (ht : 0 < t.val) :
-    hubbleConstant (powerLawScaleFactor t₀ n) t = n / t.val := by
+    hubbleConstant (fun s : Time => (s.val / t₀) ^ n) t = n / t.val := by
   unfold hubbleConstant
-  rw [deriv_powerLawScaleFactor ht₀.ne' n ht.ne', powerLawScaleFactor,
-    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_powerLaw ht₀.ne' n ht.ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
 
-/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `t > 0`,
+/-- The deceleration parameter of the power-law solution is `(1 - n) / n` for `0 < t.val`,
   `n ≠ 0`. -/
-lemma decelerationParameter_powerLawScaleFactor {t₀ n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
+lemma decelerationParameter_powerLaw {t₀ : ℝ} {n : ℝ} (ht₀ : 0 < t₀) (hn : n ≠ 0)
     {t : Time} (ht : 0 < t.val) :
-    decelerationParameter (powerLawScaleFactor t₀ n) t = (1 - n) / n := by
+    decelerationParameter (fun s : Time => (s.val / t₀) ^ n) t = (1 - n) / n := by
   unfold decelerationParameter
-  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, deriv_powerLawScaleFactor ht₀.ne' n ht.ne',
-    powerLawScaleFactor, Real.rpow_sub_one (div_pos ht ht₀).ne',
-    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_deriv_powerLaw ht₀.ne' n ht, deriv_powerLaw ht₀.ne' n ht.ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   field_simp
   ring
 
-/-- The density imposed on the flat power-law solution by the first-order Friedmann equation,
-  `ρ = 3 n² / (8 π G t²)`. -/
-noncomputable def powerLawDensity (G n : ℝ) : Time → ℝ :=
-  fun t => 3 * n ^ 2 / (8 * π * G * t.val ^ 2)
-
 /-- The flat power-law solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0` and the density `powerLawDensity`, for `t > 0`. -/
-lemma powerLawScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+  `Λ = 0` and the density `ρ = 3 n² / (8 π G t²)` that it imposes, for `0 < t.val`. -/
+lemma powerLaw_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
     (n : ℝ) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n) 0 0 G c t := by
+    FirstOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+      (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2)) 0 0 G c t := by
   unfold FirstOrderFriedmann
-  have hH := hubbleConstant_powerLawScaleFactor ht₀ n ht
+  have hH := hubbleConstant_powerLaw ht₀ n ht
   unfold hubbleConstant at hH
-  rw [hH, powerLawDensity]
+  rw [hH]
   have hπ := Real.pi_pos
   field_simp
   ring
 
 /-- The second-order Friedmann equation for the flat power-law solution with the pressure
-  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `t > 0`. -/
-lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
+  `p = w ρ c²`, where `1 + 3 w = 2 (1 - n) / n`, for `0 < t.val`. -/
+lemma powerLaw_secondOrderFriedmann {t₀ : ℝ} {G c n w : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
     (hc : 0 < c) (hn : n ≠ 0) (hw : 1 + 3 * w = 2 * (1 - n) / n) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (powerLawScaleFactor t₀ n) (powerLawDensity G n)
-      (fun s => w * powerLawDensity G n s * c ^ 2) 0 G c t := by
+    SecondOrderFriedmann (fun s : Time => (s.val / t₀) ^ n)
+      (fun s => 3 * n ^ 2 / (8 * π * G * s.val ^ 2))
+      (fun s => w * (3 * n ^ 2 / (8 * π * G * s.val ^ 2)) * c ^ 2) 0 G c t := by
   unfold SecondOrderFriedmann
-  simp only [powerLawDensity]
-  rw [deriv_deriv_powerLawScaleFactor ht₀.ne' n ht, powerLawScaleFactor,
-    Real.rpow_sub_one (div_pos ht ht₀).ne', Real.rpow_sub_one (div_pos ht ht₀).ne']
+  rw [deriv_deriv_powerLaw ht₀.ne' n ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
   have hx : (t.val / t₀) ^ n ≠ 0 := (Real.rpow_pos_of_pos (div_pos ht ht₀) n).ne'
   have hπ := Real.pi_pos
   rw [show w = (2 * (1 - n) / n - 1) / 3 by linarith]
@@ -307,54 +301,50 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-- The radiation-dominated scale factor `a(t) = (t / t₀) ^ (1/2)`. -/
 noncomputable def radiationScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  powerLawScaleFactor t₀ (1 / 2)
-
-/-- The density of the flat radiation-dominated solution, `ρ = 3 / (32 π G t²)`, imposed by
-  the first-order Friedmann equation. -/
-noncomputable def radiationDensity (G : ℝ) : Time → ℝ :=
-  fun t => 3 / (32 * π * G * t.val ^ 2)
-
-/-- The radiation pressure `p = ρ c² / 3`. -/
-noncomputable def radiationPressure (G c : ℝ) : Time → ℝ :=
-  fun t => radiationDensity G t * c ^ 2 / 3
-
-lemma radiationDensity_eq (G : ℝ) : radiationDensity G = powerLawDensity G (1 / 2) := by
-  funext t
-  simp only [radiationDensity, powerLawDensity]
-  ring
+  fun t => (t.val / t₀) ^ (1 / 2 : ℝ)
 
 /-- The radiation-dominated solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma radiationScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
-    {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) 0 0 G c t := by
-  rw [radiationScaleFactor, radiationDensity_eq]
-  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+  `Λ = 0` and the density `ρ = 3 / (32 π G t²)`, for `0 < t.val`. -/
+lemma radiationScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
+    FirstOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
+      0 0 G c t := by
+  unfold FirstOrderFriedmann radiationScaleFactor
+  have hH := hubbleConstant_powerLaw ht₀ (1 / 2) ht
+  unfold hubbleConstant at hH
+  rw [hH]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
 
-/-- The radiation-dominated solution solves the second-order Friedmann equation with
-  `p = ρ c² / 3`, `Λ = 0`, for `t > 0`. -/
-lemma radiationScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀) (hG : 0 < G)
-    (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (radiationScaleFactor t₀) (radiationDensity G) (radiationPressure G c)
-      0 G c t := by
-  have h := powerLawScaleFactor_secondOrderFriedmann (w := 1 / 3) ht₀ hG hc
-    (by norm_num : (1 / 2 : ℝ) ≠ 0) (by norm_num) ht
-  rw [radiationScaleFactor, radiationDensity_eq]
-  convert h using 2
-  simp only [radiationPressure, radiationDensity_eq]
+/-- The radiation-dominated solution solves the second-order Friedmann equation with the
+  density `ρ = 3 / (32 π G t²)`, the pressure `p = ρ c² / 3` and `Λ = 0`, for `0 < t.val`. -/
+lemma radiationScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
+    (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
+    SecondOrderFriedmann (radiationScaleFactor t₀) (fun s => 3 / (32 * π * G * s.val ^ 2))
+      (fun s => 3 / (32 * π * G * s.val ^ 2) * c ^ 2 / 3) 0 G c t := by
+  unfold SecondOrderFriedmann radiationScaleFactor
+  rw [deriv_deriv_powerLaw ht₀.ne' (1 / 2) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ (1 / 2 : ℝ) ≠ 0 :=
+    (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
+  have hπ := Real.pi_pos
+  field_simp
   ring
 
 /-- The deceleration parameter of the radiation-dominated solution is `q = 1`. -/
 lemma decelerationParameter_radiationScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
     (ht : 0 < t.val) :
     decelerationParameter (radiationScaleFactor t₀) t = 1 := by
-  rw [radiationScaleFactor, decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  unfold radiationScaleFactor
+  rw [decelerationParameter_powerLaw ht₀ (by norm_num) ht]
   norm_num
 
 /-- `H(t₀) = 1 / (2 t₀)` for the radiation-dominated solution, that is `t₀ = 1 / (2 H₀)`. -/
 lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
     hubbleConstant (radiationScaleFactor t₀) ⟨t₀⟩ = 1 / (2 * t₀) := by
-  rw [radiationScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  unfold radiationScaleFactor
+  rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
 
 /-!
@@ -365,52 +355,50 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-- The Einstein-de Sitter (flat, dust) scale factor `a(t) = (t / t₀) ^ (2/3)`. -/
 noncomputable def einsteinDeSitterScaleFactor (t₀ : ℝ) : Time → ℝ :=
-  powerLawScaleFactor t₀ (2 / 3)
-
-/-- The dust density of the Einstein-de Sitter solution, `ρ = 1 / (6 π G t²)`, imposed by the
-  first-order Friedmann equation. -/
-noncomputable def einsteinDeSitterDensity (G : ℝ) : Time → ℝ :=
-  fun t => 1 / (6 * π * G * t.val ^ 2)
-
-lemma einsteinDeSitterDensity_eq (G : ℝ) :
-    einsteinDeSitterDensity G = powerLawDensity G (2 / 3) := by
-  funext t
-  simp only [einsteinDeSitterDensity, powerLawDensity]
-  ring
+  fun t => (t.val / t₀) ^ (2 / 3 : ℝ)
 
 /-- The Einstein-de Sitter solution solves the first-order Friedmann equation with `k = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+  `Λ = 0` and the dust density `ρ = 1 / (6 π G t²)`, for `0 < t.val`. -/
+lemma einsteinDeSitterScaleFactor_firstOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
     (hG : 0 < G) {t : Time} (ht : 0 < t.val) :
-    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+    FirstOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       0 0 G c t := by
-  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
-  exact powerLawScaleFactor_firstOrderFriedmann ht₀ hG _ ht
+  unfold FirstOrderFriedmann einsteinDeSitterScaleFactor
+  have hH := hubbleConstant_powerLaw ht₀ (2 / 3) ht
+  unfold hubbleConstant at hH
+  rw [hH]
+  have hπ := Real.pi_pos
+  field_simp
+  ring
 
-/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with `p = 0`,
-  `Λ = 0`, for `t > 0`. -/
-lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ G c : ℝ} (ht₀ : 0 < t₀)
+/-- The Einstein-de Sitter solution solves the second-order Friedmann equation with the dust
+  density `ρ = 1 / (6 π G t²)`, `p = 0` and `Λ = 0`, for `0 < t.val`. -/
+lemma einsteinDeSitterScaleFactor_secondOrderFriedmann {t₀ : ℝ} {G c : ℝ} (ht₀ : 0 < t₀)
     (hG : 0 < G) (hc : 0 < c) {t : Time} (ht : 0 < t.val) :
-    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (einsteinDeSitterDensity G)
+    SecondOrderFriedmann (einsteinDeSitterScaleFactor t₀) (fun s => 1 / (6 * π * G * s.val ^ 2))
       (fun _ => 0) 0 G c t := by
-  have h := powerLawScaleFactor_secondOrderFriedmann (w := 0) ht₀ hG hc
-    (by norm_num : (2 / 3 : ℝ) ≠ 0) (by norm_num) ht
-  rw [einsteinDeSitterScaleFactor, einsteinDeSitterDensity_eq]
-  convert h using 2
+  unfold SecondOrderFriedmann einsteinDeSitterScaleFactor
+  rw [deriv_deriv_powerLaw ht₀.ne' (2 / 3) ht, Real.rpow_sub_one (div_pos ht ht₀).ne',
+    Real.rpow_sub_one (div_pos ht ht₀).ne']
+  have hx : (t.val / t₀) ^ (2 / 3 : ℝ) ≠ 0 :=
+    (Real.rpow_pos_of_pos (div_pos ht ht₀) _).ne'
+  have hπ := Real.pi_pos
+  field_simp
   ring
 
 /-- The deceleration parameter of the Einstein-de Sitter solution is `q = 1 / 2`. -/
-lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀) {t : Time}
-    (ht : 0 < t.val) :
+lemma decelerationParameter_einsteinDeSitterScaleFactor {t₀ : ℝ} (ht₀ : 0 < t₀)
+    {t : Time} (ht : 0 < t.val) :
     decelerationParameter (einsteinDeSitterScaleFactor t₀) t = 1 / 2 := by
-  rw [einsteinDeSitterScaleFactor,
-    decelerationParameter_powerLawScaleFactor ht₀ (by norm_num) ht]
+  unfold einsteinDeSitterScaleFactor
+  rw [decelerationParameter_powerLaw ht₀ (by norm_num) ht]
   norm_num
 
 /-- `H(t₀) = 2 / (3 t₀)` for the Einstein-de Sitter solution, that is `t₀ = 2 / (3 H₀)`. -/
 lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
     hubbleConstant (einsteinDeSitterScaleFactor t₀) ⟨t₀⟩ = 2 / (3 * t₀) := by
-  rw [einsteinDeSitterScaleFactor, hubbleConstant_powerLawScaleFactor ht₀ _ ht₀]
+  unfold einsteinDeSitterScaleFactor
+  rw [hubbleConstant_powerLaw ht₀ _ ht₀]
   ring
 
 /-!

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -46,17 +46,16 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 
 ## iii. Table of contents
 
-- A. Time derivatives of curves given by a function of the coordinate
-- B. The de Sitter solution
-  - B.1. The scale factor and its derivatives
-  - B.2. The Friedmann equations
-  - B.3. The Hubble and deceleration parameters
-- C. The spatially flat power-law solutions
-  - C.1. The power-law scale factor and its derivatives
-  - C.2. The Hubble and deceleration parameters
-  - C.3. The radiation-dominated solution
-  - C.4. The Einstein-de Sitter solution
-- D. Remaining TODO items
+- A. The de Sitter solution
+  - A.1. The scale factor and its derivatives
+  - A.2. The Friedmann equations
+  - A.3. The Hubble and deceleration parameters
+- B. The spatially flat power-law solutions
+  - B.1. The power-law scale factor and its derivatives
+  - B.2. The Hubble and deceleration parameters
+  - B.3. The radiation-dominated solution
+  - B.4. The Einstein-de Sitter solution
+- C. Remaining TODO items
 
 -/
 
@@ -68,33 +67,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives of curves given by a function of the coordinate
-
-A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
-its time derivative is the Mathlib derivative of `γ`.
-
--/
-
-/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
-lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
-    ∂ₜ (fun s : Time => γ s.val) t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
-
-/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
-  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
-lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
-    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
-
-/-!
-
-## B. The de Sitter solution
+## A. The de Sitter solution
 
 -/
 
 /-!
 
-### B.1. The scale factor and its derivatives
+### A.1. The scale factor and its derivatives
 
 -/
 
@@ -103,19 +82,17 @@ lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
 noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
   fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
 
-/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
-lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
-    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
-  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
       fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
   funext t
-  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val)) t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul a₀
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
@@ -123,8 +100,15 @@ lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
         Real.exp (σ * √(Λ / 3) * c * t.val) := by
   rw [deriv_deSitterScaleFactor]
   funext t
-  exact deriv_comp_val
-    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val))
+      t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul
+      (a₀ * (σ * √(Λ / 3) * c))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
 lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
@@ -134,7 +118,7 @@ lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1
 
 /-!
 
-### B.2. The Friedmann equations
+### A.2. The Friedmann equations
 
 -/
 
@@ -169,7 +153,7 @@ lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 <
 
 /-!
 
-### B.3. The Hubble and deceleration parameters
+### A.3. The Hubble and deceleration parameters
 
 -/
 
@@ -202,7 +186,7 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. The spatially flat power-law solutions
+## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
 `a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
@@ -213,7 +197,7 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 
 /-!
 
-### C.1. The power-law scale factor and its derivatives
+### B.1. The power-law scale factor and its derivatives
 
 -/
 
@@ -221,20 +205,17 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
   fun t => (t.val / t₀) ^ n
 
-/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
-lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
-    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
-  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
-    (Or.inl (div_ne_zero hx ht₀))
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 /-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
 lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
-  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+      (Or.inl (div_ne_zero ht ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
   only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
@@ -243,14 +224,21 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
     ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
+      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+      (Or.inl (div_ne_zero ht.ne' ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
-### C.2. The Hubble and deceleration parameters
+### B.2. The Hubble and deceleration parameters
 
 -/
 
@@ -313,7 +301,7 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-!
 
-### C.3. The radiation-dominated solution
+### B.3. The radiation-dominated solution
 
 -/
 
@@ -371,7 +359,7 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-!
 
-### C.4. The Einstein-de Sitter solution
+### B.4. The Einstein-de Sitter solution
 
 -/
 
@@ -427,7 +415,7 @@ lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < 
 
 /-!
 
-## D. Remaining TODO items
+## C. Remaining TODO items
 
 -/
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -54,19 +54,18 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
 
 ## iii. Table of contents
 
-- A. Time derivatives of curves given by a function of the coordinate
-- B. The de Sitter solution
-  - B.1. The scale factor and its derivatives
-  - B.2. The Friedmann equations
-  - B.3. The Hubble and deceleration parameters
-- C. The spatially flat power-law solutions
-  - C.1. The power-law scale factor and its derivatives
-  - C.2. The Hubble and deceleration parameters
-  - C.3. The radiation-dominated solution
-  - C.4. The Einstein-de Sitter solution
-- D. The Milne solution
-- E. The Einstein static universe
-- F. Remaining TODO items
+- A. The de Sitter solution
+  - A.1. The scale factor and its derivatives
+  - A.2. The Friedmann equations
+  - A.3. The Hubble and deceleration parameters
+- B. The spatially flat power-law solutions
+  - B.1. The power-law scale factor and its derivatives
+  - B.2. The Hubble and deceleration parameters
+  - B.3. The radiation-dominated solution
+  - B.4. The Einstein-de Sitter solution
+- C. The Milne solution
+- D. The Einstein static universe
+- E. Remaining TODO items
 
 -/
 
@@ -78,33 +77,13 @@ open Real Time
 
 /-!
 
-## A. Time derivatives of curves given by a function of the coordinate
-
-A curve `t ↦ γ t.val` on `Time` is the pull-back through `toRealCLE` of the curve `γ` on `ℝ`;
-its time derivative is the Mathlib derivative of `γ`.
-
--/
-
-/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
-lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
-    ∂ₜ (fun s : Time => γ s.val) t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
-
-/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
-  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
-lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
-    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
-  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
-
-/-!
-
-## B. The de Sitter solution
+## A. The de Sitter solution
 
 -/
 
 /-!
 
-### B.1. The scale factor and its derivatives
+### A.1. The scale factor and its derivatives
 
 -/
 
@@ -113,19 +92,17 @@ lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
 noncomputable def deSitterScaleFactor (a₀ σ Λ c : ℝ) : Time → ℝ :=
   fun t => a₀ * Real.exp (σ * √(Λ / 3) * c * t.val)
 
-/-- Mathlib derivative of `y ↦ a₀ exp (K y)`. -/
-lemma hasDerivAt_mul_exp_mul (a₀ K x : ℝ) :
-    HasDerivAt (fun y : ℝ => a₀ * Real.exp (K * y)) (a₀ * K * Real.exp (K * x)) x := by
-  have h := (((hasDerivAt_id x).const_mul K).exp).const_mul a₀
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 lemma deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (deSitterScaleFactor a₀ σ Λ c) =
       fun t => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val) := by
   funext t
-  exact deriv_comp_val (hasDerivAt_mul_exp_mul a₀ (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val)) t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul a₀
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
     ∂ₜ (∂ₜ (deSitterScaleFactor a₀ σ Λ c)) =
@@ -133,8 +110,15 @@ lemma deriv_deriv_deSitterScaleFactor (a₀ σ Λ c : ℝ) :
         Real.exp (σ * √(Λ / 3) * c * t.val) := by
   rw [deriv_deSitterScaleFactor]
   funext t
-  exact deriv_comp_val
-    (hasDerivAt_mul_exp_mul (a₀ * (σ * √(Λ / 3) * c)) (σ * √(Λ / 3) * c) t.val)
+  have h : HasDerivAt (fun y : ℝ => a₀ * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * y))
+      (a₀ * (σ * √(Λ / 3) * c) * (σ * √(Λ / 3) * c) * Real.exp (σ * √(Λ / 3) * c * t.val))
+      t.val := by
+    have h := (((hasDerivAt_id t.val).const_mul (σ * √(Λ / 3) * c)).exp).const_mul
+      (a₀ * (σ * √(Λ / 3) * c))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `σ² (√(Λ/3))² c² = Λ c² / 3` for `σ = ±1` and `0 ≤ Λ`. -/
 lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1) :
@@ -144,7 +128,7 @@ lemma sq_deSitterRate {σ Λ c : ℝ} (hΛ : 0 ≤ Λ) (hσ : σ = 1 ∨ σ = -1
 
 /-!
 
-### B.2. The Friedmann equations
+### A.2. The Friedmann equations
 
 -/
 
@@ -179,7 +163,7 @@ lemma deSitterScaleFactor_secondOrderFriedmann {a₀ σ Λ G c : ℝ} (hΛ : 0 <
 
 /-!
 
-### B.3. The Hubble and deceleration parameters
+### A.3. The Hubble and deceleration parameters
 
 -/
 
@@ -212,7 +196,7 @@ lemma decelerationParameter_deSitterScaleFactor {a₀ σ Λ c : ℝ} (hΛ : 0 < 
 
 /-!
 
-## C. The spatially flat power-law solutions
+## B. The spatially flat power-law solutions
 
 The radiation-dominated and Einstein-de Sitter solutions are both of the form
 `a(t) = (t / t₀) ^ n` for `t > 0`; the Hubble parameter is `n / t` and the deceleration
@@ -223,7 +207,7 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 
 /-!
 
-### C.1. The power-law scale factor and its derivatives
+### B.1. The power-law scale factor and its derivatives
 
 -/
 
@@ -231,20 +215,17 @@ parameter `(1 - n) / n`. Their densities are imposed by the first-order Friedman
 noncomputable def powerLawScaleFactor (t₀ n : ℝ) : Time → ℝ :=
   fun t => (t.val / t₀) ^ n
 
-/-- Mathlib derivative of `y ↦ (y / t₀) ^ n` away from `y = 0`. -/
-lemma hasDerivAt_div_rpow {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {x : ℝ} (hx : x ≠ 0) :
-    HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (x / t₀) ^ (n - 1)) x := by
-  have h := ((hasDerivAt_id x).div_const t₀).rpow_const (p := n)
-    (Or.inl (div_ne_zero hx ht₀))
-  refine h.congr_deriv ?_
-  simp only [id_eq]
-  ring
-
 /-- `∂ₜ a = n / t₀ (t / t₀) ^ (n - 1)` away from `t = 0`. -/
 lemma deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ) {t : Time}
     (ht : t.val ≠ 0) :
-    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) :=
-  deriv_comp_val (hasDerivAt_div_rpow ht₀ n ht)
+    ∂ₜ (powerLawScaleFactor t₀ n) t = n / t₀ * (t.val / t₀) ^ (n - 1) := by
+  have h : HasDerivAt (fun y : ℝ => (y / t₀) ^ n) (n / t₀ * (t.val / t₀) ^ (n - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n)
+      (Or.inl (div_ne_zero ht ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  exact deriv_comp_val h
 
 /-- `∂ₜ ∂ₜ a = n (n - 1) / t₀² (t / t₀) ^ (n - 2)` for `t > 0`. The derivative `∂ₜ a` is
   only known away from `t = 0`, which is enough since `t > 0` is an open condition. -/
@@ -253,14 +234,21 @@ lemma deriv_deriv_powerLawScaleFactor {t₀ : ℝ} (ht₀ : t₀ ≠ 0) (n : ℝ
     ∂ₜ (∂ₜ (powerLawScaleFactor t₀ n)) t =
       n / t₀ * ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) := by
   apply deriv_eq_of_hasDerivAt
-  have h := (hasDerivAt_div_rpow ht₀ (n - 1) ht.ne').const_mul (n / t₀)
+  have h₁ : HasDerivAt (fun y : ℝ => (y / t₀) ^ (n - 1))
+      ((n - 1) / t₀ * (t.val / t₀) ^ (n - 1 - 1)) t.val := by
+    have h := ((hasDerivAt_id t.val).div_const t₀).rpow_const (p := n - 1)
+      (Or.inl (div_ne_zero ht.ne' ht₀))
+    refine h.congr_deriv ?_
+    simp only [id_eq]
+    ring
+  have h := h₁.const_mul (n / t₀)
   refine h.congr_of_eventuallyEq ?_
   filter_upwards [eventually_ne_nhds ht.ne'] with τ hτ
   exact deriv_powerLawScaleFactor ht₀ n (t := ⟨τ⟩) hτ
 
 /-!
 
-### C.2. The Hubble and deceleration parameters
+### B.2. The Hubble and deceleration parameters
 
 -/
 
@@ -323,7 +311,7 @@ lemma powerLawScaleFactor_secondOrderFriedmann {t₀ G c n w : ℝ} (ht₀ : 0 <
 
 /-!
 
-### C.3. The radiation-dominated solution
+### B.3. The radiation-dominated solution
 
 -/
 
@@ -381,7 +369,7 @@ lemma hubbleConstant_radiationScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < t₀) :
 
 /-!
 
-### C.4. The Einstein-de Sitter solution
+### B.4. The Einstein-de Sitter solution
 
 -/
 
@@ -437,7 +425,7 @@ lemma hubbleConstant_einsteinDeSitterScaleFactor_t₀ {t₀ : ℝ} (ht₀ : 0 < 
 
 /-!
 
-## D. The Milne solution
+## C. The Milne solution
 
 The Milne universe is the empty (`ρ = 0`, `p = 0`, `Λ = 0`) solution with `k = -1` and
 `a(t) = c t` for `t > 0`. That it is Minkowski space in expanding coordinates (vanishing
@@ -485,7 +473,7 @@ lemma decelerationParameter_milneScaleFactor (c : ℝ) (t : Time) :
 
 /-!
 
-## E. The Einstein static universe
+## D. The Einstein static universe
 
 At an instant where `∂ₜ a = ∂ₜ ∂ₜ a = 0`, the two Friedmann equations with dust (`p = 0`)
 force the density `ρ = Λ c² / (4 π G)`, twice the density `ρ_Λ = Λ c² / (8 π G)` associated
@@ -540,7 +528,7 @@ lemma einsteinStatic_curvature_pos {a ρ : Time → ℝ} {k Λ G c : ℝ} {t : T
 
 /-!
 
-## F. Remaining TODO items
+## E. Remaining TODO items
 
 -/
 

--- a/Physlib/Cosmology/FLRW/Solutions.lean
+++ b/Physlib/Cosmology/FLRW/Solutions.lean
@@ -52,7 +52,7 @@ coordinate `t.val`. Its time derivative `∂ₜ a` is computed through the bridg
   scale factor `a = c t` solves the empty (`ρ = 0`, `p = 0`, `Λ = 0`) Friedmann equations with
   `k = -1`; `q = 0`.
 - `einsteinStatic_density`, `einsteinStatic_curvature`: if `∂ₜ a = ∂ₜ ∂ₜ a = 0` at `t` and the
-  Friedmann equations hold there with `p = 0`, then `ρ = Λ c² / (4 π G) = 2 ρ_Λ` and
+  Friedmann equations hold there with `p = 0`, then `ρ = Λ c² / (4 π G)` and
   `k c² / a² = 4 π G ρ`, so that `k > 0` when `ρ > 0` (`einsteinStatic_curvature_pos`).
 
 In the power-law solutions `t₀ : Time` is the normalisation epoch (`a(t₀) = 1`) and the Big
@@ -478,24 +478,20 @@ lemma decelerationParameter_milneScaleFactor (c : ℝ) (t : Time) :
 ## D. The Einstein static universe
 
 At an instant where `∂ₜ a = ∂ₜ ∂ₜ a = 0`, the two Friedmann equations with dust (`p = 0`)
-force the density `ρ = Λ c² / (4 π G)`, twice the density `ρ_Λ = Λ c² / (8 π G)` associated
-with the cosmological constant, and `k c² / a² = 4 π G ρ`, hence a positive curvature
+force the density `ρ = Λ c² / (4 π G)` (twice the density `Λ c² / (8 π G)` that the
+cosmological constant carries as a `w = -1` fluid, a matter-content statement that belongs to
+`Physlib.Cosmology.FLRW.MatterContent`) and `k c² / a² = 4 π G ρ`, hence a positive curvature
 parameter when `ρ > 0`. That this equilibrium is unstable is not stated here.
 
 -/
 
-/-- The density `ρ_Λ = Λ c² / (8 π G)` associated with the cosmological constant. -/
-noncomputable def cosmologicalConstantDensity (Λ G c : ℝ) : ℝ :=
-  Λ * c ^ 2 / (8 * π * G)
-
-/-- In the Einstein static universe the dust density is `ρ = Λ c² / (4 π G) = 2 ρ_Λ`. -/
+/-- In the Einstein static universe the dust density is `ρ = Λ c² / (4 π G)`. -/
 lemma einsteinStatic_density {a ρ : Time → ℝ} {Λ G c : ℝ} {t : Time} (hG : 0 < G)
     (h2 : ∂ₜ (∂ₜ a) t = 0) (hF2 : SecondOrderFriedmann a ρ (fun _ => 0) Λ G c t) :
-    ρ t = 2 * cosmologicalConstantDensity Λ G c := by
+    ρ t = Λ * c ^ 2 / (4 * π * G) := by
   unfold SecondOrderFriedmann at hF2
   rw [h2, zero_div] at hF2
   simp only [mul_zero, zero_div, add_zero] at hF2
-  unfold cosmologicalConstantDensity
   have hπ := Real.pi_pos
   field_simp
   linarith

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -115,6 +115,17 @@ lemma deriv_comp_toRealCLE_of_hasDerivAt [NormedAddCommGroup M] [NormedSpace ℝ
     fderiv_eq_smul_deriv, h.deriv]
   exact Eq.trans (by rfl) (Time.one_val ▸ one_smul _ v)
 
+/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
+lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
+    ∂ₜ (fun s : Time => γ s.val) t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
+  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
+lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
+    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
+
 /-!
 
 ### A.3. Derivatives of functions into manifolds

--- a/Physlib/SpaceAndTime/Time/Derivatives.lean
+++ b/Physlib/SpaceAndTime/Time/Derivatives.lean
@@ -115,6 +115,24 @@ lemma deriv_comp_toRealCLE_of_hasDerivAt [NormedAddCommGroup M] [NormedSpace ℝ
     fderiv_eq_smul_deriv, h.deriv]
   exact Eq.trans (by rfl) (Time.one_val ▸ one_smul _ v)
 
+/-- The time derivative of `t ↦ γ t.val` at `t` is the derivative of `γ` at `t.val`. -/
+lemma deriv_comp_val {γ : ℝ → ℝ} {t : Time} {v : ℝ} (h : HasDerivAt γ v t.val) :
+    ∂ₜ (fun s : Time => γ s.val) t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt γ t v h
+
+/-- The time derivative of any `f : Time → ℝ` at `t` is the derivative at `t.val` of the curve
+  `τ ↦ f ⟨τ⟩` on `ℝ`. -/
+lemma deriv_eq_of_hasDerivAt {f : Time → ℝ} {t : Time} {v : ℝ}
+    (h : HasDerivAt (fun τ : ℝ => f ⟨τ⟩) v t.val) : ∂ₜ f t = v :=
+  deriv_comp_toRealCLE_of_hasDerivAt (fun τ : ℝ => f ⟨τ⟩) t v h
+
+/-- A curve `f : Time → ℝ` differentiable at `⟨τ⟩` gives the curve `σ ↦ f ⟨σ⟩` on `ℝ`,
+  whose Mathlib derivative at `τ` is the time derivative `∂ₜ f ⟨τ⟩`. -/
+lemma hasDerivAt_mk_of_differentiableAt {f : Time → ℝ} {τ : ℝ}
+    (hf : DifferentiableAt ℝ f ⟨τ⟩) :
+    HasDerivAt (fun σ : ℝ => f ⟨σ⟩) (∂ₜ f ⟨τ⟩) τ :=
+  hasDerivAt_comp_toRealCLE_symm f τ hf
+
 /-!
 
 ### A.3. Derivatives of functions into manifolds


### PR DESCRIPTION
## AI disclosure

**AI disclosure.** This PR was generated with Claude Fable 5.1 (Claude Code) under my
supervision, following `AI-POLICY.md` and `AGENTS.md`. I have read every definition and lemma
statement and vouch that they state what the docstrings say. The statements were fixed before
the proofs were written and checked symbolically (sympy) against the Friedmann equations of
`Physlib.Cosmology.FLRW.Basic`; no textbook is cited, the TODO items of the file are the
specification.

**Stacked on #1639** (`flrw-distances-8`): the diff includes the earlier commits of this series; only the last commit is new here.

Resolves the remaining four TODOs of `Distances.lean`, the two expansion TODOs through their
coefficients.

Declarations added:
- `lookbackTime`; `deriv_redshift_self` (`∂ₜ z = - H₀` at `t₀`), `deriv_redshift_eq`,
  `deriv_deriv_redshift_self` (`∂ₜ ∂ₜ z = H₀² (2 + q₀)` at `t₀`): the coefficients of
  `t₀ - t = H₀⁻¹ [z - ½ (2 + q₀) z² + …]`.
- `luminosityDistance`, `angularDiameterDistance`, `luminosityDistance_eq` (Etherington,
  `d_L = (1 + z)² d_A`).
- `deriv_deriv_comovingDistance_self` (`∂ₜ ∂ₜ χ = c H₀ / a₀`), `comovingDistance_coeff_one`
  (`dχ/dz = c / (a₀ H₀)`), `comovingDistance_coeff_two` (`d²χ/dz² = - c (1 + q₀) / (a₀ H₀)`),
  `luminosityDistance_coeff_two`, `angularDiameterDistance_coeff_two` (flat case: `c (1 - q₀) /
  (a₀ H₀)` and `- c (3 + q₀) / (a₀ H₀)`).

Not included, said in the docstring: the Taylor expansions themselves (with remainder, through the
inverse of `t ↦ z(t)`); only their coefficients are proved.

Reviewer map: F (second derivative of `z`), G (Etherington, short), H (the quotient identities).

**Update (Sept 11).** Applied the review remarks of #1642 across the series: no isolated general-purpose lemma (the one-off `HasDerivAt` and `rpow` helpers are inlined in the proofs that used them), and the three small bridges between `Time.deriv` and Mathlib's `HasDerivAt` now live next to the definition of the time derivative, in `Physlib/SpaceAndTime/Time/Derivatives.lean` (`deriv_comp_val`, `deriv_eq_of_hasDerivAt`, `hasDerivAt_mk_of_differentiableAt`, each introduced by the first PR of the series that needs it). Section letters shifted accordingly.

**Update (Sept 17).** Merged the review of #1635 (statements at `t : Time`, `Time.deriv_comp_val` dropped in favour of `Time.deriv_eq_of_hasDerivAt`); `API-map.yaml` now records what this PR completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

