### PR TITLE
feat(QuantumMechanics): number Hamiltonian of the harmonic oscillator, adjointness of the ladder operators

### DIFF
--- a/Physlib/QuantumMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/Basic.lean
@@ -124,6 +124,14 @@ lemma ξ_inv : (Q.ξ i)⁻¹ = √Q.m * √(Q.ω i) / √ℏ := by simp [ξ_eq]
 
 lemma ξ_inv' : (Q.ξ i)⁻¹ = Q.m * Q.ω i * Q.ξ i / ℏ := by field_simp; simp [ξ_sq, mul_assoc]
 
+/-- `ξᵢ² m ωᵢ = ℏ`, as complex numbers. -/
+lemma ξ_sq_mul_ofReal :
+    ((Q.ξ i : ℝ) : ℂ) ^ 2 * ((Q.m : ℝ) : ℂ) * ((Q.ω i : ℝ) : ℂ) = (ℏ : ℂ) := by
+  have h := Q.ξ_sq i
+  rw [eq_div_iff (mul_ne_zero Q.m_ne_zero (Q.ω_ne_zero i))] at h
+  have h' : Q.ξ i ^ 2 * Q.m * Q.ω i = ℏ := by rw [mul_assoc]; exact h
+  exact_mod_cast h'
+
 /-!
 ### B.1. Coordinate rescaling
 -/
@@ -183,6 +191,30 @@ def potentialQuadraticForm : QuadraticForm ℝ (Fin d → ℝ) := Q.potentialMat
 def potentialFunction : Space d → ℝ := Q.potentialQuadraticForm ∘ Space.val
 
 lemma potentialFunction_eq : Q.potentialFunction = Q.potentialQuadraticForm ∘ Space.val := rfl
+
+/-- `V(x) = ∑ᵢ ½ m ωᵢ² xᵢ²`. -/
+lemma potentialFunction_apply (x : Space d) :
+    Q.potentialFunction x = ∑ i, 2⁻¹ * Q.m * Q.ω i ^ 2 * x i ^ 2 := by
+  simp only [potentialFunction_eq, potentialQuadraticForm, Matrix.toQuadraticForm',
+    Function.comp_apply]
+  simp [Matrix.toLinearMap₂'_apply, potentialMatrix_eq, Matrix.diagonal_apply, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun i _ => by ring
+
+/-- The potential function, as a complex-valued function, has temperate growth. -/
+lemma potentialFunction_hasTemperateGrowth :
+    Function.HasTemperateGrowth (fun x : Space d => (Q.potentialFunction x : ℂ)) := by
+  have hc : ∀ i, Function.HasTemperateGrowth (fun x : Space d => ((x i : ℝ) : ℂ)) := fun i => by
+    have h := (Complex.ofRealCLM ∘L Space.coordCLM i).hasTemperateGrowth
+    convert h using 1
+    ext x
+    simp [Space.coordCLM_apply, Space.coord_apply]
+  have h : (fun x : Space d => (Q.potentialFunction x : ℂ)) =
+      fun x => ∑ i, ((2⁻¹ * Q.m * Q.ω i ^ 2 : ℝ) : ℂ) * ((x i : ℝ) : ℂ) ^ 2 := by
+    ext x
+    simp [potentialFunction_apply]
+  rw [h]
+  exact Function.HasTemperateGrowth.sum fun i _ =>
+    (Function.HasTemperateGrowth.const _).mul ((hc i).pow 2)
 
 /-- The potential function for the harmonic oscillator is a.e. strongly measurable. -/
 informal_lemma potentialFunction_aestronglyMeasurable where

--- a/Physlib/QuantumMechanics/HarmonicOscillator/Basic.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/Basic.lean
@@ -118,6 +118,9 @@ lemma ξ_nonneg : 0 ≤ Q.ξ i := (Q.ξ_pos i).le
 @[simp]
 lemma ξ_ne_zero : Q.ξ i ≠ 0 := (Q.ξ_pos i).ne'
 
+/-- The characteristic length is nonzero as a complex number. -/
+lemma ξ_ofReal_ne_zero : ((Q.ξ i : ℝ) : ℂ) ≠ 0 := by exact_mod_cast Q.ξ_ne_zero i
+
 lemma ξ_sq : (Q.ξ i) ^ 2 = ℏ / (Q.m * Q.ω i) := by rw [Q.ξ_eq]; field_simp; simp [← mul_rotate]
 
 lemma ξ_inv : (Q.ξ i)⁻¹ = √Q.m * √(Q.ω i) / √ℏ := by simp [ξ_eq]

--- a/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
@@ -50,9 +50,7 @@ number operators and its relation to the Hamiltonian of `Basic.lean` are still T
 @[expose] public section
 
 noncomputable section
-namespace QuantumMechanics
-
-namespace HarmonicOscillator
+namespace QuantumMechanics.HarmonicOscillator
 
 open Complex Constants KroneckerDelta Bracket SchwartzMap ContinuousLinearMap
 
@@ -75,27 +73,21 @@ variable {d : ℕ} (Q : HarmonicOscillator d) (i j : Fin d)
 
 /-- The lowering (annihilation) operator `aᵢ = (xᵢ/ξᵢ + i ξᵢ pᵢ/ℏ)/√2`, as a continuous linear
   map on Schwartz maps. -/
-def lowering : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+def loweringCLM : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
   (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i + (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i)
 
 /-- The raising (creation) operator `aᵢ† = (xᵢ/ξᵢ - i ξᵢ pᵢ/ℏ)/√2`, as a continuous linear
   map on Schwartz maps. -/
-def raising : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+def raisingCLM : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
   (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i - (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i)
 
-lemma lowering_eq : Q.lowering i =
+lemma loweringCLM_eq : Q.loweringCLM i =
     (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i + (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i) :=
   rfl
 
-lemma raising_eq : Q.raising i =
+lemma raisingCLM_eq : Q.raisingCLM i =
     (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i - (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i) :=
   rfl
-
-/-- The characteristic length is nonzero as a complex number. -/
-lemma ξ_ofReal_ne_zero : ((Q.ξ i : ℝ) : ℂ) ≠ 0 := by exact_mod_cast Q.ξ_ne_zero i
-
-/-- `ℏ` is nonzero as a complex number. -/
-lemma ℏ_ofReal_ne_zero : (ℏ : ℂ) ≠ 0 := by exact_mod_cast ℏ_ne_zero
 
 /-- `(√2)² = 2` as complex numbers. -/
 lemma sqrt_two_sq_ofReal : ((Real.sqrt 2 : ℝ) : ℂ) ^ 2 = 2 := by
@@ -110,8 +102,8 @@ lemma sqrt_two_sq_ofReal : ((Real.sqrt 2 : ℝ) : ℂ) ^ 2 = 2 := by
 
 /-- `[aᵢ, aⱼ†] = δᵢⱼ 𝟙`. -/
 lemma lowering_commutation_raising :
-    ⁅Q.lowering i, Q.raising j⁆ = δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
-  simp only [lowering, raising, lie_smul, smul_lie, add_lie, lie_sub,
+    ⁅Q.loweringCLM i, Q.raisingCLM j⁆ = δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
+  simp only [loweringCLM, raisingCLM, lie_smul, smul_lie, add_lie, lie_sub,
     position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
     ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_add, smul_neg, smul_smul, KroneckerDelta.symm j i]
   rcases eq_or_ne i j with rfl | hne
@@ -120,14 +112,14 @@ lemma lowering_commutation_raising :
     simp only [smul_apply, neg_apply, sub_apply, id_apply, smul_eq_mul]
     have hξ := Q.ξ_ofReal_ne_zero i
     have hℏ := ℏ_ofReal_ne_zero
+    ring_nf
+    rw [I_sq, inv_pow, sqrt_two_sq_ofReal]
     field_simp
-    rw [I_sq, sqrt_two_sq_ofReal]
-    ring
   · simp only [eq_zero_of_ne hne, zero_smul, smul_zero, sub_zero, neg_zero, add_zero]
 
 /-- `[aᵢ, aⱼ] = 0`. -/
-lemma lowering_commutation_lowering : ⁅Q.lowering i, Q.lowering j⁆ = 0 := by
-  simp only [lowering, lie_smul, smul_lie, lie_add, add_lie,
+lemma lowering_commutation_lowering : ⁅Q.loweringCLM i, Q.loweringCLM j⁆ = 0 := by
+  simp only [loweringCLM, lie_smul, smul_lie, lie_add, add_lie,
     position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
     ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_add, smul_neg, smul_smul, KroneckerDelta.symm j i]
   rcases eq_or_ne i j with rfl | hne
@@ -141,8 +133,8 @@ lemma lowering_commutation_lowering : ⁅Q.lowering i, Q.lowering j⁆ = 0 := by
   · simp [eq_zero_of_ne hne]
 
 /-- `[aᵢ†, aⱼ†] = 0`. -/
-lemma raising_commutation_raising : ⁅Q.raising i, Q.raising j⁆ = 0 := by
-  simp only [raising, lie_smul, smul_lie, lie_sub, sub_lie,
+lemma raising_commutation_raising : ⁅Q.raisingCLM i, Q.raisingCLM j⁆ = 0 := by
+  simp only [raisingCLM, lie_smul, smul_lie, lie_sub, sub_lie,
     position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
     ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_sub, smul_neg, smul_smul, KroneckerDelta.symm j i]
   rcases eq_or_ne i j with rfl | hne
@@ -158,7 +150,7 @@ lemma raising_commutation_raising : ⁅Q.raising i, Q.raising j⁆ = 0 := by
 
 /-- `[aᵢ†, aⱼ] = -δᵢⱼ 𝟙`. -/
 lemma raising_commutation_lowering :
-    ⁅Q.raising i, Q.lowering j⁆ = -(δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ)) := by
+    ⁅Q.raisingCLM i, Q.loweringCLM j⁆ = -(δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ)) := by
   rw [← lie_skew, lowering_commutation_raising, KroneckerDelta.symm j i]
 
 /-!
@@ -169,26 +161,26 @@ lemma raising_commutation_lowering :
 
 /-- `xᵢ = (ξᵢ/√2) (aᵢ + aᵢ†)`. -/
 lemma position_eq_lowering_add_raising :
-    𝐱 i = (((Q.ξ i : ℝ) : ℂ) / (Real.sqrt 2 : ℂ)) • (Q.lowering i + Q.raising i) := by
+    𝐱 i = (((Q.ξ i : ℝ) : ℂ) / (Real.sqrt 2 : ℂ)) • (Q.loweringCLM i + Q.raisingCLM i) := by
   ext ψ x
-  simp [lowering, raising]
+  simp [loweringCLM, raisingCLM]
   have hξ := Q.ξ_ofReal_ne_zero i
   have hℏ := ℏ_ofReal_ne_zero
-  field_simp
   ring_nf
-  rw [sqrt_two_sq_ofReal]
+  rw [inv_pow, sqrt_two_sq_ofReal]
+  field_simp
 
 /-- `pᵢ = (i ℏ/(√2 ξᵢ)) (aᵢ† - aᵢ)`. -/
 lemma momentum_eq_raising_sub_lowering :
     𝐩 i = (I * (ℏ : ℂ) / ((Real.sqrt 2 : ℂ) * ((Q.ξ i : ℝ) : ℂ))) •
-      (Q.raising i - Q.lowering i) := by
+      (Q.raisingCLM i - Q.loweringCLM i) := by
   ext ψ x
-  simp [lowering, raising]
+  simp [loweringCLM, raisingCLM]
   have hξ := Q.ξ_ofReal_ne_zero i
   have hℏ := ℏ_ofReal_ne_zero
+  ring_nf
+  rw [I_pow_three, inv_pow, sqrt_two_sq_ofReal]
   field_simp
-  rw [I_sq, sqrt_two_sq_ofReal]
-  ring
 
 TODO "Prove that the raising/lowering operators are adjoints of one another (tag as simp?)."
 
@@ -205,9 +197,9 @@ TODO "Prove that the raising/lowering operators are adjoints of one another (tag
 -/
 
 /-- The number operator `Nᵢ = aᵢ† aᵢ`. -/
-def number : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := Q.raising i ∘L Q.lowering i
+def numberCLM : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := Q.raisingCLM i ∘L Q.loweringCLM i
 
-lemma number_eq : Q.number i = Q.raising i ∘L Q.lowering i := rfl
+lemma numberCLM_eq : Q.numberCLM i = Q.raisingCLM i ∘L Q.loweringCLM i := rfl
 
 TODO "Prove that the number operators are symmetric/self-adjoint."
 
@@ -219,8 +211,8 @@ TODO "Prove that the number operators are symmetric/self-adjoint."
 
 /-- `[Nᵢ, aⱼ] = -δᵢⱼ aⱼ`. -/
 lemma number_commutation_lowering :
-    ⁅Q.number i, Q.lowering j⁆ = -(δ[i,j] • Q.lowering j) := by
-  rw [number_eq, leibniz_lie, lowering_commutation_lowering, raising_commutation_lowering,
+    ⁅Q.numberCLM i, Q.loweringCLM j⁆ = -(δ[i,j] • Q.loweringCLM j) := by
+  rw [numberCLM_eq, leibniz_lie, lowering_commutation_lowering, raising_commutation_lowering,
     comp_zero, zero_add, neg_comp, smul_comp, id_comp]
   rcases eq_or_ne i j with rfl | hne
   · rfl
@@ -228,16 +220,16 @@ lemma number_commutation_lowering :
 
 /-- `[Nᵢ, aⱼ†] = δᵢⱼ aⱼ†`. -/
 lemma number_commutation_raising :
-    ⁅Q.number i, Q.raising j⁆ = δ[i,j] • Q.raising j := by
-  rw [number_eq, leibniz_lie, lowering_commutation_raising, raising_commutation_raising,
+    ⁅Q.numberCLM i, Q.raisingCLM j⁆ = δ[i,j] • Q.raisingCLM j := by
+  rw [numberCLM_eq, leibniz_lie, lowering_commutation_raising, raising_commutation_raising,
     zero_comp, add_zero, comp_smul, comp_id]
   rcases eq_or_ne i j with rfl | hne
   · rfl
   · simp [eq_zero_of_ne hne]
 
 /-- `[Nᵢ, Nⱼ] = 0`. -/
-lemma number_commutation_number : ⁅Q.number i, Q.number j⁆ = 0 := by
-  simp only [number_eq]
+lemma number_commutation_number : ⁅Q.numberCLM i, Q.numberCLM j⁆ = 0 := by
+  simp only [numberCLM_eq]
   rw [leibniz_lie, lie_leibniz, lie_leibniz, lowering_commutation_lowering,
     lowering_commutation_raising, raising_commutation_lowering, raising_commutation_raising]
   rcases eq_or_ne i j with rfl | hne
@@ -248,10 +240,11 @@ lemma number_commutation_number : ⁅Q.number i, Q.number j⁆ = 0 := by
 
 /-- `aᵢ aᵢ† = Nᵢ + 𝟙`. -/
 lemma lowering_comp_raising :
-    Q.lowering i ∘L Q.raising i = Q.number i + ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
+    Q.loweringCLM i ∘L Q.raisingCLM i =
+      Q.numberCLM i + ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
   have h := Q.lowering_commutation_raising i i
   rw [eq_one_of_same, one_nsmul, Ring.lie_def, mul_def, mul_def] at h
-  rw [number_eq, add_comm]
+  rw [numberCLM_eq, add_comm]
   exact sub_eq_iff_eq_add.mp h
 
 /-!
@@ -269,8 +262,6 @@ TODO "Relate the 'number operator' Hamiltonian to the 'K + T' Hamiltonian
 
 TODO "Prove that the two Hamiltonians define the same quantum system."
 
-end HarmonicOscillator
-
-end QuantumMechanics
+end QuantumMechanics.HarmonicOscillator
 
 end

--- a/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
@@ -1,47 +1,263 @@
 /-
 Copyright (c) 2026 Gregory J. Loges. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gregory J. Loges
+Authors: Philippe Kevorkian, Gregory J. Loges
 -/
 module
 
 public import Physlib.QuantumMechanics.HarmonicOscillator.Basic
+public import Physlib.QuantumMechanics.Operators.Commutation
 /-!
 
 # Ladder operators
 
-This is currently a stub, intended to house the ladder operators of the quantum harmonic oscillator.
+## i. Overview
+
+The ladder operators of the `d`-dimensional quantum harmonic oscillator, acting on Schwartz maps:
+the lowering (annihilation) operators `aᵢ = (xᵢ/ξᵢ + i ξᵢ pᵢ/ℏ)/√2`, the raising (creation)
+operators `aᵢ† = (xᵢ/ξᵢ - i ξᵢ pᵢ/ℏ)/√2` and the number operators `Nᵢ = aᵢ† aᵢ`, together with
+their commutation relations, which all follow from the canonical commutation relations
+`position_commutation_momentum`. The adjointness of `aᵢ` and `aᵢ†`, the Hamiltonian in terms of the
+number operators and its relation to the Hamiltonian of `Basic.lean` are still TODO items.
+
+## ii. Key results
+
+- `lowering_commutation_raising`: `[aᵢ, aⱼ†] = δᵢⱼ 𝟙`; `lowering_commutation_lowering`,
+  `raising_commutation_raising`: `[aᵢ, aⱼ] = 0`, `[aᵢ†, aⱼ†] = 0`.
+- `position_eq_lowering_add_raising`, `momentum_eq_raising_sub_lowering`: the position and
+  momentum operators in terms of the ladder operators.
+- `number_commutation_number`: `[Nᵢ, Nⱼ] = 0`; `number_commutation_lowering`,
+  `number_commutation_raising`: `[Nᵢ, aⱼ] = -δᵢⱼ aⱼ`, `[Nᵢ, aⱼ†] = δᵢⱼ aⱼ†`.
+- `lowering_comp_raising`: `aᵢ aᵢ† = Nᵢ + 𝟙`.
+
+## iii. Table of contents
+
+- A. Ladder operators
+  - A.1. Definitions
+  - A.2. Commutation relations
+  - A.3. Position and momentum in terms of the ladder operators
+- B. Number operators
+  - B.1. Definition
+  - B.2. Commutation relations
+- C. Hamiltonian
+
+## iv. References
+
+* None.
 
 -/
 
 @[expose] public section
 
+noncomputable section
+namespace QuantumMechanics
+
+namespace HarmonicOscillator
+
+open Complex Constants KroneckerDelta Bracket SchwartzMap ContinuousLinearMap
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance 100] LieAlgebra.ofAssociativeAlgebra
+
+variable {d : ℕ} (Q : HarmonicOscillator d) (i j : Fin d)
+
 /-!
+
 ## A. Ladder operators
+
 -/
 
-TODO "Define the raising/lowering operators for the quantum harmonic oscillator."
+/-!
+
+### A.1. Definitions
+
+-/
+
+/-- The lowering (annihilation) operator `aᵢ = (xᵢ/ξᵢ + i ξᵢ pᵢ/ℏ)/√2`, as a continuous linear
+  map on Schwartz maps. -/
+def lowering : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+  (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i + (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i)
+
+/-- The raising (creation) operator `aᵢ† = (xᵢ/ξᵢ - i ξᵢ pᵢ/ℏ)/√2`, as a continuous linear
+  map on Schwartz maps. -/
+def raising : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+  (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i - (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i)
+
+lemma lowering_eq : Q.lowering i =
+    (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i + (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i) :=
+  rfl
+
+lemma raising_eq : Q.raising i =
+    (Real.sqrt 2 : ℂ)⁻¹ • (((Q.ξ i : ℝ) : ℂ)⁻¹ • 𝐱 i - (I * ((Q.ξ i : ℝ) : ℂ) / (ℏ : ℂ)) • 𝐩 i) :=
+  rfl
+
+/-- The characteristic length is nonzero as a complex number. -/
+lemma ξ_ofReal_ne_zero : ((Q.ξ i : ℝ) : ℂ) ≠ 0 := by exact_mod_cast Q.ξ_ne_zero i
+
+/-- `ℏ` is nonzero as a complex number. -/
+lemma ℏ_ofReal_ne_zero : (ℏ : ℂ) ≠ 0 := by exact_mod_cast ℏ_ne_zero
+
+/-- `(√2)² = 2` as complex numbers. -/
+lemma sqrt_two_sq_ofReal : ((Real.sqrt 2 : ℝ) : ℂ) ^ 2 = 2 := by
+  rw [sq, ← Complex.ofReal_mul, Real.mul_self_sqrt (by norm_num)]
+  norm_num
+
+/-!
+
+### A.2. Commutation relations
+
+-/
+
+/-- `[aᵢ, aⱼ†] = δᵢⱼ 𝟙`. -/
+lemma lowering_commutation_raising :
+    ⁅Q.lowering i, Q.raising j⁆ = δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
+  simp only [lowering, raising, lie_smul, smul_lie, add_lie, lie_sub,
+    position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
+    ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_add, smul_neg, smul_smul, KroneckerDelta.symm j i]
+  rcases eq_or_ne i j with rfl | hne
+  · simp only [eq_one_of_same, one_nsmul, add_zero]
+    ext ψ x
+    simp only [smul_apply, neg_apply, sub_apply, id_apply, smul_eq_mul]
+    have hξ := Q.ξ_ofReal_ne_zero i
+    have hℏ := ℏ_ofReal_ne_zero
+    field_simp
+    rw [I_sq, sqrt_two_sq_ofReal]
+    ring
+  · simp only [eq_zero_of_ne hne, zero_smul, smul_zero, sub_zero, neg_zero, add_zero]
+
+/-- `[aᵢ, aⱼ] = 0`. -/
+lemma lowering_commutation_lowering : ⁅Q.lowering i, Q.lowering j⁆ = 0 := by
+  simp only [lowering, lie_smul, smul_lie, lie_add, add_lie,
+    position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
+    ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_add, smul_neg, smul_smul, KroneckerDelta.symm j i]
+  rcases eq_or_ne i j with rfl | hne
+  · ext ψ x
+    simp only [eq_one_of_same, one_smul, add_zero, smul_add, smul_neg, add_apply, neg_apply,
+      smul_apply, id_apply, smul_eq_mul, zero_apply]
+    have hξ := Q.ξ_ofReal_ne_zero i
+    have hℏ := ℏ_ofReal_ne_zero
+    field_simp
+    ring
+  · simp [eq_zero_of_ne hne]
+
+/-- `[aᵢ†, aⱼ†] = 0`. -/
+lemma raising_commutation_raising : ⁅Q.raising i, Q.raising j⁆ = 0 := by
+  simp only [raising, lie_smul, smul_lie, lie_sub, sub_lie,
+    position_commutation_position, momentum_commutation_momentum, position_commutation_momentum,
+    ← lie_skew (𝐩 i) (𝐱 j), smul_zero, zero_sub, smul_neg, smul_smul, KroneckerDelta.symm j i]
+  rcases eq_or_ne i j with rfl | hne
+  · ext ψ x
+    simp only [eq_one_of_same, one_smul, neg_neg, sub_zero, smul_apply, sub_apply, id_apply,
+      smul_eq_mul, zero_apply, mul_eq_zero, inv_eq_zero, ofReal_eq_zero, Nat.ofNat_nonneg,
+      Real.sqrt_eq_zero, OfNat.ofNat_ne_zero, false_or]
+    have hξ := Q.ξ_ofReal_ne_zero i
+    have hℏ := ℏ_ofReal_ne_zero
+    field_simp
+    ring
+  · simp [eq_zero_of_ne hne]
+
+/-- `[aᵢ†, aⱼ] = -δᵢⱼ 𝟙`. -/
+lemma raising_commutation_lowering :
+    ⁅Q.raising i, Q.lowering j⁆ = -(δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ)) := by
+  rw [← lie_skew, lowering_commutation_raising, KroneckerDelta.symm j i]
+
+/-!
+
+### A.3. Position and momentum in terms of the ladder operators
+
+-/
+
+/-- `xᵢ = (ξᵢ/√2) (aᵢ + aᵢ†)`. -/
+lemma position_eq_lowering_add_raising :
+    𝐱 i = (((Q.ξ i : ℝ) : ℂ) / (Real.sqrt 2 : ℂ)) • (Q.lowering i + Q.raising i) := by
+  ext ψ x
+  simp [lowering, raising]
+  have hξ := Q.ξ_ofReal_ne_zero i
+  have hℏ := ℏ_ofReal_ne_zero
+  field_simp
+  ring_nf
+  rw [sqrt_two_sq_ofReal]
+
+/-- `pᵢ = (i ℏ/(√2 ξᵢ)) (aᵢ† - aᵢ)`. -/
+lemma momentum_eq_raising_sub_lowering :
+    𝐩 i = (I * (ℏ : ℂ) / ((Real.sqrt 2 : ℂ) * ((Q.ξ i : ℝ) : ℂ))) •
+      (Q.raising i - Q.lowering i) := by
+  ext ψ x
+  simp [lowering, raising]
+  have hξ := Q.ξ_ofReal_ne_zero i
+  have hℏ := ℏ_ofReal_ne_zero
+  field_simp
+  rw [I_sq, sqrt_two_sq_ofReal]
+  ring
 
 TODO "Prove that the raising/lowering operators are adjoints of one another (tag as simp?)."
 
-TODO "Prove the commutation relations for the ladder operators, `[a, a†] = δ`."
-
 /-!
+
 ## B. Number operators
+
 -/
 
-TODO "Define the number operators for the quantum harmonic oscillator
-  in terms of the ladder operators."
+/-!
+
+### B.1. Definition
+
+-/
+
+/-- The number operator `Nᵢ = aᵢ† aᵢ`. -/
+def number : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := Q.raising i ∘L Q.lowering i
+
+lemma number_eq : Q.number i = Q.raising i ∘L Q.lowering i := rfl
 
 TODO "Prove that the number operators are symmetric/self-adjoint."
 
-TODO "Prove the commutation relations for the number operators, `[N i, N j] = 0`."
+/-!
 
-TODO "Prove the commutation relations between number and ladder operators,
-  `[N, a] = -δ a` and `[N, a†] = δ a†`."
+### B.2. Commutation relations
+
+-/
+
+/-- `[Nᵢ, aⱼ] = -δᵢⱼ aⱼ`. -/
+lemma number_commutation_lowering :
+    ⁅Q.number i, Q.lowering j⁆ = -(δ[i,j] • Q.lowering j) := by
+  rw [number_eq, leibniz_lie, lowering_commutation_lowering, raising_commutation_lowering,
+    comp_zero, zero_add, neg_comp, smul_comp, id_comp]
+  rcases eq_or_ne i j with rfl | hne
+  · rfl
+  · simp [eq_zero_of_ne hne]
+
+/-- `[Nᵢ, aⱼ†] = δᵢⱼ aⱼ†`. -/
+lemma number_commutation_raising :
+    ⁅Q.number i, Q.raising j⁆ = δ[i,j] • Q.raising j := by
+  rw [number_eq, leibniz_lie, lowering_commutation_raising, raising_commutation_raising,
+    zero_comp, add_zero, comp_smul, comp_id]
+  rcases eq_or_ne i j with rfl | hne
+  · rfl
+  · simp [eq_zero_of_ne hne]
+
+/-- `[Nᵢ, Nⱼ] = 0`. -/
+lemma number_commutation_number : ⁅Q.number i, Q.number j⁆ = 0 := by
+  simp only [number_eq]
+  rw [leibniz_lie, lie_leibniz, lie_leibniz, lowering_commutation_lowering,
+    lowering_commutation_raising, raising_commutation_lowering, raising_commutation_raising]
+  rcases eq_or_ne i j with rfl | hne
+  · simp only [eq_one_of_same, one_nsmul, comp_zero, zero_add, id_comp, comp_id, neg_comp,
+      comp_neg, zero_comp, add_zero]
+    abel
+  · simp [eq_zero_of_ne hne]
+
+/-- `aᵢ aᵢ† = Nᵢ + 𝟙`. -/
+lemma lowering_comp_raising :
+    Q.lowering i ∘L Q.raising i = Q.number i + ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by
+  have h := Q.lowering_commutation_raising i i
+  rw [eq_one_of_same, one_nsmul, Ring.lie_def, mul_def, mul_def] at h
+  rw [number_eq, add_comm]
+  exact sub_eq_iff_eq_add.mp h
 
 /-!
+
 ## C. Hamiltonian
+
 -/
 
 TODO "Define a Hamiltonian in terms of the number operators."
@@ -52,3 +268,9 @@ TODO "Relate the 'number operator' Hamiltonian to the 'K + T' Hamiltonian
   (=/≤/≥ depending on their domains)."
 
 TODO "Prove that the two Hamiltonians define the same quantum system."
+
+end HarmonicOscillator
+
+end QuantumMechanics
+
+end

--- a/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
+++ b/Physlib/QuantumMechanics/HarmonicOscillator/LadderOperators.lean
@@ -17,8 +17,13 @@ The ladder operators of the `d`-dimensional quantum harmonic oscillator, acting 
 the lowering (annihilation) operators `aᵢ = (xᵢ/ξᵢ + i ξᵢ pᵢ/ℏ)/√2`, the raising (creation)
 operators `aᵢ† = (xᵢ/ξᵢ - i ξᵢ pᵢ/ℏ)/√2` and the number operators `Nᵢ = aᵢ† aᵢ`, together with
 their commutation relations, which all follow from the canonical commutation relations
-`position_commutation_momentum`. The adjointness of `aᵢ` and `aᵢ†`, the Hamiltonian in terms of the
-number operators and its relation to the Hamiltonian of `Basic.lean` are still TODO items.
+`position_commutation_momentum`. The ladder operators are then lifted to unbounded operators on the
+Hilbert space with the Schwartz submodule as domain (like `momentumOperator`): `aᵢ†` is the formal
+adjoint of `aᵢ` and `Nᵢ` is symmetric. The Hamiltonian `H_N = ∑ᵢ ℏ ωᵢ (Nᵢ + ½)` commutes with
+the number operators, lowers and raises energies by `ℏ ωᵢ`, and coincides with the
+kinetic-plus-potential Hamiltonian of `Basic.lean` on Schwartz maps: as unbounded operators,
+`numberHamiltonian ≤ hamiltonian`. Whether the two define the same quantum system (essential
+self-adjointness) is still a TODO item.
 
 ## ii. Key results
 
@@ -29,6 +34,13 @@ number operators and its relation to the Hamiltonian of `Basic.lean` are still T
 - `number_commutation_number`: `[Nᵢ, Nⱼ] = 0`; `number_commutation_lowering`,
   `number_commutation_raising`: `[Nᵢ, aⱼ] = -δᵢⱼ aⱼ`, `[Nᵢ, aⱼ†] = δᵢⱼ aⱼ†`.
 - `lowering_comp_raising`: `aᵢ aᵢ† = Nᵢ + 𝟙`.
+- `loweringOperator_isFormalAdjoint_raisingOperator`: `aᵢ†` is the formal adjoint of `aᵢ`;
+  `numberOperator_isSymmetric`, `numberHamiltonian_isSymmetric`.
+- `numberHamiltonianCLM_commutation_lowering`, `numberHamiltonianCLM_commutation_raising`,
+  `numberHamiltonianCLM_commutation_number`: `[H_N, aᵢ] = -ℏ ωᵢ aᵢ`, `[H_N, aᵢ†] = ℏ ωᵢ aᵢ†`,
+  `[H_N, Nᵢ] = 0`.
+- `numberHamiltonianCLM_apply`: `H_N ψ = (1/2m) ∑ᵢ pᵢ (pᵢ ψ) + V ψ` on Schwartz maps;
+  `numberHamiltonian_le_hamiltonian`: `numberHamiltonian ≤ hamiltonian` as unbounded operators.
 
 ## iii. Table of contents
 
@@ -36,10 +48,15 @@ number operators and its relation to the Hamiltonian of `Basic.lean` are still T
   - A.1. Definitions
   - A.2. Commutation relations
   - A.3. Position and momentum in terms of the ladder operators
+  - A.4. The ladder operators as unbounded operators, adjointness
 - B. Number operators
   - B.1. Definition
   - B.2. Commutation relations
+  - B.3. The number operators as unbounded operators, symmetry
 - C. Hamiltonian
+  - C.1. The Hamiltonian in terms of the number operators
+  - C.2. Commutation relations
+  - C.3. Relation to the kinetic-plus-potential Hamiltonian
 
 ## iv. References
 
@@ -54,7 +71,9 @@ namespace QuantumMechanics
 
 namespace HarmonicOscillator
 
-open Complex Constants KroneckerDelta Bracket SchwartzMap ContinuousLinearMap
+open Complex Constants KroneckerDelta Bracket SchwartzMap ContinuousLinearMap SpaceDHilbertSpace
+open MeasureTheory SchwartzSubmodule
+open scoped InnerProductSpace
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 attribute [local instance 100] LieAlgebra.ofAssociativeAlgebra
@@ -190,7 +209,54 @@ lemma momentum_eq_raising_sub_lowering :
   rw [I_sq, sqrt_two_sq_ofReal]
   ring
 
-TODO "Prove that the raising/lowering operators are adjoints of one another (tag as simp?)."
+/-!
+
+### A.4. The ladder operators as unbounded operators, adjointness
+
+-/
+
+/-- The lowering operator as an unbounded operator with domain the Schwartz submodule. -/
+def loweringOperator : Q.HS →ₗ.[ℂ] Q.HS where
+  domain := SchwartzSubmodule d
+  toFun := (schwartzIncl volume).1 ∘ₗ (Q.lowering i).1 ∘ₗ (schwartzEquiv volume).symm.1
+
+/-- The raising operator as an unbounded operator with domain the Schwartz submodule. -/
+def raisingOperator : Q.HS →ₗ.[ℂ] Q.HS where
+  domain := SchwartzSubmodule d
+  toFun := (schwartzIncl volume).1 ∘ₗ (Q.raising i).1 ∘ₗ (schwartzEquiv volume).symm.1
+
+lemma loweringOperator_apply (ψ : SchwartzSubmodule d) :
+    Q.loweringOperator i ψ = schwartzEquiv volume (Q.lowering i ((schwartzEquiv volume).symm ψ)) :=
+  rfl
+
+lemma raisingOperator_apply (ψ : SchwartzSubmodule d) :
+    Q.raisingOperator i ψ = schwartzEquiv volume (Q.raising i ((schwartzEquiv volume).symm ψ)) :=
+  rfl
+
+/-- `⟪aᵢ f, g⟫ = ⟪f, aᵢ† g⟫` for Schwartz maps `f`, `g`. -/
+lemma lowering_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(schwartzEquiv volume (Q.lowering i f) : Q.HS), schwartzEquiv volume g⟫_ℂ
+      = ⟪(schwartzEquiv volume f : Q.HS), schwartzEquiv volume (Q.raising i g)⟫_ℂ := by
+  simp only [lowering_eq, raising_eq, map_add, map_smul, map_sub, smul_apply, add_apply, sub_apply,
+    Submodule.coe_add, Submodule.coe_smul, Submodule.coe_sub, inner_add_left, inner_smul_left,
+    inner_smul_right, inner_sub_right, positionCLM_inner, momentumCLM_inner]
+  simp only [map_inv₀, map_mul, map_div₀, Complex.conj_ofReal, Complex.conj_I]
+  ring
+
+/-- `⟪aᵢ† f, g⟫ = ⟪f, aᵢ g⟫` for Schwartz maps `f`, `g`. -/
+lemma raising_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(schwartzEquiv volume (Q.raising i f) : Q.HS), schwartzEquiv volume g⟫_ℂ
+      = ⟪(schwartzEquiv volume f : Q.HS), schwartzEquiv volume (Q.lowering i g)⟫_ℂ := by
+  rw [← inner_conj_symm, ← Q.lowering_inner i, inner_conj_symm]
+
+/-- The raising operator is the formal adjoint of the lowering operator. -/
+lemma loweringOperator_isFormalAdjoint_raisingOperator :
+    (Q.loweringOperator i).IsFormalAdjoint (Q.raisingOperator i) := by
+  intro ψ φ
+  obtain ⟨f, rfl⟩ := (schwartzEquiv volume).surjective ψ
+  obtain ⟨g, rfl⟩ := (schwartzEquiv volume).surjective φ
+  simp only [loweringOperator_apply, raisingOperator_apply, LinearEquiv.symm_apply_apply]
+  exact Q.lowering_inner i f g
 
 /-!
 
@@ -208,8 +274,6 @@ TODO "Prove that the raising/lowering operators are adjoints of one another (tag
 def number : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) := Q.raising i ∘L Q.lowering i
 
 lemma number_eq : Q.number i = Q.raising i ∘L Q.lowering i := rfl
-
-TODO "Prove that the number operators are symmetric/self-adjoint."
 
 /-!
 
@@ -256,16 +320,222 @@ lemma lowering_comp_raising :
 
 /-!
 
+### B.3. The number operators as unbounded operators, symmetry
+
+-/
+
+/-- The number operator as an unbounded operator with domain the Schwartz submodule. -/
+def numberOperator : Q.HS →ₗ.[ℂ] Q.HS where
+  domain := SchwartzSubmodule d
+  toFun := (schwartzIncl volume).1 ∘ₗ (Q.number i).1 ∘ₗ (schwartzEquiv volume).symm.1
+
+lemma numberOperator_apply (ψ : SchwartzSubmodule d) :
+    Q.numberOperator i ψ = schwartzEquiv volume (Q.number i ((schwartzEquiv volume).symm ψ)) :=
+  rfl
+
+/-- `⟪Nᵢ f, g⟫ = ⟪f, Nᵢ g⟫` for Schwartz maps `f`, `g`. -/
+lemma number_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(schwartzEquiv volume (Q.number i f) : Q.HS), schwartzEquiv volume g⟫_ℂ
+      = ⟪(schwartzEquiv volume f : Q.HS), schwartzEquiv volume (Q.number i g)⟫_ℂ := by
+  rw [number_eq, comp_apply, Q.raising_inner i, Q.lowering_inner i, comp_apply]
+
+/-- The number operator is symmetric. -/
+lemma numberOperator_isSymmetric : (Q.numberOperator i).IsSymmetric := by
+  intro ψ φ
+  obtain ⟨f, rfl⟩ := (schwartzEquiv volume).surjective ψ
+  obtain ⟨g, rfl⟩ := (schwartzEquiv volume).surjective φ
+  simp only [numberOperator_apply, LinearEquiv.symm_apply_apply]
+  exact Q.number_inner i f g
+
+TODO "Prove that the number operators are essentially self-adjoint."
+
+/-!
+
 ## C. Hamiltonian
 
 -/
 
-TODO "Define a Hamiltonian in terms of the number operators."
+/-!
 
-TODO "Prove the commutation relations between the Hamiltonian and ladder/number operators."
+### C.1. The Hamiltonian in terms of the number operators
 
-TODO "Relate the 'number operator' Hamiltonian to the 'K + T' Hamiltonian
-  (=/≤/≥ depending on their domains)."
+-/
+
+/-- The Hamiltonian in terms of the number operators, `H_N = ∑ᵢ ℏ ωᵢ (Nᵢ + ½)`, on Schwartz maps. -/
+def numberHamiltonianCLM : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) :=
+  ∑ i, ((ℏ * Q.ω i : ℝ) : ℂ) • (Q.number i + (2⁻¹ : ℂ) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ))
+
+lemma numberHamiltonianCLM_eq : Q.numberHamiltonianCLM =
+    ∑ i, ((ℏ * Q.ω i : ℝ) : ℂ) •
+      (Q.number i + (2⁻¹ : ℂ) • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ)) :=
+  rfl
+
+/-- The Hamiltonian `H_N` as an unbounded operator with domain the Schwartz submodule. -/
+def numberHamiltonian : Q.HS →ₗ.[ℂ] Q.HS where
+  domain := SchwartzSubmodule d
+  toFun := (schwartzIncl volume).1 ∘ₗ (Q.numberHamiltonianCLM).1 ∘ₗ (schwartzEquiv volume).symm.1
+
+lemma numberHamiltonian_apply (ψ : SchwartzSubmodule d) :
+    Q.numberHamiltonian ψ =
+      schwartzEquiv volume (Q.numberHamiltonianCLM ((schwartzEquiv volume).symm ψ)) :=
+  rfl
+
+/-!
+
+### C.2. Commutation relations
+
+-/
+
+/-- `[H_N, aᵢ] = -ℏ ωᵢ aᵢ`. -/
+lemma numberHamiltonianCLM_commutation_lowering :
+    ⁅Q.numberHamiltonianCLM, Q.lowering i⁆ = -(((ℏ * Q.ω i : ℝ) : ℂ) • Q.lowering i) := by
+  simp only [numberHamiltonianCLM_eq, sum_lie, smul_lie, add_lie, number_commutation_lowering,
+    id_commutation, smul_zero, add_zero, smul_neg]
+  rw [Finset.sum_eq_single i (fun b _ hb => by simp [eq_zero_of_ne hb]) (by simp)]
+  simp [eq_one_of_same]
+
+/-- `[H_N, aᵢ†] = ℏ ωᵢ aᵢ†`. -/
+lemma numberHamiltonianCLM_commutation_raising :
+    ⁅Q.numberHamiltonianCLM, Q.raising i⁆ = ((ℏ * Q.ω i : ℝ) : ℂ) • Q.raising i := by
+  simp only [numberHamiltonianCLM_eq, sum_lie, smul_lie, add_lie, number_commutation_raising,
+    id_commutation, smul_zero, add_zero]
+  rw [Finset.sum_eq_single i (fun b _ hb => by simp [eq_zero_of_ne hb]) (by simp)]
+  simp [eq_one_of_same]
+
+/-- `[H_N, Nᵢ] = 0`. -/
+lemma numberHamiltonianCLM_commutation_number : ⁅Q.numberHamiltonianCLM, Q.number i⁆ = 0 := by
+  simp [numberHamiltonianCLM_eq, sum_lie, smul_lie, add_lie, number_commutation_number,
+    id_commutation]
+
+/-!
+
+### C.3. Relation to the kinetic-plus-potential Hamiltonian
+
+-/
+
+/-- On Schwartz maps, `H_N ψ = (1/2m) ∑ᵢ pᵢ (pᵢ ψ) + V ψ`: the Hamiltonian in terms of the number
+  operators is the kinetic-plus-potential Hamiltonian. -/
+lemma numberHamiltonianCLM_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
+    Q.numberHamiltonianCLM ψ x =
+      ((2 * Q.m : ℝ) : ℂ)⁻¹ * ∑ i, 𝐩 i (𝐩 i ψ) x + (Q.potentialFunction x : ℂ) * ψ x := by
+  simp only [numberHamiltonianCLM_eq, FunLike.coe_sum, Finset.sum_apply, smul_apply, add_apply,
+    id_apply, smul_eq_mul]
+  rw [potentialFunction_apply, Finset.mul_sum, ofReal_sum, Finset.sum_mul, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hccr := position_commutation_momentum_apply i ψ x
+  have hξ := Q.ξ_sq_mul_ofReal i
+  have hξ0 := Q.ξ_ofReal_ne_zero i
+  have hℏ0 := ℏ_ofReal_ne_zero
+  have hm0 : ((Q.m : ℝ) : ℂ) ≠ 0 := by exact_mod_cast Q.m_ne_zero
+  have hω0 : ((Q.ω i : ℝ) : ℂ) ≠ 0 := by exact_mod_cast Q.ω_ne_zero i
+  simp only [number_eq, lowering_eq, raising_eq, comp_apply, map_add, map_smul, smul_apply,
+    add_apply, sub_apply, smul_eq_mul, positionCLM_apply]
+  push_cast
+  field_simp
+  linear_combination
+    (2 * I * (ℏ : ℂ) * ((Q.m : ℝ) : ℂ) * ((Q.ω i : ℝ) : ℂ) * ((Q.ξ i : ℝ) : ℂ) ^ 2) * hccr
+    - ((ℏ : ℂ) * ((Q.ξ i : ℝ) : ℂ) ^ 2 * (𝐩 i (𝐩 i ψ) x
+        - (ℏ : ℂ) * ((Q.m : ℝ) : ℂ) * ((Q.ω i : ℝ) : ℂ) * ψ x
+        + ((Q.m : ℝ) : ℂ) ^ 2 * ((Q.ω i : ℝ) : ℂ) ^ 2 * ψ x * ((x i : ℝ) : ℂ) ^ 2))
+      * sqrt_two_sq_ofReal
+    - (2 * (-(𝐩 i (𝐩 i ψ) x * ((Q.ξ i : ℝ) : ℂ) ^ 2)
+        + (ℏ : ℂ) * ((Q.m : ℝ) : ℂ) * ((Q.ω i : ℝ) : ℂ) * ψ x * ((x i : ℝ) : ℂ) ^ 2)) * hξ
+    + (2 * ((Q.ω i : ℝ) : ℂ) * (ℏ : ℂ) ^ 2 * ψ x * ((Q.ξ i : ℝ) : ℂ) ^ 2 * ((Q.m : ℝ) : ℂ)
+        - 2 * ((Q.ω i : ℝ) : ℂ) * ((Q.ξ i : ℝ) : ℂ) ^ 4 * 𝐩 i (𝐩 i ψ) x * ((Q.m : ℝ) : ℂ)) * I_sq
+
+/-- The kinetic operator on a Schwartz map, `(1/2m) ∑ᵢ pᵢ (pᵢ f)`. -/
+lemma kineticOperator_apply_schwartz (f : 𝓢(Space d, ℂ))
+    (h : (schwartzEquiv volume f : Q.HS) ∈ Q.kineticOperator.domain) :
+    Q.kineticOperator ⟨schwartzEquiv volume f, h⟩
+      = schwartzEquiv volume (((2 * Q.m)⁻¹ : ℝ) • ∑ i, 𝐩 i (𝐩 i f)) := by
+  have h1 : Q.kineticOperator ⟨schwartzEquiv volume f, h⟩ =
+      (2 * Q.m)⁻¹ • momentumSqOperator ⟨schwartzEquiv volume f, h⟩ :=
+    LinearPMap.smul_apply _ _ _
+  rw [h1]
+  erw [LinearPMap.sum_apply]
+  rw [RCLike.real_smul_eq_coe_smul (K := ℂ), RCLike.real_smul_eq_coe_smul (K := ℂ), map_smul,
+    map_sum, Submodule.coe_smul, Submodule.coe_sum]
+  congr 1
+  refine Finset.sum_congr rfl fun a _ => ?_
+  have hr : ∀ x : (𝓟 a).domain, 𝓟 a x ∈ (𝓟 a).domain := momentumOperator_range a
+  have key : ∀ H, ((𝓟 a).comp (𝓟 a) hr) ⟨(schwartzEquiv volume f : Q.HS), H⟩
+      = schwartzEquiv volume (𝐩 a (𝐩 a f)) := fun H => by
+    have H' : (schwartzEquiv volume f : Q.HS) ∈ (𝓟 a).domain := H
+    have e3 : (⟨𝓟 a ⟨(schwartzEquiv volume f : Q.HS), H'⟩, hr _⟩ : (𝓟 a).domain)
+        = ⟨(schwartzEquiv volume (𝐩 a f) : Q.HS), (schwartzEquiv volume (𝐩 a f)).2⟩ := by
+      apply Subtype.ext
+      show 𝓟 a (schwartzEquiv volume f) = (schwartzEquiv volume (𝐩 a f) : Q.HS)
+      rw [momentumOperator_apply, LinearEquiv.symm_apply_apply]
+    show 𝓟 a ⟨𝓟 a ⟨(schwartzEquiv volume f : Q.HS), H'⟩, hr _⟩ = _
+    rw [e3]
+    show 𝓟 a (schwartzEquiv volume (𝐩 a f)) = _
+    rw [momentumOperator_apply, LinearEquiv.symm_apply_apply]
+  exact key _
+
+/-- The potential operator on a Schwartz map, almost everywhere `V f`. -/
+lemma potentialOperator_apply_schwartz (f : 𝓢(Space d, ℂ))
+    (h : (schwartzEquiv volume f : Q.HS) ∈ Q.potentialOperator.domain) :
+    ⇑(Q.potentialOperator ⟨schwartzEquiv volume f, h⟩) =ᵐ[volume]
+      fun x => (Q.potentialFunction x : ℂ) * f x := by
+  have h1 : ⇑(Q.potentialOperator ⟨schwartzEquiv volume f, h⟩) =ᵐ[volume]
+      (ofReal ∘ Q.potentialFunction) • ⇑(schwartzEquiv volume f : Q.HS) := mulOperator_apply_ae _
+  filter_upwards [h1, schwartzEquiv_coe_ae (μ := volume) f] with x hx1 hx2
+  rw [hx1]
+  simp [hx2]
+
+/-- As unbounded operators, `H_N` (with the Schwartz submodule as domain) is contained in the
+  kinetic-plus-potential Hamiltonian. -/
+lemma numberHamiltonian_le_hamiltonian : Q.numberHamiltonian ≤ Q.hamiltonian := by
+  refine ⟨?_, ?_⟩
+  · show SchwartzSubmodule d ≤ _
+    rw [hamiltonain_eq, LinearPMap.add_domain, kineticOperator, LinearPMap.smul_domain,
+      momentumSqOperator_domain_eq]
+    exact le_inf le_rfl (mulOperator_domain_ge_of_hasTemperateGrowth
+      Q.potentialFunction_hasTemperateGrowth volume)
+  · intro ψ φ hψφ
+    obtain ⟨f, hf⟩ := (schwartzEquiv volume).surjective ψ
+    subst hf
+    have hk := (φ.2 : (φ : Q.HS) ∈ Q.kineticOperator.domain ⊓ Q.potentialOperator.domain).1
+    have hp := (φ.2 : (φ : Q.HS) ∈ Q.kineticOperator.domain ⊓ Q.potentialOperator.domain).2
+    have hadd : Q.hamiltonian φ = Q.kineticOperator ⟨φ, hk⟩ + Q.potentialOperator ⟨φ, hp⟩ :=
+      LinearPMap.add_apply _ _ φ
+    have hk' : (⟨(φ : Q.HS), hk⟩ : Q.kineticOperator.domain) =
+        ⟨schwartzEquiv volume f, hψφ ▸ hk⟩ :=
+      Subtype.ext hψφ.symm
+    have hp' : (⟨(φ : Q.HS), hp⟩ : Q.potentialOperator.domain) =
+        ⟨schwartzEquiv volume f, hψφ ▸ hp⟩ :=
+      Subtype.ext hψφ.symm
+    have hN : Q.numberHamiltonian (schwartzEquiv volume f) =
+        schwartzEquiv volume (Q.numberHamiltonianCLM f) := by
+      rw [numberHamiltonian_apply, LinearEquiv.symm_apply_apply]
+    apply MeasureTheory.Lp.ext
+    rw [hadd, hk', hp', Q.kineticOperator_apply_schwartz, hN]
+    have h1 := schwartzEquiv_coe_ae (μ := volume) (((2 * Q.m)⁻¹ : ℝ) • ∑ i, 𝐩 i (𝐩 i f))
+    have h2 := schwartzEquiv_coe_ae (μ := volume) (Q.numberHamiltonianCLM f)
+    have h3 := MeasureTheory.Lp.coeFn_add
+      (schwartzEquiv volume (((2 * Q.m)⁻¹ : ℝ) • ∑ i, 𝐩 i (𝐩 i f)) : Q.HS)
+      (Q.potentialOperator ⟨schwartzEquiv volume f, hψφ ▸ hp⟩)
+    filter_upwards [h1, h2, h3, Q.potentialOperator_apply_schwartz f _] with x hx1 hx2 hx3 hx4
+    rw [hx2, hx3, numberHamiltonianCLM_apply, Pi.add_apply, hx1, hx4]
+    simp only [smul_apply, FunLike.coe_sum, Finset.sum_apply, Complex.real_smul,
+      Complex.ofReal_inv, Complex.ofReal_mul, Complex.ofReal_ofNat]
+
+/-- `⟪H_N f, g⟫ = ⟪f, H_N g⟫` for Schwartz maps `f`, `g`. -/
+lemma numberHamiltonianCLM_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(schwartzEquiv volume (Q.numberHamiltonianCLM f) : Q.HS), schwartzEquiv volume g⟫_ℂ
+      = ⟪(schwartzEquiv volume f : Q.HS), schwartzEquiv volume (Q.numberHamiltonianCLM g)⟫_ℂ := by
+  simp only [numberHamiltonianCLM_eq, FunLike.coe_sum, Finset.sum_apply, smul_apply, add_apply,
+    id_apply, map_sum, map_smul, map_add, Submodule.coe_sum, Submodule.coe_smul, Submodule.coe_add,
+    sum_inner, inner_sum, inner_smul_left, inner_smul_right, inner_add_left, inner_add_right,
+    Q.number_inner, Complex.conj_ofReal, map_inv₀, map_ofNat]
+
+/-- The Hamiltonian `H_N` is symmetric. -/
+lemma numberHamiltonian_isSymmetric : Q.numberHamiltonian.IsSymmetric := by
+  intro ψ φ
+  obtain ⟨f, rfl⟩ := (schwartzEquiv volume).surjective ψ
+  obtain ⟨g, rfl⟩ := (schwartzEquiv volume).surjective φ
+  simp only [numberHamiltonian_apply, LinearEquiv.symm_apply_apply]
+  exact Q.numberHamiltonianCLM_inner f g
 
 TODO "Prove that the two Hamiltonians define the same quantum system."
 

--- a/Physlib/QuantumMechanics/Operators/Commutation.lean
+++ b/Physlib/QuantumMechanics/Operators/Commutation.lean
@@ -80,6 +80,11 @@ lemma comp_eq_comp_add_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d,
   dsimp only [Bracket.bracket]
   simp only [ContinuousLinearMap.mul_def, add_sub_cancel]
 
+/-- The identity commutes with everything. -/
+lemma id_commutation (A : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
+    ⁅ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ), A⁆ = 0 := by
+  rw [Ring.lie_def, ← ContinuousLinearMap.one_def, one_mul, mul_one, sub_self]
+
 lemma comp_eq_comp_sub_commute (A B : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ)) :
     A ∘L B = B ∘L A - ⁅B, A⁆ := by
   dsimp only [Bracket.bracket]
@@ -164,6 +169,13 @@ lemma position_commutation_momentum : ⁅𝐱 i, 𝐩 j⁆ =
   rcases eq_or_ne i j with (rfl | hne)
   · simp
   · simp [eq_zero_of_ne hne, hne.symm]
+
+/-- The canonical commutation relations, pointwise: `xᵢ (pᵢ ψ)(x) - (pᵢ (xᵢ ψ))(x) = iℏ ψ(x)`. -/
+lemma position_commutation_momentum_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) :
+    ((x i : ℝ) : ℂ) * 𝐩 i ψ x - 𝐩 i (𝐱 i ψ) x = I * ℏ * ψ x := by
+  have h := congrArg (fun T : 𝓢(Space d, ℂ) →L[ℂ] 𝓢(Space d, ℂ) => T ψ x)
+    (position_commutation_momentum (d := d) i i)
+  simpa [Ring.lie_def, eq_one_of_same] using h
 
 lemma momentum_comp_position_eq : 𝐩 j ∘L 𝐱 i =
     𝐱 i ∘L 𝐩 j - (I * ℏ) • δ[i,j] • ContinuousLinearMap.id ℂ 𝓢(Space d, ℂ) := by

--- a/Physlib/QuantumMechanics/Operators/Momentum.lean
+++ b/Physlib/QuantumMechanics/Operators/Momentum.lean
@@ -137,6 +137,15 @@ lemma momentumOperator_isSymmetric : (𝓟 i).IsSymmetric := by
   congr 2
   exact integral_mul_fderiv_eq_neg_fderiv_mul_of_integrable hI₂ hI₃ hI₄ (by fun_prop) (by fun_prop)
 
+open scoped InnerProductSpace in
+/-- The momentum operator is symmetric on Schwartz maps, in terms of `momentumCLM`. -/
+lemma momentumCLM_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(schwartzEquiv volume (𝐩 i f) : SpaceDHilbertSpace d), schwartzEquiv volume g⟫_ℂ
+      = ⟪(schwartzEquiv volume f : SpaceDHilbertSpace d), schwartzEquiv volume (𝐩 i g)⟫_ℂ := by
+  have h := momentumOperator_isSymmetric (d := d) i (schwartzEquiv volume f)
+    (schwartzEquiv volume g)
+  simpa [momentumOperator_apply] using h
+
 lemma momentumOperator_isUnbounded : (𝓟 i).IsUnbounded := by
   refine (LinearPMap.IsSymmetric.isUnbounded_iff_hasDenseDomain ?_).mpr ?_
   · exact momentumOperator_isSymmetric i

--- a/Physlib/QuantumMechanics/Operators/Position.lean
+++ b/Physlib/QuantumMechanics/Operators/Position.lean
@@ -93,6 +93,19 @@ lemma positionCLM_apply_fun (ψ : 𝓢(Space d, ℂ)) : 𝐱 i ψ = (fun x : Spa
 lemma positionCLM_apply (ψ : 𝓢(Space d, ℂ)) (x : Space d) : 𝐱 i ψ x = x i * ψ x := by
   simp [positionCLM_apply_fun]
 
+open scoped InnerProductSpace in
+/-- The position operator is symmetric on Schwartz maps, in terms of `positionCLM`. -/
+lemma positionCLM_inner (f g : 𝓢(Space d, ℂ)) :
+    ⟪(SpaceDHilbertSpace.schwartzEquiv volume (𝐱 i f) : SpaceDHilbertSpace d),
+      SpaceDHilbertSpace.schwartzEquiv volume g⟫_ℂ
+      = ⟪(SpaceDHilbertSpace.schwartzEquiv volume f : SpaceDHilbertSpace d),
+        SpaceDHilbertSpace.schwartzEquiv volume (𝐱 i g)⟫_ℂ := by
+  simp only [← Submodule.coe_inner, SchwartzSubmodule.schwartzEquiv_inner, positionCLM_apply]
+  congr 1
+  ext x
+  simp only [map_mul, Complex.conj_ofReal]
+  ring
+
 /-!
 ### A.2. Radius powers (regularized)
 -/

--- a/Physlib/QuantumMechanics/PlanckConstant.lean
+++ b/Physlib/QuantumMechanics/PlanckConstant.lean
@@ -38,6 +38,9 @@ lemma ℏ_nonneg : 0 ≤ (ℏ : ℝ) := le_of_lt ℏ.2
 @[simp]
 lemma ℏ_ne_zero : (ℏ : ℝ) ≠ 0 := ne_of_gt ℏ.2
 
+/-- reduced Planck's constant is not equal to zero, as a complex number. -/
+lemma ℏ_ofReal_ne_zero : ((ℏ : ℝ) : ℂ) ≠ 0 := by exact_mod_cast ℏ_ne_zero
+
 /-- The definition of Planck's constant in terms of Reduced Planck's constant,
  defined as `2 π ℏ` -/
 noncomputable def h : Subtype fun x : ℝ => 0 < x := ⟨2 * Real.pi * (ℏ : ℝ),


### PR DESCRIPTION
## AI disclosure

**AI disclosure.** This PR was generated with Claude Fable 5.1 (Claude Code) under my
supervision, following `AI-POLICY.md` and `AGENTS.md`. I have read every definition and lemma
statement and vouch that they state what the docstrings say. The statements were fixed before
the proofs were written and the operator identities were checked symbolically (sympy, in the
Schrodinger representation) beforehand.

Was stacked on #1644 (`oscillator-ladder-1`, now merged); master is merged in.

Fills the remaining TODO items of `LadderOperators.lean` except the last one (same quantum system,
which needs essential self-adjointness; left as a TODO together with the essential self-adjointness of
the number operators). No new Hamiltonian is defined: the lemmas are about the Hamiltonian
`kineticOperator + potentialOperator` of `Basic.lean`.

`LadderOperators.lean`, in namespace `QuantumMechanics.HarmonicOscillator`:
- A.4: `loweringOperator`, `raisingOperator` (unbounded operators with the Schwartz submodule as
  domain, modelled on `momentumOperator`), `loweringCLM_inner`, `raisingCLM_inner`,
  `loweringOperator_isFormalAdjoint_raisingOperator`: `aᵢ†` is the formal adjoint of `aᵢ`.
- B.3: `numberCLM_inner`: `⟪Nᵢ f, g⟫ = ⟪f, Nᵢ g⟫` for Schwartz maps.
- C.1: `sum_number_commutation_lowering`, `_raising`, `_number`: with `H_N = ∑ᵢ ℏ ωᵢ (Nᵢ + ½)`
  written out, `[H_N, aᵢ] = -ℏ ωᵢ aᵢ`, `[H_N, aᵢ†] = ℏ ωᵢ aᵢ†`, `[H_N, Nᵢ] = 0`.
- C.2: `sum_number_apply`: `H_N ψ = (1/2m) ∑ᵢ pᵢ (pᵢ ψ) + V ψ` pointwise on Schwartz maps (the
  canonical commutation relation and `ξᵢ² m ωᵢ = ℏ` do the work); `schwartzSubmodule_le_hamiltonian_domain`
  (by temperate growth of the potential); `hamiltonian_apply_schwartz`: on a Schwartz map the Hamiltonian
  of `Basic.lean` acts as `H_N` (almost-everywhere identification of the potential operator);
  `hamiltonian_inner_schwartz`: the Hamiltonian is symmetric on the Schwartz submodule.

`HarmonicOscillator/NumberOperator.lean` (new file): `numberOperator` (unbounded operator with the
Schwartz submodule as domain), `numberOperator_apply`, `numberOperator_isSymmetric`.

Small lemmas placed next to the objects they are about:
- `HarmonicOscillator/Basic.lean`: `ξ_sq_mul_ofReal`, `potentialFunction_apply`
  (`V(x) = ∑ᵢ ½ m ωᵢ² xᵢ²`), `potentialFunction_hasTemperateGrowth`; `kineticOperator_apply_schwartz`
  and `potentialOperator_apply_schwartz`, right after the definitions of the two operators.
- `Operators/Commutation.lean`: `id_commutation`, `position_commutation_momentum_apply` (the
  canonical commutation relation pointwise).
- `Operators/Position.lean`, `Operators/Momentum.lean`: `positionCLM_inner`, `momentumCLM_inner`
  (symmetry of `xᵢ` and `pᵢ` on Schwartz maps, in terms of the continuous linear maps).

Reviewer map: `loweringCLM_inner` (the adjointness computation), `sum_number_apply` (the identity
`H_N = K + V`), then `hamiltonian_apply_schwartz` (domain inclusion and the almost-everywhere
identification of the potential operator).

**Update (Sept 16).** Review of Sept 15 applied: the two `_apply_schwartz` lemmas moved next to their
definitions, the number operators as unbounded operators moved to their own file, and the separate
definitions `numberHamiltonianCLM` / `numberHamiltonian` replaced by lemmas about the existing
Hamiltonian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
